### PR TITLE
fix(trusty-mpm): resolve the relaunch target explicitly, never a bare --continue (Refs #6765)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6765-no-bare-continue-on-relaunch.md
+++ b/crates/trusty-mpm/changelog.d/6765-no-bare-continue-on-relaunch.md
@@ -1,0 +1,18 @@
+Fixed
+- A managed relaunch no longer emits a bare `claude --continue`. Both relaunch
+  paths — the tmux-pane resume and the in-place `tm` exec — now resolve the
+  target explicitly: `--resume <id>` when the session record carries a
+  `claude_session_id` that exists in that session's OWN store, otherwise a fresh
+  launch. The eligibility check behind the old `--continue` branch read
+  `~/.claude/projects`, the operator's store, while the command it built exported
+  the managed `CLAUDE_CONFIG_DIR`; the check therefore answered `true` on any
+  machine with transcripts and `--continue` resolved "most recent conversation"
+  against the managed store instead. When that store's newest conversation was a
+  still-live `claude agents` background job, Claude Code refused to double-attach,
+  printed "Your most recent conversation is running in the background", and exited
+  0 — leaving the pane at a bare shell
+  ([#6765](https://github.com/bobmatnyc/trusty-tools/issues/6765)).
+- `has_prior_conversation` / `has_prior_conversation_in` are deleted: with no
+  `--continue` branch they had no caller. `session_id_exists`, which already
+  resolves the store through `projects_dir_for(config_dir)`, is now the only
+  conversation-store lookup either relaunch path makes.

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -493,8 +493,8 @@ pub(crate) enum InPlaceOutcome {
 /// daemon call, so a dead workspace can never be masked by a durably-committed
 /// `Active` record nor exec'd into; (3) builds the resume argv via
 /// [`trusty_mpm::runtime::build_inplace_resume_command`] (the SAME
-/// `--resume`-existence-check → `--continue`/fresh-spawn fallback logic the
-/// tmux-pane resume path uses, #2013) — this is PURE/local (resolving the
+/// `--resume`-existence-check → fresh-spawn fallback logic the
+/// tmux-pane resume path uses, #2013, #6765) — this is PURE/local (resolving the
 /// `claude` binary can fail with `BinaryNotFound`) and runs BEFORE any daemon
 /// mutation, so a missing binary never flips the record to a false `Active`;
 /// (4) reactivates the record on the daemon (step 3 of #2023 C — see

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -732,11 +732,14 @@ fn inplace_exec_command_forwards_every_arg_in_order() {
     // #4336 core regression: the Command handed to `exec` must carry the
     // composed argv VERBATIM. An empty (or truncated) `get_args()` here is
     // precisely the reported "execs claude with zero args" defect.
+    // #6765: `--resume <id>`, not `--continue` — the composer no longer emits a
+    // bare `--continue`, so the sample argv tracks what it really produces.
     let resume = synthetic_resume(&[
         "--setting-sources",
         "project,local",
         "--dangerously-skip-permissions",
-        "--continue",
+        "--resume",
+        "abc-123",
     ]);
     let cmd = build_inplace_exec_command(&resume, std::path::Path::new("/fake/cwd"));
 
@@ -750,7 +753,8 @@ fn inplace_exec_command_forwards_every_arg_in_order() {
             "--setting-sources",
             "project,local",
             "--dangerously-skip-permissions",
-            "--continue"
+            "--resume",
+            "abc-123"
         ],
         "the exec seam must forward the composed argv verbatim and in order"
     );

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -905,7 +905,7 @@ fn resolve_statusline_binary() -> String {
 /// Why: separating the resolution PRIORITY from the actual `current_exe()` /
 /// PATH syscalls lets each branch (current-exe hit, PATH-lookup fallback, bare
 /// last resort) be exercised deterministically, mirroring the
-/// `has_prior_conversation_in` injected-I/O-root pattern used elsewhere in
+/// `session_id_exists_in` injected-I/O-root pattern used elsewhere in
 /// this crate (`crate::runtime::claude_code`).
 /// What: returns `current_exe()`'s path as a `String` when it resolves to
 /// valid UTF-8 AND is not an ephemeral build/worktree path (#2229 — a

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -1574,8 +1574,8 @@ pub async fn resume_managed(
     let tmux_arc = mgr.tmux_driver();
     let adapter = build_adapter(record.runtime, tmux_arc);
     // #1744: prefer --resume <id> when a claude_session_id was captured at
-    // SessionStart; fall back to --continue (most-recent conversation in the
-    // workspace) when the id is absent. ClaudeCodeAdapter overrides spawn_resume
+    // SessionStart; launch fresh when the id is absent or stale (#6765 — no
+    // --continue fallback). ClaudeCodeAdapter overrides spawn_resume
     // to implement this; TcodeAdapter's default delegates to plain spawn.
     // Sibling-window hijack fix (follow-up to #2456): pass the record's OWN
     // `record.pane_id` through so the adapter targets that SPECIFIC pane

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -442,28 +442,30 @@ fn build_prompt_file(project_dir: &Path, session_id: Option<&str>) -> Option<std
     file
 }
 
-/// Build a resume-aware Claude Code command (#1744, #1840).
+/// Build a resume-aware Claude Code command (#1744, #1840, #6765).
 ///
 /// Why: `resume_managed` must restore the prior conversation when one is known.
 /// `--resume <id>` restores the exact Claude Code conversation identified by
-/// `claude_session_id`; `--continue` resumes the most-recent conversation in
-/// the workspace when the id is absent AND prior conversation history exists;
-/// neither flag is passed when there is no prior conversation, preventing the
-/// "No conversation found to continue" error that would otherwise drop the
-/// session to a bare shell (#1840).
-/// What: `Some(id)` → `--resume <id>`. `None, has_prior_conv=true` → `--continue`.
-/// `None, has_prior_conv=false` → plain spawn (no resume flag), so the session
-/// starts a fresh conversation instead of erroring. All three share the same
-/// env prefix (scrub + `CLAUDE_CONFIG_DIR`) and isolation flags as
-/// [`spawn_command`], and all three get [`on_exit_hint_suffix`] appended
-/// (#2023 component D) so the pane always prints the relaunch hint once
+/// `claude_session_id`. There is no `--continue` fallback (#6765): the command
+/// exports the MANAGED `CLAUDE_CONFIG_DIR`, so a bare `--continue` resolves
+/// "most recent conversation" against `<config_dir>/projects` — a store this
+/// process cannot reason about, and which may hold a still-live conversation
+/// Claude Code refuses to double-attach to (it prints "Your most recent
+/// conversation is running in the background" and exits 0, dropping the pane to
+/// a bare shell). Resolving the target EXPLICITLY, or launching fresh, keeps
+/// the decision independent of Claude Code's undocumented background-job layout.
+/// What: `Some(id)` → `--resume <id>`; `None` → plain spawn (no resume flag), so
+/// the session starts a fresh conversation. Both share the same env prefix
+/// (scrub + `CLAUDE_CONFIG_DIR`) and isolation flags as [`spawn_command`], and
+/// both get [`on_exit_hint_suffix`] appended (#2023 component D) so the pane
+/// always prints the relaunch hint once
 /// `claude` exits, whichever branch fired. `prompt_file` (#2230) carries the
 /// PM system prompt via `--append-system-prompt-file` the same way
 /// [`spawn_command`] does, so resumed/guided-resume/crash-recovery sessions
 /// get the identical carrier a fresh spawn gets instead of falling back to a
 /// vanilla `claude` invocation.
 /// Test: `resume_command_with_id_uses_resume_flag`,
-/// `resume_command_without_id_with_prior_conv_uses_continue`,
+/// `resume_command_without_id_never_uses_continue`,
 /// `resume_command_without_id_no_prior_conv_uses_plain_spawn`,
 /// `resume_command_sets_claude_config_dir`,
 /// `resume_command_exports_managed_session_id`,
@@ -490,7 +492,6 @@ fn resume_command(
     claude_bin: &str,
     config_dir: Option<&Path>,
     claude_session_id: Option<&str>,
-    has_prior_conv: bool,
     session_id: &str,
     prompt_file: Option<&Path>,
     oauth_token: Option<&str>,
@@ -509,8 +510,9 @@ fn resume_command(
     );
     let cmd = match claude_session_id {
         Some(id) => format!("{base} --resume {id}"),
-        None if has_prior_conv => format!("{base} --continue"),
-        None => base, // No prior conversation: start fresh to avoid "no conversation found".
+        // #6765: never a bare `--continue` — it would resolve against the
+        // managed store this process did not choose. No usable id → start fresh.
+        None => base,
     };
     let body = format!("{cmd}{}", on_exit_hint_suffix());
     cd_and_group(cwd, &body)
@@ -518,18 +520,14 @@ fn resume_command(
 
 /// Encode a workspace path the same way Claude Code names its project dir.
 ///
-/// Why: both the `--continue`-eligibility check ([`has_prior_conversation_in`])
-/// and the `--resume <id>`-existence check ([`session_id_exists_in`]) must
-/// derive the SAME on-disk project directory name for a given `cwd` — if the
-/// two ever computed the encoding differently (e.g. one gets tweaked and the
-/// other doesn't), `--continue` detection and `--resume` existence detection
-/// would silently disagree about which conversations exist. Sharing one
-/// helper makes that impossible.
+/// Why: every on-disk lookup against a Claude Code session store — today only
+/// the `--resume <id>`-existence check ([`session_id_exists_in`]) — must derive
+/// the SAME project directory name for a given `cwd`. Sharing one helper makes
+/// two callers computing the encoding differently impossible.
 /// What: replaces every `/` in the path with `-` (Claude Code's project-dir
 /// naming scheme). A leading `/` becomes `-`, so `/private/tmp/foo` →
 /// `-private-tmp-foo`.
 /// Test: `encode_project_dir_replaces_slashes`,
-/// `has_prior_conversation_returns_true_when_jsonl_exists`,
 /// `session_id_exists_true_for_real_jsonl_file`,
 /// `session_id_exists_finds_hardcoded_dir_name_for_known_cwd` (non-circular
 /// regression guard against encoding-scheme drift).
@@ -537,46 +535,14 @@ fn encode_project_dir(cwd: &Path) -> String {
     cwd.to_string_lossy().replace('/', "-")
 }
 
-/// Detect whether Claude Code has prior conversation history for `cwd` (#1840).
-///
-/// Why: `claude --continue` exits with "No conversation found to continue" when
-/// no prior conversation exists for the workspace. This guard prevents that error.
-/// What: delegates to [`has_prior_conversation_in`] with the standard
-/// `~/.claude/projects/` directory derived from `dirs::home_dir()`.
-/// Test: `has_prior_conversation_returns_false_for_fresh_workspace` exercises
-/// the inner function directly via `has_prior_conversation_in`.
-fn has_prior_conversation(cwd: &Path) -> bool {
-    let Some(home) = dirs::home_dir() else {
-        return false;
-    };
-    has_prior_conversation_in(cwd, &home.join(".claude").join("projects"))
-}
-
-/// Inner implementation of conversation-history detection, testable with injected dir.
-///
-/// Why: allows unit tests to pass a temp directory as `projects_dir` without
-/// mutating the `HOME` environment variable (which is thread-unsafe under parallel
-/// test execution). Separating the I/O root from the detection logic keeps the
-/// detection pure and mockable.
-/// What: returns `true` when `<projects_dir>/<encoded-cwd>/` exists and contains
-/// at least one `.jsonl` file. The encoded path comes from
-/// [`encode_project_dir`] (every `/` replaced with `-`); a leading `/` becomes
-/// `-`, so `/private/tmp/foo` → `-private-tmp-foo`.
-/// Test: `has_prior_conversation_returns_false_for_fresh_workspace`,
-/// `has_prior_conversation_returns_true_when_jsonl_exists`.
-fn has_prior_conversation_in(cwd: &Path, projects_dir: &Path) -> bool {
-    if !projects_dir.is_dir() {
-        return false;
-    }
-    let project_dir = projects_dir.join(encode_project_dir(cwd));
-    project_dir.is_dir()
-        && std::fs::read_dir(&project_dir)
-            .map(|d| {
-                d.flatten()
-                    .any(|e| e.path().extension().and_then(|x| x.to_str()) == Some("jsonl"))
-            })
-            .unwrap_or(false)
-}
+// #6765: `has_prior_conversation` / `has_prior_conversation_in` used to live
+// here as the `--continue`-eligibility check. They hardcoded
+// `~/.claude/projects` — the OPERATOR's store — while every managed relaunch
+// exports a managed `CLAUDE_CONFIG_DIR`, so the check answered for one store
+// and the flag acted on another. Both relaunch paths now resolve the target
+// explicitly (`--resume <id>` verified against the session's OWN store, else a
+// fresh launch), leaving neither function a caller. Deleted rather than
+// repointed: with no `--continue` branch there is nothing to gate.
 
 /// Resolve the Claude Code `projects` directory used for session storage.
 ///
@@ -590,8 +556,9 @@ fn has_prior_conversation_in(cwd: &Path, projects_dir: &Path) -> bool {
 /// `~/.claude/projects` — otherwise every id would appear "missing" for managed
 /// sessions and resume would never use `--resume`.
 /// What: `<config_dir>/projects` when a managed config dir is resolved; falls
-/// back to `~/.claude/projects` when `config_dir` is `None` (home-unresolved
-/// legacy path, matching [`has_prior_conversation`]'s fallback).
+/// back to `~/.claude/projects` when `config_dir` is `None` — the unmanaged
+/// default store, which is where an unrelocated `claude` really does keep its
+/// conversations.
 /// Test: `session_id_exists_prefers_config_dir_projects_when_present`,
 /// `session_id_exists_falls_back_to_home_claude_when_no_config_dir`.
 fn projects_dir_for(config_dir: Option<&Path>) -> Option<std::path::PathBuf> {
@@ -608,13 +575,14 @@ fn projects_dir_for(config_dir: Option<&Path>) -> Option<std::path::PathBuf> {
 /// session file was pruned, moved, or never made it to disk after a crash).
 /// `claude --resume <missing-id>` fails hard with no graceful recovery, which
 /// turns `tm` resume into a dead end. Checking first lets the caller fall back
-/// to `--continue` or a plain spawn instead of a hard failure.
+/// to a plain spawn instead of a hard failure.
 /// What: best-effort filesystem check — `true` only when
 /// `<projects_dir>/<encoded-cwd>/<id>.jsonl` exists as a regular file, where
 /// `projects_dir` is resolved via [`projects_dir_for`] and the cwd is encoded
-/// via the shared [`encode_project_dir`] helper (every `/` becomes `-`) — the
-/// same encoding [`has_prior_conversation_in`] uses, so the two checks can
-/// never silently disagree.
+/// via the shared [`encode_project_dir`] helper (every `/` becomes `-`).
+/// #6765: this is now the ONLY conversation-store lookup either relaunch path
+/// makes — it is the check that consults the store the spawned process will
+/// actually use, which is exactly what the deleted `--continue` gate did not.
 /// Never panics: an unresolvable projects dir, a missing file, or any I/O
 /// error all conservatively resolve to `false` (safest outcome — it only ever
 /// causes an extra fallback, never a hard failure or a wrong `--resume`).
@@ -635,7 +603,8 @@ pub(crate) fn session_id_exists(cwd: &Path, config_dir: Option<&Path>, id: &str)
 }
 
 /// Inner implementation of the session-id existence check, testable with an
-/// injected `projects_dir` (mirrors [`has_prior_conversation_in`]'s pattern).
+/// injected `projects_dir` (the injected-I/O-root pattern used throughout this
+/// module).
 ///
 /// Why: unit tests need to point at a temp directory rather than mutating
 /// `HOME`/`CLAUDE_CONFIG_DIR` process-globals.
@@ -787,7 +756,7 @@ pub struct InPlaceResumeCommand {
 
 /// Pure argv composition shared by [`build_inplace_resume_command`] (#2023 C).
 ///
-/// Why: separating the resume/continue/fresh SELECTION from claude-binary
+/// Why: separating the resume/fresh SELECTION from claude-binary
 /// resolution (which needs a real `claude` install to exercise end-to-end)
 /// keeps the decision itself testable in every CI environment — mirroring how
 /// [`resume_command`]'s selection tests pass a fake `claude_bin` string rather
@@ -798,9 +767,10 @@ pub struct InPlaceResumeCommand {
 /// [`crate::core::model_inject::PERMISSION_MODE_FLAG`], whitespace-split
 /// into argv tokens since both constants are simple space-separated flags with
 /// no embedded quoting) followed by `--resume <id>` (id exists under
-/// `config_dir`, per [`session_id_exists`]), `--continue` (no usable id but
-/// [`has_prior_conversation`] is true), or neither (fresh start) — the exact
-/// same three-way selection [`resume_command`] makes.
+/// `config_dir`, per [`session_id_exists`]) or neither flag (fresh start) — the
+/// exact same two-way selection [`resume_command`] makes. #6765: there is no
+/// `--continue` fallback on either path; see [`resume_command`]'s doc for why a
+/// bare `--continue` under a managed `CLAUDE_CONFIG_DIR` is unsafe.
 ///
 /// `prompt_file` (#4336): this path previously omitted the PM system prompt BY
 /// DESIGN, so an in-place relaunch silently restored the operator into vanilla
@@ -814,7 +784,7 @@ pub struct InPlaceResumeCommand {
 /// filename claude then fails to open.
 /// Test: `compose_inplace_args_uses_resume_for_existing_id`,
 /// `compose_inplace_args_falls_back_for_missing_id`,
-/// `compose_inplace_args_uses_continue_when_no_id_but_prior_conv`,
+/// `compose_inplace_args_never_continues_from_home_store`,
 /// `compose_inplace_args_carries_prompt_file_unquoted`,
 /// `compose_inplace_args_omits_prompt_flag_when_absent`.
 fn compose_inplace_args(
@@ -838,13 +808,11 @@ fn compose_inplace_args(
             .map(str::to_owned),
     );
 
-    match effective_id {
-        Some(id) => {
-            args.push("--resume".to_owned());
-            args.push(id.to_owned());
-        }
-        None if has_prior_conversation(cwd) => args.push("--continue".to_owned()),
-        None => {}
+    // #6765: an id verified against the session's OWN store, or a fresh launch.
+    // Never a bare `--continue` — see `resume_command`'s doc.
+    if let Some(id) = effective_id {
+        args.push("--resume".to_owned());
+        args.push(id.to_owned());
     }
     args
 }
@@ -853,11 +821,10 @@ fn compose_inplace_args(
 /// (#2023 component C).
 ///
 /// Why: the in-place relaunch must use the SAME `--resume <id>`
-/// existence-check → `--continue`/fresh-spawn fallback semantics as the
-/// tmux-pane resume path (#2013) — reusing [`session_id_exists`] /
-/// [`has_prior_conversation`] / [`prepare_managed_config`] directly (via
-/// [`compose_inplace_args`]), rather than re-deriving them, means the two
-/// paths can never silently drift.
+/// existence-check → fresh-spawn fallback semantics as the tmux-pane resume
+/// path (#2013, #6765) — reusing [`session_id_exists`] /
+/// [`prepare_managed_config`] directly (via [`compose_inplace_args`]), rather
+/// than re-deriving them, means the two paths can never silently drift.
 /// What: resolves the `claude` binary (`Err(RuntimeError::BinaryNotFound)` if
 /// missing), provisions/trust-seeds the managed `CLAUDE_CONFIG_DIR` via
 /// [`prepare_managed_config`] (logged under the synthetic session name
@@ -1089,7 +1056,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
         Ok(())
     }
 
-    /// Resume Claude Code with conversation continuity (#1744, #1840, #2013).
+    /// Resume Claude Code with conversation continuity (#1744, #2013, #6765).
     ///
     /// Why: `resume_managed` must restore the prior conversation rather than
     /// starting fresh. If the stored `claude_session_id` is available AND
@@ -1097,15 +1064,14 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     /// [`session_id_exists`], #2013), `--resume <id>` restores the exact
     /// conversation. A stale id (the session was pruned, moved, or never
     /// reached disk) is NOT passed to `--resume` — `claude --resume <missing>`
-    /// fails hard with no recovery — instead it is treated like "no id" and
-    /// falls back to the existing #1840 semantics: `--continue` when prior
-    /// conversation history is detected (via [`has_prior_conversation`]), else
-    /// a plain spawn, avoiding the "No conversation found to continue" error
-    /// that would otherwise drop the session to a bare shell.
+    /// fails hard with no recovery — instead the pane launches FRESH. #6765:
+    /// there is no `--continue` fallback; the target is resolved explicitly or
+    /// not at all, so the decision never depends on which conversation the
+    /// managed store happens to consider "most recent".
     /// What: resolves the claude binary, provisions + trust-seeds the tm-owned
     /// `CLAUDE_CONFIG_DIR` via [`prepare_managed_config`], existence-checks
-    /// `claude_session_id` against the resolved config dir, falls back when it
-    /// is missing, checks for prior conversation when no usable id remains,
+    /// `claude_session_id` against the resolved config dir, falls back to a
+    /// fresh launch when it is missing,
     /// builds the PM system-prompt file via [`build_prompt_file`] (#2230 —
     /// same carrier `spawn` uses, previously missing from every resume path),
     /// resolves an optional `CLAUDE_CODE_OAUTH_TOKEN` via
@@ -1120,6 +1086,7 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
     /// send, preserving prior behavior for that case.
     /// Test: `spawn_resume_with_id_uses_resume_flag`,
     /// `spawn_resume_without_id_no_prior_conv_sends_plain_spawn`,
+    /// `spawn_resume_never_sends_bare_continue`,
     /// `spawn_resume_sends_prompt_file_when_binary_available`,
     /// `spawn_resume_sends_oauth_token_when_available`,
     /// `spawn_resume_targets_stored_pane_id_when_known`,
@@ -1186,14 +1153,8 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
                  Stopped within ~60 s (#1744)"
             );
         }
-        // #1840: only use --continue when prior conversation history exists for cwd.
-        // Without this guard, --continue fails with "No conversation found" for
-        // sessions that were stopped before claude ever ran (e.g. provisioning error,
-        // or a fresh worktree that was never used).
-        // Compute file_history separately so the debug log reflects the actual
-        // filesystem check result rather than the combined (id || file) value.
-        let file_history = effective_id.is_none() && has_prior_conversation(cwd);
-        let prior = effective_id.is_some() || file_history;
+        // #6765: no `--continue` fallback — a usable id resumes by id, anything
+        // else launches fresh.
         debug!(
             session = %tmux_name,
             pane_id = pane_id.unwrap_or("<none>"),
@@ -1201,7 +1162,6 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             task = %task,
             claude = %claude_bin,
             resume = effective_id.is_some(),
-            has_prior_conv = file_history, // reflects actual .jsonl file check, not the combined value
             "resuming claude-code in tmux pane"
         );
         let cmd = resume_command(
@@ -1213,7 +1173,6 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
             &crate::core::spawn_disclaim::disclaim_pane_command(&claude_bin),
             config_dir.as_deref(),
             effective_id,
-            prior,
             session_id,
             prompt_file.as_deref(),
             oauth_token.as_deref(),

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -724,7 +724,7 @@ fn prepare_managed_config(tmux_name: &str, cwd: &Path) -> Option<std::path::Path
 /// exactly what the caller (the `tm` CLI binary) needs to construct that
 /// [`std::process::Command`] itself.
 /// What: `claude_bin` (resolved absolute path), `args` (the isolation flags
-/// plus `--resume <id>`/`--continue`/neither, mirroring [`resume_command`]'s
+/// plus `--resume <id>` or neither, mirroring [`resume_command`]'s
 /// selection — see [`compose_inplace_args`]), `config_dir` (the tm-owned
 /// `CLAUDE_CONFIG_DIR`, when resolved), and `oauth_token` (issue #2246 — the
 /// resolved [`crate::core::oauth_token::resolve_oauth_token`] value, when
@@ -737,7 +737,7 @@ fn prepare_managed_config(tmux_name: &str, cwd: &Path) -> Option<std::path::Path
 pub struct InPlaceResumeCommand {
     /// Resolved `claude` binary (absolute path).
     pub claude_bin: String,
-    /// Full argv (isolation flags + resume/continue selection), EXCLUDING the
+    /// Full argv (isolation flags + resume-or-fresh selection), EXCLUDING the
     /// binary itself.
     pub args: Vec<String>,
     /// The tm-owned `CLAUDE_CONFIG_DIR`, when resolved (`None` when home is

--- a/crates/trusty-mpm/src/runtime/claude_code_gh_env_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_gh_env_tests.rs
@@ -236,7 +236,6 @@ fn resume_command_sources_gh_env_file_before_env_invocation() {
         "claude",
         None,
         None,
-        false,
         TEST_SESSION_ID,
         None,
         None,

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -219,7 +219,6 @@ fn resume_command_loads_the_user_tier_when_config_dir_is_relocated() {
             "/home/bob/.trusty-tools/trusty-mpm/claude-config",
         )),
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -403,7 +402,6 @@ fn resume_command_scrubs_inherited_session_markers() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -564,7 +562,6 @@ fn resume_command_sets_oauth_token_when_available() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         Some("sk-ant-oat01-fake-token"),
@@ -588,7 +585,6 @@ fn resume_command_omits_oauth_token_when_absent() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -611,7 +607,6 @@ fn resume_command_without_token_pins_the_exact_command() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -686,7 +681,6 @@ fn resume_command_defaults_the_alternate_screen_off() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -732,7 +726,6 @@ fn env_bin_prefix_quotes_config_dir_with_space() {
         "claude",
         Some(dir),
         None,
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -1121,7 +1114,6 @@ fn resume_command_with_id_uses_resume_flag() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -1153,7 +1145,6 @@ fn resume_command_exports_managed_session_id() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -1189,7 +1180,6 @@ fn resume_command_sets_claude_config_dir() {
         "claude",
         Some(dir),
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -1212,16 +1202,21 @@ fn resume_command_sets_claude_config_dir() {
 }
 
 #[test]
-fn resume_command_without_id_with_prior_conv_uses_continue() {
-    // Why (#1744 / #1840): when no claude_session_id is stored but prior
-    // conversation history exists, --continue resumes the most-recent
-    // conversation in the workspace rather than starting fresh.
+fn resume_command_without_id_never_uses_continue() {
+    // Why (#6765): this test replaces
+    // `resume_command_without_id_with_prior_conv_uses_continue`, which asserted
+    // the OPPOSITE — that a missing id falls back to `--continue`. The command
+    // exports the managed `CLAUDE_CONFIG_DIR`, so `--continue` resolved against
+    // a store the caller never inspected and could attach (or fail to attach)
+    // to an unrelated conversation. With no id there is no safe target: launch
+    // fresh.
     let cmd = resume_command(
         Path::new(TEST_CWD),
         "claude",
+        Some(Path::new(
+            "/home/bob/.trusty-tools/trusty-mpm/claude-config",
+        )),
         None,
-        None,
-        true,
         TEST_SESSION_ID,
         None,
         None,
@@ -1229,8 +1224,8 @@ fn resume_command_without_id_with_prior_conv_uses_continue() {
         &[],
     );
     assert!(
-        cmd.contains("--continue"),
-        "resume command without id + prior conv must use --continue: {cmd}"
+        !cmd.contains("--continue"),
+        "resume command without id must NEVER use --continue: {cmd}"
     );
     assert!(
         !cmd.contains("--resume"),
@@ -1248,7 +1243,6 @@ fn resume_command_without_id_no_prior_conv_uses_plain_spawn() {
         "claude",
         None,
         None,
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -1269,45 +1263,12 @@ fn resume_command_without_id_no_prior_conv_uses_plain_spawn() {
     );
 }
 
-#[test]
-fn has_prior_conversation_returns_false_for_fresh_workspace() {
-    // Why (#1840): a fresh worktree has no Claude conversation history;
-    // has_prior_conversation must return false to avoid "No conversation found".
-    // Uses has_prior_conversation_in with a temp projects_dir — no HOME env
-    // mutation, making this test safe for parallel execution.
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let projects_dir = tmp.path().join("projects");
-    // projects_dir does not exist → always returns false.
-    assert!(
-        !has_prior_conversation_in(tmp.path(), &projects_dir),
-        "no projects dir → false"
-    );
-    // Create the projects dir but with no entry for this workspace → still false.
-    std::fs::create_dir_all(&projects_dir).unwrap();
-    assert!(
-        !has_prior_conversation_in(tmp.path(), &projects_dir),
-        "projects dir exists but no entry for this workspace → false"
-    );
-}
-
-#[test]
-fn has_prior_conversation_returns_true_when_jsonl_exists() {
-    // Why (#1840): verify the positive path — a workspace with a .jsonl file
-    // in its encoded project dir must return true.
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let cwd = tmp.path().join("my-workspace");
-    std::fs::create_dir_all(&cwd).unwrap();
-    let projects_dir = tmp.path().join("projects");
-    // Encode the cwd path as Claude does: replace '/' with '-'.
-    let encoded = cwd.to_string_lossy().replace('/', "-");
-    let project_dir = projects_dir.join(&encoded);
-    std::fs::create_dir_all(&project_dir).unwrap();
-    std::fs::write(project_dir.join("session.jsonl"), "{}").unwrap();
-    assert!(
-        has_prior_conversation_in(&cwd, &projects_dir),
-        "workspace with .jsonl must return true"
-    );
-}
+// #6765: `has_prior_conversation_returns_false_for_fresh_workspace` and
+// `has_prior_conversation_returns_true_when_jsonl_exists` were deleted with the
+// functions they covered. The `--continue` branch they gated is gone from both
+// relaunch paths, so there is no eligibility question left to answer; what
+// replaced them is `session_id_exists_*` (which reads the session's OWN store)
+// plus the two `#6765` never-a-bare-continue tests at the end of this file.
 
 #[serial_test::serial]
 #[test]
@@ -1697,7 +1658,6 @@ fn spawn_resume_without_id_no_prior_conv_sends_plain_spawn() {
         "__fake_claude__",
         None,
         None,
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -1789,7 +1749,6 @@ fn resume_command_prefixes_cd_to_workdir() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -1851,7 +1810,6 @@ fn resume_command_prints_relaunch_hint_after_claude_exits() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         None,
         None,
@@ -1881,7 +1839,6 @@ fn resume_command_with_prompt_file_contains_flag() {
         "claude",
         None,
         Some("abc-123"),
-        false,
         TEST_SESSION_ID,
         Some(path),
         None,
@@ -1947,34 +1904,12 @@ fn compose_inplace_args_falls_back_for_missing_id() {
     );
 }
 
-#[serial_test::serial]
-#[test]
-fn compose_inplace_args_uses_continue_when_no_id_but_prior_conv() {
-    // has_prior_conversation (unlike session_id_exists) always looks under
-    // `~/.claude/projects` regardless of `config_dir` — mirroring exactly
-    // what `resume_command`'s own `has_prior_conv` computation does — so
-    // this test redirects $HOME rather than seeding under a config dir.
-    let _home = HomeGuard::set();
-    let home = dirs::home_dir().expect("home resolves under redirected HOME");
-    let cwd = std::path::PathBuf::from("/tmp/inplace-continue-test");
-    // Seed prior conversation history (a .jsonl under the encoded cwd dir)
-    // WITHOUT seeding the specific stale id, so has_prior_conversation is
-    // true but session_id_exists for "stale-id" is false.
-    let encoded = cwd.to_string_lossy().replace('/', "-");
-    let project_dir = home.join(".claude").join("projects").join(&encoded);
-    std::fs::create_dir_all(&project_dir).unwrap();
-    std::fs::write(project_dir.join("some-other-session.jsonl"), "{}").unwrap();
-
-    let args = compose_inplace_args(&cwd, None, Some("stale-id"), None);
-    assert!(
-        !args.contains(&"--resume".to_owned()),
-        "a stale id must not be passed to --resume: {args:?}"
-    );
-    assert!(
-        args.contains(&"--continue".to_owned()),
-        "prior conversation history exists: must fall back to --continue: {args:?}"
-    );
-}
+// #6765: `compose_inplace_args_uses_continue_when_no_id_but_prior_conv` was
+// deleted — it asserted the defect. It seeded `~/.claude/projects` (the
+// OPERATOR store) and required `--continue`, while the composed argv runs under
+// the MANAGED `CLAUDE_CONFIG_DIR`. Its replacement,
+// `compose_inplace_args_never_continues_from_home_store`, seeds the same wrong
+// store and requires a fresh launch instead.
 
 #[test]
 fn compose_inplace_args_carries_prompt_file_unquoted() {
@@ -2400,4 +2335,108 @@ fn prepare_managed_config_writes_no_mcp_json_and_no_approval() {
             "{name} must be declared in user scope: {servers:?}"
         );
     }
+}
+
+// ── #6765: a managed relaunch never emits a bare `--continue` ───────────
+
+#[serial_test::serial]
+#[test]
+fn compose_inplace_args_never_continues_from_home_store() {
+    // Why (#6765): the in-place relaunch exports the MANAGED
+    // `CLAUDE_CONFIG_DIR`, so `claude --continue` resolves "most recent
+    // conversation" against `<config_dir>/projects`, NOT `~/.claude/projects`.
+    // The old eligibility check read `~/.claude/projects` — always populated on
+    // an operator machine — so `--continue` fired unconditionally and attached
+    // to whatever the managed store held most recently. In the reported case
+    // that was a live `claude agents` daemon, which refused the second attach
+    // and exited 0, dropping the pane to a bare shell.
+    //
+    // With no usable id the only safe selection is a FRESH launch: never a bare
+    // `--continue`, whatever `~/.claude` happens to contain.
+    let _home = HomeGuard::set();
+    let home = dirs::home_dir().expect("home resolves under redirected HOME");
+    let cwd = std::path::PathBuf::from("/tmp/inplace-6765-test");
+    let encoded = cwd.to_string_lossy().replace('/', "-");
+    // Populate the OPERATOR store (the wrong one) with prior history.
+    let home_project_dir = home.join(".claude").join("projects").join(&encoded);
+    std::fs::create_dir_all(&home_project_dir).unwrap();
+    std::fs::write(home_project_dir.join("some-other-session.jsonl"), "{}").unwrap();
+    // The managed store the spawned process will actually read stays empty.
+    let config_dir = home.join("managed-config-6765");
+    std::fs::create_dir_all(config_dir.join("projects")).unwrap();
+
+    // (a) a null claude_session_id starts fresh — neither flag.
+    let args = compose_inplace_args(&cwd, Some(&config_dir), None, None);
+    assert!(
+        !args.contains(&"--continue".to_owned()),
+        "a null claude_session_id must never emit a bare --continue: {args:?}"
+    );
+    assert!(
+        !args.contains(&"--resume".to_owned()),
+        "a null claude_session_id must not emit --resume either: {args:?}"
+    );
+
+    // (b) an id absent from the session's OWN store also starts fresh.
+    let args = compose_inplace_args(&cwd, Some(&config_dir), Some("stale-id-6765"), None);
+    assert!(
+        !args.contains(&"--continue".to_owned()),
+        "a stale id must fall back to a fresh launch, not --continue: {args:?}"
+    );
+    assert!(
+        !args.contains(&"--resume".to_owned()),
+        "a stale id must not be passed to --resume: {args:?}"
+    );
+
+    // (c) an id that DOES exist in the session's own store still resumes by id.
+    let managed_project_dir = config_dir.join("projects").join(&encoded);
+    std::fs::create_dir_all(&managed_project_dir).unwrap();
+    std::fs::write(managed_project_dir.join("live-id-6765.jsonl"), "{}").unwrap();
+    let args = compose_inplace_args(&cwd, Some(&config_dir), Some("live-id-6765"), None);
+    assert!(
+        args.windows(2).any(|w| w == ["--resume", "live-id-6765"]),
+        "an id present in the session's own store must resume by id: {args:?}"
+    );
+    assert!(
+        !args.contains(&"--continue".to_owned()),
+        "--resume must never be paired with --continue: {args:?}"
+    );
+}
+
+#[serial_test::serial]
+#[test]
+fn spawn_resume_never_sends_bare_continue() {
+    // Why (#6765): the tmux-pane relaunch half of the same defect. The pane
+    // command exports the managed `CLAUDE_CONFIG_DIR`, so a bare `--continue`
+    // resolves against the managed store while eligibility was decided from
+    // `~/.claude/projects`. A record with `claude_session_id: null` must
+    // produce a plain spawn even when the operator's home store is full of
+    // transcripts for the same cwd.
+    let _home = HomeGuard::set();
+    let home = dirs::home_dir().expect("home resolves under redirected HOME");
+    let cwd = std::path::PathBuf::from("/tmp/tmux-6765-test");
+    let encoded = cwd.to_string_lossy().replace('/', "-");
+    let home_project_dir = home.join(".claude").join("projects").join(&encoded);
+    std::fs::create_dir_all(&home_project_dir).unwrap();
+    std::fs::write(home_project_dir.join("some-other-session.jsonl"), "{}").unwrap();
+
+    let Some(_claude_bin) = ClaudeCodeAdapter::resolve_claude() else {
+        return; // adapter path needs the real binary; the pure test above does not
+    };
+    let fake = FakeTmux::new();
+    let adapter = ClaudeCodeAdapter::new(fake.clone());
+    adapter
+        .spawn_resume("tmpm-6765", None, &cwd, "task", None, TEST_SESSION_ID, &[])
+        .expect("spawn_resume with a null claude_session_id");
+    let sends = fake.sends.lock().unwrap();
+    assert_eq!(sends.len(), 1);
+    assert!(
+        !sends[0].1.contains("--continue"),
+        "a null claude_session_id must never emit a bare --continue: {}",
+        sends[0].1
+    );
+    assert!(
+        !sends[0].1.contains("--resume"),
+        "a null claude_session_id must not emit --resume either: {}",
+        sends[0].1
+    );
 }

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -109,8 +109,9 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Why (#1744): when resuming a managed session that exited ungracefully
     /// (tmux pane killed, terminal closed without `/quit`), the operator wants
     /// the prior conversation restored. Passing `--resume <claude_session_id>`
-    /// restores the exact Claude Code conversation; `--continue` resumes the
-    /// most-recent one when the id is unknown; plain `spawn` starts fresh.
+    /// restores the exact Claude Code conversation; an unknown or stale id
+    /// starts fresh (#6765 removed the `--continue` fallback, which resolved
+    /// against the managed store rather than the intended conversation).
     /// The default implementation delegates to [`Self::spawn`] (no resume flag),
     /// which is correct for the `tcode` adapter and any other runtime that does
     /// not support conversation continuity.

--- a/crates/trusty-mpm/src/session_manager/hook_sync.rs
+++ b/crates/trusty-mpm/src/session_manager/hook_sync.rs
@@ -26,8 +26,8 @@ impl SessionManager {
     /// UUID via `CLAUDE_SESSION_ID`. Persisting it lets `resume` pass
     /// `--resume <id>` to the new `claude` process, restoring the prior
     /// conversation even after an ungraceful exit (terminal kill, tmux pane
-    /// closed without `/quit`). Without this id, resume falls back to
-    /// `--continue` (most-recent conversation) or a fresh launch.
+    /// closed without `/quit`). Without this id, resume launches FRESH — #6765
+    /// removed the `--continue` fallback.
     /// What: looks up the record, sets `claude_session_id`, and persists.
     /// No tmux I/O — the hook handler calls this after correlating the
     /// `SessionStart` event to the right managed session.

--- a/crates/trusty-mpm/src/session_manager/record.rs
+++ b/crates/trusty-mpm/src/session_manager/record.rs
@@ -405,8 +405,9 @@ pub struct SessionRecord {
     /// conversation by passing `--resume <id>` to the new `claude` process.
     /// This field holds the UUID that Claude Code assigns to its own session,
     /// delivered via the `CLAUDE_SESSION_ID` env var and forwarded through the
-    /// `SessionStart` hook. Without it, resume falls back to `--continue`
-    /// (most-recent conversation in the workspace) or a fresh launch.
+    /// `SessionStart` hook. Without it, resume launches FRESH — #6765 removed
+    /// the `--continue` fallback, which resolved against the managed store
+    /// rather than the conversation the caller meant.
     ///
     /// `#[serde(default)]` keeps records persisted before this field existed
     /// deserializable — they load with `claude_session_id = None`, which is


### PR DESCRIPTION
Refs #6765

## The defect

`tm`'s managed-session relaunch emitted a bare `claude --continue` decided against the **wrong conversation store**.

- `has_prior_conversation` hardcoded `~/.claude/projects/<encoded-cwd>` — the operator's store, populated on any real machine — so the check returned `true` and the `--continue` arm always fired.
- The command it built exports `CLAUDE_CONFIG_DIR=<managed>/claude-config`, so the spawned `claude` resolved "most recent conversation" against `<config_dir>/projects` instead. The check answered for one store; the flag acted on another.
- When that store's newest conversation was a still-live `claude agents` background daemon, Claude Code refused to double-attach, printed `Your most recent conversation is running in the background (session <uuid>)…`, and exited 0 — leaving the pane at a bare shell.
- The `--resume <id>` arm never ran: the registry record carried `claude_session_id: null`.
- Archiving the offending job's on-disk `jobs/*/state.json` did **not** stop the recurrence — the refusal comes from the live daemon process, not the record.

## The fix

Resolve the relaunch target **explicitly**, on both paths:

1. `claude_session_id` present **and** verified to exist in that session's OWN store (`session_id_exists`, which already resolves through `projects_dir_for(config_dir)`) → `--resume <id>`.
2. Otherwise → launch fresh. No `--continue`, ever.

That is the load-bearing half: it makes the decision independent of Claude Code's undocumented background-job layout, so nothing here relies on knowing which conversation the managed store considers "most recent" or whether it is attachable.

The secondary half — "consult the store the spawned process will actually use" — resolves itself. With no `--continue` arm, `has_prior_conversation` / `has_prior_conversation_in` had **no remaining caller**, so they are **deleted** rather than repointed at `config_dir`: threading `config_dir` through would only have made a dead check correct. `session_id_exists`, which already reads the right store, is now the only conversation-store lookup either relaunch path makes.

## Diff by file

| File | Change |
|---|---|
| `crates/trusty-mpm/src/runtime/claude_code.rs` | `resume_command` drops the `has_prior_conv` parameter and the `--continue` arm (tmux pane); `compose_inplace_args` drops its `--continue` arm (in-place exec); `has_prior_conversation` + `has_prior_conversation_in` deleted; `spawn_resume` drops the now-dead `file_history` / `prior` computation and the `has_prior_conv` debug field; doc comments across the module updated |
| `crates/trusty-mpm/src/runtime/claude_code_tests.rs` | Two new `#6765` regression tests; `..._uses_continue_when_no_id_but_prior_conv` and `resume_command_without_id_with_prior_conv_uses_continue` replaced (they asserted the defect); the two `has_prior_conversation_*` unit tests deleted with the functions; 14 `resume_command` call sites drop the removed argument |
| `crates/trusty-mpm/src/runtime/claude_code_gh_env_tests.rs` | 1 `resume_command` call site drops the removed argument |
| `crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs` | Verbatim-forwarding sample argv uses `--resume abc-123` instead of a `--continue` the composer can no longer emit |
| `crates/trusty-mpm/src/runtime/mod.rs`, `src/session_manager/record.rs`, `src/session_manager/hook_sync.rs`, `src/daemon/managed_routes/lifecycle.rs`, `src/bin/tm/commands/guided_inplace.rs`, `src/core/session_launch/settings.rs` | Doc/comment only — the "falls back to `--continue`" contract these described is gone |
| `crates/trusty-mpm/changelog.d/6765-no-bare-continue-on-relaunch.md` | New fragment (`Fixed`) |

## Regression test — before

Both new tests were written and run **against the pre-fix source**:

```
running 2 tests
test runtime::claude_code::tests::compose_inplace_args_never_continues_from_home_store ...
thread '...' panicked at crates/trusty-mpm/src/runtime/claude_code_tests.rs:2435:5:
a null claude_session_id must never emit a bare --continue: ["--setting-sources", "user,project,local", "--dangerously-skip-permissions", "--continue"]
FAILED

test runtime::claude_code::tests::spawn_resume_never_sends_bare_continue ...
thread '...' panicked at crates/trusty-mpm/src/runtime/claude_code_tests.rs:2497:5:
a null claude_session_id must never emit a bare --continue: cd '/tmp/tmux-6765-test' && { export TM_MANAGED_SESSION_ID='...'; env -u ANTHROPIC_API_KEY ... CLAUDE_CONFIG_DIR='/var/folders/.../.trusty-tools/trusty-mpm/claude-config' ... /Users/masa/.local/bin/claude --append-system-prompt-file '...' --setting-sources user,project,local --dangerously-skip-permissions --continue; echo 'tm: run `tm` to relaunch this session'; }
FAILED

failures:
    runtime::claude_code::tests::compose_inplace_args_never_continues_from_home_store
    runtime::claude_code::tests::spawn_resume_never_sends_bare_continue

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 5887 filtered out
```

The second panic message is the whole bug in one line: `CLAUDE_CONFIG_DIR='…/claude-config'` and `--continue` in the same command, with the eligibility for that flag having been read from `~/.claude`.

## Regression test — after

```
$ cargo test -p trusty-mpm --lib --no-fail-fast -- never_continues_from_home_store never_sends_bare_continue resume_command_without_id --test-threads=1

running 4 tests
test runtime::claude_code::tests::compose_inplace_args_never_continues_from_home_store ... ok
test runtime::claude_code::tests::resume_command_without_id_never_uses_continue ... ok
test runtime::claude_code::tests::resume_command_without_id_no_prior_conv_uses_plain_spawn ... ok
test runtime::claude_code::tests::spawn_resume_never_sends_bare_continue ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 5882 filtered out; finished in 0.38s
```

`compose_inplace_args_never_continues_from_home_store` pins all three arms in one hermetic test (no `claude` binary needed): null id → neither flag; id absent from the session's own store → neither flag; id present in the session's own store → `--resume <id>` and no `--continue`.

## Rung 3 — localized behavior inside one crate

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo check -p trusty-mpm --all-targets` | clean |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | clean |
| `cargo test -p trusty-mpm --no-fail-fast` | **54 targets, 10410 passed, 0 failed, 19 ignored** |

Doc gates (a doc comment changed): `check_line_cap.sh` — 4460 files measured, 0 violations. `check_changelog_fragment.sh` — 11 changed paths scanned, 7 crate-source paths attributed, fragment present and valid. `check_test_pointers.sh` — 30399 `Test:` citations resolved, 0 dangling. `check_sld.sh` — 0 errors, 0 warnings.

Rung 3 and not 4: the change is confined to `trusty-mpm`; `resume_command` and `compose_inplace_args` are private to `runtime::claude_code` and `session_id_exists` is `pub(crate)`, so no public API moved and no other crate can observe the change.

## Out of scope

The `;`-sequenced on-exit hint and the fire-and-forget `send_line` are #6766 and ship separately. No running process on the host was touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
