### PR TITLE
docs(agents): effort matches blast radius; --no-fail-fast and the trusty-common features trap

### DIFF
--- a/.claude/skills/cargo-commands/SKILL.md
+++ b/.claude/skills/cargo-commands/SKILL.md
@@ -14,7 +14,8 @@ when_to_use: When you need a cargo invocation beyond the five everyday one-liner
 🔴 **Single-path workflows — use exactly these commands.**
 
 The five everyday one-liners (`cargo build`, `cargo check -p <crate>`,
-`cargo test -p <crate>`, `cargo clippy -p <crate> --all-targets -- -D warnings`,
+`cargo test -p <crate> --no-fail-fast`,
+`cargo clippy -p <crate> --all-targets -- -D warnings`,
 `cargo fmt`) are resident in the root `CLAUDE.md` and are not repeated here.
 This skill is the exhaustive variant list.
 
@@ -23,6 +24,23 @@ Rust Test Ladder in `CLAUDE.md`, with the per-rung command chains in
 [docs/reference/test-ladder-baseline.md](../../../docs/reference/test-ladder-baseline.md).
 This skill tells you how to *spell* a command, not whether you owe it.
 
+## Two Rules That Apply to Every `cargo test` Here
+
+🔴 **`--no-fail-fast` is not optional.** Cargo runs each test target as its own
+binary and stops issuing further targets the moment one target reports a
+failure — it does not run them all and report the aggregate. One failing `--lib`
+test therefore hides every integration target behind it, and the run exits
+having covered far less than its counts suggest. Name the flag beside any counts
+you report. (See `CLAUDE.md`; this has been missed twice — issue #5324 and
+PR #5904.)
+
+🔴 **`trusty-common` takes `--features` on every test run.** Its default feature
+set is empty, so a bare `cargo test -p trusty-common` is a `compile_error!`.
+Name what you changed — `--features memory-core,embedder-test-support` — or
+`--features unconditional-only` for the always-compiled surface.
+`--all-features` is unavailable: the `embedder-*` ORT variants are mutually
+exclusive. `cargo build` and `cargo check -p trusty-common` are unaffected.
+
 ## Workspace-wide
 
 ```bash
@@ -30,7 +48,7 @@ This skill tells you how to *spell* a command, not whether you owe it.
 cargo build --release
 
 # Run all tests across the workspace
-cargo test
+cargo test --no-fail-fast
 
 # Lint workspace-wide, all targets
 cargo clippy --workspace --all-targets -- -D warnings
@@ -40,7 +58,7 @@ cargo fmt --check
 cargo fmt
 
 # Run ONNX-backed integration tests (slow; skipped in CI)
-cargo test -- --include-ignored
+cargo test --no-fail-fast -- --include-ignored
 
 # Update dependencies (review the Cargo.lock diff before committing)
 cargo update
@@ -60,7 +78,7 @@ cargo build --release -p trusty-search
 cargo build --release -p trusty-mpm
 
 # Test a single crate with a specific feature
-cargo test -p trusty-common --features axum-server
+cargo test -p trusty-common --features axum-server --no-fail-fast
 
 # Test a single test by name within a crate
 cargo test -p trusty-search -- my_test_name
@@ -69,7 +87,7 @@ cargo test -p trusty-search -- my_test_name
 cargo test -p <crate> <test> -- --exact --nocapture
 
 # Test a single crate including its #[ignore]-tagged tests
-cargo test -p trusty-embedderd -- --include-ignored
+cargo test -p trusty-embedderd --no-fail-fast -- --include-ignored
 
 # Run a binary from a specific crate
 cargo run -p trusty-search -- start

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11368,7 +11368,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-common"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -7,7 +7,11 @@ name = "trusty-agents-common"
 # preview_unmanaged_bundled_skills, audit_agent_tier all gained a fallible
 # Result-wrapped return; TierAuditError is a new public type) — for a 0.y.z
 # crate, Cargo's rule makes the MINOR position the breaking position.
-version = "0.6.3"
+#
+# PR #6764: patch bump. 0.6.3 is live on crates.io and this PR edits
+# src/assets/agents/*.md (prose only — no item signature changed), which
+# scripts/check-pr-version-bump.sh requires be bumped in the same PR (#4421).
+version = "0.6.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-agents-common/changelog.d/6764-agent-velocity-principles.md
+++ b/crates/trusty-agents-common/changelog.d/6764-agent-velocity-principles.md
@@ -1,0 +1,11 @@
+Documentation
+
+- `BASE-AGENT.md` gains an "Effort Matches Blast Radius" section: verification
+  effort is proportional to what the change can break, consolidation ships
+  inside the next change that touches that code rather than as a standalone
+  cleanup, and a defect in code you are already editing is fixed now.
+- `rust-engineer.md` carries the two Rust traps already in `CLAUDE.md` —
+  `--no-fail-fast` on every `cargo test` (cargo stops issuing targets on the
+  first target failure, so the counts overstate coverage; #5324, PR #5904), and
+  `trusty-common` needing `--features` on every test run because its default
+  feature set is empty.

--- a/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
@@ -242,6 +242,20 @@ reserved for the top-level PM/orchestrator.
 Accomplish the task with the minimum necessary additions. Prefer deleting code
 to adding it. If removing something doesn't break functionality, remove it.
 
+## Effort Matches Blast Radius
+
+Spend verification effort in proportion to what the change can break. Run the
+smallest deterministic gate that covers what you changed; widen when the change
+is wider, never by default. A broad gate on a narrow change adds no signal and
+imports unrelated failures.
+
+Consolidation — deduplication, a file split, a stale doc, a rename — ships
+inside the next change that touches that code. Do not open a standalone cleanup
+change for it, and do not grow the current change to absorb it.
+
+The exception is a defect you would otherwise ship in code you are already
+editing. A bug, a security hole, a broken contract: fix it now, not later.
+
 ## Agent Responsibilities
 
 | DO | DO NOT |

--- a/crates/trusty-agents-common/src/assets/agents/rust-engineer.md
+++ b/crates/trusty-agents-common/src/assets/agents/rust-engineer.md
@@ -27,9 +27,24 @@ every gate to the crate you changed — a crate-scoped run finishes well under t
 ```bash
 cargo check -p <crate>                                # must pass
 cargo clippy -p <crate> --all-targets -- -D warnings  # zero warnings
-cargo test -p <crate>                                 # all tests pass
+cargo test -p <crate> --no-fail-fast                  # EVERY test target runs
 cargo fmt --check                                     # no formatting drift
 ```
+
+🔴 **`--no-fail-fast` is not optional.** Cargo runs each test target as its own
+binary and stops issuing further targets the moment one target reports a
+failure — it does not run them all and report the aggregate. One failing `--lib`
+test therefore hides every integration target behind it, and the run exits
+having covered far less than its counts suggest. Name the flag beside any counts
+you report. (See `CLAUDE.md`; this has been missed twice — issue #5324 and
+PR #5904.)
+
+🔴 **`trusty-common` takes `--features` on every test run.** Its default feature
+set is empty, so a bare `cargo test -p trusty-common` is a `compile_error!`.
+Name what you changed — `--features memory-core,embedder-test-support` — or
+`--features unconditional-only` for the always-compiled surface.
+`--all-features` is unavailable: the `embedder-*` ORT variants are mutually
+exclusive.
 
 Widen the scope when the change is wider, not by default:
 
@@ -37,17 +52,16 @@ Widen the scope when the change is wider, not by default:
 |---|---|
 | Docs/comments/changelog only | No Cargo test required |
 | Localized crate behavior | Targeted regression test + the four commands above |
-| Public API or shared library | The above, plus `cargo check --workspace` and `cargo test -p <consumer>` for each directly affected consumer |
+| Public API or shared library | The above, plus `cargo check --workspace` and `cargo test -p <consumer> --no-fail-fast` for each directly affected consumer |
 | Cross-crate contract, persistence, security, process lifecycle, release tooling | The above, plus dependent suites and failure-path/concurrency tests |
 
 `cargo test --workspace` belongs at hardening and release boundaries. Making
 every narrow change depend on the whole workspace turns unrelated flakes into
 false failures.
 
-🔴 **Editing `trusty-common`?** Its default feature set is empty, so a bare
-`cargo test -p trusty-common` is a compile error. Run
-`scripts/test_trusty_common_lanes.sh` instead of the four-command bar above —
-it runs every feature lane the crate actually needs covered.
+🔴 **Editing `trusty-common`?** Run `scripts/test_trusty_common_lanes.sh`
+instead of the four-command bar above — it runs every feature lane the crate
+actually needs covered.
 
 🔴 **Touched a doc comment? Run the doc gates too:** `bash
 scripts/check_line_cap.sh`, `bash scripts/check_changelog_fragment.sh`, and


### PR DESCRIPTION
## What

Two workflow principles the canonical agent assets did not carry.

### `BASE-AGENT.md` — new `## Effort Matches Blast Radius` section

Sibling to the existing Minimalism Principle (which covers minimum additions and
preferring deletion; this does not restate it). Three rules: verification effort
is proportional to what the change can break; consolidation ships inside the next
change that touches that code, never as a standalone cleanup and never bolted
onto the current change; a defect you would otherwise ship in code you are
already editing is the exception and gets fixed now.

### `rust-engineer.md` and `.claude/skills/cargo-commands/SKILL.md` — two Rust traps

Both already recorded in `CLAUDE.md`, neither present in the agent assets:

- 🔴 `--no-fail-fast` is not optional. Cargo stops issuing test targets the
  moment one target reports a failure, so one failing `--lib` test hides every
  integration target behind it and the counts overstate coverage. Missed twice —
  issue #5324 and PR #5904.
- 🔴 `trusty-common` takes `--features` on every test run. Its default feature
  set is empty, so a bare `cargo test -p trusty-common` is a `compile_error!`.
  `--all-features` is unavailable — the `embedder-*` ORT variants are mutually
  exclusive.

Every prescriptive `cargo test` in both files now carries `--no-fail-fast`: the
quality-bar command block, the "Public API or shared library" table row, and the
skill's workspace / feature-gated / ignore-tagged examples. Two bare occurrences
are left alone deliberately — the anti-example inside the `trusty-common` rule,
and `cargo test --workspace` named as a release-boundary gate rather than a
command to run.

The pre-existing `trusty-common` note in `rust-engineer.md` keeps its pointer to
`scripts/test_trusty_common_lanes.sh` and drops the compile-error claim the new
rule now states in full, so the file carries one statement of that trap, not two.

## Canonical `cargo-commands` path

`.claude/skills/cargo-commands/SKILL.md` is the only tracked copy in the repo —
`git ls-files | grep cargo-commands` returns exactly that one path. There is no
`.agents/` directory here at all, and no `crates/*/src/assets/skills/cargo-commands`
(the crate-bundled skill assets under `crates/trusty-code/src/assets/skills/`
do not include it). Nothing generates it from another source. It is the source
of truth and the only file edited.

## Version bump

`trusty-agents-common` 0.6.3 → 0.6.4, in the third commit. `check-pr-version-bump.sh`
(#4421) failed the first push: 0.6.3 is live on crates.io and this PR changes
`crates/trusty-agents-common/src/**`, which would turn main's version-parity
workflow red after merge. The gate names the fix and requires it in this PR, so
the bump lands here rather than at release time. Patch, not minor — the change
is prose inside compiled-in assets, no public item signature moved, and
dependents pin `^0.6.0`, which 0.6.4 satisfies unchanged. `Cargo.lock` follows.

## Test ladder

Rung 1 — documentation and agent-asset markdown only, no Rust source touched.
A changelog fragment is included because the change lands under
`crates/trusty-agents-common/src/**`.

Gates run and raw output are in the review thread.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
