### PR TITLE
fix(trusty-audit): resolve a 409 on index registration instead of silently dropping the evidence tier (Refs #6783)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11481,7 +11481,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.13.3"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -10,7 +10,14 @@ name = "trusty-audit"
 # the cut ships as 0.13.1 with that fragment folded in. This bump also carries
 # the `[tools]` pin refresh in templates/engagement.template.toml onto the
 # versions this cut publishes. No public API change.
-version = "0.13.3"
+# 0.13.3 -> 0.14.0 (milestone 71, #6783): MINOR. 0.13.3 is already on crates.io,
+# and this PR is the first of the milestone to change `src/**`, so it carries the
+# bump for the set. MINOR rather than PATCH because the siblings landing under
+# the same version add public fields — `index_report::IndexEntry` alone gains
+# `search_evidence` here, which `cargo-semver-checks` reports as
+# `struct_missing_field` against 0.13.3; for a 0.y.z crate the breaking bump is
+# the MINOR position.
+version = "0.14.0"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/6783-index-409-resolution.md
+++ b/crates/trusty-audit/changelog.d/6783-index-409-resolution.md
@@ -1,0 +1,15 @@
+Fixed
+
+- A `409 Conflict` from `POST /indexes` no longer costs a repository its whole
+  search-derived evidence tier. trusty-audit reads the daemon's registry, reuses
+  the registration that already names this checkout, deregisters the stale row
+  when one holds the id at another root or holds this tree under an obsolete id,
+  and retries the create once. Deregistration never destroys the corpus and is
+  guarded by the root it was decided on (#6783).
+- Every arm that loses the search index now leads with one phrase —
+  `evidence tier degraded: search index unavailable (<error>)` — and names the
+  trusty-analyze pass that did not run with it, so a skipped analyze pass is the
+  same headline rather than a separate silent gap (#6783).
+- A run's `index.md` counts the repositories audited without search evidence and
+  qualifies its coverage line, so an "M of M" run whose search tier was empty no
+  longer reads as complete (#6783).

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -59,6 +59,7 @@ use crate::tools::RequiredTool;
 use crate::workdir::WorkDir;
 
 pub mod churn;
+pub mod conflict;
 pub mod cve;
 pub mod daemons;
 pub mod ecosystem;
@@ -75,6 +76,31 @@ pub mod topology;
 
 #[cfg(test)]
 mod grounding_tests;
+
+/// The phrase every search-index degradation leads with (#6783).
+///
+/// Why: until #6783 each arm that lost the index wrote its own sentence, and the
+/// only reader who could tell that a report had no search evidence was one who
+/// read all four sentences and knew what they had in common. A run's index
+/// counts these, `trusty-review`'s gap section leads with them, and both need
+/// ONE phrase to key on rather than four to keep in step.
+/// What: the literal every arm below interpolates, and the substring
+/// [`search_tier_degraded`] matches. It is a report-facing string and a
+/// cross-module contract at once, so it is spelled here once.
+/// Test: `grounding_tests::every_search_tier_gap_leads_with_the_headline`.
+pub const SEARCH_TIER_HEADLINE: &str = "evidence tier degraded: search index unavailable";
+
+/// True when these gaps say this unit was audited without search evidence.
+///
+/// Why: the analyze pass reads the same index, so a repository that lost the
+/// index lost its findings, its complexity distribution and its health factors
+/// together — one fact, not four. `crate::index_report` counts units by this
+/// predicate so the run's completion line cannot read as unqualified coverage.
+/// Test: `grounding_tests::every_search_tier_gap_leads_with_the_headline`.
+#[must_use]
+pub fn search_tier_degraded(gaps: &[String]) -> bool {
+    gaps.iter().any(|gap| gap.contains(SEARCH_TIER_HEADLINE))
+}
 
 /// The two daemons this module drives: where they are, and what starts them.
 ///
@@ -235,10 +261,12 @@ pub async fn ground(
 
     let Some(index_id) = index::index_id_for(checkout) else {
         return churn_only(
-            format!(
-                "{display}: {} has no final path component, so no trusty-search index id could be \
-                 derived — the report's code-analysis sections are not assessed for it",
-                checkout.display()
+            search_tier_gap(
+                display,
+                &format!(
+                    "{} has no final path component, so no trusty-search index id could be derived",
+                    checkout.display()
+                ),
             ),
             None,
             churn_files,
@@ -248,24 +276,22 @@ pub async fn ground(
 
     if let Err(cause) = daemons::ensure_search(tools).await {
         return churn_only(
-            format!(
-                "{display}: {cause} — the report's findings, complexity distribution and health \
-                 factors are not assessed for it, and its investigation pass ranks files by path \
-                 name alone"
-            ),
+            search_tier_gap(display, &cause),
             None,
             churn_files,
             churn_gaps,
         );
     }
 
-    if let Err(cause) = index::ensure_indexed(&tools.search, checkout, &index_id) {
+    // #6783: a `409` here is a stale registration from an earlier run, not a
+    // reason to give up the whole evidence tier — the collision is cleared and
+    // the create retried before anything is reported.
+    if let Err(cause) =
+        index::ensure_indexed_resolved(&tools.search, &tools.search_socket, checkout, &index_id)
+            .await
+    {
         return churn_only(
-            format!(
-                "{display}: {cause} — the report's findings, complexity distribution and health \
-                 factors are not assessed for it, and its investigation pass ranks files by path \
-                 name alone"
-            ),
+            search_tier_gap(display, &cause),
             Some(index_id),
             churn_files,
             churn_gaps,
@@ -277,11 +303,7 @@ pub async fn ground(
     // index, so a wrong root poisons the evidence AND the measurements.
     if let Err(cause) = index::root_matches(&tools.search_socket, &index_id, checkout).await {
         return churn_only(
-            format!(
-                "{display}: complexity data unavailable: index root mismatch — {cause}. Its \
-                 evidence discovery and complexity hotspots are not assessed, and its \
-                 investigation pass ranks files by path name alone"
-            ),
+            search_tier_gap(display, &format!("index root mismatch — {cause}")),
             Some(index_id),
             churn_files,
             churn_gaps,
@@ -338,6 +360,25 @@ pub async fn ground(
         gaps,
         churn: churn_files,
     }
+}
+
+/// The one line every arm that lost the search index reports (#6783).
+///
+/// Why: four arms of [`ground`] end with the same consequence — no index means
+/// no per-dimension evidence, and the trusty-analyze pass reads that same index,
+/// so its findings, complexity distribution and health factors go with it. A run
+/// that stated the consequence four ways let the 2026-09 client sweep hollow out
+/// 59 reports without any one line, or any count, saying the tier was gone.
+/// What: `<display>: <SEARCH_TIER_HEADLINE> (<cause>) — <what the report loses>`,
+/// always one line. [`search_tier_degraded`] matches it and
+/// `crate::index_report` counts it.
+/// Test: `grounding_tests::every_search_tier_gap_leads_with_the_headline`.
+fn search_tier_gap(display: &str, cause: &str) -> String {
+    format!(
+        "{display}: {SEARCH_TIER_HEADLINE} ({cause}) — the report's findings, complexity \
+         distribution and health factors are not assessed for it, no trusty-analyze pass ran for \
+         it, and its investigation pass ranks files by path name alone"
+    )
 }
 
 /// A grounding carrying nothing but the churn leg's output and one other gap.

--- a/crates/trusty-audit/src/grounding/conflict.rs
+++ b/crates/trusty-audit/src/grounding/conflict.rs
@@ -1,0 +1,327 @@
+//! Resolving a `409 Conflict` from `POST /indexes` instead of skipping it (#6783).
+//!
+//! Why: `trusty-search index <path> --name <id>` registers the checkout before
+//! it indexes it, and the daemon refuses that registration with `409` in two
+//! cases — the id is already registered at a DIFFERENT root, or this root is
+//! already registered under a DIFFERENT id. Both are stale rows left by an
+//! earlier run on the same machine, and #6149 made the second one routine: it
+//! changed the id derivation, so every repository an older release registered
+//! under its checkout basename now collides with the hashed id this release
+//! derives for the same tree. A client sweep of 59 repositories hit it 59 times.
+//! [`super::index::ensure_indexed`] reported the refusal and [`super::ground`]
+//! turned it into a gap, so the run produced 59 reports with no search evidence,
+//! no complexity, no health factors, and no finding verified against a symbol —
+//! over a clean exit and a "59 of 59" index. A stale row is recoverable, and a
+//! recoverable failure that costs a whole evidence tier must be recovered.
+//!
+//! ## The policy
+//!
+//! Read the registry, decide, act, retry the create ONCE:
+//!
+//! | What the registry says | What happens |
+//! |---|---|
+//! | `<id>` is registered at this checkout | Reuse it. Nothing is deleted. |
+//! | `<id>` is registered at another root | Deregister `<id>`, then re-create. |
+//! | This checkout is registered under another id | Deregister that id, then re-create under `<id>`. |
+//! | Neither — the registry does not explain the refusal | Report it. |
+//!
+//! Deregistration NEVER destroys data (`delete_data` stays absent, which the
+//! daemon reads as `false`), and it is guarded by `expected_root_path`, so a
+//! registration that changed between the read and the write is refused rather
+//! than deleted on stale information. The corpus survives; only the row goes.
+//!
+//! Re-creating under `<id>` rather than adopting the id already registered is
+//! deliberate: the id is a cross-process contract — `trusty_review`'s renderer
+//! and `tga`'s sweep both derive it independently through
+//! [`trusty_common::derive_checkout_index_id`] — so an index registered under
+//! any other name is one nobody looks up. See [`super::index`]'s module docs.
+//!
+//! Test: `conflict_tests`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use super::search_rpc;
+
+/// Wall-clock budget for each registry call made while resolving a conflict.
+const BUDGET: Duration = Duration::from_secs(10);
+
+/// One row of the daemon's index registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Registration {
+    /// The index id the daemon serves this row under.
+    pub id: String,
+    /// The tree it is rooted at, as the daemon spells it. `None` for a row whose
+    /// root is not valid UTF-8, which cannot be compared or guarded on.
+    pub root_path: Option<String>,
+}
+
+/// What the registry says should be done about the refusal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// The wanted id already names this checkout; the create was redundant.
+    Reuse,
+    /// One stale row stands between this checkout and its id — drop it.
+    Drop {
+        /// The registration to deregister.
+        id: String,
+        /// The root it currently claims, sent as the delete's guard.
+        root: String,
+    },
+    /// Nothing in the registry accounts for the refusal.
+    Unexplained,
+}
+
+/// What resolving the conflict actually achieved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// The daemon already serves this checkout under this id — nothing to redo.
+    Reuse,
+    /// A stale registration was dropped; the create is worth retrying.
+    Dropped {
+        /// The id that was deregistered.
+        id: String,
+    },
+}
+
+/// True when a failed `trusty-search index` says the daemon refused with `409`.
+///
+/// Why: the CLI reports the refusal as one stderr line and exits non-zero, so
+/// the status code is all that distinguishes a recoverable registration
+/// collision from every other reason indexing fails — an unapproved root, a dead
+/// embedder, a full disk. Only the collision is worth a second attempt.
+/// What: matches on the code and a second token, so a `409` occurring inside a
+/// checkout path is not mistaken for a status.
+/// Test: `conflict_tests::{a_409_from_the_create_route_is_a_registration_conflict,
+/// an_unrelated_failure_is_not_a_registration_conflict}`.
+#[must_use]
+pub fn is_registration_conflict(reason: &str) -> bool {
+    reason.contains("409")
+        && (reason.contains("Conflict")
+            || reason.contains("conflict")
+            || reason.contains("indexes"))
+}
+
+/// Read `{"indexes": [...]}` as registry rows, dropping anything unreadable.
+///
+/// The daemon answers `search.indexes.list` with bare id strings by default and
+/// with objects under `{"details": true}`; both shapes are accepted so a
+/// response that lost its detail fields still yields ids.
+fn registrations(body: &serde_json::Value) -> Vec<Registration> {
+    let Some(rows) = body.get("indexes").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    rows.iter()
+        .filter_map(|row| match row {
+            serde_json::Value::String(id) => Some(Registration {
+                id: id.clone(),
+                root_path: None,
+            }),
+            other => Some(Registration {
+                id: other.get("id")?.as_str()?.to_owned(),
+                root_path: other
+                    .get("root_path")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
+            }),
+        })
+        .collect()
+}
+
+/// The policy table in the module docs, as a pure function.
+///
+/// Why pure and separate from the calls that carry it out: the decision is the
+/// part worth asserting, and asserting it against a live daemon would make the
+/// table's arms untestable without one.
+/// What: the wanted id wins — a row under `index_id` decides the outcome by
+/// itself, and only when there is none does a foreign row owning this checkout
+/// matter. A row whose root is unreadable cannot be compared OR guarded on, so
+/// it never produces a `Drop`.
+/// Test: `conflict_tests::{the_wanted_id_at_this_checkout_is_reused,
+/// the_wanted_id_at_another_root_is_dropped,
+/// this_checkout_under_a_foreign_id_drops_the_foreign_row,
+/// a_registry_that_explains_nothing_is_unexplained}`.
+#[must_use]
+pub fn decide(rows: &[Registration], index_id: &str, checkout: &Path) -> Decision {
+    if let Some(mine) = rows.iter().find(|r| r.id == index_id) {
+        let Some(root) = &mine.root_path else {
+            return Decision::Unexplained;
+        };
+        if super::index::same_tree(Path::new(root), checkout) {
+            return Decision::Reuse;
+        }
+        return Decision::Drop {
+            id: mine.id.clone(),
+            root: root.clone(),
+        };
+    }
+    for row in rows {
+        let Some(root) = &row.root_path else { continue };
+        if super::index::same_tree(Path::new(root), checkout) {
+            return Decision::Drop {
+                id: row.id.clone(),
+                root: root.clone(),
+            };
+        }
+    }
+    Decision::Unexplained
+}
+
+/// Ask the daemon what it is serving, decide, and clear the stale row.
+///
+/// # Errors
+///
+/// One line, safe to show the recipient, when the registry cannot be read, when
+/// it does not account for the refusal, or when the daemon refuses the delete.
+/// The caller reports it beside the original refusal; nothing here fails a run.
+///
+/// # Postconditions
+/// Never panics. On [`Resolution::Dropped`] exactly one registration was
+/// deregistered and its data was left on disk.
+///
+/// Test: `super::grounding_tests::a_409_registration_conflict_clears_the_stale_row_and_retries`,
+/// `super::grounding_tests::an_unresolvable_409_degrades_the_evidence_tier_out_loud`.
+pub async fn resolve(socket: &Path, index_id: &str, checkout: &Path) -> Result<Resolution, String> {
+    let listed = search_rpc::call(
+        socket,
+        search_rpc::METHOD_INDEXES_LIST,
+        serde_json::json!({ "details": true }),
+        BUDGET,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+    match decide(&registrations(&listed), index_id, checkout) {
+        Decision::Reuse => Ok(Resolution::Reuse),
+        Decision::Unexplained => Err(format!(
+            "trusty-search refused the registration of '{index_id}' but serves no index at {} \
+             and none named '{index_id}' — the collision is not a stale registration this run \
+             can clear",
+            checkout.display()
+        )),
+        Decision::Drop { id, root } => {
+            // #6783: `delete_data` is deliberately absent — the daemon reads it
+            // as false, so the corpus survives and only the row goes.
+            search_rpc::call(
+                socket,
+                search_rpc::METHOD_INDEX_DELETE,
+                serde_json::json!({ "index_id": id, "expected_root_path": root }),
+                BUDGET,
+            )
+            .await
+            .map_err(|e| {
+                format!("the stale registration '{id}' at {root} could not be dropped: {e}")
+            })?;
+            Ok(Resolution::Dropped { id })
+        }
+    }
+}
+
+#[cfg(test)]
+mod conflict_tests {
+    use super::*;
+
+    fn row(id: &str, root: &str) -> Registration {
+        Registration {
+            id: id.to_owned(),
+            root_path: Some(root.to_owned()),
+        }
+    }
+
+    /// The exact line the client run produced 59 times (#6783).
+    #[test]
+    fn a_409_from_the_create_route_is_a_registration_conflict() {
+        let line = "`trusty-search index /w/repos/xsv --name xsv-9f2a` failed (exit status: 1): \
+                    daemon returned 409 Conflict for POST /indexes";
+        assert!(is_registration_conflict(line), "{line}");
+    }
+
+    #[test]
+    fn an_unrelated_failure_is_not_a_registration_conflict() {
+        for line in [
+            "`trusty-search index /w/repos/xsv --name xsv` failed (exit status: 1): \
+             indexing refused: root is not allowlisted",
+            "`trusty-search index /w/409-experiments/xsv --name xsv` failed (exit status: 1): \
+             embedder initializing",
+        ] {
+            assert!(!is_registration_conflict(line), "{line}");
+        }
+    }
+
+    #[test]
+    fn the_wanted_id_at_this_checkout_is_reused() {
+        let rows = vec![row("xsv-9f2a", "/w/repos/xsv"), row("other", "/w/repos/y")];
+        assert_eq!(
+            decide(&rows, "xsv-9f2a", Path::new("/w/repos/xsv")),
+            Decision::Reuse
+        );
+    }
+
+    #[test]
+    fn the_wanted_id_at_another_root_is_dropped() {
+        let rows = vec![row("xsv-9f2a", "/w/repos/other-xsv")];
+        assert_eq!(
+            decide(&rows, "xsv-9f2a", Path::new("/w/repos/xsv")),
+            Decision::Drop {
+                id: "xsv-9f2a".to_owned(),
+                root: "/w/repos/other-xsv".to_owned(),
+            }
+        );
+    }
+
+    /// #6149 changed the id derivation, so an older run's basename row owns the
+    /// tree this run wants under a hashed id. That row is what must go.
+    #[test]
+    fn this_checkout_under_a_foreign_id_drops_the_foreign_row() {
+        let rows = vec![row("unrelated", "/w/repos/y"), row("xsv", "/w/repos/xsv")];
+        assert_eq!(
+            decide(&rows, "xsv-9f2a", Path::new("/w/repos/xsv")),
+            Decision::Drop {
+                id: "xsv".to_owned(),
+                root: "/w/repos/xsv".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_registry_that_explains_nothing_is_unexplained() {
+        let rows = vec![row("unrelated", "/w/repos/y")];
+        assert_eq!(
+            decide(&rows, "xsv-9f2a", Path::new("/w/repos/xsv")),
+            Decision::Unexplained
+        );
+        assert_eq!(
+            decide(&[], "xsv-9f2a", Path::new("/w/repos/xsv")),
+            Decision::Unexplained
+        );
+    }
+
+    /// A row with no readable root can be neither compared nor guarded on, so it
+    /// must never be deleted on a guess.
+    #[test]
+    fn a_row_with_no_readable_root_is_never_dropped() {
+        let rows = vec![Registration {
+            id: "xsv-9f2a".to_owned(),
+            root_path: None,
+        }];
+        assert_eq!(
+            decide(&rows, "xsv-9f2a", Path::new("/w/repos/xsv")),
+            Decision::Unexplained
+        );
+    }
+
+    #[test]
+    fn both_listing_shapes_parse() {
+        let detailed = serde_json::json!({
+            "indexes": [{"id": "xsv", "root_path": "/w/repos/xsv", "size_bytes": 12}]
+        });
+        assert_eq!(registrations(&detailed), vec![row("xsv", "/w/repos/xsv")]);
+
+        let flat = serde_json::json!({ "indexes": ["xsv", "acme"] });
+        let parsed = registrations(&flat);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].id, "xsv");
+        assert_eq!(parsed[0].root_path, None);
+
+        assert!(registrations(&serde_json::json!({})).is_empty());
+    }
+}

--- a/crates/trusty-audit/src/grounding/grounding_tests.rs
+++ b/crates/trusty-audit/src/grounding/grounding_tests.rs
@@ -968,3 +968,246 @@ fn the_installed_copies_are_preferred_over_the_path() {
     // so what is asserted is only that it did NOT resolve to the tools/ copy.
     assert_ne!(t.analyze, RequiredTool::TrustyAnalyze.path_in(&work));
 }
+
+// ─── #6783: a 409 from the create route is resolved, never skipped ───────────
+
+/// A socket that records what it was asked and answers the conflict-resolution
+/// pair (#6783).
+///
+/// `registry` is the `search.indexes.list` result; `search.index.delete` always
+/// succeeds and `search.index.status` reports `root`, so the root backstop
+/// passes once the collision has been cleared.
+fn recording_search_socket(
+    dir: &Path,
+    registry: serde_json::Value,
+    root: &Path,
+) -> (PathBuf, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let sink = std::sync::Arc::clone(&seen);
+    let root = root.display().to_string();
+    let socket = answering_socket(dir, "recording-search", move |request| {
+        sink.lock()
+            .expect("the stub log is not poisoned")
+            .push(request.to_owned());
+        if request.contains("search.health") {
+            r#"{"jsonrpc":"2.0","id":1,"result":{"status":"ok","version":"0.0.0","indexes":1}}"#
+                .to_owned()
+        } else if request.contains("search.indexes.list") {
+            format!(r#"{{"jsonrpc":"2.0","id":1,"result":{registry}}}"#)
+        } else if request.contains("search.index.delete") {
+            r#"{"jsonrpc":"2.0","id":1,"result":{"deleted":true}}"#.to_owned()
+        } else if request.contains("search.index.status") {
+            format!(r#"{{"jsonrpc":"2.0","id":1,"result":{{"root_path":"{root}"}}}}"#)
+        } else {
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32004,"message":"no such index"}}"#
+                .to_owned()
+        }
+    });
+    (socket, seen)
+}
+
+/// A `trusty-search` whose `index` verb 409s once and then succeeds.
+///
+/// `index add` always approves and `index-status` always reports the index as
+/// unserved, so every call reaches the create. The marker file is what makes the
+/// second create succeed — the shape of a stale registration having been cleared
+/// between the two attempts.
+#[cfg(unix)]
+fn search_that_conflicts_once(at: &Path, marker: &Path) -> PathBuf {
+    stub_binary(
+        at,
+        "trusty-search",
+        &format!(
+            "#!/bin/sh\n\
+             if [ \"$1\" = 'index-status' ]; then exit 1; fi\n\
+             if [ \"$2\" = 'add' ]; then exit 0; fi\n\
+             if [ -f '{marker}' ]; then exit 0; fi\n\
+             : > '{marker}'\n\
+             echo 'daemon returned 409 Conflict for POST /indexes' >&2\n\
+             exit 1\n",
+            marker = marker.display()
+        ),
+    )
+}
+
+/// A `trusty-search` whose `index` verb always fails, with `reason` on stderr.
+#[cfg(unix)]
+fn search_that_always_fails(at: &Path, reason: &str) -> PathBuf {
+    stub_binary(
+        at,
+        "trusty-search",
+        &format!(
+            "#!/bin/sh\n\
+             if [ \"$1\" = 'index-status' ]; then exit 1; fi\n\
+             if [ \"$2\" = 'add' ]; then exit 0; fi\n\
+             echo '{reason}' >&2\n\
+             exit 1\n"
+        ),
+    )
+}
+
+/// Tools pointing at one stub binary and one recording socket.
+#[cfg(unix)]
+fn conflict_tools(search: PathBuf, socket: PathBuf, tmp: &Path) -> Tools {
+    tools(
+        search,
+        socket,
+        PathBuf::from("/nonexistent/trusty-analyze"),
+        dead_socket(tmp),
+    )
+}
+
+/// #6783's headline case, and the one a client run hit 59 times: #6149 changed
+/// the id derivation, so an earlier run's row owns this tree under its old
+/// basename id. The row is dropped and the create retried — the tier survives.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_409_registration_conflict_clears_the_stale_row_and_retries() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("repos").join("acme-api");
+    std::fs::create_dir_all(&checkout).expect("create the checkout");
+    let search = search_that_conflicts_once(tmp.path(), &tmp.path().join("conflicted"));
+    // The stale row: the SAME tree, registered under the pre-#6149 basename id.
+    let registry = serde_json::json!({
+        "indexes": [{ "id": "acme-api", "root_path": checkout.display().to_string() }]
+    });
+    let (socket, seen) = recording_search_socket(tmp.path(), registry, &checkout);
+    let t = conflict_tools(search, socket, tmp.path());
+
+    let out = ground(
+        &t,
+        &checkout,
+        "acme-api",
+        None,
+        priority::Budget::from_env(),
+    )
+    .await;
+
+    assert!(
+        !search_tier_degraded(&out.gaps),
+        "the collision was resolvable, so nothing may report the tier as lost: {:?}",
+        out.gaps
+    );
+    let asked = seen.lock().expect("the stub log is not poisoned").clone();
+    assert!(
+        asked.iter().any(|r| r.contains("search.indexes.list")),
+        "the registry must be read before anything is deleted: {asked:?}"
+    );
+    let deleted: Vec<&String> = asked
+        .iter()
+        .filter(|r| r.contains("search.index.delete"))
+        .collect();
+    assert_eq!(deleted.len(), 1, "exactly one stale row goes: {asked:?}");
+    assert!(deleted[0].contains("\"acme-api\""), "{:?}", deleted[0]);
+    assert!(
+        deleted[0].contains("expected_root_path"),
+        "the delete is guarded by the root it was decided on: {:?}",
+        deleted[0]
+    );
+    assert!(
+        !deleted[0].contains("delete_data"),
+        "deregistration never destroys the corpus: {:?}",
+        deleted[0]
+    );
+}
+
+/// The other half of the fail-open contract: when the registry does not explain
+/// the refusal there is nothing to clear, and the run says so in the headline
+/// rather than shipping a report whose evidence tier is quietly empty.
+#[cfg(unix)]
+#[tokio::test]
+async fn an_unresolvable_409_degrades_the_evidence_tier_out_loud() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("repos").join("acme-api");
+    std::fs::create_dir_all(&checkout).expect("create the checkout");
+    let search =
+        search_that_always_fails(tmp.path(), "daemon returned 409 Conflict for POST /indexes");
+    let (socket, seen) =
+        recording_search_socket(tmp.path(), serde_json::json!({ "indexes": [] }), &checkout);
+    let t = conflict_tools(search, socket, tmp.path());
+
+    let out = ground(
+        &t,
+        &checkout,
+        "acme-api",
+        None,
+        priority::Budget::from_env(),
+    )
+    .await;
+
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains(SEARCH_TIER_HEADLINE), "{:?}", gaps[0]);
+    assert!(gaps[0].contains("acme-api"), "{:?}", gaps[0]);
+    assert!(gaps[0].contains("409"), "{:?}", gaps[0]);
+    assert!(
+        gaps[0].contains("no trusty-analyze pass ran"),
+        "{:?}",
+        gaps[0]
+    );
+    assert_eq!(
+        gaps[0].lines().count(),
+        1,
+        "must stay one line: {:?}",
+        gaps[0]
+    );
+    let asked = seen.lock().expect("the stub log is not poisoned").clone();
+    assert!(
+        asked.iter().any(|r| r.contains("search.indexes.list")),
+        "the resolution must have been attempted: {asked:?}"
+    );
+    assert!(
+        !asked.iter().any(|r| r.contains("search.index.delete")),
+        "a registry that explains nothing licenses no delete: {asked:?}"
+    );
+}
+
+/// A refusal that is not a collision — an unapproved root, a dead embedder — is
+/// not a stale row, so nothing is read and nothing is deleted on its account.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_non_conflict_index_failure_is_not_retried() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let checkout = tmp.path().join("repos").join("acme-api");
+    std::fs::create_dir_all(&checkout).expect("create the checkout");
+    let search = search_that_always_fails(tmp.path(), "indexing refused: root is not allowlisted");
+    let registry = serde_json::json!({
+        "indexes": [{ "id": "acme-api", "root_path": checkout.display().to_string() }]
+    });
+    let (socket, seen) = recording_search_socket(tmp.path(), registry, &checkout);
+    let t = conflict_tools(search, socket, tmp.path());
+
+    let out = ground(
+        &t,
+        &checkout,
+        "acme-api",
+        None,
+        priority::Budget::from_env(),
+    )
+    .await;
+
+    let gaps = without_churn_leg(out.gaps);
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("root is not allowlisted"), "{:?}", gaps[0]);
+    let asked = seen.lock().expect("the stub log is not poisoned").clone();
+    assert!(
+        !asked.iter().any(|r| r.contains("search.indexes.list")),
+        "only a collision is worth a registry read: {asked:?}"
+    );
+}
+
+/// Every arm that loses the index leads with one phrase, because
+/// `crate::index_report` counts on it and the report's gap section leads with
+/// it. Four sentences that merely meant the same thing is what #6783 replaced.
+#[test]
+fn every_search_tier_gap_leads_with_the_headline() {
+    let line = search_tier_gap("acme-api", "daemon returned 409 Conflict for POST /indexes");
+    assert!(line.starts_with("acme-api: "), "{line}");
+    assert!(line.contains(SEARCH_TIER_HEADLINE), "{line}");
+    assert_eq!(line.lines().count(), 1, "must stay one line: {line}");
+    assert!(search_tier_degraded(&[line]));
+    assert!(!search_tier_degraded(&[
+        "acme-api: trusty-analyze is unreachable".to_owned()
+    ]));
+    assert!(!search_tier_degraded(&[]));
+}

--- a/crates/trusty-audit/src/grounding/index.rs
+++ b/crates/trusty-audit/src/grounding/index.rs
@@ -131,7 +131,11 @@ pub async fn root_matches(socket: &Path, index_id: &str, checkout: &Path) -> Res
 /// Falls back to a separator-normalised string compare when either path cannot
 /// be canonicalised, which is the case in tests and for a root the daemon holds
 /// but this machine cannot stat.
-fn same_tree(served: &Path, checkout: &Path) -> bool {
+///
+/// Shared with [`super::conflict`] (#6783), which asks the same question of the
+/// same registry rows: a second answer to "is this the tree we audited" is how
+/// the root backstop and the conflict resolver would drift apart.
+pub(super) fn same_tree(served: &Path, checkout: &Path) -> bool {
     match (served.canonicalize(), checkout.canonicalize()) {
         (Ok(a), Ok(b)) => a == b,
         _ => {
@@ -199,6 +203,57 @@ pub fn ensure_indexed(
     match refusal(checkout, index_id, &output) {
         Some(reason) => Err(reason),
         None => Ok(IndexStatus::Indexed),
+    }
+}
+
+/// [`ensure_indexed`], resolving a registration conflict rather than reporting it.
+///
+/// Why: `POST /indexes` answers `409` when a stale row from an earlier run on
+/// this machine holds either the id or the tree, and until #6783 that refusal
+/// went straight to a gap — 59 repositories in one client sweep lost their
+/// findings, complexity and health factors to rows the daemon would have given
+/// up on request. A stale row is recoverable; see [`super::conflict`] for the
+/// policy and why re-creating under the derived id beats adopting another.
+/// What: runs [`ensure_indexed`]; on a `409` asks [`super::conflict::resolve`]
+/// to clear the collision and runs it again, ONCE. Every other failure is
+/// returned untouched, and a resolution that itself fails is reported beside the
+/// refusal that prompted it rather than replacing it.
+///
+/// A [`super::conflict::Resolution::Reuse`] does not re-run the create: the
+/// daemon is already serving this checkout under this id, and `trusty-search
+/// index` reindexes as part of its own retry, so the only case that needs a
+/// second spawn is the one that follows a drop.
+///
+/// # Errors
+///
+/// One line, safe to show the recipient. The caller turns it into the gap
+/// headline; nothing here fails a run.
+///
+/// Test: `super::grounding_tests::{a_409_registration_conflict_clears_the_stale_row_and_retries,
+/// an_unresolvable_409_degrades_the_evidence_tier_out_loud,
+/// a_non_conflict_index_failure_is_not_retried}`.
+pub async fn ensure_indexed_resolved(
+    search: &Path,
+    socket: &Path,
+    checkout: &Path,
+    index_id: &str,
+) -> Result<IndexStatus, String> {
+    let refusal = match ensure_indexed(search, checkout, index_id) {
+        Ok(status) => return Ok(status),
+        Err(reason) => reason,
+    };
+    // #6783: only a registration collision is worth a second attempt.
+    if !super::conflict::is_registration_conflict(&refusal) {
+        return Err(refusal);
+    }
+    match super::conflict::resolve(socket, index_id, checkout).await {
+        Ok(super::conflict::Resolution::Reuse) => Ok(IndexStatus::AlreadyServed),
+        Ok(super::conflict::Resolution::Dropped { id }) => {
+            ensure_indexed(search, checkout, index_id).map_err(|retry| {
+                format!("{refusal}; the stale registration '{id}' was cleared and {retry}")
+            })
+        }
+        Err(cause) => Err(format!("{refusal}; {cause}")),
     }
 }
 

--- a/crates/trusty-audit/src/grounding/search_rpc.rs
+++ b/crates/trusty-audit/src/grounding/search_rpc.rs
@@ -56,6 +56,18 @@ pub const METHOD_HEALTH: &str = "search.health";
 /// One index's stages, capabilities and footprint — `GET /indexes/{id}/status`.
 pub const METHOD_INDEX_STATUS: &str = "search.index.status";
 
+/// Every registered index — `GET /indexes`. With `{"details": true}` each entry
+/// carries its `root_path`, which is what makes a registration conflict
+/// diagnosable (#6783).
+pub const METHOD_INDEXES_LIST: &str = "search.indexes.list";
+
+/// Deregister one index — `DELETE /indexes/{id}` (#6783).
+///
+/// `{"index_id": id}` deregisters and leaves the corpus on disk;
+/// `expected_root_path` makes the delete refuse unless the registration still
+/// has the root the caller just read.
+pub const METHOD_INDEX_DELETE: &str = "search.index.delete";
+
 /// Hybrid search within one index — `POST /indexes/{id}/search`.
 pub const METHOD_QUERY: &str = "search.query";
 
@@ -240,6 +252,9 @@ mod search_rpc_tests {
         assert_eq!(METHOD_HEALTH, "search.health");
         assert_eq!(METHOD_INDEX_STATUS, "search.index.status");
         assert_eq!(METHOD_QUERY, "search.query");
+        // #6783: the registration-conflict pair.
+        assert_eq!(METHOD_INDEXES_LIST, "search.indexes.list");
+        assert_eq!(METHOD_INDEX_DELETE, "search.index.delete");
         assert_eq!(ENV_SEARCH_SOCKET, "TRUSTY_SEARCH_SOCKET");
     }
 

--- a/crates/trusty-audit/src/index_report.rs
+++ b/crates/trusty-audit/src/index_report.rs
@@ -210,6 +210,15 @@ pub struct IndexEntry {
     pub carried_over: bool,
     /// Wall clock around this unit, or `None` when this run did not measure it.
     pub duration: Option<Duration>,
+    /// Whether the search-derived evidence tier survived for this unit (#6783).
+    ///
+    /// `false` means trusty-search never indexed this repository, so its
+    /// findings, complexity distribution and health factors are unassessed and
+    /// no trusty-analyze pass ran for it. Each producer reads it off that unit's
+    /// gaps with [`crate::grounding::search_tier_degraded`], which is the same
+    /// line the report itself leads with — one fact with one source, rather than
+    /// a flag that can disagree with the prose beside it.
+    pub search_evidence: bool,
 }
 
 /// Everything the index states, before it is rendered against a directory.
@@ -345,12 +354,33 @@ fn summary(report: &IndexReport, out: &mut String) {
         "- Produced by: trusty-audit {}\n",
         env!("CARGO_PKG_VERSION")
     ));
+    // #6783: a repository with no search index still produces a report, so the
+    // count above says nothing about whether that report was assessed. When any
+    // unit lost the tier the coverage line is qualified rather than left to read
+    // as complete, and the next line names the number.
+    let unassessed = report.entries.iter().filter(|e| !e.search_evidence).count();
+    let coverage = if unassessed == 0 {
+        String::new()
+    } else {
+        " — not fully assessed, see the next line".to_owned()
+    };
     out.push_str(&format!(
-        "- Reports: {} of {} {}\n",
+        "- Reports: {} of {} {}{}\n",
         produced,
         report.entries.len(),
-        unit
+        unit,
+        coverage
     ));
+    if unassessed > 0 {
+        out.push_str(&format!(
+            "- Search evidence: {} of {} {} audited WITHOUT search evidence — trusty-search never \
+             indexed them, so their findings, complexity distribution and health factors are not \
+             assessed and no trusty-analyze pass ran for them. Each report states its own reason.\n",
+            unassessed,
+            report.entries.len(),
+            unit
+        ));
+    }
     match report.total {
         Some(total) => out.push_str(&format!("- Total wall clock: {}\n\n", human(total))),
         None => out.push_str("- Total wall clock: not recorded\n\n"),
@@ -749,6 +779,9 @@ pub fn write_sweep(
             },
             carried_over: run.resumed,
             duration: run.duration_ms.map(Duration::from_millis),
+            // #6783: read off the gaps this repository actually stated, which a
+            // resumed entry carries forward with the rest of its record.
+            search_evidence: !crate::grounding::search_tier_degraded(&run.gaps),
         })
         .collect();
     let index = IndexReport {
@@ -810,6 +843,9 @@ pub fn write_render(
             },
             carried_over: false,
             duration: rendered.duration_ms.map(Duration::from_millis),
+            // #6783: a re-render indexes any checkout present on this machine,
+            // so it loses the tier the same way a sweep does and says so here.
+            search_evidence: !crate::grounding::search_tier_degraded(&rendered.gaps),
         })
         .collect();
     let index = IndexReport {
@@ -841,6 +877,7 @@ mod index_tests {
             failure: None,
             carried_over: false,
             duration: Some(Duration::from_millis(1_500)),
+            search_evidence: true,
         }
     }
 
@@ -884,6 +921,53 @@ mod index_tests {
             text.contains("[00-acme-api/00-acme-api.md](00-acme-api/00-acme-api.md)"),
             "the one report must be linked relatively: {text}"
         );
+    }
+
+    /// #6783: a repository whose search index never registered still produces a
+    /// report, so the coverage line said "59 of 59" over 59 hollow reports. When
+    /// any unit lost the tier the line is qualified and the count is named.
+    #[test]
+    fn a_run_that_lost_the_search_tier_qualifies_its_coverage_line() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("out");
+        let one = dir.join("00-acme-api");
+        let two = dir.join("01-acme-web");
+        std::fs::create_dir_all(&one).expect("mkdir");
+        std::fs::create_dir_all(&two).expect("mkdir");
+
+        let mut degraded = entry("acme/api", one);
+        degraded.search_evidence = false;
+        let text = render(
+            &report(Producer::Sweep, vec![degraded, entry("acme/web", two)]),
+            &dir,
+        );
+
+        assert!(
+            text.contains("Reports: 2 of 2 repositories — not fully assessed"),
+            "the coverage line must not read as complete: {text}"
+        );
+        assert!(
+            text.contains("Search evidence: 1 of 2 repositories audited WITHOUT search evidence"),
+            "{text}"
+        );
+    }
+
+    /// The other side of it: a run that kept the tier says nothing extra, so the
+    /// qualifier stays a signal rather than boilerplate.
+    #[test]
+    fn a_run_that_kept_the_search_tier_says_nothing_about_it() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("out");
+        let unit = dir.join("00-acme-api");
+        std::fs::create_dir_all(&unit).expect("mkdir");
+
+        let text = render(
+            &report(Producer::Sweep, vec![entry("acme/api", unit)]),
+            &dir,
+        );
+
+        assert!(text.contains("- Reports: 1 of 1 repository\n"), "{text}");
+        assert!(!text.contains("WITHOUT search evidence"), "{text}");
     }
 
     /// Why: #6135, owner ruling 2026-08-21 — "The report should include which

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -151,6 +151,9 @@ pub(super) fn render_index(
                 },
                 carried_over: run.resumed,
                 duration: run.duration_ms.map(std::time::Duration::from_millis),
+                // #6783: the recipient's copy of the coverage count, read off
+                // the same gaps the sweep's own index reads.
+                search_evidence: !crate::grounding::search_tier_degraded(&run.gaps),
             }
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
A `409 Conflict` from `POST /indexes` cost a repository its entire search-derived
evidence tier: `ensure_indexed` reported the refusal, `ground` turned it into a
gap, and the run still shipped a report with no findings, no complexity
distribution, no health factors and no symbol-verified finding — over a clean
exit and an unqualified "59 of 59" coverage line. A client sweep hit it on all 59
repositories.

## Cause

`POST /indexes` refuses with `409` on two arms, both in
`crates/trusty-search/src/service/server/helpers.rs`:

- `root_path_mismatch_response` (line 447) — the id is registered at a
  **different root**.
- `root_path_collision_response` (line 475) — this **root** is already
  registered under a **different id**.

The second arm is what made the failure universal. #6149 changed index-id
derivation from the checkout basename to a path hash, so every row an older
release wrote now collides with the id this release derives for the same tree.
The CLI surfaces only the status line, so trusty-audit could not tell a
recoverable stale row from an unapproved root and treated both as fatal.

## Policy

trusty-audit reads the registry over `search.indexes.list` (`details: true`,
which carries `root_path`), decides, acts, and retries the create **once**:

| Registry says | Action |
|---|---|
| `<id>` is registered at this checkout | Reuse. Nothing deleted, nothing re-run. |
| `<id>` is registered at another root | Deregister `<id>`, re-create. |
| This checkout is registered under another id | Deregister that id, re-create under `<id>`. |
| Nothing explains the refusal | Report it in the headline. |

Deregistration sends no `delete_data`, so the corpus survives, and carries
`expected_root_path`, so a row that moved between the read and the write is
refused rather than deleted on stale information. Re-creating under the derived
id rather than adopting the registered one keeps the cross-process id contract
that trusty-review's renderer and tga's sweep both derive independently.

No trusty-search change: `search.indexes.list` and `search.index.delete` are
already registered socket methods.

## Never silent

Every arm that loses the index now leads with one phrase — `evidence tier
degraded: search index unavailable (<error>)` — and names the trusty-analyze pass
that did not run with it, so a skipped analyze pass is the same headline rather
than a separate silent gap. The run's `index.md` counts those units and qualifies
its coverage line with `N of M repositories audited WITHOUT search evidence`, so
an M-of-M run whose search tier was empty can no longer read as complete.

## Gates (rung 3)

`cargo fmt --check` → clean.
`cargo check -p trusty-audit` → clean.
`cargo clippy -p trusty-audit --all-targets -- -D warnings` → clean.
`cargo test -p trusty-audit --no-fail-fast` → `898 passed; 0 failed; 5 ignored`
(lib), plus 33 across the seven integration targets, 0 failed.
`check_line_cap.sh` (0 violations), `check_test_pointers.sh` (0 dangling),
`check_changelog_fragment.sh` (OK), `check_sld.sh` (0 errors).

Fail-open check: with only the call site reverted to `ensure_indexed`,
`a_409_registration_conflict_clears_the_stale_row_and_retries` and
`an_unresolvable_409_degrades_the_evidence_tier_out_loud` both fail; the first on
the tier being reported as lost, the second on the registry never being read.

Milestone #71.

Refs #6783, #6149, #6081.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
