### PR TITLE
docs(cargo-publish): the tga tag to push is trusty-git-analytics-v<version>, never tga-v*

### DIFF
--- a/.claude/skills/cargo-publish/SKILL.md
+++ b/.claude/skills/cargo-publish/SKILL.md
@@ -459,22 +459,29 @@ If 404 after 120s, something went wrong. Check:
 cargo search <crate> --limit 1
 ```
 
-## Tag Pattern: <crate-package-name>-v<version>
+## Tag Pattern: <crate-directory-name>-v<version>
 
-Use the **crate package name** from `Cargo.toml`, NOT the directory name.
+Use the **crate directory name** under `crates/`, NOT the package name from
+`Cargo.toml`. This matches `tag_prefix_for()` in `scripts/check-publish-ready.sh`,
+which derives the prefix from the directory unconditionally.
 
 **Reference: Abbreviations table from CLAUDE.md**:
-- `trusty-git-analytics` → `-p tga` → tag: **`tga-v1.4.2`** ✓
+- `trusty-git-analytics` → `-p tga` → tag: **`trusty-git-analytics-v1.4.2`** ✓
 - `trusty-search` → `-p trusty-search` → tag: **`trusty-search-v0.13.1`** ✓
 - `trusty-common` → `-p trusty-common` → tag: **`trusty-common-v0.8.0`** ✓
 - `trusty-agents` → `-p trusty-agents` → tag: **`trusty-agents-v0.2.3`** ✓
 
-> **tga tag aliases (issue #1128):** the binary-release workflow accepts **both**
-> `tga-v<version>` and `trusty-git-analytics-v<version>` — they resolve to the
-> same build config and Homebrew formula (the parse step canonicalizes the `tga`
-> prefix to `trusty-git-analytics`). The documented form above (`tga-v<version>`,
-> matching the published package name) is preferred; you no longer need a second
-> `trusty-git-analytics-v<version>` tag to trigger a successful binary release.
+> **tga tag aliases (issue #1128) — read alias only, never push both:** the tag
+> to PUSH for `trusty-git-analytics` is **`trusty-git-analytics-v<version>`**,
+> same as every other crate. `check-publish-ready.sh` GUARD 2 and
+> `check-tag-publish-parity.sh` additionally recognize the legacy short form
+> `tga-v<version>` if that is the tag they find on origin, and the binary-release
+> workflow resolves either spelling to the same build config and Homebrew
+> formula. That acceptance exists for compatibility with tags already pushed
+> under the old convention — it is not a second option to choose from. Pushing
+> both spellings for one release risks a TAG-SPLIT
+> (`scripts/check-tag-publish-parity.sh`), which cannot be repaired afterward
+> because release tags here are immutable (#6178).
 
 The crate name **always** comes from the `name` field in `Cargo.toml`:
 

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -3,14 +3,22 @@
 Each crate is tagged independently using the pattern `<crate-name>-v<version>`,
 e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
 
-> **`tga` tag aliases (issue #1128):** `trusty-git-analytics` publishes under the
-> short package name `tga`. The binary-release workflow accepts **both**
-> `tga-v<version>` and `trusty-git-analytics-v<version>` tags — they resolve to
-> the same build config and Homebrew formula. The parse step canonicalizes the
-> `tga` prefix to `trusty-git-analytics` for config/path lookups while keeping
-> changelog `--tag-pattern` matched to the literal pushed tag. Either form works;
-> you no longer need to push a second `trusty-git-analytics-v<version>` tag after
-> a `tga-v<version>` push.
+> **`tga` tag aliases (issue #1128) — read alias only, never push both:**
+> `trusty-git-analytics` publishes under the short package name `tga`, but the
+> tag to PUSH is **`trusty-git-analytics-v<version>`**, same as every other
+> crate — `tag_prefix_for()` in `scripts/check-publish-ready.sh` derives the
+> prefix from the crate directory name unconditionally, and the legacy short
+> form `tga-v<version>` is not what it generates or recommends. The
+> binary-release workflow, `check-publish-ready.sh` GUARD 2, and
+> `check-tag-publish-parity.sh` all still recognize `tga-v<version>` if that is
+> the tag they find on origin (they resolve to the same build config and
+> Homebrew formula, and the parse step canonicalizes the `tga` prefix to
+> `trusty-git-analytics` for config/path lookups while keeping changelog
+> `--tag-pattern` matched to the literal pushed tag) — that acceptance exists
+> for tags already pushed under the old convention, not as a second option to
+> choose from. Push only `trusty-git-analytics-v<version>`; pushing both
+> spellings for one release risks a TAG-SPLIT that cannot be repaired
+> afterward, because release tags here are immutable (#6178).
 
 ## Release Steps
 


### PR DESCRIPTION
The cargo-publish skill's "Tag Pattern" section told publishers to use the crate package name (tga) and marked `tga-v<version>` as the preferred tag, and `docs/reference/release-workflow.md` said either spelling was fine to push — both contradict `tag_prefix_for()` in `scripts/check-publish-ready.sh`, which always derives the tag prefix from the crate directory name (`trusty-git-analytics`), and contradict that file's own comment stating tga tags are `trusty-git-analytics-v*`, never `tga-v*`. `check-publish-ready.sh` GUARD 2 and `check-tag-publish-parity.sh` accept `tga-v<version>` only as a read alias for tags already pushed under the old convention, not as an equally-valid choice going forward, and pushing both spellings for one release risks an unrepairable TAG-SPLIT since release tags here are immutable (#6178). This PR is docs-only: it corrects the skill's "Tag Pattern" section and the release-workflow.md callout to state the tag to push is `trusty-git-analytics-v<version>`, with no script or `.rs` file changes.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools