### PR TITLE
fix(trusty-mpm): encode project dirs the way Claude Code does so managed relaunch can --resume (Refs #6777)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6777-encode-project-dir-dot.md
+++ b/crates/trusty-mpm/changelog.d/6777-encode-project-dir-dot.md
@@ -1,0 +1,20 @@
+Fixed
+- A managed relaunch now finds the session's stored conversation.
+  `encode_project_dir` folded only `/` to `-`, but Claude Code folds every
+  character outside `[A-Za-z0-9]`, so a workspace under `.worktrees/` encoded to
+  `…-.worktrees-<id>` while the directory Claude Code really creates is
+  `…--worktrees-<id>`. Because every tm-provisioned workspace sits under
+  `.worktrees/` or `.claude/worktrees/`, `session_id_exists` returned false for
+  every managed session: `spawn_resume` dropped `--resume <id>` and started a
+  fresh conversation each time, and the SessionStart correlation
+  ([#4337](https://github.com/bobmatnyc/trusty-tools/issues/4337)) judged the
+  stored id stale and overwrote it on every launch. This also made the
+  [#6765](https://github.com/bobmatnyc/trusty-tools/issues/6765) relaunch fix
+  unreachable in practice — that change resolves the target explicitly via
+  `--resume <id>`, and the id never resolved
+  ([#6777](https://github.com/bobmatnyc/trusty-tools/issues/6777)).
+- The encoder now reproduces Claude Code's `sanitizePath` in full: it folds the
+  whole `[^A-Za-z0-9]` class, counts UTF-16 code units (one astral character
+  yields two dashes), and truncates past 200 characters to `<200 chars>-<base36
+  of the int32 path hash>`. tm's own managed worktree paths already reach 188
+  characters, so the truncation branch is reachable, not theoretical.

--- a/crates/trusty-mpm/src/core/project_discovery.rs
+++ b/crates/trusty-mpm/src/core/project_discovery.rs
@@ -128,10 +128,18 @@ fn scan_sessions(dir: &Path) -> (usize, Option<SystemTime>) {
 
 /// Decode a Claude Code projects directory name back into a filesystem path.
 ///
-/// Why: Claude Code encodes a project's absolute path by replacing every `/`
-/// with `-`. Because real directory names may *also* contain `-`, a blind
-/// "replace all `-` with `/`" can produce a path that does not exist; the
-/// decoder must verify the result and fall back to a smarter search.
+/// Why: Claude Code encodes a project's absolute path by replacing every
+/// character outside `[A-Za-z0-9]` with `-` (#6777 — not `/` alone, as this
+/// doc used to say). Because real directory names may *also* contain `-`, a
+/// blind "replace all `-` with `/`" can produce a path that does not exist;
+/// the decoder must verify the result and fall back to a smarter search.
+///
+/// // #6777: the greedy walk below only ever re-attaches a segment with a
+/// literal `-`, so it cannot reconstruct a `.`-prefixed component such as
+/// `.worktrees`. Decoding is best-effort and lossy by construction (the
+/// encoding is not injective); widening the candidate set is a separate
+/// change. `encode_project_dir` in `runtime::claude_code` is the exact
+/// forward direction and is the one used for every store lookup.
 /// What: the directory name begins with `-` (the leading `/`). First tries the
 /// simple decoding (all `-` → `/`) and returns it if that path exists. Otherwise
 /// walks the segments greedily: starting from `/`, it joins segments one at a

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1854,9 +1854,17 @@ impl Drop for HomeGuard {
 ///
 /// What: `<home>/.trusty-tools/trusty-mpm/claude-config/projects/<encoded
 /// cwd>/<id>.jsonl`, mirroring `managed_claude_config_dir` +
-/// `encode_project_dir`'s `/` → `-` encoding.
+/// `encode_project_dir`'s `[^A-Za-z0-9]` → `-` encoding. Every caller passes a
+/// cwd made only of `/` and alphanumerics, so the local fold below matches
+/// (#6777 — a cwd with a `.` in it would need the real encoder, which is
+/// private to `runtime::claude_code`).
 fn seed_fake_transcript(home: &std::path::Path, cwd: &std::path::Path, id: &str) {
-    let encoded = cwd.to_str().expect("utf8 cwd").replace('/', "-");
+    let encoded: String = cwd
+        .to_str()
+        .expect("utf8 cwd")
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
     let dir = home
         .join(".trusty-tools")
         .join("trusty-mpm")

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1854,17 +1854,10 @@ impl Drop for HomeGuard {
 ///
 /// What: `<home>/.trusty-tools/trusty-mpm/claude-config/projects/<encoded
 /// cwd>/<id>.jsonl`, mirroring `managed_claude_config_dir` +
-/// `encode_project_dir`'s `[^A-Za-z0-9]` → `-` encoding. Every caller passes a
-/// cwd made only of `/` and alphanumerics, so the local fold below matches
-/// (#6777 — a cwd with a `.` in it would need the real encoder, which is
-/// private to `runtime::claude_code`).
+/// [`crate::runtime::encode_project_dir`] — the one encoder the check under
+/// test uses, so this fixture cannot disagree with it (#6777).
 fn seed_fake_transcript(home: &std::path::Path, cwd: &std::path::Path, id: &str) {
-    let encoded: String = cwd
-        .to_str()
-        .expect("utf8 cwd")
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect();
+    let encoded = crate::runtime::encode_project_dir(cwd);
     let dir = home
         .join(".trusty-tools")
         .join("trusty-mpm")

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -512,21 +512,99 @@ fn resume_command(
     cd_and_group(cwd, &body)
 }
 
+/// Length at which Claude Code truncates a project key and appends a path hash
+/// (its `MAX_SANITIZED_LENGTH`). Verified live: a 370-character cwd produced a
+/// 207-character directory name — 200 kept characters, `-`, then the hash.
+const MAX_PROJECT_KEY_LEN: usize = 200;
+
 /// Encode a workspace path the same way Claude Code names its project dir.
 ///
 /// Why: every on-disk lookup against a Claude Code session store — today only
 /// the `--resume <id>`-existence check ([`session_id_exists_in`]) — must derive
 /// the SAME project directory name for a given `cwd`. Sharing one helper makes
 /// two callers computing the encoding differently impossible.
-/// What: replaces every `/` in the path with `-` (Claude Code's project-dir
-/// naming scheme). A leading `/` becomes `-`, so `/private/tmp/foo` →
-/// `-private-tmp-foo`.
+///
+/// What: folds every character outside `[A-Za-z0-9]` to `-`, counting UTF-16
+/// code units rather than Rust `char`s, then truncates to
+/// [`MAX_PROJECT_KEY_LEN`] plus `-<base36 hash>` when the result is longer.
+/// Uppercase is preserved; `/`, `.`, `_`, space, `@`, `+`, `~`, quotes,
+/// brackets and every non-ASCII character all become `-`. So
+/// `/private/tmp/foo` → `-private-tmp-foo`, and
+/// `/repo/.worktrees/w1` → `-repo--worktrees-w1`.
+///
+/// // #6777: this used to fold `/` alone, so every path segment starting with
+/// a dot encoded one character short of the real directory name. Rule
+/// re-derived from Claude Code 2.1.260's `sanitizePath`
+/// (`s.replace(/[^a-zA-Z0-9]/g, "-")`, then `slice(0,200) + "-" + base36`) and
+/// confirmed against live probe runs — see the doc on [`js_path_hash`] for the
+/// hash half.
+///
 /// Test: `encode_project_dir_replaces_slashes`,
-/// `session_id_exists_true_for_real_jsonl_file`,
-/// `session_id_exists_finds_hardcoded_dir_name_for_known_cwd` (non-circular
-/// regression guard against encoding-scheme drift).
+/// `encode_project_dir_folds_dot_in_worktrees_path`,
+/// `encode_project_dir_folds_every_non_alphanumeric`,
+/// `encode_project_dir_folds_astral_char_to_two_dashes`,
+/// `encode_project_dir_truncates_and_hashes_a_long_path`,
+/// `session_id_exists_finds_hardcoded_dir_name_for_dotted_cwd` (non-circular
+/// regression guards against encoding-scheme drift).
 fn encode_project_dir(cwd: &Path) -> String {
-    cwd.to_string_lossy().replace('/', "-")
+    let path = cwd.to_string_lossy();
+    let mut key = String::with_capacity(path.len());
+    for c in path.chars() {
+        if c.is_ascii_alphanumeric() {
+            key.push(c);
+        } else {
+            // JavaScript's `String.prototype.replace` walks UTF-16 code units,
+            // so one astral `char` (a surrogate pair) yields TWO dashes.
+            for _ in 0..c.len_utf16() {
+                key.push('-');
+            }
+        }
+    }
+    if key.len() <= MAX_PROJECT_KEY_LEN {
+        return key;
+    }
+    // `key` is pure ASCII here, so a byte truncation is a character truncation.
+    key.truncate(MAX_PROJECT_KEY_LEN);
+    key.push('-');
+    key.push_str(&to_base36(js_path_hash(&path).unsigned_abs()));
+    key
+}
+
+/// Claude Code's 32-bit path hash, used only for the over-length key suffix.
+///
+/// Why: an over-length project key ends in `-<base36 of abs(hash)>`, so
+/// reproducing the directory name for a deep worktree requires the exact same
+/// hash. tm's own managed worktree paths already reach 188 characters, so this
+/// branch is reachable, not theoretical.
+/// What: ports `h = (h << 5) - h + unit | 0` over the path's UTF-16 code units.
+/// Every JS step truncates to int32, which is wrapping `i32` arithmetic here.
+/// Test: `encode_project_dir_truncates_and_hashes_a_long_path`.
+fn js_path_hash(path: &str) -> i32 {
+    let mut hash: i32 = 0;
+    for unit in path.encode_utf16() {
+        hash = hash
+            .wrapping_shl(5)
+            .wrapping_sub(hash)
+            .wrapping_add(i32::from(unit));
+    }
+    hash
+}
+
+/// Render `n` in lowercase base 36, matching JavaScript's `Number#toString(36)`.
+///
+/// Test: `encode_project_dir_truncates_and_hashes_a_long_path`.
+fn to_base36(mut n: u32) -> String {
+    const DIGITS: &[u8; 36] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    if n == 0 {
+        return "0".to_string();
+    }
+    let mut out = Vec::new();
+    while n > 0 {
+        out.push(DIGITS[(n % 36) as usize]);
+        n /= 36;
+    }
+    out.reverse();
+    out.into_iter().map(char::from).collect()
 }
 
 // #6765: `has_prior_conversation` / `has_prior_conversation_in` used to live
@@ -573,7 +651,8 @@ fn projects_dir_for(config_dir: Option<&Path>) -> Option<std::path::PathBuf> {
 /// What: best-effort filesystem check — `true` only when
 /// `<projects_dir>/<encoded-cwd>/<id>.jsonl` exists as a regular file, where
 /// `projects_dir` is resolved via [`projects_dir_for`] and the cwd is encoded
-/// via the shared [`encode_project_dir`] helper (every `/` becomes `-`).
+/// via the shared [`encode_project_dir`] helper (every character outside
+/// `[A-Za-z0-9]` becomes `-`).
 /// #6765: this is now the ONLY conversation-store lookup either relaunch path
 /// makes — it is the check that consults the store the spawned process will
 /// actually use, which is exactly what the deleted `--continue` gate did not.
@@ -602,11 +681,13 @@ pub(crate) fn session_id_exists(cwd: &Path, config_dir: Option<&Path>, id: &str)
 ///
 /// Why: unit tests need to point at a temp directory rather than mutating
 /// `HOME`/`CLAUDE_CONFIG_DIR` process-globals.
-/// What: encodes `cwd` via [`encode_project_dir`] (every `/` → `-`) and checks
-/// `<projects_dir>/<encoded-cwd>/<id>.jsonl` is a regular file.
+/// What: encodes `cwd` via [`encode_project_dir`] (every character outside
+/// `[A-Za-z0-9]` → `-`) and checks `<projects_dir>/<encoded-cwd>/<id>.jsonl` is
+/// a regular file.
 /// Test: `session_id_exists_true_for_real_jsonl_file`,
 /// `session_id_exists_false_for_missing_id`,
-/// `session_id_exists_finds_hardcoded_dir_name_for_known_cwd`.
+/// `session_id_exists_finds_hardcoded_dir_name_for_known_cwd`,
+/// `session_id_exists_finds_hardcoded_dir_name_for_dotted_cwd`.
 fn session_id_exists_in(cwd: &Path, projects_dir: &Path, id: &str) -> bool {
     projects_dir
         .join(encode_project_dir(cwd))

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -544,9 +544,14 @@ const MAX_PROJECT_KEY_LEN: usize = 200;
 /// `encode_project_dir_folds_every_non_alphanumeric`,
 /// `encode_project_dir_folds_astral_char_to_two_dashes`,
 /// `encode_project_dir_truncates_and_hashes_a_long_path`,
-/// `session_id_exists_finds_hardcoded_dir_name_for_dotted_cwd` (non-circular
-/// regression guards against encoding-scheme drift).
-fn encode_project_dir(cwd: &Path) -> String {
+/// `session_id_exists_finds_hardcoded_dir_name_for_dotted_cwd`,
+/// `spawn_resume_uses_resume_flag_for_a_worktree_cwd` (non-circular regression
+/// guards against encoding-scheme drift).
+///
+/// `pub(crate)` (#6777): the daemon's `SessionStart` correlation tests seed
+/// transcripts under this same directory name, and a second hand-rolled fold
+/// there would drift — it did, and it silently omitted the truncation branch.
+pub(crate) fn encode_project_dir(cwd: &Path) -> String {
     let path = cwd.to_string_lossy();
     let mut key = String::with_capacity(path.len());
     for c in path.chars() {

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -1295,7 +1295,7 @@ fn spawn_resume_with_id_uses_resume_flag() {
     let cwd = Path::new("/tmp");
     let config_dir = crate::core::trusty_tools_config::managed_claude_config_dir()
         .expect("config dir resolves under redirected HOME");
-    let encoded = cwd.to_string_lossy().replace('/', "-");
+    let encoded = encode_project_dir(cwd);
     let project_dir = config_dir.join("projects").join(&encoded);
     std::fs::create_dir_all(&project_dir).unwrap();
     std::fs::write(project_dir.join("my-session-id.jsonl"), "{}").unwrap();
@@ -1556,7 +1556,9 @@ fn session_id_exists_true_for_real_jsonl_file() {
     let cwd = tmp.path().join("my-workspace");
     std::fs::create_dir_all(&cwd).unwrap();
     let projects_dir = tmp.path().join("projects");
-    let encoded = cwd.to_string_lossy().replace('/', "-");
+    // #6777: build the fixture through the ONE encoder — a hand-rolled
+    // `replace('/', "-")` here would not fold the `.` in a tempdir's name.
+    let encoded = encode_project_dir(&cwd);
     let project_dir = projects_dir.join(&encoded);
     std::fs::create_dir_all(&project_dir).unwrap();
     std::fs::write(project_dir.join("abc-123.jsonl"), "{}").unwrap();
@@ -1575,7 +1577,9 @@ fn session_id_exists_false_for_missing_id() {
     let cwd = tmp.path().join("my-workspace");
     std::fs::create_dir_all(&cwd).unwrap();
     let projects_dir = tmp.path().join("projects");
-    let encoded = cwd.to_string_lossy().replace('/', "-");
+    // #6777: build the fixture through the ONE encoder — a hand-rolled
+    // `replace('/', "-")` here would not fold the `.` in a tempdir's name.
+    let encoded = encode_project_dir(&cwd);
     let project_dir = projects_dir.join(&encoded);
     std::fs::create_dir_all(&project_dir).unwrap();
     std::fs::write(project_dir.join("other-session.jsonl"), "{}").unwrap();
@@ -1613,16 +1617,135 @@ fn encode_project_dir_replaces_slashes() {
 }
 
 #[test]
+fn encode_project_dir_folds_dot_in_worktrees_path() {
+    // Why (#6777): every tm-provisioned workspace sits under `.worktrees/` or
+    // `.claude/worktrees/`, and Claude Code folds the `.` to `-` exactly as it
+    // folds `/`. Encoding only `/` produced `…-.worktrees-<id>` while the real
+    // directory is `…--worktrees-<id>`, so `session_id_exists` answered false
+    // for every managed session and `--resume` was never passed (#6765).
+    //
+    // Both literals below are transcribed from the LIVE store at
+    // ~/.trusty-tools/trusty-mpm/claude-config/projects/, where 25 directories
+    // matched `--worktrees` and 0 matched `-.worktrees`.
+    assert_eq!(
+        encode_project_dir(Path::new(
+            "/Users/masa/trusty-mpm-projects/bobmatnyc/xflux/.worktrees/tm-xflux-01"
+        )),
+        "-Users-masa-trusty-mpm-projects-bobmatnyc-xflux--worktrees-tm-xflux-01"
+    );
+    assert_eq!(
+        encode_project_dir(Path::new(
+            "/Users/masa/Projects/claude-mpm/.claude/worktrees/agent-a0cdd0670f2217acb"
+        )),
+        "-Users-masa-Projects-claude-mpm--claude-worktrees-agent-a0cdd0670f2217acb"
+    );
+}
+
+#[test]
+fn encode_project_dir_folds_every_non_alphanumeric() {
+    // Why (#6777): the rule is `[^a-zA-Z0-9]` → `-`, not `/` → `-`, so every
+    // punctuation class a real path can carry must fold. Established by a live
+    // probe: `claude` launched in a directory literally named
+    // `a_b c@d+e.f~g'h(i)` created a project dir ending `a-b-c-d-e-f-g-h-i-`.
+    // Case is NOT folded — `/Users`, `/Volumes` and `Projects` all survive
+    // capitalised in the live store.
+    for (raw, expected) in [
+        ("/a.b", "-a-b"),
+        ("/a_b", "-a-b"),
+        ("/a b", "-a-b"),
+        ("/a@b", "-a-b"),
+        ("/a+b", "-a-b"),
+        ("/a~b", "-a-b"),
+        ("/a'b", "-a-b"),
+        ("/a(b)", "-a-b-"),
+        ("/a:b", "-a-b"),
+        ("/a#b", "-a-b"),
+        ("/a%b", "-a-b"),
+        ("/a=b", "-a-b"),
+        ("/a,b", "-a-b"),
+        // Already-legal characters pass through untouched.
+        ("/a-b", "-a-b"),
+        ("/AbZ9", "-AbZ9"),
+        // One BMP non-ASCII char is one UTF-16 unit, so one dash.
+        ("/café", "-caf-"),
+        ("/日本", "---"),
+    ] {
+        assert_eq!(
+            encode_project_dir(Path::new(raw)),
+            expected,
+            "encoding {raw} must fold to {expected}"
+        );
+    }
+}
+
+#[test]
+fn encode_project_dir_folds_astral_char_to_two_dashes() {
+    // Why (#6777): Claude Code runs the fold with a JavaScript regex, which
+    // walks UTF-16 code units. A non-BMP character is one Rust `char` but two
+    // UTF-16 units, so it must contribute TWO dashes, not one. Live probe: a
+    // directory named `emo-🚀x` produced a project dir ending `emo---x`.
+    assert_eq!(encode_project_dir(Path::new("/emo-🚀x")), "-emo---x");
+}
+
+#[test]
+fn encode_project_dir_truncates_and_hashes_a_long_path() {
+    // Why (#6777): past 200 characters Claude Code keeps the first 200 and
+    // appends `-<base36 of abs(int32 path hash)>`. tm's own managed worktree
+    // paths already reach 188 characters in the live store, so this branch is
+    // reachable. Both the cwd and the expected name below are transcribed from
+    // a live probe run against a throwaway CLAUDE_CONFIG_DIR — the encoder is
+    // never called to build the expectation.
+    let cwd = "/private/tmp/claude-502/-Users-masa-trusty-mpm-projects-bobmatnyc-trusty-tools/\
+b78af0a6-4985-419f-b85c-2ef5a67239f6/scratchpad/enc/seg00/seg01/seg02/seg03/seg04/seg05/seg06/\
+seg07/seg08/seg09/seg10/seg11/seg12/seg13/seg14/seg15/seg16/seg17/seg18/seg19/seg20/seg21/seg22/\
+seg23/seg24/seg25/seg26/seg27/seg28/seg29/seg30/seg31/seg32/seg33/seg34/seg35/seg36/seg37/seg38/\
+seg39";
+    let expected = "-private-tmp-claude-502--Users-masa-trusty-mpm-projects-bobmatnyc-trusty-\
+tools-b78af0a6-4985-419f-b85c-2ef5a67239f6-scratchpad-enc-seg00-seg01-seg02-seg03-seg04-seg05-\
+seg06-seg07-seg08-seg09-seg10-seg-3dhgpp";
+    let encoded = encode_project_dir(Path::new(cwd));
+    assert_eq!(
+        encoded, expected,
+        "an over-length cwd must truncate to 200 chars plus the base36 path hash"
+    );
+    assert_eq!(
+        encoded.len(),
+        207,
+        "200 kept characters, one separator, and a 6-character hash"
+    );
+}
+
+#[test]
+fn session_id_exists_finds_hardcoded_dir_name_for_dotted_cwd() {
+    // Why (#6777): the pre-existing hand-typed guard used a DOTLESS cwd, so it
+    // stayed green while every real tm worktree lookup missed. This one seeds
+    // the fixture under the hand-typed name a dotted cwd really produces; the
+    // pre-fix encoder yields `-repo-.worktrees-w1` and finds nothing.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let projects_dir = tmp.path().join("projects");
+    let project_dir = projects_dir.join("-repo--worktrees-w1");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(project_dir.join("dotted-id.jsonl"), "{}").unwrap();
+    assert!(
+        session_id_exists_in(Path::new("/repo/.worktrees/w1"), &projects_dir, "dotted-id"),
+        "a cwd under .worktrees/ must resolve to the '--worktrees-' directory \
+             Claude Code really creates"
+    );
+}
+
+#[test]
 fn session_id_exists_finds_hardcoded_dir_name_for_known_cwd() {
     // Why (#2013 cleanup, MEDIUM): the other session_id_exists tests build
-    // their expected path via the SAME formula the implementation uses
-    // (`cwd.to_string_lossy().replace('/', "-")` / `encode_project_dir`),
-    // so they cannot catch a future drift in the encoding scheme — the
-    // test and the code would drift together. This test instead types the
-    // expected directory name BY HAND as a literal, so if the encoding
-    // scheme ever changes (e.g. Claude Code starts hashing paths instead
-    // of dash-joining them), this assertion breaks independently of the
-    // implementation.
+    // their expected path via the SAME `encode_project_dir` the
+    // implementation uses, so they cannot catch a future drift in the
+    // encoding scheme — the test and the code would drift together. This
+    // test instead types the expected directory name BY HAND as a literal,
+    // so if the encoding scheme ever changes this assertion breaks
+    // independently of the implementation.
+    //
+    // #6777: this cwd is DOTLESS, which is why it stayed green through the
+    // dot-folding defect. `session_id_exists_finds_hardcoded_dir_name_for_\
+    // dotted_cwd` is the companion that covers a real worktree path.
     let tmp = tempfile::tempdir().expect("tempdir");
     let projects_dir = tmp.path().join("projects");
     // Hand-typed literal for cwd "/tmp/my-workspace" — NOT derived by
@@ -1950,7 +2073,9 @@ fn compose_inplace_args_uses_resume_for_existing_id() {
     let cwd = tmp.path().join("workspace");
     std::fs::create_dir_all(&cwd).unwrap();
     let config_dir = tmp.path().join("config");
-    let encoded = cwd.to_string_lossy().replace('/', "-");
+    // #6777: build the fixture through the ONE encoder — a hand-rolled
+    // `replace('/', "-")` here would not fold the `.` in a tempdir's name.
+    let encoded = encode_project_dir(&cwd);
     let project_dir = config_dir.join("projects").join(&encoded);
     std::fs::create_dir_all(&project_dir).unwrap();
     std::fs::write(project_dir.join("existing-id.jsonl"), "{}").unwrap();
@@ -2443,7 +2568,9 @@ fn compose_inplace_args_never_continues_from_home_store() {
     let _home = HomeGuard::set();
     let home = dirs::home_dir().expect("home resolves under redirected HOME");
     let cwd = std::path::PathBuf::from("/tmp/inplace-6765-test");
-    let encoded = cwd.to_string_lossy().replace('/', "-");
+    // #6777: build the fixture through the ONE encoder — a hand-rolled
+    // `replace('/', "-")` here would not fold the `.` in a tempdir's name.
+    let encoded = encode_project_dir(&cwd);
     // Populate the OPERATOR store (the wrong one) with prior history.
     let home_project_dir = home.join(".claude").join("projects").join(&encoded);
     std::fs::create_dir_all(&home_project_dir).unwrap();
@@ -2501,7 +2628,9 @@ fn spawn_resume_never_sends_bare_continue() {
     let _home = HomeGuard::set();
     let home = dirs::home_dir().expect("home resolves under redirected HOME");
     let cwd = std::path::PathBuf::from("/tmp/tmux-6765-test");
-    let encoded = cwd.to_string_lossy().replace('/', "-");
+    // #6777: build the fixture through the ONE encoder — a hand-rolled
+    // `replace('/', "-")` here would not fold the `.` in a tempdir's name.
+    let encoded = encode_project_dir(&cwd);
     let home_project_dir = home.join(".claude").join("projects").join(&encoded);
     std::fs::create_dir_all(&home_project_dir).unwrap();
     std::fs::write(home_project_dir.join("some-other-session.jsonl"), "{}").unwrap();

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -1334,6 +1334,52 @@ fn spawn_resume_with_id_uses_resume_flag() {
 
 #[serial_test::serial]
 #[test]
+fn spawn_resume_uses_resume_flag_for_a_worktree_cwd() {
+    // Why (#6777): the closure condition for this fix, end to end. Every
+    // tm-provisioned workspace sits under `.worktrees/`, and the sibling
+    // `spawn_resume_with_id_uses_resume_flag` uses a DOTLESS `/tmp`, so it
+    // stayed green while every real managed relaunch dropped `--resume` and
+    // started a fresh conversation. The transcript is seeded under the
+    // hand-typed directory name Claude Code really creates for this cwd —
+    // the pre-fix encoder looked under `-tmp-tm6777-proj-.worktrees-w1` and
+    // found nothing.
+    let _home = HomeGuard::set();
+    if ClaudeCodeAdapter::resolve_claude().is_none() {
+        return;
+    };
+    let cwd = Path::new("/tmp/tm6777-proj/.worktrees/w1");
+    let config_dir = crate::core::trusty_tools_config::managed_claude_config_dir()
+        .expect("config dir resolves under redirected HOME");
+    let project_dir = config_dir
+        .join("projects")
+        .join("-tmp-tm6777-proj--worktrees-w1");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    std::fs::write(project_dir.join("worktree-session-id.jsonl"), "{}").unwrap();
+
+    let fake = FakeTmux::new();
+    let adapter = ClaudeCodeAdapter::new(fake.clone());
+    adapter
+        .spawn_resume(
+            "tmpm-test",
+            None,
+            cwd,
+            "task",
+            Some("worktree-session-id"),
+            TEST_SESSION_ID,
+            &[],
+        )
+        .expect("spawn_resume");
+    let sends = fake.sends.lock().unwrap();
+    assert_eq!(sends.len(), 1);
+    assert!(
+        sends[0].1.contains("--resume worktree-session-id"),
+        "a cwd under .worktrees/ must still reach --resume: {}",
+        sends[0].1
+    );
+}
+
+#[serial_test::serial]
+#[test]
 fn spawn_resume_sends_prompt_file_when_binary_available() {
     // #2230: spawn_resume must inject --append-system-prompt-file just
     // like spawn() does — before this fix, every resume path (including
@@ -1624,20 +1670,18 @@ fn encode_project_dir_folds_dot_in_worktrees_path() {
     // directory is `…--worktrees-<id>`, so `session_id_exists` answered false
     // for every managed session and `--resume` was never passed (#6765).
     //
-    // Both literals below are transcribed from the LIVE store at
-    // ~/.trusty-tools/trusty-mpm/claude-config/projects/, where 25 directories
-    // matched `--worktrees` and 0 matched `-.worktrees`.
+    // Both expected names below are transcribed from a LIVE probe: `claude`
+    // was launched in each of these two directories against a throwaway
+    // CLAUDE_CONFIG_DIR, and these are the project directories it created.
     assert_eq!(
-        encode_project_dir(Path::new(
-            "/Users/masa/trusty-mpm-projects/bobmatnyc/xflux/.worktrees/tm-xflux-01"
-        )),
-        "-Users-masa-trusty-mpm-projects-bobmatnyc-xflux--worktrees-tm-xflux-01"
+        encode_project_dir(Path::new("/private/tmp/tm6777/proj/.worktrees/tm-proj-01")),
+        "-private-tmp-tm6777-proj--worktrees-tm-proj-01"
     );
     assert_eq!(
         encode_project_dir(Path::new(
-            "/Users/masa/Projects/claude-mpm/.claude/worktrees/agent-a0cdd0670f2217acb"
+            "/private/tmp/tm6777/tool/.claude/worktrees/agent-0123456789abcdef0"
         )),
-        "-Users-masa-Projects-claude-mpm--claude-worktrees-agent-a0cdd0670f2217acb"
+        "-private-tmp-tm6777-tool--claude-worktrees-agent-0123456789abcdef0"
     );
 }
 
@@ -1695,14 +1739,12 @@ fn encode_project_dir_truncates_and_hashes_a_long_path() {
     // reachable. Both the cwd and the expected name below are transcribed from
     // a live probe run against a throwaway CLAUDE_CONFIG_DIR — the encoder is
     // never called to build the expectation.
-    let cwd = "/private/tmp/claude-502/-Users-masa-trusty-mpm-projects-bobmatnyc-trusty-tools/\
-b78af0a6-4985-419f-b85c-2ef5a67239f6/scratchpad/enc/seg00/seg01/seg02/seg03/seg04/seg05/seg06/\
-seg07/seg08/seg09/seg10/seg11/seg12/seg13/seg14/seg15/seg16/seg17/seg18/seg19/seg20/seg21/seg22/\
-seg23/seg24/seg25/seg26/seg27/seg28/seg29/seg30/seg31/seg32/seg33/seg34/seg35/seg36/seg37/seg38/\
-seg39";
-    let expected = "-private-tmp-claude-502--Users-masa-trusty-mpm-projects-bobmatnyc-trusty-\
-tools-b78af0a6-4985-419f-b85c-2ef5a67239f6-scratchpad-enc-seg00-seg01-seg02-seg03-seg04-seg05-\
-seg06-seg07-seg08-seg09-seg10-seg-3dhgpp";
+    let cwd = "/private/tmp/tm6777/deep/seg00/seg01/seg02/seg03/seg04/seg05/seg06/seg07/seg08/\
+seg09/seg10/seg11/seg12/seg13/seg14/seg15/seg16/seg17/seg18/seg19/seg20/seg21/seg22/seg23/seg24/\
+seg25/seg26/seg27/seg28/seg29/seg30/seg31/seg32/seg33/seg34/seg35/seg36/seg37/seg38/seg39";
+    let expected = "-private-tmp-tm6777-deep-seg00-seg01-seg02-seg03-seg04-seg05-seg06-seg07-\
+seg08-seg09-seg10-seg11-seg12-seg13-seg14-seg15-seg16-seg17-seg18-seg19-seg20-seg21-seg22-seg23-\
+seg24-seg25-seg26-seg27-seg28-s-fy7046";
     let encoded = encode_project_dir(Path::new(cwd));
     assert_eq!(
         encoded, expected,

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -29,6 +29,10 @@ mod tcode;
 pub(crate) mod test_helpers;
 
 pub(crate) use claude_code::session_id_exists;
+// #6777: the ONE project-dir encoder. Re-exported so nothing outside
+// `claude_code` re-derives Claude Code's `[^A-Za-z0-9]` → `-` fold by hand.
+#[cfg(test)]
+pub(crate) use claude_code::encode_project_dir;
 // #4467: re-exported so the `transcript_saving` doctor check can read the scrub
 // set out of the REAL managed-spawn env prefix rather than restating the marker
 // constant — a check that compared the constant against itself could not fail.


### PR DESCRIPTION
## The defect

`encode_project_dir` replaced only `/` with `-`, but Claude Code folds every character outside `[A-Za-z0-9]`, so a workspace under `.worktrees/` encoded to `…-.worktrees-<id>` while the directory Claude Code creates is `…--worktrees-<id>`. Because every tm-provisioned workspace sits under `.worktrees/` or `.claude/worktrees/`, `session_id_exists` returned false for every managed session: `spawn_resume` never emitted `--resume <id>`, each relaunch started a fresh conversation, and the SessionStart correlation (#4337) judged the stored id stale and overwrote it on every launch.

This also made #6765 unreachable in practice — that fix resolves the relaunch target explicitly through `--resume <id>` verified against the session's own store, and the id never resolved.

## The encoding rule

```
key(cwd) = fold every character outside [A-Za-z0-9] to '-', per UTF-16 code unit
           if len <= 200 { key } else { key[..200] + "-" + base36(abs(int32_hash(cwd))) }
int32_hash: h = 0; for each UTF-16 unit u: h = wrapping_i32((h << 5) - h + u)
```

Uppercase is preserved. `/`, `.`, `_`, space, `@`, `+`, `~`, quotes, brackets and every non-ASCII character all fold. A non-BMP character is one Rust `char` but two UTF-16 units, so it yields **two** dashes.

### Evidence

**Vendor source**, Claude Code 2.1.260 (`strings` over the binary). `_A` is exported as `sanitizePath`, `dh` as `getProjectKey`, `Dp` as `getProjectDir`, `Aq` as `MAX_SANITIZED_LENGTH`:

```js
var Aq = 200;
function Pq(t){let e=0;for(let r=0;r<t.length;r++)e=(e<<5)-e+t.charCodeAt(r)|0;return e}
function Te(e){return Math.abs(Pq(e)).toString(36)}
function k(e){return e.replace(/[^a-zA-Z0-9]/g,"-")}
function _A(e){let n=k(e);if(n.length<=Aq)return n;return `${n.slice(0,Aq)}-${Te(e)}`}
function Zc(){return S(Se(),"projects")}        // getProjectsDir
function dh(e){return Var()??_A(e)}             // getProjectKey
function Dp(e){return S(Zc(),dh(e))}            // getProjectDir
```

A sibling validator pins the output alphabet: `clt = /^[A-Za-z0-9-]{1,255}$/`, applied to `project_dir_key`.

**Live store, both roots.** Each transcript records its own `cwd`. Re-encoding those recorded cwds reproduced the containing directory name for **105 of 105** directories that had one (58 in the managed store, 47 in `~/.claude/projects`), zero mismatches. In the managed store 25 directories match `--worktrees` and 0 match `-.worktrees`. The store alone cannot classify anything but `.` — no recorded cwd contains another special character, which is why the probes below were needed.

**Live probes.** `claude` launched against a throwaway `CLAUDE_CONFIG_DIR` creates the project directory before it needs auth, so these cost no API call:

| cwd (tail) | directory Claude Code created (tail) |
|---|---|
| `a_b c@d+e.f~g'h(i)` | `a-b-c-d-e-f-g-h-i-` |
| `uni-café-日本-Ω` | `uni-caf------` |
| `emo-🚀x` | `emo---x` |
| `/private/tmp/tm6777/proj/.worktrees/tm-proj-01` | `-private-tmp-tm6777-proj--worktrees-tm-proj-01` |
| `/private/tmp/tm6777/tool/.claude/worktrees/agent-0123456789abcdef0` | `-private-tmp-tm6777-tool--claude-worktrees-agent-0123456789abcdef0` |
| 264-char `/private/tmp/tm6777/deep/seg00/…/seg39` | 207 chars: 200 kept, `-`, `fy7046` |

Nothing was left unclassified. The truncation branch is reachable here, not theoretical: tm's own managed worktree paths already reach 188 characters in the live store.

## Changes

- `runtime/claude_code.rs` — `encode_project_dir` rewritten, plus `js_path_hash` and `to_base36`. Now `pub(crate)` and re-exported from `runtime::mod` under `#[cfg(test)]` so nothing re-derives the fold by hand.
- `runtime/claude_code_tests.rs` — six new tests; every fixture builder that hand-rolled `replace('/', "-")` routes through the encoder (a `tempfile::tempdir()` name is `.tmpXXXX`, so three of them would otherwise have broken).
- `daemon/api_tests.rs` — `seed_fake_transcript` folded `/` only and omitted the truncation branch; it calls the one encoder now.
- `core/project_discovery.rs` — `decode_project_path`'s doc asserted the disproven rule. Corrected, with the `.`-component limitation of its greedy walk recorded. **No behavior change**; the decoder feeds `ProjectDiscovery`, not resume. Widening its candidate set is separate work.

All six new tests fail against the pre-fix encoder. `spawn_resume_uses_resume_flag_for_a_worktree_cwd` is the end-to-end proof: pre-fix, the composed send carries no `--resume` at all.

`encode_project_dir_replaces_slashes` and `session_id_exists_finds_hardcoded_dir_name_for_known_cwd` both pass pre-fix — the latter used a dotless cwd, which is why this shipped. Its dotted companion is added beside it.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                      EXIT=0
cargo check -p trusty-mpm --all-targets                EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=0
cargo test -p trusty-mpm --no-fail-fast                EXIT=0
```

`--no-fail-fast`, 52 targets, all green. `test result: ok. 5895 passed; 0 failed; 8 ignored` (lib), `2067 passed; 0 failed; 1 ignored` (each `tm` bin target), `128 passed` (`tm_hook_pm_guard`), `34 passed` (e2e), `3 passed` (doc-tests). No pre-existing failures to account for.

```
test-pointers: resolved 30424 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.
line-cap: measured 4462 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
changelog-fragment gate: scanned 6 changed path(s); attributed 3 crate-source path(s); all 1 crate(s) with source changes are recorded.
sld-lint: scanned 63 spec doc(s) + 3619 code file(s); 0 error(s), 0 warning(s)
```

`claude_code.rs` is 461/500 SLOC after the change.

Refs #6777
Refs #6765

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
