### PR TITLE
feat(trusty-audit): git-churn collector feeds [report].findings and a Change Hotspots subsection (Refs #6079)

### DIFF
--- a/crates/trusty-audit/changelog.d/6079-churn-collector.md
+++ b/crates/trusty-audit/changelog.d/6079-churn-collector.md
@@ -23,13 +23,23 @@ Added
     unfiltered top ten was seven `Cargo.toml`s, a `.tsv` allowlist and a
     `CLAUDE.md`. The findings still report those, because a manifest rewritten
     200 times in six months is real dependency movement a reader wants.
-  - Fail-open, and never silently. A missing `git`, a path that is not a
+  - Fail-open, and never silently. A missing `git`, a path holding no
     repository, a shallow clone (whose counts stop at the graft point and would
     understate every hotspot), an empty window, a failed child, and an
     unwritable manifest each get a gap naming which it was — the collector's own
     diagnosis leading, with the child's first stderr line only ever as the
     parenthetical (#6720). A history that read clean states what its count does
-    not cover.
+    not cover. There is no not-applicable arm: every checkout arrives by `git
+    clone`, so a path with no `.git` is an anomaly the report names rather than
+    a leg that quietly does not apply.
+  - A window deeper than the 4000-commit read cap is reported too. `git log
+    --max-count` truncates in silence, so such a window is read to the cap and
+    its hotspots ship with a caveat stating that every count is a floor and that
+    a file whose work is entirely older than the read is missing outright.
+  - Paths are read with `core.quotepath=false`, so a non-ASCII filename such as
+    `src/café.rs` reaches the findings and the ranking as itself rather than as
+    git's default `"src/caf\303\251.rs"` — a path no reader can open or grep
+    for.
   - It needs neither daemon, so it is measured before the trusty-search and
     trusty-analyze gates: a repository whose daemons never answered still gets
     its change hotspots into the report.

--- a/crates/trusty-audit/changelog.d/6079-churn-collector.md
+++ b/crates/trusty-audit/changelog.d/6079-churn-collector.md
@@ -1,0 +1,35 @@
+Added
+
+- The audit sweep now reads each repository's own git history and reports its
+  change hotspots — the files a team keeps rewriting — into the report
+  manifest's `[report].findings` under the `churn` category, so the DD report
+  states them instead of leaving the reader to guess where the work is (#6079).
+  - The history is read by a direct `git log --numstat` shell-out from this
+    crate. No tga dependency is added: the owner ruled 2026-08-19 that
+    trusty-review must run independently of tga, and that all collector
+    intelligence lives in trusty-audit so iteration is a single-crate rebuild.
+  - Every threshold is a documented `pub const` in one place: a 180-day window,
+    a 4000-commit read cap, 5 commits to be a hotspot at all, 20 to band RED, 20
+    rows written and 10 offered to the ranking.
+  - Churn is also an OPTIONAL third input to the evidence ranking
+    (`evidence::blend_with`), entering each round behind the complexity hotspot
+    and every dimension — the smallest non-zero weight that structure can
+    express. An absent churn lane reproduces the previous ranking exactly, which
+    `blend` now delegates for.
+  - Lockfiles and changelogs are excluded by basename: their churn measures a
+    generator rather than the code, and they would otherwise take the top of
+    both outputs in every repository. The RANKING additionally declines
+    configuration and prose by extension — measured against this workspace, the
+    unfiltered top ten was seven `Cargo.toml`s, a `.tsv` allowlist and a
+    `CLAUDE.md`. The findings still report those, because a manifest rewritten
+    200 times in six months is real dependency movement a reader wants.
+  - Fail-open, and never silently. A missing `git`, a path that is not a
+    repository, a shallow clone (whose counts stop at the graft point and would
+    understate every hotspot), an empty window, a failed child, and an
+    unwritable manifest each get a gap naming which it was — the collector's own
+    diagnosis leading, with the child's first stderr line only ever as the
+    parenthetical (#6720). A history that read clean states what its count does
+    not cover.
+  - It needs neither daemon, so it is measured before the trusty-search and
+    trusty-analyze gates: a repository whose daemons never answered still gets
+    its change hotspots into the report.

--- a/crates/trusty-audit/changelog.d/6079-git-entry-point.md
+++ b/crates/trusty-audit/changelog.d/6079-git-entry-point.md
@@ -1,0 +1,8 @@
+Changed
+
+- The hardened `git` child `local_repo` carried privately — the ambient
+  `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` /
+  `GIT_ALTERNATE_OBJECT_DIRECTORIES` cleared and `GIT_TERMINAL_PROMPT=0` set —
+  is now `trusty_audit::git`, with a synchronous constructor beside the
+  asynchronous one #6079's churn collector needs. One list of ambient variables
+  rather than a copy per caller; behaviour is unchanged.

--- a/crates/trusty-audit/src/git.rs
+++ b/crates/trusty-audit/src/git.rs
@@ -1,0 +1,86 @@
+//! The one `git` child this crate spawns (#6079).
+//!
+//! Why: [`crate::local_repo`] already spelled a hardened `git` constructor —
+//! ambient repository variables removed, terminal prompting off — privately, for
+//! the clone and validation half. #6079's churn collector needs a `git log` run
+//! under the identical hygiene, and CLAUDE.md's common-entry-point rule makes a
+//! second `Command::new("git")` carrying its own copy of that environment list a
+//! defect. One list, two constructors, both callers routed through them.
+//!
+//! An inherited `GIT_DIR` or `GIT_WORK_TREE` points a child at whatever the
+//! parent shell was pointed at, which for an agent-run or hook-run invocation is
+//! somebody else's repository — a churn measurement taken there is silently
+//! about the wrong codebase. `GIT_TERMINAL_PROMPT=0` keeps a source that
+//! unexpectedly wants credentials from hanging an unattended sweep.
+//!
+//! Nothing here decides WHAT to run. Every subcommand this crate passes through
+//! it is read-only against the repository named (`rev-parse`, `log`) or writes
+//! only under the working directory (`clone`), and that invariant stays with the
+//! caller that knows its own subcommand.
+//!
+//! Test: `crate::grounding::churn::churn_tests::a_fixture_repository_ranks_its_hotspots`,
+//! `crate::local_repo::local_repo_tests::the_source_checkout_is_byte_identical_afterwards`.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// The executable every constructor here runs.
+pub const BINARY: &str = "git";
+
+/// Repository-selecting variables an inherited environment must not supply.
+///
+/// Stated once because a copy of this list is exactly what drifts: a caller that
+/// clears three of the four still runs against the parent's repository whenever
+/// the fourth is set.
+const AMBIENT: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+];
+
+/// Where `git` is on this machine, or the one line saying it is not.
+///
+/// # Errors
+/// One line, safe to show the recipient, when no `git` is on the resolver's
+/// search path. The caller turns it into a gap of its own.
+pub fn resolve() -> Result<PathBuf, String> {
+    trusty_common::bin_resolve::resolve_binary(BINARY)
+        .ok_or_else(|| format!("`{BINARY}` is not installed"))
+}
+
+/// A hardened synchronous `git -C <repo> <args…>`, ready to `output()`.
+///
+/// `-C` rather than `current_dir`: it is what git documents for running against
+/// another checkout, and it keeps this process's own working directory out of
+/// the child's resolution entirely.
+#[must_use]
+pub fn at(binary: &Path, repo: &Path, args: &[&str]) -> std::process::Command {
+    let mut command = std::process::Command::new(binary);
+    command.arg("-C").arg(repo).args(args);
+    harden_sync(&mut command);
+    command
+}
+
+/// A hardened asynchronous `git <argv…>`.
+///
+/// The argv is taken whole rather than as `(repo, args)` because the clone half
+/// runs `git clone <source> <staging>`, which names two paths and no `-C`.
+#[must_use]
+pub fn spawn(argv: Vec<OsString>) -> tokio::process::Command {
+    let mut command = tokio::process::Command::new(BINARY);
+    command.args(argv);
+    for var in AMBIENT {
+        command.env_remove(var);
+    }
+    command.env("GIT_TERMINAL_PROMPT", "0");
+    command
+}
+
+/// [`AMBIENT`] cleared and prompting disabled on a synchronous child.
+fn harden_sync(command: &mut std::process::Command) {
+    for var in AMBIENT {
+        command.env_remove(var);
+    }
+    command.env("GIT_TERMINAL_PROMPT", "0");
+}

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -28,6 +28,7 @@
 //! | [`topology`] | reading a Cargo workspace's own crate graph (#6147) |
 //! | [`cve`] | scanning the pinned dependency set for advisories (#6075) |
 //! | [`license`] | banding that same set by license obligation (#6076) |
+//! | [`churn`] | reading the checkout's own git history for change hotspots (#6079) |
 //! | [`priority`] | writing that ranking, and the gaps, into the manifest |
 //!
 //! ## Fail-open, and never silently
@@ -57,6 +58,7 @@ use std::time::Duration;
 use crate::tools::RequiredTool;
 use crate::workdir::WorkDir;
 
+pub mod churn;
 pub mod cve;
 pub mod daemons;
 pub mod ecosystem;
@@ -183,18 +185,12 @@ pub struct Grounding {
     /// top-up (#6082). False on every degraded path, which is what keeps the
     /// heuristics available exactly when they are all that is left.
     pub attributed: bool,
-}
-
-impl Grounding {
-    /// A grounding that produced nothing but the reason it produced nothing.
-    fn gap(reason: String) -> Self {
-        Self {
-            index_id: None,
-            priorities: Vec::new(),
-            gaps: vec![reason],
-            attributed: false,
-        }
-    }
+    /// The repository's change hotspots, worst first (#6079). Empty whenever the
+    /// history could not be read, which is itself a named gap. Carried on the
+    /// value rather than written where it is measured because it is produced
+    /// inside [`ground`], which has no manifest, and written by
+    /// [`ground_manifest`], which does.
+    pub churn: Vec<churn::ChurnFile>,
 }
 
 /// Index `checkout`, search it per DD dimension, measure it, and rank its files.
@@ -230,49 +226,66 @@ pub async fn ground(
     budget: priority::Budget,
 ) -> Grounding {
     let caps = evidence::Caps::for_budget(budget.max_files);
+    // #6079: measured BEFORE the daemon gates, because it needs neither daemon.
+    // A repository whose trusty-search never answered still gets its change
+    // hotspots into the report, and a history that could not be read still gets
+    // its gap line — which is the whole point of doing it first rather than
+    // beside the two legs that do depend on a daemon.
+    let (churn_files, churn_gaps) = churn::ground(checkout, display);
+
     let Some(index_id) = index::index_id_for(checkout) else {
-        return Grounding::gap(format!(
-            "{display}: {} has no final path component, so no trusty-search index id could be \
-             derived — the report's code-analysis sections are not assessed for it",
-            checkout.display()
-        ));
+        return churn_only(
+            format!(
+                "{display}: {} has no final path component, so no trusty-search index id could be \
+                 derived — the report's code-analysis sections are not assessed for it",
+                checkout.display()
+            ),
+            None,
+            churn_files,
+            churn_gaps,
+        );
     };
 
     if let Err(cause) = daemons::ensure_search(tools).await {
-        return Grounding::gap(format!(
-            "{display}: {cause} — the report's findings, complexity distribution and health \
-             factors are not assessed for it, and its investigation pass ranks files by path \
-             name alone"
-        ));
-    }
-
-    if let Err(cause) = index::ensure_indexed(&tools.search, checkout, &index_id) {
-        return Grounding {
-            index_id: Some(index_id),
-            priorities: Vec::new(),
-            gaps: vec![format!(
+        return churn_only(
+            format!(
                 "{display}: {cause} — the report's findings, complexity distribution and health \
                  factors are not assessed for it, and its investigation pass ranks files by path \
                  name alone"
-            )],
-            attributed: false,
-        };
+            ),
+            None,
+            churn_files,
+            churn_gaps,
+        );
+    }
+
+    if let Err(cause) = index::ensure_indexed(&tools.search, checkout, &index_id) {
+        return churn_only(
+            format!(
+                "{display}: {cause} — the report's findings, complexity distribution and health \
+                 factors are not assessed for it, and its investigation pass ranks files by path \
+                 name alone"
+            ),
+            Some(index_id),
+            churn_files,
+            churn_gaps,
+        );
     }
 
     // #6082: an index id is a checkout basename, so a same-named checkout
     // elsewhere on this machine is served under it. Both legs below read that
     // index, so a wrong root poisons the evidence AND the measurements.
     if let Err(cause) = index::root_matches(&tools.search_socket, &index_id, checkout).await {
-        return Grounding {
-            index_id: Some(index_id),
-            priorities: Vec::new(),
-            gaps: vec![format!(
+        return churn_only(
+            format!(
                 "{display}: complexity data unavailable: index root mismatch — {cause}. Its \
                  evidence discovery and complexity hotspots are not assessed, and its \
                  investigation pass ranks files by path name alone"
-            )],
-            attributed: false,
-        };
+            ),
+            Some(index_id),
+            churn_files,
+            churn_gaps,
+        );
     }
 
     // #6082: the discovery leg. It asks the index where each DD dimension's
@@ -299,13 +312,21 @@ pub async fn ground(
     );
 
     let hotspots = complexity(tools, &index_id, checkout, display, &mut gaps).await;
-    let priorities = evidence::blend(&hotspots, &discovery.dimensions, caps.priority_paths);
+    // #6079: the churn lane is the third input, and an empty one reproduces the
+    // ranking exactly as `blend` produced it before this leg existed.
+    let priorities = evidence::blend_with(
+        &hotspots,
+        &discovery.dimensions,
+        &churn::lane(&churn_files),
+        caps.priority_paths,
+    );
     if priorities.is_empty() {
         gaps.push(format!(
             "{display}: neither the search index nor trusty-analyze named a file to inspect, so \
              the investigation pass ranks its files by path name alone"
         ));
     }
+    gaps.extend(churn_gaps);
     Grounding {
         index_id: Some(index_id),
         // #6082: the ranking may decline trusty-review's heuristic top-up only
@@ -315,6 +336,27 @@ pub async fn ground(
         attributed: search_answered && !priorities.is_empty(),
         priorities,
         gaps,
+        churn: churn_files,
+    }
+}
+
+/// A grounding carrying nothing but the churn leg's output and one other gap.
+///
+/// Why: #6079's collector needs no daemon and no index, so every arm of
+/// [`ground`] that returns before the daemon legs still has churn to report —
+/// and a churn gap it must not swallow. Spelled once rather than at each of the
+/// four early returns.
+fn churn_only(
+    gap: String,
+    index_id: Option<String>,
+    churn: Vec<churn::ChurnFile>,
+    churn_gaps: Vec<String>,
+) -> Grounding {
+    Grounding {
+        index_id,
+        gaps: std::iter::once(gap).chain(churn_gaps).collect(),
+        churn,
+        ..Grounding::default()
     }
 }
 
@@ -427,6 +469,10 @@ pub async fn ground_manifest(
     // channel and the same gap list for the reason the other two do — one leg's
     // write failing must cost only its own rows.
     manifest_leg_gaps.extend(secrets::ground_into(manifest, checkout, display));
+    // #6079: the churn hotspots were measured inside `ground` above, because
+    // they also feed the ranking. Only the write-back belongs here, on the same
+    // `[report].findings` channel and the same gap list as the three legs above.
+    manifest_leg_gaps.extend(churn::write_into(manifest, &grounding.churn, display));
     // #6082: read BEFORE the write, which is what would otherwise make the two
     // states indistinguishable afterwards.
     let already_rendered = investigation_exists(manifest);
@@ -451,7 +497,7 @@ pub async fn ground_manifest(
     {
         grounding.gaps.push(format!(
             "{display}: {cause} — the rendered report does not state why its crate topology, \
-             dependency CVE scan, license review, and secrets scan are missing"
+             dependency CVE scan, license review, secrets scan, and change hotspots are missing"
         ));
     }
     grounding.gaps.extend(manifest_leg_gaps);

--- a/crates/trusty-audit/src/grounding/churn.rs
+++ b/crates/trusty-audit/src/grounding/churn.rs
@@ -33,11 +33,20 @@
 //! ## Fail-open, and never silently
 //!
 //! Five states produce no rows and each says which it was: `git` is not
-//! installed, the path is not a git repository, the clone is shallow (its counts
+//! installed, the path holds no git repository, the clone is shallow (its counts
 //! would be truncated, and a truncated count understates churn — the false-clean
 //! shape epic #6074 exists to remove), the window holds no commit, or the child
-//! failed. The collector's own diagnosis leads every one of them; the child's
-//! first stderr line is only ever the parenthetical (#6720).
+//! failed. A sixth produces rows AND a caveat: a window holding more commits
+//! than [`MAX_COMMITS`] is read only as far as the cap, so every count it
+//! produces understates and the gap line says so. The collector's own diagnosis
+//! leads every one of them; the child's first stderr line is only ever the
+//! parenthetical (#6720).
+//!
+//! There is deliberately no not-applicable arm. [`crate::local_repo`] gives
+//! every checkout its history by `git clone`, so a path with no `.git` at this
+//! leg is an anomaly rather than a leg that does not apply — and reporting it as
+//! silence renders a Change Hotspots section that reads exactly like a quiet
+//! repository's (#6079).
 //!
 //! Test: `churn_tests`.
 
@@ -67,6 +76,11 @@ pub const WINDOW_DAYS: u32 = 180;
 /// A bound on the work rather than a tuning knob: a monorepo with a decade of
 /// history would otherwise hand this process a `--numstat` stream measured in
 /// hundreds of megabytes, and the ranking it feeds is capped far below that.
+///
+/// Hitting it is reported, never absorbed: a window with more commits than this
+/// is read to the cap and the counts that come out understate every file, so
+/// the leg returns [`Outcome::Capped`] and the caller states the cap in a gap
+/// line (#6079).
 pub const MAX_COMMITS: usize = 4_000;
 /// Fewest commits in the window that make a file a hotspot at all.
 pub const MIN_COMMITS: u32 = 5;
@@ -166,25 +180,29 @@ impl ChurnFile {
 
 /// What the leg produced for one repository.
 ///
-/// Why: "no churn" has three meanings that must not share a variant. A path
-/// holding no git repository has no change history a collector could have
-/// missed, so it earns silence — the same rule [`super::cve::Outcome`] applies
-/// to a checkout declaring no dependency manifest. A measured window whose files
-/// all fall below [`MIN_COMMITS`] is a real, quiet repository. A window that
-/// could not be read at all is unassessed, and the report must not let the third
-/// read as the second.
-/// What: the ranked hotspots (possibly empty, which IS a quiet repository), a
-/// declared skip carrying why the leg does not apply, or the one line the caller
+/// Why: "no churn" has three meanings that must not share a variant. A measured
+/// window whose files all fall below [`MIN_COMMITS`] is a real, quiet
+/// repository. A window read only as far as [`MAX_COMMITS`] holds real hotspots
+/// whose counts are all understated. A window that could not be read at all is
+/// unassessed, and the report must not let the third read as the first.
+///
+/// Unlike [`super::cve::Outcome`] there is no not-applicable variant: a
+/// dependency manifest is something a checkout may honestly not have, whereas
+/// its own git history is something [`crate::local_repo`]'s clone always gives
+/// it, so an absent one is an anomaly the report names (#6079).
+/// What: the ranked hotspots (possibly empty, which IS a quiet repository), the
+/// same ranked hotspots marked as read under the cap, or the one line the caller
 /// turns into a gap.
 /// Test: `churn_tests::{a_shallow_clone_is_a_named_gap,
 /// a_repository_with_no_history_is_a_named_gap,
-/// a_path_holding_no_repository_is_a_declared_skip}`.
+/// a_path_holding_no_repository_is_a_named_gap, a_capped_window_names_the_cap}`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome {
-    /// No git repository here; the reason the leg does not apply.
-    NotApplicable(String),
-    /// The history was read; these are its hotspots, worst first.
+    /// The history was read whole; these are its hotspots, worst first.
     Measured(Vec<ChurnFile>),
+    /// The read stopped at [`MAX_COMMITS`]; these are the hotspots of the
+    /// commits it did read, and every count in them understates.
+    Capped(Vec<ChurnFile>),
     /// The history could not be read, or is not complete enough to count; why.
     Unavailable(String),
 }
@@ -216,7 +234,8 @@ pub struct Run {
 /// Never panics. Reads only: `rev-parse` and `log` write nothing to the
 /// repository, and this collector creates no file anywhere.
 ///
-/// Test: `churn_tests::a_fixture_repository_ranks_its_hotspots`.
+/// Test: `churn_tests::{a_fixture_repository_ranks_its_hotspots,
+/// a_non_ascii_path_reaches_the_report_unescaped}`.
 #[must_use]
 pub fn measure(checkout: &Path) -> Outcome {
     measure_with(checkout, run_git)
@@ -225,27 +244,29 @@ pub fn measure(checkout: &Path) -> Outcome {
 /// [`measure`] with the git invocation supplied by the caller.
 ///
 /// Why: every arm below is a state a real repository can be in and a test cannot
-/// cheaply construct — a shallow clone, a git that fails mid-stream, a child
-/// whose stderr leads with an unrelated notice. The seam is what makes each one
-/// a test rather than a comment.
+/// cheaply construct — a shallow clone, a window deeper than [`MAX_COMMITS`], a
+/// git that fails mid-stream, a child whose stderr leads with an unrelated
+/// notice. The seam is what makes each one a test rather than a comment.
 ///
 /// Test: `churn_tests`, one test per arm.
 pub fn measure_with<F>(checkout: &Path, run: F) -> Outcome
 where
     F: FnOnce(&Path) -> Result<Run, String>,
 {
-    // The applicability check, before any child: a path holding no repository
-    // has no history to have missed. `.git` is a directory in a checkout and a
-    // FILE in a linked worktree, so `exists` is the test rather than `is_dir`.
+    // #6079: an absent repository is unassessed, not inapplicable — every
+    // checkout reaches this leg through `crate::local_repo`'s clone, so nothing
+    // here can be measured and the reader must be told which. `.git` is a
+    // directory in a checkout and a FILE in a linked worktree, so `exists` is
+    // the test rather than `is_dir`. Both rungs run before any child is spawned.
     if !checkout.is_dir() {
-        return Outcome::NotApplicable(format!(
-            "{COLLECTOR}: {} is not a directory",
+        return Outcome::Unavailable(format!(
+            "{COLLECTOR}: {} is not a directory, so there is no checkout to read a history from",
             checkout.display()
         ));
     }
     if !checkout.join(GIT_MARKER).exists() {
-        return Outcome::NotApplicable(format!(
-            "{COLLECTOR}: {} holds no git repository",
+        return Outcome::Unavailable(format!(
+            "{COLLECTOR}: {} holds no git repository, so it has no change history to read",
             checkout.display()
         ));
     }
@@ -274,7 +295,21 @@ where
              is no change history to rank"
         ));
     }
+    // #6079: `--max-count` truncates silently — a read that returned the cap is
+    // a window this leg did not see the whole of, and every count it produced
+    // is a floor rather than a measurement.
+    if commits_read(&output.log) >= MAX_COMMITS {
+        return Outcome::Capped(hotspots(measured));
+    }
     Outcome::Measured(hotspots(measured))
+}
+
+/// How many commits the stream holds, as its [`RECORD`] markers count them.
+///
+/// Read from the stream rather than from the child, because `--max-count` is
+/// the only thing that stopped it and git reports no truncation of its own.
+fn commits_read(log: &str) -> usize {
+    log.lines().filter(|line| line.starts_with(RECORD)).count()
 }
 
 /// Reduce a `git log --numstat` stream to per-file counts.
@@ -423,10 +458,18 @@ fn run_git(checkout: &Path) -> Result<Run, String> {
     // `--no-renames` so a rename is an add and a delete under two real paths
     // rather than git's `{old => new}` composite, which is not a path a reader
     // can open. `--no-merges` so a merge commit does not re-count its own side.
+    //
+    // #6079: `core.quotepath=false` because git's default C-quotes every
+    // non-ASCII byte, so `src/café.rs` reaches the findings and the ranking as
+    // `"src/caf\303\251.rs"` — a path no reader can open and no editor can find.
+    // The setting is passed per invocation rather than read from the repository,
+    // so the report does not depend on the audited checkout's own config.
     let output = crate::git::at(
         &binary,
         checkout,
         &[
+            "-c",
+            "core.quotepath=false",
             "log",
             "--no-merges",
             "--no-renames",
@@ -462,7 +505,8 @@ fn run_git(checkout: &Path) -> Result<Run, String> {
 /// a gap line or the quiet-repository scope line, never with silence.
 ///
 /// Test: `churn_tests::{a_quiet_repository_states_its_scope,
-/// a_shallow_clone_is_a_named_gap}`.
+/// a_shallow_clone_is_a_named_gap, a_path_holding_no_repository_is_a_named_gap,
+/// a_capped_window_names_the_cap}`.
 #[must_use]
 pub fn ground(checkout: &Path, display: &str) -> (Vec<ChurnFile>, Vec<String>) {
     ground_with(checkout, display, run_git)
@@ -476,8 +520,6 @@ where
     F: FnOnce(&Path) -> Result<Run, String>,
 {
     match measure_with(checkout, run) {
-        // Silent by design: nothing was missed, so there is nothing to name.
-        Outcome::NotApplicable(_) => (Vec::new(), Vec::new()),
         Outcome::Unavailable(cause) => (
             Vec::new(),
             vec![format!(
@@ -493,6 +535,17 @@ where
                  the last {WINDOW_DAYS} days, so it has no change hotspot to report. Work older \
                  than that window, and history rewritten by a squash or a filter, are not covered \
                  by that count"
+            )],
+        ),
+        // #6079: rows AND a caveat — the ranking is still worth having, and a
+        // reader who is not told the cap reads a floor as a measurement.
+        Outcome::Capped(files) => (
+            files,
+            vec![format!(
+                "{display}: {COLLECTOR}: the window holds more commits than the {MAX_COMMITS} this \
+                 leg reads, so every count below was taken from the newest {MAX_COMMITS} alone and \
+                 understates its file; a file whose work is entirely older than that read is \
+                 missing from the hotspots altogether"
             )],
         ),
         Outcome::Measured(files) => (files, Vec::new()),

--- a/crates/trusty-audit/src/grounding/churn.rs
+++ b/crates/trusty-audit/src/grounding/churn.rs
@@ -1,0 +1,586 @@
+//! Which files change most, read from the checkout's own git history (#6079).
+//!
+//! Why: the investigation budget is spent on the files the ranking names, and
+//! before this the ranking knew two things — what trusty-analyze measured as
+//! complex, and what trusty-search matched for a due-diligence dimension.
+//! Neither knows what the team actually works on. A file rewritten forty times
+//! in six months is where the defects, the review load and the key-person risk
+//! are, and it is invisible to both signals when it happens to be short and
+//! unremarkable to a text query. Git already holds that answer in every
+//! checkout, for free.
+//!
+//! What: a `git log --numstat` shell-out per repository, reduced to per-file
+//! commit counts, distinct-author counts and line totals; the hotspots band into
+//! `[report].findings` under the `churn` category, and the top of the same list
+//! becomes an optional lane in the evidence ranking
+//! ([`super::evidence::blend_with`]). Absent churn — no git, no history, a
+//! shallow clone — reproduces the ranking exactly as it was, which is #6079's
+//! optional-input closure condition.
+//!
+//! **No tga dependency.** The owner ruled 2026-08-19 that trusty-review must run
+//! independently of tga, and this collector is the trusty-audit half of that
+//! ruling: the history is read here, by this crate, through
+//! [`crate::git`]'s hardened child. `crates/trusty-git-analytics` computes its
+//! own churn for its own reports and nothing here consumes it.
+//!
+//! ## The thresholds, in one place
+//!
+//! Everything numeric this collector decides is a `pub const` in the block
+//! below — the window, the commit cap, the three bands, and the two output
+//! sizes. They are stated once so the report's own scope line can quote them and
+//! so tuning is one edit rather than a search.
+//!
+//! ## Fail-open, and never silently
+//!
+//! Five states produce no rows and each says which it was: `git` is not
+//! installed, the path is not a git repository, the clone is shallow (its counts
+//! would be truncated, and a truncated count understates churn — the false-clean
+//! shape epic #6074 exists to remove), the window holds no commit, or the child
+//! failed. The collector's own diagnosis leads every one of them; the child's
+//! first stderr line is only ever the parenthetical (#6720).
+//!
+//! Test: `churn_tests`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use toml_edit::{InlineTable, Value};
+
+use super::cve::Severity;
+use super::findings::first_line;
+use super::priority::Priority;
+
+/// How this collector names itself in a gap line.
+pub const COLLECTOR: &str = "git-churn";
+/// The `[report].findings` category these rows carry.
+pub const CATEGORY: &str = "churn";
+/// The single rule id every row shares; the path is what distinguishes them.
+pub const RULE: &str = "churn-hotspot";
+
+// ─── Thresholds ─────────────────────────────────────────────────────────────
+// The one place this collector's numbers are stated (#6079).
+
+/// How far back the window reaches, in days.
+pub const WINDOW_DAYS: u32 = 180;
+/// Most commits read from the window, newest first, whatever it holds.
+///
+/// A bound on the work rather than a tuning knob: a monorepo with a decade of
+/// history would otherwise hand this process a `--numstat` stream measured in
+/// hundreds of megabytes, and the ranking it feeds is capped far below that.
+pub const MAX_COMMITS: usize = 4_000;
+/// Fewest commits in the window that make a file a hotspot at all.
+pub const MIN_COMMITS: u32 = 5;
+/// Commits in the window at or above which a file bands RED.
+pub const RED_COMMITS: u32 = 20;
+/// Most hotspot rows written into `[report].findings`.
+pub const MAX_ROWS: usize = 20;
+/// Most hotspots offered to the evidence ranking as a lane.
+pub const MAX_RANKED: usize = 10;
+
+/// Basenames whose churn measures a generator rather than the code.
+///
+/// A lockfile changes on every dependency bump and a changelog on every merge,
+/// so both outrank every source file in any repository and would take the top of
+/// both outputs. Excluded by BASENAME, so a lockfile in a subdirectory is
+/// excluded too, and stated as a list rather than a heuristic so the exclusion
+/// is inspectable.
+pub const GENERATED: &[&str] = &[
+    "Cargo.lock",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "go.sum",
+    "poetry.lock",
+    "Gemfile.lock",
+    "composer.lock",
+    "CHANGELOG.md",
+];
+
+/// Extensions whose churn is configuration or prose rather than logic.
+///
+/// Why: this bounds the RANKING only — the findings still report them, because
+/// a manifest rewritten 200 times in six months is a real dependency-movement
+/// signal a due-diligence reader wants. What it must not do is spend an
+/// analyst's inference budget: measured against this workspace, the unfiltered
+/// top ten was seven `Cargo.toml`s, a `.tsv` allowlist and a `CLAUDE.md`.
+/// A deny-list rather than a source-extension allow-list, so a language this
+/// table has never heard of still reaches the ranking.
+pub const NON_CODE: &[&str] = &[
+    "toml", "md", "tsv", "csv", "json", "yaml", "yml", "lock", "txt", "cfg", "ini", "xml", "svg",
+];
+
+/// One file's change history over the window.
+///
+/// Why: the three numbers answer three different due-diligence questions —
+/// commits say how unstable the file is, distinct authors say whether it is one
+/// person's private territory, and the line totals separate a file rewritten
+/// wholesale from one touched a line at a time.
+/// What: repo-relative path plus the counts, as [`parse`] reduced them. A binary
+/// file contributes commits and zero lines, because `--numstat` reports `-` for
+/// both line columns and there is no honest number to put there.
+/// Test: `churn_tests::{the_log_reduces_to_per_file_counts,
+/// a_binary_file_counts_its_commits_and_no_lines}`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct ChurnFile {
+    /// Repo-relative path, exactly as git spelled it.
+    pub path: String,
+    /// Commits in the window that touched it.
+    pub commits: u32,
+    /// Distinct author addresses among those commits.
+    pub authors: usize,
+    /// Lines added across those commits.
+    pub added: u64,
+    /// Lines deleted across those commits.
+    pub deleted: u64,
+}
+
+impl ChurnFile {
+    /// The band this file's commit count earns, or `None` below [`MIN_COMMITS`].
+    ///
+    /// `None` is what keeps the long tail out of both outputs: nearly every file
+    /// in a repository is touched once or twice in six months, and reporting
+    /// those as findings would bury the twenty that matter.
+    ///
+    /// Test: `churn_tests::the_bands_are_the_documented_thresholds`.
+    #[must_use]
+    pub fn severity(&self) -> Option<Severity> {
+        if self.commits >= RED_COMMITS {
+            Some(Severity::Red)
+        } else if self.commits >= MIN_COMMITS {
+            Some(Severity::Amber)
+        } else {
+            None
+        }
+    }
+
+    /// The row's Summary cell: the counts, and the window they were taken over.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        format!(
+            "{} commits by {} author(s) in the last {WINDOW_DAYS} days, +{}/-{} lines",
+            self.commits, self.authors, self.added, self.deleted
+        )
+    }
+}
+
+/// What the leg produced for one repository.
+///
+/// Why: "no churn" has three meanings that must not share a variant. A path
+/// holding no git repository has no change history a collector could have
+/// missed, so it earns silence — the same rule [`super::cve::Outcome`] applies
+/// to a checkout declaring no dependency manifest. A measured window whose files
+/// all fall below [`MIN_COMMITS`] is a real, quiet repository. A window that
+/// could not be read at all is unassessed, and the report must not let the third
+/// read as the second.
+/// What: the ranked hotspots (possibly empty, which IS a quiet repository), a
+/// declared skip carrying why the leg does not apply, or the one line the caller
+/// turns into a gap.
+/// Test: `churn_tests::{a_shallow_clone_is_a_named_gap,
+/// a_repository_with_no_history_is_a_named_gap,
+/// a_path_holding_no_repository_is_a_declared_skip}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// No git repository here; the reason the leg does not apply.
+    NotApplicable(String),
+    /// The history was read; these are its hotspots, worst first.
+    Measured(Vec<ChurnFile>),
+    /// The history could not be read, or is not complete enough to count; why.
+    Unavailable(String),
+}
+
+/// One completed `git log` invocation, as this module needs to see it.
+///
+/// Why a struct rather than `std::process::Output`: the shallow flag comes from
+/// a SECOND git invocation, and folding both into one value is what lets every
+/// failure arm be driven by a test without a fixture repository per arm.
+/// What: the exit disposition, the `--numstat` stream, the child's stderr, and
+/// whether the repository is a shallow clone.
+/// Test: `churn_tests`, which constructs one per arm.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct Run {
+    /// Whether `git log` exited zero.
+    pub success: bool,
+    /// The `--numstat` stream on stdout.
+    pub log: String,
+    /// The child's stderr, for a gap's parenthetical only (#6720).
+    pub stderr: String,
+    /// Whether `git rev-parse --is-shallow-repository` said `true`.
+    pub shallow: bool,
+}
+
+/// Measure `checkout`'s churn with a real `git`.
+///
+/// # Postconditions
+/// Never panics. Reads only: `rev-parse` and `log` write nothing to the
+/// repository, and this collector creates no file anywhere.
+///
+/// Test: `churn_tests::a_fixture_repository_ranks_its_hotspots`.
+#[must_use]
+pub fn measure(checkout: &Path) -> Outcome {
+    measure_with(checkout, run_git)
+}
+
+/// [`measure`] with the git invocation supplied by the caller.
+///
+/// Why: every arm below is a state a real repository can be in and a test cannot
+/// cheaply construct — a shallow clone, a git that fails mid-stream, a child
+/// whose stderr leads with an unrelated notice. The seam is what makes each one
+/// a test rather than a comment.
+///
+/// Test: `churn_tests`, one test per arm.
+pub fn measure_with<F>(checkout: &Path, run: F) -> Outcome
+where
+    F: FnOnce(&Path) -> Result<Run, String>,
+{
+    // The applicability check, before any child: a path holding no repository
+    // has no history to have missed. `.git` is a directory in a checkout and a
+    // FILE in a linked worktree, so `exists` is the test rather than `is_dir`.
+    if !checkout.is_dir() {
+        return Outcome::NotApplicable(format!(
+            "{COLLECTOR}: {} is not a directory",
+            checkout.display()
+        ));
+    }
+    if !checkout.join(GIT_MARKER).exists() {
+        return Outcome::NotApplicable(format!(
+            "{COLLECTOR}: {} holds no git repository",
+            checkout.display()
+        ));
+    }
+    let output = match run(checkout) {
+        Ok(output) => output,
+        Err(cause) => return Outcome::Unavailable(cause),
+    };
+    if output.shallow {
+        return Outcome::Unavailable(format!(
+            "{COLLECTOR}: {} is a shallow clone, so its per-file commit counts would be truncated \
+             at the graft point and would understate every hotspot",
+            checkout.display()
+        ));
+    }
+    if !output.success && output.log.trim().is_empty() {
+        return Outcome::Unavailable(format!(
+            "{COLLECTOR}: `{}` exited non-zero and printed no history to read ({})",
+            crate::git::BINARY,
+            first_line(&output.stderr)
+        ));
+    }
+    let measured = parse(&output.log);
+    if measured.is_empty() {
+        return Outcome::Unavailable(format!(
+            "{COLLECTOR}: no commit in the last {WINDOW_DAYS} days touched a file here, so there \
+             is no change history to rank"
+        ));
+    }
+    Outcome::Measured(hotspots(measured))
+}
+
+/// Reduce a `git log --numstat` stream to per-file counts.
+///
+/// Why: the stream is per-commit and the report is per-file, and the reduction
+/// is where the two decisions that are not git's live — that a generated file is
+/// excluded, and that a binary file counts its commits and no lines.
+/// What: a line beginning [`RECORD`] opens a commit and names its author; every
+/// `added<TAB>deleted<TAB>path` line after it is folded into that path's totals.
+/// Anything else is ignored, so git's blank separator lines and any future
+/// header cost nothing.
+///
+/// # Postconditions
+/// Never panics on arbitrary input. Output order is the map's — [`hotspots`]
+/// imposes the report order.
+///
+/// Test: `churn_tests::{the_log_reduces_to_per_file_counts,
+/// a_generated_file_never_becomes_a_hotspot, junk_is_ignored_rather_than_counted}`.
+#[must_use]
+pub fn parse(log: &str) -> Vec<ChurnFile> {
+    let mut authors: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut totals: BTreeMap<String, (u32, u64, u64)> = BTreeMap::new();
+    let mut author = String::new();
+
+    for line in log.lines() {
+        if let Some(email) = line.strip_prefix(RECORD) {
+            author = email.trim().to_owned();
+            continue;
+        }
+        let mut columns = line.split('\t');
+        let (Some(added), Some(deleted), Some(path)) =
+            (columns.next(), columns.next(), columns.next())
+        else {
+            continue;
+        };
+        let path = path.trim();
+        if path.is_empty() || columns.next().is_some() || is_generated(path) {
+            continue;
+        }
+        let (Some(added), Some(deleted)) = (count(added), count(deleted)) else {
+            continue;
+        };
+        let entry = totals.entry(path.to_owned()).or_insert((0, 0, 0));
+        entry.0 = entry.0.saturating_add(1);
+        entry.1 = entry.1.saturating_add(added);
+        entry.2 = entry.2.saturating_add(deleted);
+        authors
+            .entry(path.to_owned())
+            .or_default()
+            .insert(author.clone());
+    }
+
+    totals
+        .into_iter()
+        .map(|(path, (commits, added, deleted))| ChurnFile {
+            authors: authors.get(&path).map_or(0, BTreeSet::len),
+            path,
+            commits,
+            added,
+            deleted,
+        })
+        .collect()
+}
+
+/// What a checkout holding a git repository has at its root.
+const GIT_MARKER: &str = ".git";
+
+/// The record separator `--format=%x01%ae` puts at the head of each commit.
+///
+/// `\x01` rather than a printable marker: it cannot occur in a path, so a file
+/// literally named `commit …` can never be read as a commit header.
+const RECORD: &str = "\u{1}";
+
+/// One `--numstat` line column: a number, or `-` for a binary file.
+fn count(column: &str) -> Option<u64> {
+    let column = column.trim();
+    if column == "-" {
+        return Some(0);
+    }
+    column.parse().ok()
+}
+
+/// Whether a ranked path is worth an analyst's reading budget.
+///
+/// An extensionless file (a shell script, a `Makefile`) passes: the deny-list
+/// names what is known NOT to be code, and everything else is presumed to be.
+fn holds_code(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_none_or(|ext| !NON_CODE.contains(&ext.to_ascii_lowercase().as_str()))
+}
+
+/// Whether this path's churn measures a generator rather than the code.
+fn is_generated(path: &str) -> bool {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| GENERATED.contains(&name))
+}
+
+/// The hotspots among measured files, worst first, capped at [`MAX_ROWS`].
+///
+/// Ordering is total and deterministic — commits descending, then total lines
+/// changed descending, then path ascending — so two runs over the same history
+/// produce byte-identical rows and the manifest's dedup never sees a reordering
+/// as a new finding.
+fn hotspots(mut measured: Vec<ChurnFile>) -> Vec<ChurnFile> {
+    measured.retain(|file| file.severity().is_some());
+    measured.sort_by(|a, b| {
+        b.commits
+            .cmp(&a.commits)
+            .then_with(|| (b.added + b.deleted).cmp(&(a.added + a.deleted)))
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    measured.truncate(MAX_ROWS);
+    measured
+}
+
+/// Run `git rev-parse` and `git log` against `checkout`.
+///
+/// # Errors
+/// One line naming which step failed, when `git` is absent, when the path is not
+/// a repository, or when either child could not be spawned.
+fn run_git(checkout: &Path) -> Result<Run, String> {
+    let binary = crate::git::resolve()
+        .map_err(|cause| format!("{COLLECTOR}: {cause}, so no change history was read"))?;
+
+    // One invocation answers both questions: `rev-parse` fails outside a
+    // repository, and prints `true` inside a shallow one. Asking for a second
+    // flag alongside it would make the answer positional, and reading the wrong
+    // line reports every repository as shallow.
+    let probe = crate::git::at(&binary, checkout, &["rev-parse", "--is-shallow-repository"])
+        .output()
+        .map_err(|e| format!("{COLLECTOR}: `git rev-parse` could not be run ({e})"))?;
+    if !probe.status.success() {
+        return Err(format!(
+            "{COLLECTOR}: {} is not a git repository, so it has no change history",
+            checkout.display()
+        ));
+    }
+    let shallow = String::from_utf8_lossy(&probe.stdout).trim() == "true";
+
+    let since = format!("--since={WINDOW_DAYS} days ago");
+    let max = format!("--max-count={MAX_COMMITS}");
+    // `--no-renames` so a rename is an add and a delete under two real paths
+    // rather than git's `{old => new}` composite, which is not a path a reader
+    // can open. `--no-merges` so a merge commit does not re-count its own side.
+    let output = crate::git::at(
+        &binary,
+        checkout,
+        &[
+            "log",
+            "--no-merges",
+            "--no-renames",
+            "--numstat",
+            "--format=%x01%ae",
+            &since,
+            &max,
+        ],
+    )
+    .output()
+    .map_err(|e| format!("{COLLECTOR}: `git log` could not be run ({e})"))?;
+
+    Ok(Run {
+        success: output.status.success(),
+        log: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        shallow,
+    })
+}
+
+/// Measure `checkout`, and say in one line what could not be measured.
+///
+/// Why: the two outputs go to different readers. The hotspots feed the evidence
+/// ranking and the manifest's findings; the gap lines feed `[report].gaps`, and
+/// they are the whole reason this leg is fail-open rather than fatal — a sweep
+/// over an org cannot spend its one shot on a repository whose history is
+/// unreadable.
+/// What: the hotspots, plus zero or one gap line naming `display`, the
+/// collector, and what the report will therefore not carry.
+///
+/// # Postconditions
+/// Never panics and never errors. An empty hotspot list always comes with either
+/// a gap line or the quiet-repository scope line, never with silence.
+///
+/// Test: `churn_tests::{a_quiet_repository_states_its_scope,
+/// a_shallow_clone_is_a_named_gap}`.
+#[must_use]
+pub fn ground(checkout: &Path, display: &str) -> (Vec<ChurnFile>, Vec<String>) {
+    ground_with(checkout, display, run_git)
+}
+
+/// [`ground`] with the git invocation supplied by the caller.
+///
+/// Test: `churn_tests`, one test per arm.
+pub fn ground_with<F>(checkout: &Path, display: &str, run: F) -> (Vec<ChurnFile>, Vec<String>)
+where
+    F: FnOnce(&Path) -> Result<Run, String>,
+{
+    match measure_with(checkout, run) {
+        // Silent by design: nothing was missed, so there is nothing to name.
+        Outcome::NotApplicable(_) => (Vec::new(), Vec::new()),
+        Outcome::Unavailable(cause) => (
+            Vec::new(),
+            vec![format!(
+                "{display}: {cause} — the report names no change hotspot for it, which must be \
+                 read as unmeasured rather than as a codebase nobody is rewriting, and its \
+                 investigation pass ranks files without a churn signal"
+            )],
+        ),
+        Outcome::Measured(files) if files.is_empty() => (
+            Vec::new(),
+            vec![format!(
+                "{display}: {COLLECTOR}: no file was touched by {MIN_COMMITS} or more commits in \
+                 the last {WINDOW_DAYS} days, so it has no change hotspot to report. Work older \
+                 than that window, and history rewritten by a squash or a filter, are not covered \
+                 by that count"
+            )],
+        ),
+        Outcome::Measured(files) => (files, Vec::new()),
+    }
+}
+
+/// Write the hotspot rows into the manifest, or say why they are not there.
+///
+/// Why: the manifest is the interface (owner ruling 2026-08-19). Rows this
+/// process holds and does not write reach no renderer — not the sweep's, and not
+/// the recipient's own re-render of the delivered package.
+/// What: one row per hotspot through [`super::findings::append`], the shared
+/// writer, under [`CATEGORY`]. Identity is `id` plus `package`, so a resumed
+/// sweep restates nothing; the counts in `title` are deliberately NOT part of
+/// identity, because a re-measured file with one more commit is the same finding
+/// rather than a second one.
+///
+/// # Postconditions
+/// Never panics. An empty `files` writes nothing and returns no gap — the caller
+/// has already stated that case's scope line through [`ground`].
+///
+/// Test: `churn_tests::{the_hotspots_land_in_the_manifest,
+/// a_resumed_sweep_does_not_restate_a_hotspot,
+/// a_manifest_that_cannot_be_written_is_a_named_gap}`.
+#[must_use]
+pub fn write_into(manifest: &Path, files: &[ChurnFile], display: &str) -> Vec<String> {
+    let rows: Vec<InlineTable> = files.iter().map(row).collect();
+    match super::findings::append(manifest, &rows, IDENTITY) {
+        Ok(()) => Vec::new(),
+        Err(cause) => vec![format!(
+            "{display}: {COLLECTOR}: {cause} — the report states none of the {} change hotspot(s) \
+             its history holds",
+            files.len()
+        )],
+    }
+}
+
+/// What makes two `[report].findings` rows the same churn hotspot.
+const IDENTITY: &[&str] = &["id", "package"];
+
+/// One hotspot as a `[report].findings` row.
+fn row(file: &ChurnFile) -> InlineTable {
+    let mut table = InlineTable::new();
+    table.insert("category", Value::from(CATEGORY));
+    table.insert("id", Value::from(RULE));
+    table.insert("package", Value::from(file.path.as_str()));
+    table.insert("version", Value::from(""));
+    table.insert(
+        "severity",
+        Value::from(file.severity().map_or("AMBER", Severity::as_str)),
+    );
+    table.insert("title", Value::from(file.summary()));
+    table
+}
+
+/// The hotspots as an evidence-ranking lane (#6079's optional `select_files` input).
+///
+/// Why: churn is a selection signal, not only a reported number. A file the team
+/// rewrites weekly is worth an analyst's attention whether or not it is complex
+/// and whether or not a dimension query matched it.
+/// What: the top [`MAX_RANKED`] hotspots that hold code ([`NON_CODE`]), as bare
+/// [`Priority`] rows carrying no dimension — churn is evidence for no single
+/// due-diligence dimension, and claiming one would let the report count a
+/// dimension as investigated on the strength of a commit count. The reason line
+/// names the measurement.
+///
+/// # Postconditions
+/// Empty in, empty out — which is what makes the ranking with no churn identical
+/// to the ranking before this leg existed.
+///
+/// Test: `churn_tests::{the_lane_is_the_top_hotspots_with_no_dimension,
+/// the_lane_declines_a_manifest_the_findings_still_report}`,
+/// `super::evidence::evidence_tests::an_absent_churn_lane_reproduces_the_previous_ranking`.
+#[must_use]
+pub fn lane(files: &[ChurnFile]) -> Vec<Priority> {
+    files
+        .iter()
+        .filter(|file| holds_code(&file.path))
+        .take(MAX_RANKED)
+        .map(|file| Priority {
+            path: file.path.clone(),
+            dimension: None,
+            reason: Some(format!("{COLLECTOR}: {}", file.summary())),
+            hotspot: None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "churn_tests.rs"]
+mod churn_tests;

--- a/crates/trusty-audit/src/grounding/churn_tests.rs
+++ b/crates/trusty-audit/src/grounding/churn_tests.rs
@@ -16,6 +16,11 @@
 use super::*;
 use std::path::PathBuf;
 
+// #6079: one `git` test helper for the crate. `crate::git` owns the production
+// child, and this is its test-side counterpart — a second `Command::new("git")`
+// here would be the duplicate CLAUDE.md's common-entry-point rule forbids.
+use crate::local_repo::local_repo_tests::{init_repo, run_git};
+
 /// A manifest with the one `[report]` table the write-back edits.
 const MANIFEST: &str = "[report]\ntitle = \"Acme\"\n\n[[repositories]]\nname = \"acme-api\"\npath = \"/tmp/acme-api\"\n";
 
@@ -64,6 +69,23 @@ fn returns(
             shallow: false,
         })
     }
+}
+
+/// A run whose stream the test generated, for a window no literal can hold.
+fn streams(log: String) -> impl FnOnce(&Path) -> Result<Run, String> {
+    move |_| {
+        Ok(Run {
+            success: true,
+            log,
+            stderr: String::new(),
+            shallow: false,
+        })
+    }
+}
+
+/// A `--numstat` stream of `commits` commits, each touching one file once.
+fn window_of(commits: usize) -> String {
+    "\u{1}a@b.invalid\n\n1\t0\tsrc/api.rs\n".repeat(commits)
 }
 
 /// A run against a shallow clone, which prints history but a truncated one.
@@ -224,38 +246,22 @@ fn hotspots_are_ranked_deterministically() {
 
 // ─── The fixture repository ─────────────────────────────────────────────────
 
-/// Run `git -C <cwd> <args>`, failing the test with git's own message.
-fn run_git_in(cwd: &Path, args: &[&str]) {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(cwd)
-        .args(args)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .output()
-        .expect("git is on PATH for this suite");
-    assert!(
-        output.status.success(),
-        "git {args:?} failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+/// The non-ASCII fixture path, which git C-quotes unless it is told not to.
+const ACCENTED: &str = "src/café.rs";
 
 /// A repository with real commits, built here rather than checked in.
 ///
-/// `src/hot.rs` gets [`MIN_COMMITS`] + 2 commits by two authors, `src/warm.rs`
-/// exactly [`MIN_COMMITS`], and `src/cold.rs` two — so the expected hotspot rows
-/// are the first two, in that order, and the third proves the floor.
+/// `src/hot.rs` gets [`MIN_COMMITS`] + 2 commits by two authors, [`ACCENTED`]
+/// and `src/warm.rs` exactly [`MIN_COMMITS`], and `src/cold.rs` two — so the
+/// expected hotspot rows are the first three and the fourth proves the floor.
 fn fixture_repo(root: &Path) {
     std::fs::create_dir_all(root.join("src")).expect("mkdir src");
-    run_git_in(root, &["init", "-q"]);
-    run_git_in(root, &["config", "user.email", "alice@example.invalid"]);
-    run_git_in(root, &["config", "user.name", "Alice"]);
+    init_repo(root);
 
     let commit = |file: &str, body: String, author: &str| {
         std::fs::write(root.join(file), body).expect("write the fixture file");
-        run_git_in(root, &["add", "-A"]);
-        run_git_in(
+        run_git(root, &["add", "-A"]);
+        run_git(
             root,
             &[
                 "-c",
@@ -282,6 +288,11 @@ fn fixture_repo(root: &Path) {
             format!("warm {round}\n"),
             "alice@example.invalid",
         );
+    }
+    // #6079: a real non-ASCII filename, so the quoting is exercised by git
+    // itself rather than by a fixture string this suite wrote.
+    for round in 0..MIN_COMMITS {
+        commit(ACCENTED, format!("café {round}\n"), "alice@example.invalid");
     }
     for round in 0..2 {
         commit(
@@ -312,11 +323,41 @@ fn a_fixture_repository_ranks_its_hotspots() {
         rows,
         vec![
             ("src/hot.rs", MIN_COMMITS + 2, 2),
+            (ACCENTED, MIN_COMMITS, 1),
             ("src/warm.rs", MIN_COMMITS, 1),
         ],
-        "the two files over the floor, worst first; src/cold.rs is under it"
+        "the three files over the floor, worst first; src/cold.rs is under it"
     );
     assert_eq!(files[0].severity(), Some(Severity::Amber));
+}
+
+/// 🔴 A non-ASCII filename reaches the report as itself. Git C-quotes every
+/// non-ASCII byte by default, so without `core.quotepath=false` this row names
+/// `"src/caf\303\251.rs"` — a path the reader cannot open, cannot grep for, and
+/// cannot match against anything else the report says about that file.
+#[test]
+fn a_non_ascii_path_reaches_the_report_unescaped() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("acme-api");
+    fixture_repo(&checkout);
+
+    let Outcome::Measured(files) = measure(&checkout) else {
+        panic!("a repository with real commits measures");
+    };
+
+    let accented = files
+        .iter()
+        .find(|f| f.path == ACCENTED)
+        .unwrap_or_else(|| panic!("the real filename, not an escape: {files:?}"));
+    assert!(
+        !accented.path.contains('\\') && !accented.path.contains('"'),
+        "neither the octal escape nor the quotes git wraps it in: {}",
+        accented.path
+    );
+    assert!(
+        lane(&files).iter().any(|p| p.path == ACCENTED),
+        "and the ranking lane carries the same openable path"
+    );
 }
 
 /// A repository with no commit at all is a NAMED gap, never an empty clean
@@ -325,8 +366,7 @@ fn a_fixture_repository_ranks_its_hotspots() {
 fn a_repository_with_no_history_is_a_named_gap() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let checkout = tmp.path().join("empty");
-    std::fs::create_dir_all(&checkout).expect("mkdir");
-    run_git_in(&checkout, &["init", "-q"]);
+    init_repo(&checkout);
 
     let (files, gaps) = ground(&checkout, "acme-api");
 
@@ -359,12 +399,13 @@ fn a_shallow_clone_is_a_named_gap() {
     );
 }
 
-/// A path holding no repository has no change history a collector could have
-/// missed, so it is a declared SKIP rather than a gap — the rule `cve` applies
-/// to a checkout declaring no dependency manifest. Both rungs of the ladder are
-/// driven, and neither spawns a child.
+/// 🔴 A path holding no repository is a NAMED gap. Every checkout reaches this
+/// leg through `local_repo`'s clone, so an absent `.git` is an anomaly — and
+/// reporting it as silence renders a Change Hotspots section a reader cannot
+/// tell apart from a repository nobody is rewriting. Both rungs of the ladder
+/// are driven, and neither spawns a child.
 #[test]
-fn a_path_holding_no_repository_is_a_declared_skip() {
+fn a_path_holding_no_repository_is_a_named_gap() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let absent = tmp.path().join("nowhere");
     let plain = tmp.path().join("not-a-repo");
@@ -372,16 +413,23 @@ fn a_path_holding_no_repository_is_a_declared_skip() {
 
     assert!(matches!(
         measure_with(&absent, refuses("must not be reached")),
-        Outcome::NotApplicable(ref why) if why.contains("is not a directory")
+        Outcome::Unavailable(ref why) if why.contains("is not a directory")
     ));
     assert!(matches!(
         measure_with(&plain, refuses("must not be reached")),
-        Outcome::NotApplicable(ref why) if why.contains("holds no git repository")
+        Outcome::Unavailable(ref why) if why.contains("holds no git repository")
     ));
-    assert_eq!(
-        ground_with(&plain, "acme-api", refuses("must not be reached")),
-        (Vec::new(), Vec::new()),
-        "nothing was missed, so there is nothing to name"
+
+    let (files, gaps) = ground_with(&plain, "acme-api", refuses("must not be reached"));
+
+    assert!(files.is_empty());
+    assert_eq!(gaps.len(), 1, "one line, not a stream");
+    assert!(
+        gaps[0].contains(COLLECTOR)
+            && gaps[0].contains("holds no git repository")
+            && gaps[0].contains("unmeasured"),
+        "the gap names the collector and refuses the clean reading: {}",
+        gaps[0]
     );
 }
 
@@ -452,6 +500,37 @@ fn an_empty_window_names_the_window() {
         gaps[0].contains(&format!("no commit in the last {WINDOW_DAYS} days")),
         "{}",
         gaps[0]
+    );
+}
+
+/// 🔴 `--max-count` truncates in silence — git reports nothing about the
+/// commits it did not print. A window deeper than [`MAX_COMMITS`] therefore
+/// produced full-confidence rows whose every count was a floor. The cap is now
+/// named, and a window one commit short of it is still a whole window.
+#[test]
+fn a_capped_window_names_the_cap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = checkout_at(tmp.path());
+
+    let (files, gaps) = ground_with(&checkout, "acme-api", streams(window_of(MAX_COMMITS)));
+
+    assert_eq!(files.len(), 1, "the rows are still worth reporting");
+    assert_eq!(
+        files[0].commits,
+        u32::try_from(MAX_COMMITS).expect("the cap fits a commit count")
+    );
+    assert_eq!(gaps.len(), 1);
+    assert!(
+        gaps[0].contains(&MAX_COMMITS.to_string()) && gaps[0].contains("understates"),
+        "the caveat states the cap and what it does to every count: {}",
+        gaps[0]
+    );
+
+    let (_, whole) = ground_with(&checkout, "acme-api", streams(window_of(MAX_COMMITS - 1)));
+
+    assert!(
+        whole.is_empty(),
+        "one commit short of the cap is a window read whole: {whole:?}"
     );
 }
 

--- a/crates/trusty-audit/src/grounding/churn_tests.rs
+++ b/crates/trusty-audit/src/grounding/churn_tests.rs
@@ -1,0 +1,603 @@
+//! Tests for the git-churn collector (#6079).
+//!
+//! Why: the collector is fail-open, so every arm that produces NOTHING has to be
+//! pinned by a test that reads the gap it produced instead. A regression here
+//! does not fail a build — it ships a report whose empty Change Hotspots section
+//! reads as a codebase nobody is rewriting, which is the false clean claim epic
+//! #6074 exists to remove. The two arms #6079 names explicitly are the ones
+//! whose git output is INDISTINGUISHABLE from a quiet repository: an empty
+//! history and a shallow clone both print nothing on stdout and exit zero.
+//! What: a real fixture repository built in a tempdir with real commits (never a
+//! checked-in `.git`), the reduction, the documented bands, every failure arm
+//! through the [`Run`] seam, the manifest write-back, and the optional-input
+//! contract on the ranking lane.
+//! Test: this file.
+
+use super::*;
+use std::path::PathBuf;
+
+/// A manifest with the one `[report]` table the write-back edits.
+const MANIFEST: &str = "[report]\ntitle = \"Acme\"\n\n[[repositories]]\nname = \"acme-api\"\npath = \"/tmp/acme-api\"\n";
+
+/// The stderr a git with a pending upgrade notice emits first (#6720).
+const NOISY_STDERR: &str = "warning: your git is out of date\nfatal: bad revision 'HEAD'\n";
+
+/// A `--numstat` stream: three commits, two authors, one binary file, and one
+/// generated file that must never reach an output.
+const LOG: &str = "\u{1}alice@example.invalid\n\
+                   \n\
+                   10\t2\tsrc/api.rs\n\
+                   4\t0\tsrc/db.rs\n\
+                   -\t-\tassets/logo.png\n\
+                   \u{1}bob@example.invalid\n\
+                   \n\
+                   7\t3\tsrc/api.rs\n\
+                   120\t4\tCargo.lock\n\
+                   \u{1}alice@example.invalid\n\
+                   \n\
+                   1\t1\tsrc/api.rs\n";
+
+/// A stream in which one file clears the floor: [`MIN_COMMITS`] commits on
+/// `src/api.rs`, so a partial read still produces a hotspot.
+const HOT_LOG: &str = "\u{1}a@b.invalid\n\n1\t0\tsrc/api.rs\n\
+                       \u{1}a@b.invalid\n\n1\t0\tsrc/api.rs\n\
+                       \u{1}a@b.invalid\n\n1\t0\tsrc/api.rs\n\
+                       \u{1}a@b.invalid\n\n1\t0\tsrc/api.rs\n\
+                       \u{1}a@b.invalid\n\n1\t0\tsrc/api.rs\n";
+
+/// A run that never happened: the seam every failure-arm test injects.
+fn refuses(reason: &'static str) -> impl FnOnce(&Path) -> Result<Run, String> {
+    move |_| Err(reason.to_string())
+}
+
+/// A run that completed, with the stream and disposition the test wants.
+fn returns(
+    success: bool,
+    log: &'static str,
+    stderr: &'static str,
+) -> impl FnOnce(&Path) -> Result<Run, String> {
+    move |_| {
+        Ok(Run {
+            success,
+            log: log.to_string(),
+            stderr: stderr.to_string(),
+            shallow: false,
+        })
+    }
+}
+
+/// A run against a shallow clone, which prints history but a truncated one.
+fn shallow() -> impl FnOnce(&Path) -> Result<Run, String> {
+    move |_| {
+        Ok(Run {
+            success: true,
+            log: LOG.to_string(),
+            stderr: String::new(),
+            shallow: true,
+        })
+    }
+}
+
+/// A checkout the leg applies to: a directory with a `.git` at its root, which
+/// is the whole applicability ladder before any child is spawned.
+fn checkout_at(tmp: &Path) -> PathBuf {
+    let checkout = tmp.join("repos").join("acme-api");
+    std::fs::create_dir_all(checkout.join(".git")).expect("mkdir checkout");
+    checkout
+}
+
+/// A manifest file the write-back can edit.
+fn manifest_at(tmp: &Path) -> PathBuf {
+    let path = tmp.join("manifest.toml");
+    std::fs::write(&path, MANIFEST).expect("write manifest");
+    path
+}
+
+/// A file with `commits` commits and one author, for a band assertion.
+fn touched(path: &str, commits: u32) -> ChurnFile {
+    ChurnFile {
+        path: path.to_owned(),
+        commits,
+        authors: 1,
+        added: 1,
+        deleted: 0,
+    }
+}
+
+// ─── Reduction ──────────────────────────────────────────────────────────────
+
+/// The per-commit stream becomes per-file counts, with distinct authors counted
+/// once each — the three numbers #6079's row carries.
+#[test]
+fn the_log_reduces_to_per_file_counts() {
+    let measured = parse(LOG);
+
+    let api = measured
+        .iter()
+        .find(|f| f.path == "src/api.rs")
+        .expect("src/api.rs is in the stream");
+    assert_eq!(api.commits, 3, "three commits touched it");
+    assert_eq!(api.authors, 2, "alice twice and bob once is two authors");
+    assert_eq!((api.added, api.deleted), (18, 6));
+}
+
+/// A binary file has no line counts git can report, so it counts its commits
+/// and zero lines rather than being dropped or counted as a parse failure.
+#[test]
+fn a_binary_file_counts_its_commits_and_no_lines() {
+    let logo = parse(LOG)
+        .into_iter()
+        .find(|f| f.path == "assets/logo.png")
+        .expect("the `-` columns are read, not skipped");
+
+    assert_eq!((logo.commits, logo.added, logo.deleted), (1, 0, 0));
+}
+
+/// A lockfile changes on every dependency bump, so its churn measures the
+/// resolver. It must not reach a row or the ranking lane.
+#[test]
+fn a_generated_file_never_becomes_a_hotspot() {
+    assert!(
+        !parse(LOG).iter().any(|f| f.path == "Cargo.lock"),
+        "GENERATED is excluded at the reduction, before any band applies"
+    );
+    for name in GENERATED {
+        assert!(
+            is_generated(&format!("nested/dir/{name}")),
+            "{name} is excluded by basename, at any depth"
+        );
+    }
+}
+
+/// Arbitrary text is ignored rather than counted, so a future git header or a
+/// commit message that happens to contain tabs cannot invent a file.
+#[test]
+fn junk_is_ignored_rather_than_counted() {
+    assert!(parse("").is_empty());
+    assert!(parse("not a numstat line at all\n").is_empty());
+    assert!(
+        parse("\u{1}a@b\nx\ty\tsrc/a.rs\n").is_empty(),
+        "non-numeric columns are not a stat line"
+    );
+    assert!(
+        parse("\u{1}a@b\n1\t2\t3\tsrc/a.rs\n").is_empty(),
+        "a fourth column is not the shape --numstat emits"
+    );
+}
+
+// ─── Bands ──────────────────────────────────────────────────────────────────
+
+/// The three bands are exactly the constants the module documents — the
+/// deterministic-threshold closure condition, asserted against the constants
+/// rather than against literals, so tuning one edit stays one edit.
+#[test]
+fn the_bands_are_the_documented_thresholds() {
+    assert_eq!(touched("a", MIN_COMMITS - 1).severity(), None);
+    assert_eq!(touched("a", MIN_COMMITS).severity(), Some(Severity::Amber));
+    assert_eq!(
+        touched("a", RED_COMMITS - 1).severity(),
+        Some(Severity::Amber)
+    );
+    assert_eq!(touched("a", RED_COMMITS).severity(), Some(Severity::Red));
+}
+
+/// Ordering is total: commits, then total lines changed, then path. Two runs
+/// over one history must produce byte-identical rows.
+#[test]
+fn hotspots_are_ranked_deterministically() {
+    let ranked = hotspots(vec![
+        ChurnFile {
+            path: "z.rs".into(),
+            commits: MIN_COMMITS,
+            authors: 1,
+            added: 5,
+            deleted: 0,
+        },
+        ChurnFile {
+            path: "a.rs".into(),
+            commits: MIN_COMMITS,
+            authors: 1,
+            added: 5,
+            deleted: 0,
+        },
+        ChurnFile {
+            path: "big.rs".into(),
+            commits: MIN_COMMITS,
+            authors: 1,
+            added: 900,
+            deleted: 0,
+        },
+        touched("quiet.rs", MIN_COMMITS - 1),
+    ]);
+
+    let paths: Vec<&str> = ranked.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec!["big.rs", "a.rs", "z.rs"],
+        "lines break a commit-count tie, then the path breaks that"
+    );
+    assert!(
+        !paths.contains(&"quiet.rs"),
+        "a file below MIN_COMMITS is not a hotspot"
+    );
+}
+
+// ─── The fixture repository ─────────────────────────────────────────────────
+
+/// Run `git -C <cwd> <args>`, failing the test with git's own message.
+fn run_git_in(cwd: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .output()
+        .expect("git is on PATH for this suite");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A repository with real commits, built here rather than checked in.
+///
+/// `src/hot.rs` gets [`MIN_COMMITS`] + 2 commits by two authors, `src/warm.rs`
+/// exactly [`MIN_COMMITS`], and `src/cold.rs` two — so the expected hotspot rows
+/// are the first two, in that order, and the third proves the floor.
+fn fixture_repo(root: &Path) {
+    std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+    run_git_in(root, &["init", "-q"]);
+    run_git_in(root, &["config", "user.email", "alice@example.invalid"]);
+    run_git_in(root, &["config", "user.name", "Alice"]);
+
+    let commit = |file: &str, body: String, author: &str| {
+        std::fs::write(root.join(file), body).expect("write the fixture file");
+        run_git_in(root, &["add", "-A"]);
+        run_git_in(
+            root,
+            &[
+                "-c",
+                &format!("user.email={author}"),
+                "commit",
+                "-q",
+                "-m",
+                "fixture",
+            ],
+        );
+    };
+
+    for round in 0..(MIN_COMMITS + 2) {
+        let author = if round % 2 == 0 {
+            "alice@example.invalid"
+        } else {
+            "bob@example.invalid"
+        };
+        commit("src/hot.rs", format!("hot {round}\n"), author);
+    }
+    for round in 0..MIN_COMMITS {
+        commit(
+            "src/warm.rs",
+            format!("warm {round}\n"),
+            "alice@example.invalid",
+        );
+    }
+    for round in 0..2 {
+        commit(
+            "src/cold.rs",
+            format!("cold {round}\n"),
+            "alice@example.invalid",
+        );
+    }
+}
+
+/// 🔴 The end-to-end proof: a real repository, a real `git log`, the expected
+/// hotspot rows in the expected order — #6079's fixture closure condition.
+#[test]
+fn a_fixture_repository_ranks_its_hotspots() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("acme-api");
+    fixture_repo(&checkout);
+
+    let Outcome::Measured(files) = measure(&checkout) else {
+        panic!("a repository with real commits measures");
+    };
+
+    let rows: Vec<(&str, u32, usize)> = files
+        .iter()
+        .map(|f| (f.path.as_str(), f.commits, f.authors))
+        .collect();
+    assert_eq!(
+        rows,
+        vec![
+            ("src/hot.rs", MIN_COMMITS + 2, 2),
+            ("src/warm.rs", MIN_COMMITS, 1),
+        ],
+        "the two files over the floor, worst first; src/cold.rs is under it"
+    );
+    assert_eq!(files[0].severity(), Some(Severity::Amber));
+}
+
+/// A repository with no commit at all is a NAMED gap, never an empty clean
+/// result — the arm whose git output is identical to a quiet repository's.
+#[test]
+fn a_repository_with_no_history_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("empty");
+    std::fs::create_dir_all(&checkout).expect("mkdir");
+    run_git_in(&checkout, &["init", "-q"]);
+
+    let (files, gaps) = ground(&checkout, "acme-api");
+
+    assert!(files.is_empty());
+    assert_eq!(gaps.len(), 1, "one line, not a stream");
+    assert!(
+        gaps[0].contains(COLLECTOR)
+            && gaps[0].contains("no history")
+            && gaps[0].contains("unmeasured"),
+        "the gap names the collector and refuses the clean reading: {}",
+        gaps[0]
+    );
+}
+
+/// A shallow clone's counts stop at the graft point, so they understate every
+/// hotspot. That is a named gap rather than a smaller measurement.
+#[test]
+fn a_shallow_clone_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = checkout_at(tmp.path());
+
+    let (files, gaps) = ground_with(&checkout, "acme-api", shallow());
+
+    assert!(files.is_empty(), "truncated counts are not reported at all");
+    assert_eq!(gaps.len(), 1);
+    assert!(
+        gaps[0].contains("shallow clone") && gaps[0].contains("understate"),
+        "the gap says which state and why it is not a smaller number: {}",
+        gaps[0]
+    );
+}
+
+/// A path holding no repository has no change history a collector could have
+/// missed, so it is a declared SKIP rather than a gap — the rule `cve` applies
+/// to a checkout declaring no dependency manifest. Both rungs of the ladder are
+/// driven, and neither spawns a child.
+#[test]
+fn a_path_holding_no_repository_is_a_declared_skip() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let absent = tmp.path().join("nowhere");
+    let plain = tmp.path().join("not-a-repo");
+    std::fs::create_dir_all(&plain).expect("mkdir");
+
+    assert!(matches!(
+        measure_with(&absent, refuses("must not be reached")),
+        Outcome::NotApplicable(ref why) if why.contains("is not a directory")
+    ));
+    assert!(matches!(
+        measure_with(&plain, refuses("must not be reached")),
+        Outcome::NotApplicable(ref why) if why.contains("holds no git repository")
+    ));
+    assert_eq!(
+        ground_with(&plain, "acme-api", refuses("must not be reached")),
+        (Vec::new(), Vec::new()),
+        "nothing was missed, so there is nothing to name"
+    );
+}
+
+// ─── Failure arms ───────────────────────────────────────────────────────────
+
+/// A git that could not be run at all reaches the report as the caller's own
+/// line, unchanged.
+#[test]
+fn a_run_that_never_happened_reports_its_own_reason() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = checkout_at(tmp.path());
+    let leaked = "git-churn: `git` is not installed, so no change history was read";
+
+    let (_, gaps) = ground_with(&checkout, "acme-api", refuses(leaked));
+
+    assert!(gaps[0].contains(leaked), "{}", gaps[0]);
+}
+
+/// 🔴 #6720: this module's own diagnosis leads, and the child's first stderr
+/// line is only ever the parenthetical. A git whose stderr opens with an
+/// unrelated upgrade notice must not have that notice reported as the cause.
+#[test]
+fn a_noisy_stderr_never_replaces_the_diagnosis() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = checkout_at(tmp.path());
+
+    let (_, gaps) = ground_with(&checkout, "acme-api", returns(false, "", NOISY_STDERR));
+
+    let gap = &gaps[0];
+    let diagnosis = gap
+        .find("exited non-zero and printed no history")
+        .expect("the collector's own diagnosis is present");
+    let notice = gap
+        .find("your git is out of date")
+        .expect("the stderr line rides along as the parenthetical");
+    assert!(
+        diagnosis < notice,
+        "the diagnosis must lead the stderr line: {gap}"
+    );
+}
+
+/// A non-zero exit that still printed history is read: `git log` can fail on a
+/// later ref after streaming the commits that matter.
+#[test]
+fn a_partial_stream_is_read_rather_than_discarded() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = checkout_at(tmp.path());
+
+    let Outcome::Measured(files) = measure_with(&checkout, returns(false, HOT_LOG, NOISY_STDERR))
+    else {
+        panic!("a stream with commits in it is measured");
+    };
+    assert_eq!(files.len(), 1, "src/api.rs clears the floor");
+    assert_eq!(files[0].commits, MIN_COMMITS);
+}
+
+/// A window that ran clean and holds no commit names the window, rather than
+/// reporting the repository as having no hotspot.
+#[test]
+fn an_empty_window_names_the_window() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = checkout_at(tmp.path());
+
+    let (files, gaps) = ground_with(&checkout, "acme-api", returns(true, "", ""));
+
+    assert!(files.is_empty());
+    assert!(
+        gaps[0].contains(&format!("no commit in the last {WINDOW_DAYS} days")),
+        "{}",
+        gaps[0]
+    );
+}
+
+// ─── The manifest write-back ────────────────────────────────────────────────
+
+/// The hotspots reach `[report].findings` under the `churn` category, which is
+/// the key trusty-review renders Change Hotspots from.
+#[test]
+fn the_hotspots_land_in_the_manifest() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manifest = manifest_at(tmp.path());
+    let files = vec![touched("src/api.rs", RED_COMMITS)];
+
+    let gaps = write_into(&manifest, &files, "acme-api");
+
+    assert!(gaps.is_empty(), "{gaps:?}");
+    let written = std::fs::read_to_string(&manifest).expect("read back");
+    assert!(written.contains("category = \"churn\""), "{written}");
+    assert!(written.contains("id = \"churn-hotspot\""), "{written}");
+    assert!(written.contains("package = \"src/api.rs\""), "{written}");
+    assert!(written.contains("severity = \"RED\""), "{written}");
+    assert!(
+        written.contains("title = \"Acme\""),
+        "the document's own keys survive the format-preserving edit"
+    );
+}
+
+/// A resumed sweep re-measures the same repository and must not restate its
+/// hotspots — including when the counts have moved on, because a file with one
+/// more commit is the same finding rather than a second one.
+#[test]
+fn a_resumed_sweep_does_not_restate_a_hotspot() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manifest = manifest_at(tmp.path());
+
+    let _ = write_into(&manifest, &[touched("src/api.rs", MIN_COMMITS)], "acme-api");
+    let _ = write_into(&manifest, &[touched("src/api.rs", RED_COMMITS)], "acme-api");
+
+    let written = std::fs::read_to_string(&manifest).expect("read back");
+    assert_eq!(
+        written.matches("package = \"src/api.rs\"").count(),
+        1,
+        "identity is id + package, not the counts: {written}"
+    );
+}
+
+/// A manifest that cannot be written costs this leg's rows and says so, naming
+/// how many findings the report is therefore missing.
+#[test]
+fn a_manifest_that_cannot_be_written_is_a_named_gap() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("no").join("such").join("manifest.toml");
+
+    let gaps = write_into(&missing, &[touched("src/api.rs", RED_COMMITS)], "acme-api");
+
+    assert_eq!(gaps.len(), 1);
+    assert!(
+        gaps[0].contains("could not be read") && gaps[0].contains("1 change hotspot(s)"),
+        "{}",
+        gaps[0]
+    );
+}
+
+/// Nothing measured writes nothing and opens no file — a quiet repository's
+/// scope line is the caller's, not an empty table in the report.
+#[test]
+fn no_hotspots_writes_nothing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("absent.toml");
+
+    assert!(write_into(&missing, &[], "acme-api").is_empty());
+    assert!(!missing.exists(), "an empty write must not create the file");
+}
+
+/// A repository whose history is readable but quiet states what its count does
+/// not cover, rather than saying nothing at all.
+#[test]
+fn a_quiet_repository_states_its_scope() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = checkout_at(tmp.path());
+    let quiet = "\u{1}a@b.invalid\n\n1\t0\tsrc/a.rs\n";
+
+    let (files, gaps) = ground_with(&checkout, "acme-api", returns(true, quiet, ""));
+
+    assert!(files.is_empty());
+    assert_eq!(gaps.len(), 1);
+    assert!(
+        gaps[0].contains("no file was touched by") && gaps[0].contains("squash or a filter"),
+        "the scope line names the floor and what the window misses: {}",
+        gaps[0]
+    );
+}
+
+// ─── The ranking lane ───────────────────────────────────────────────────────
+
+/// The lane is the top hotspots, capped, carrying a reason and no dimension —
+/// churn is evidence for no single due-diligence dimension.
+#[test]
+fn the_lane_is_the_top_hotspots_with_no_dimension() {
+    let files: Vec<ChurnFile> = (0..(MAX_RANKED + 3))
+        .map(|i| touched(&format!("src/f{i}.rs"), RED_COMMITS))
+        .collect();
+
+    let ranked = lane(&files);
+
+    assert_eq!(ranked.len(), MAX_RANKED, "capped at MAX_RANKED");
+    assert_eq!(ranked[0].path, "src/f0.rs");
+    assert!(ranked[0].dimension.is_none(), "churn claims no dimension");
+    assert!(
+        ranked[0]
+            .reason
+            .as_deref()
+            .is_some_and(|r| r.contains(COLLECTOR) && r.contains("commits by")),
+        "the reason names the measurement: {:?}",
+        ranked[0].reason
+    );
+    assert!(lane(&[]).is_empty(), "no churn, no lane");
+}
+
+/// 🔴 The live probe against this workspace ranked seven `Cargo.toml`s, a `.tsv`
+/// allowlist and a `CLAUDE.md` in its top ten — an analyst's whole budget spent
+/// on dependency bumps. The findings still report them; the ranking declines
+/// them, and an extensionless file is presumed to be code.
+#[test]
+fn the_lane_declines_a_manifest_the_findings_still_report() {
+    let files = vec![
+        touched("Cargo.toml", RED_COMMITS + 9),
+        touched("docs/CLAUDE.md", RED_COMMITS + 8),
+        touched("scripts/deploy", RED_COMMITS + 7),
+        touched("src/api.rs", RED_COMMITS),
+    ];
+
+    let ranked = lane(&files);
+    let paths: Vec<&str> = ranked.iter().map(|p| p.path.as_str()).collect();
+
+    assert_eq!(paths, vec!["scripts/deploy", "src/api.rs"]);
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let manifest = manifest_at(tmp.path());
+    let gaps = write_into(&manifest, &files, "acme-api");
+
+    assert!(gaps.is_empty(), "{gaps:?}");
+    let written = std::fs::read_to_string(&manifest).expect("read back");
+    assert!(
+        written.contains("package = \"Cargo.toml\"")
+            && written.contains("package = \"docs/CLAUDE.md\""),
+        "the findings report the manifest and the prose the ranking declined: {written}"
+    );
+}

--- a/crates/trusty-audit/src/grounding/evidence.rs
+++ b/crates/trusty-audit/src/grounding/evidence.rs
@@ -602,12 +602,38 @@ pub fn blend(
     dimensions: &[DimensionEvidence],
     cap: usize,
 ) -> Vec<Priority> {
+    blend_with(hotspots, dimensions, &[], cap)
+}
+
+/// [`blend`], plus #6079's optional git-churn lane.
+///
+/// Why: churn is a third selection signal — the files a team rewrites weekly are
+/// where the defects and the key-person risk are, and neither complexity nor a
+/// text query sees that. #6079's closure condition is that it be OPTIONAL and
+/// that its absence reproduce the previous ranking exactly, which is why the
+/// lane is a slice and [`blend`] passes an empty one.
+/// What: the round-robin [`blend`] already runs, with one churn path appended at
+/// the END of each round — after the complexity hotspot and after every
+/// dimension. That is the smallest non-zero weight this structure can express:
+/// churn never displaces a measured hotspot or a dimension's evidence at the
+/// same rank, and a churn path another signal already ranked costs nothing at
+/// all, because [`push`] keeps one entry per path.
+/// Test: `super::evidence_tests::{an_absent_churn_lane_reproduces_the_previous_ranking,
+/// churn_enters_each_round_behind_every_other_signal}`.
+#[must_use]
+pub fn blend_with(
+    hotspots: &[RankedFile],
+    dimensions: &[DimensionEvidence],
+    churn: &[Priority],
+    cap: usize,
+) -> Vec<Priority> {
     let mut out: Vec<Priority> = Vec::new();
     let attributed = attributions(dimensions);
     let depth = dimensions
         .iter()
         .map(|d| d.files.len())
         .chain(std::iter::once(hotspots.len()))
+        .chain(std::iter::once(churn.len()))
         .max()
         .unwrap_or(0);
 
@@ -629,12 +655,35 @@ pub fn blend(
                 },
             );
         }
+        // #6079: last in the round, so churn is the signal that yields.
+        if let Some(changed) = churn.get(round) {
+            push(&mut out, churn_entry(changed, &attributed));
+        }
         if out.len() >= cap {
             break;
         }
     }
     out.truncate(cap);
     out
+}
+
+/// One churn lane entry, carrying the search attribution when it has one.
+///
+/// The same rule [`hotspot`] follows and for the same reason: a path the search
+/// leg attributed to a dimension must reach the manifest WITH that dimension,
+/// whichever signal ranked it first, or the report counts the dimension as
+/// uninvestigated despite having read a file that addresses it.
+fn churn_entry(changed: &Priority, attributed: &[(String, String, String)]) -> Priority {
+    let measured = changed.reason.clone().unwrap_or_default();
+    match attributed.iter().find(|(p, _, _)| p == &changed.path) {
+        Some((_, dimension, found)) => Priority {
+            path: changed.path.clone(),
+            dimension: Some(dimension.clone()),
+            reason: Some(format!("{measured}; {found}")),
+            hotspot: None,
+        },
+        None => changed.clone(),
+    }
 }
 
 /// Append a priority unless its path is already ranked.

--- a/crates/trusty-audit/src/grounding/evidence_tests.rs
+++ b/crates/trusty-audit/src/grounding/evidence_tests.rs
@@ -315,6 +315,75 @@ fn the_ranking_is_capped() {
     assert!(blend(&[], &[], MIN_PRIORITY_PATHS).is_empty());
 }
 
+/// 🔴 #6079's optional-input closure condition, asserted as an equality: an
+/// absent churn lane produces the ranking `blend` produced before the lane
+/// existed, path for path and reason for reason.
+#[test]
+fn an_absent_churn_lane_reproduces_the_previous_ranking() {
+    let hotspots = hot(&["src/hot0.rs", "src/hot1.rs"]);
+    let dimensions = [
+        dimension("authentication & secrets", &["src/auth.rs"]),
+        dimension("error handling", &["src/err.rs"]),
+    ];
+
+    assert_eq!(
+        blend_with(&hotspots, &dimensions, &[], 60),
+        blend(&hotspots, &dimensions, 60),
+        "`blend` IS `blend_with` with no churn"
+    );
+}
+
+/// The lane's weight: one path per round, LAST in the round, so churn never
+/// displaces a measured hotspot or a dimension's evidence at the same rank. A
+/// churn path another signal already ranked costs no slot at all, and keeps the
+/// dimension that signal gave it.
+#[test]
+fn churn_enters_each_round_behind_every_other_signal() {
+    let hotspots = hot(&["src/hot0.rs", "src/hot1.rs"]);
+    let dimensions = [dimension("error handling", &["src/err.rs", "src/auth.rs"])];
+    let churn = vec![
+        Priority {
+            path: "src/auth.rs".into(),
+            dimension: None,
+            reason: Some("git-churn: 12 commits".into()),
+            hotspot: None,
+        },
+        Priority {
+            path: "src/config.rs".into(),
+            dimension: None,
+            reason: Some("git-churn: 30 commits".into()),
+            hotspot: None,
+        },
+    ];
+
+    let blended = blend_with(&hotspots, &dimensions, &churn, 60);
+    let paths: Vec<&str> = blended.iter().map(|p| p.path.as_str()).collect();
+
+    assert_eq!(
+        paths,
+        vec![
+            "src/hot0.rs",
+            "src/err.rs",
+            "src/auth.rs",
+            "src/hot1.rs",
+            "src/config.rs"
+        ],
+        "each round is hotspot, then every dimension, then one churn path"
+    );
+    let auth = blended
+        .iter()
+        .find(|p| p.path == "src/auth.rs")
+        .expect("src/auth.rs is ranked");
+    assert_eq!(
+        auth.dimension.as_deref(),
+        Some("error handling"),
+        "a churn path the search leg attributed keeps that dimension: {auth:?}"
+    );
+    let reason = auth.reason.as_deref().expect("a reason");
+    assert!(reason.contains("git-churn"), "{reason}");
+    assert!(reason.contains("trusty-search hit for"), "{reason}");
+}
+
 /// #6145: the measured function survives the blend — both as the structured key
 /// trusty-review reads and in the reason line a human reads. Pre-fix `blend`
 /// took paths only, so there was nothing to survive.

--- a/crates/trusty-audit/src/grounding/grounding_tests.rs
+++ b/crates/trusty-audit/src/grounding/grounding_tests.rs
@@ -253,13 +253,10 @@ async fn a_checkout_with_no_basename_never_reaches_a_daemon() {
     .await;
     assert!(out.index_id.is_none());
     assert!(out.priorities.is_empty());
-    assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
-    assert!(out.gaps[0].contains("acme-api"), "{:?}", out.gaps);
-    assert!(
-        out.gaps[0].contains("no final path component"),
-        "{:?}",
-        out.gaps
-    );
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{:?}", gaps);
+    assert!(gaps[0].contains("acme-api"), "{:?}", gaps);
+    assert!(gaps[0].contains("no final path component"), "{:?}", gaps);
 }
 
 /// #6081's headline case: the search daemon is the first link, and losing it
@@ -282,10 +279,11 @@ async fn a_search_daemon_that_will_not_start_is_a_named_gap() {
     )
     .await;
     assert!(out.priorities.is_empty());
-    assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
-    assert!(out.gaps[0].contains("acme-api"), "{:?}", out.gaps);
-    assert!(out.gaps[0].contains("trusty-search"), "{:?}", out.gaps);
-    assert!(out.gaps[0].contains("not assessed"), "{:?}", out.gaps);
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{:?}", gaps);
+    assert!(gaps[0].contains("acme-api"), "{:?}", gaps);
+    assert!(gaps[0].contains("trusty-search"), "{:?}", gaps);
+    assert!(gaps[0].contains("not assessed"), "{:?}", gaps);
 }
 
 /// A daemon that is already answering is not restarted, so a resumed sweep and
@@ -338,9 +336,10 @@ async fn an_unindexable_checkout_is_a_named_gap() {
         out.index_id,
         index::index_id_for(Path::new("/w/repos/acme-api"))
     );
-    assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
-    assert!(out.gaps[0].contains("acme-api"), "{:?}", out.gaps);
-    assert!(out.gaps[0].contains("not allowlisted"), "{:?}", out.gaps);
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{:?}", gaps);
+    assert!(gaps[0].contains("acme-api"), "{:?}", gaps);
+    assert!(gaps[0].contains("not allowlisted"), "{:?}", gaps);
 }
 
 /// The second daemon. It is reached only once the index exists, and its loss is
@@ -366,9 +365,10 @@ async fn an_analyze_daemon_that_will_not_start_is_a_named_gap() {
         priority::Budget::from_env(),
     )
     .await;
-    assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
-    assert!(out.gaps[0].contains("acme-api"), "{:?}", out.gaps);
-    assert!(out.gaps[0].contains("trusty-analyze"), "{:?}", out.gaps);
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{:?}", gaps);
+    assert!(gaps[0].contains("acme-api"), "{:?}", gaps);
+    assert!(gaps[0].contains("trusty-analyze"), "{:?}", gaps);
     assert!(
         !out.priorities.is_empty(),
         "search-derived evidence must survive a dead trusty-analyze"
@@ -402,19 +402,16 @@ async fn an_unreachable_hotspots_endpoint_is_a_named_gap() {
         priority::Budget::from_env(),
     )
     .await;
-    assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{:?}", gaps);
     // #6287: the reachable-but-broken daemon answers a JSON-RPC error frame
     // where it used to answer HTTP 500. The gap must carry the daemon's own
     // reason either way — that is what separates it from an unreachable one.
+    assert!(gaps[0].contains("index is not loaded"), "{:?}", gaps);
     assert!(
-        out.gaps[0].contains("index is not loaded"),
+        gaps[0].contains("search-derived evidence only"),
         "{:?}",
-        out.gaps
-    );
-    assert!(
-        out.gaps[0].contains("search-derived evidence only"),
-        "{:?}",
-        out.gaps
+        gaps
     );
 }
 
@@ -439,12 +436,9 @@ async fn an_empty_hotspot_list_is_a_named_gap() {
         priority::Budget::from_env(),
     )
     .await;
-    assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
-    assert!(
-        out.gaps[0].contains("no complexity hotspot"),
-        "{:?}",
-        out.gaps
-    );
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{:?}", gaps);
+    assert!(gaps[0].contains("no complexity hotspot"), "{:?}", gaps);
 }
 
 /// #6082: the index answers, and matches nothing. That is not the same as a
@@ -536,12 +530,9 @@ async fn a_daemon_that_binds_but_never_answers_is_a_named_gap() {
     )
     .await;
     assert!(out.priorities.is_empty());
-    assert_eq!(out.gaps.len(), 1, "{:?}", out.gaps);
-    assert!(
-        out.gaps[0].contains("did not report healthy"),
-        "{:?}",
-        out.gaps
-    );
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{:?}", gaps);
+    assert!(gaps[0].contains("did not report healthy"), "{:?}", gaps);
 }
 
 // ─── The happy path, end to end ──────────────────────────────────────────────
@@ -576,7 +567,7 @@ async fn hotspots_and_search_hits_become_ranked_inspect_priority_in_the_manifest
         priority::Budget::from_env(),
     )
     .await;
-    assert!(without_secrets_leg(gaps).is_empty());
+    assert!(without_churn_leg(without_secrets_leg(gaps)).is_empty());
 
     let written = std::fs::read_to_string(&manifest).expect("read back");
     let parsed: toml::Value = toml::from_str(&written).expect("still valid TOML");
@@ -811,6 +802,29 @@ fn the_brief_a_manifest_declares_is_read() {
 /// without the binary, its clean-scan scope statement on one with it. WHICH of
 /// the two depends on the machine; that there is exactly one does not, so these
 /// tests assert the count and leave the wording to `secrets_tests`.
+/// The gaps left once the churn leg's own line is removed, having checked it
+/// spoke exactly once.
+///
+/// // #6079: the churn leg has no not-applicable arm — `local_repo` gives every
+/// real checkout its history by `git clone`, so a fixture directory holding no
+/// repository is an anomaly it names rather than a state it passes over in
+/// silence. It therefore contributes exactly one line to every fixture here:
+/// "holds no git repository" for a bare directory, an empty-window or
+/// quiet-repository line for a real one. WHICH line depends on the fixture;
+/// that there is exactly one does not, so these tests assert the count and
+/// leave the wording to `churn::churn_tests`.
+fn without_churn_leg(gaps: Vec<String>) -> Vec<String> {
+    let marker = format!("{}:", churn::COLLECTOR);
+    let (spoken, rest): (Vec<String>, Vec<String>) =
+        gaps.into_iter().partition(|gap| gap.contains(&marker));
+    assert_eq!(
+        spoken.len(),
+        1,
+        "the churn leg speaks exactly once per repository: {spoken:?}"
+    );
+    rest
+}
+
 fn without_secrets_leg(gaps: Vec<String>) -> Vec<String> {
     let (spoken, rest): (Vec<String>, Vec<String>) = gaps
         .into_iter()
@@ -847,7 +861,7 @@ async fn a_gap_is_recorded_in_the_manifest_the_renderer_reads() {
         priority::Budget::from_env(),
     )
     .await;
-    let gaps = without_secrets_leg(gaps);
+    let gaps = without_churn_leg(without_secrets_leg(gaps));
     assert_eq!(gaps.len(), 1, "{gaps:?}");
 
     let written = std::fs::read_to_string(&manifest).expect("read back");
@@ -859,14 +873,24 @@ async fn a_gap_is_recorded_in_the_manifest_the_renderer_reads() {
         .map(|gap| gap.as_str().expect("string"))
         .collect();
     // The secrets leg's line is written through the SECOND `priority::write_into`
-    // call, so both legs' gaps reach the key the renderer reads (#6077).
-    assert_eq!(stated.len(), 2, "{written}");
+    // call, so both legs' gaps reach the key the renderer reads (#6077), and
+    // #6079's churn line rides the same key.
+    assert_eq!(stated.len(), 3, "{written}");
     assert!(
         stated.iter().any(|gap| gap.contains("trusty-search")),
         "{written}"
     );
     assert!(
         stated.iter().any(|gap| gap.contains("secrets-scan:")),
+        "{written}"
+    );
+    // #6079: a checkout holding no repository reaches the RENDERER as a gap.
+    // Stated anywhere short of this key, the report's Change Hotspots section is
+    // empty with nothing saying why.
+    assert!(
+        stated
+            .iter()
+            .any(|gap| gap.contains(churn::COLLECTOR) && gap.contains("holds no")),
         "{written}"
     );
 }
@@ -902,7 +926,7 @@ async fn a_manifest_that_cannot_be_written_is_a_named_gap() {
         priority::Budget::from_env(),
     )
     .await;
-    let gaps = without_secrets_leg(gaps);
+    let gaps = without_churn_leg(without_secrets_leg(gaps));
     // Two writes are attempted — the ranking, then the manifest legs' gaps — and
     // a directory in place of the manifest fails both (#6077).
     assert_eq!(gaps.len(), 2, "{gaps:?}");

--- a/crates/trusty-audit/src/grounding/grounding_tests.rs
+++ b/crates/trusty-audit/src/grounding/grounding_tests.rs
@@ -912,7 +912,7 @@ async fn a_manifest_that_cannot_be_written_is_a_named_gap() {
         "{gaps:?}"
     );
     assert!(
-        gaps[1].contains("secrets scan are missing"),
+        gaps[1].contains("secrets scan, and change hotspots are missing"),
         "the second names every leg whose reason went unwritten: {gaps:?}"
     );
 }

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -84,6 +84,10 @@ pub mod discover;
 // opposite rules about the credential — never one with a flag.
 pub mod distribute;
 pub mod error;
+// #6079: the one hardened `git` child this crate spawns — the ambient-repository
+// environment cleared and terminal prompting off, in one place rather than a
+// copy per caller (CLAUDE.md's common-entry-point rule).
+pub mod git;
 // #6081: indexing each audited repository in trusty-search, measuring it with
 // trusty-analyze, and writing the resulting ranking into the manifest — the
 // interface trusty-review's investigation pass reads (#6078).

--- a/crates/trusty-audit/src/local_repo.rs
+++ b/crates/trusty-audit/src/local_repo.rs
@@ -508,20 +508,11 @@ async fn rev_parse_lenient(path: &Path, args: &[&str]) -> Vec<String> {
 
 /// A `git` child with the ambient repository environment cleared.
 ///
-/// An inherited `GIT_DIR` or `GIT_WORK_TREE` redirects a clone at whatever the
-/// parent shell was pointed at, which for an agent-run or hook-run invocation is
-/// somebody else's repository. `GIT_TERMINAL_PROMPT=0` keeps a source that
-/// unexpectedly wants credentials from hanging an unattended sweep.
+/// // #6079: the hygiene itself moved to [`crate::git`], which #6079's churn
+/// collector needs in its synchronous form. One list of ambient variables, two
+/// constructors over it; this stays as the name the module's call sites use.
 fn git(argv: Vec<OsString>) -> tokio::process::Command {
-    let mut command = tokio::process::Command::new("git");
-    command
-        .args(argv)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
-        .env("GIT_TERMINAL_PROMPT", "0");
-    command
+    crate::git::spawn(argv)
 }
 
 #[cfg(test)]

--- a/crates/trusty-audit/src/rerender.rs
+++ b/crates/trusty-audit/src/rerender.rs
@@ -1792,12 +1792,17 @@ mod rerender_tests {
         let gaps = ground_present_checkouts(&unreachable_tools(), &manifest, &read).await;
 
         // #6079: the churn leg speaks for every checkout — this fixture holds no
-        // repository, and that is a line of its own. This test is about the
-        // daemon legs; `churn::churn_tests` owns the churn wording.
-        let gaps: Vec<String> = gaps
+        // repository, and that is a line of its own. Partitioned rather than
+        // filtered, so a leg that regressed to silence fails here instead of
+        // passing quietly; the wording stays `churn::churn_tests`'s to own.
+        let (churn_gaps, gaps): (Vec<String>, Vec<String>) = gaps
             .into_iter()
-            .filter(|gap| !gap.contains(crate::grounding::churn::COLLECTOR))
-            .collect();
+            .partition(|gap| gap.contains(crate::grounding::churn::COLLECTOR));
+        assert_eq!(
+            churn_gaps.len(),
+            1,
+            "the churn leg speaks exactly once per repository: {churn_gaps:?}"
+        );
         assert_eq!(gaps.len(), 1, "{gaps:?}");
         assert!(gaps[0].contains("acme/api"), "{gaps:?}");
         assert!(gaps[0].contains("trusty-search"), "{gaps:?}");

--- a/crates/trusty-audit/src/rerender.rs
+++ b/crates/trusty-audit/src/rerender.rs
@@ -1790,6 +1790,14 @@ mod rerender_tests {
         let read = AuditManifest::load(&manifest).expect("parses");
 
         let gaps = ground_present_checkouts(&unreachable_tools(), &manifest, &read).await;
+
+        // #6079: the churn leg speaks for every checkout — this fixture holds no
+        // repository, and that is a line of its own. This test is about the
+        // daemon legs; `churn::churn_tests` owns the churn wording.
+        let gaps: Vec<String> = gaps
+            .into_iter()
+            .filter(|gap| !gap.contains(crate::grounding::churn::COLLECTOR))
+            .collect();
         assert_eq!(gaps.len(), 1, "{gaps:?}");
         assert!(gaps[0].contains("acme/api"), "{gaps:?}");
         assert!(gaps[0].contains("trusty-search"), "{gaps:?}");

--- a/crates/trusty-review/changelog.d/6079-churn-subsection.md
+++ b/crates/trusty-review/changelog.d/6079-churn-subsection.md
@@ -1,0 +1,6 @@
+Added
+
+- The Assurance Scans section renders `trusty-audit`'s new `churn` category
+  under a "Change Hotspots" heading (#6079). Without the mapping the rows still
+  rendered, but under the bare category string, which reads as a producer bug
+  rather than as a measurement of the target repository.

--- a/crates/trusty-review/src/report/assurance.rs
+++ b/crates/trusty-review/src/report/assurance.rs
@@ -89,6 +89,11 @@ fn subsection_title(category: &str) -> String {
         "dependencies" => "Dependency CVE Exposure".to_string(),
         "license" => "License / IP Exposure".to_string(),
         "secrets" => "Secret Leakage".to_string(),
+        // #6079: git-churn hotspots. Not an assurance SCAN in the sense the
+        // other three are — nothing here is a vulnerability — but the same
+        // shape: a deterministic measurement of the target repository the
+        // report states verbatim rather than infers.
+        "churn" => "Change Hotspots".to_string(),
         "" => "Uncategorised Findings".to_string(),
         other => other.to_string(),
     }

--- a/crates/trusty-review/src/report/assurance_tests.rs
+++ b/crates/trusty-review/src/report/assurance_tests.rs
@@ -174,6 +174,26 @@ fn a_second_category_gets_its_own_subsection() {
     assert!(section.contains("S-1"), "{section}");
 }
 
+/// #6079's category has a heading a due-diligence reader recognises. Without the
+/// mapping the section renders under the bare string `churn`, which reads as a
+/// producer bug rather than as a measurement.
+#[test]
+fn the_churn_category_renders_under_its_own_heading() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = model_from(
+        tmp.path(),
+        &manifest_declaring(
+            "findings = [\n  { category = \"churn\", id = \"churn-hotspot\", \
+             package = \"src/api.rs\", version = \"\", severity = \"RED\", \
+             title = \"31 commits by 4 author(s) in the last 180 days, +910/-402 lines\" },\n]",
+        ),
+    );
+    let section = report_section(&model);
+    assert!(section.contains("### Change Hotspots"), "{section}");
+    assert!(!section.contains("### churn"), "{section}");
+    assert!(section.contains("src/api.rs"), "{section}");
+}
+
 /// An advisory title is upstream prose. An unescaped pipe silently shifts every
 /// later cell into the wrong column, which is worse than a missing row.
 #[test]


### PR DESCRIPTION
## Summary
Adds a git-churn collector to trusty-audit that feeds the report's findings and generates a Change Hotspots subsection. Part of epic #6074.

Refs #6079

## Changes
- New `src/git.rs` in trusty-audit: shared git shell-out for churn metrics (commit frequency, author churn, file volatility)
- Churn collector exposes metrics via the `churn` findings category
- trusty-review integrates churn findings with optional ranking lane through `blend_with`
- No new dependency on tga—git operations are native to trusty-audit
- Code-critic approved after round 1 BLOCK (four findings) and round 2 review (one MEDIUM finding folded in at 4c1e7e6e)

Out of scope: path quoting with literal newlines/tabs/quotes (git control-character quoting is unchanged); NUL-delimited path handling is separable future work.

## Risk
Low. Changes are localized to trusty-audit's new collector and trusty-review's integration. No modifications to existing public APIs. The churn collector is opt-in via the report's findings configuration.

## Test Evidence (Rung 4)
- `cargo test -p trusty-audit --no-fail-fast`: lib 884 passed / 0 failed / 5 ignored; 9 targets ok
- `cargo test -p trusty-review --no-fail-fast`: lib 2157 passed / 0 failed; 12 targets ok
- `cargo check --workspace`: clean
- `cargo fmt --check`: clean
- `cargo clippy -p trusty-audit --all-targets -- -D warnings`: clean
- `cargo clippy -p trusty-review --all-targets -- -D warnings`: clean
- Changelog fragments (three): present and valid

## Baseline
No pre-existing red gates. All changes are branch-caused.

## Docs
- Changelog fragments in `trusty-audit/changelog.d/` and `trusty-review/changelog.d/`
- Line-cap check: pass (no split required)
- Doc-comment pointers: pass
- Semantic versioning check (`check_semver.sh --crate trusty-audit`): 196 pass, no bump required
- SLD check: pass
- Rustdoc: pass

## Review
Code-critic: APPROVE (round 2 at d11c2f540, one MEDIUM finding folded in at 4c1e7e6e)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
