### PR TITLE
feat(trusty-audit): bundle-level technical-debt roll-up in report.json (Refs #6781)

### DIFF
--- a/crates/trusty-audit/changelog.d/6781-debt-rollup.md
+++ b/crates/trusty-audit/changelog.d/6781-debt-rollup.md
@@ -1,0 +1,12 @@
+Added
+
+- A bundle-level technical-debt roll-up (#6781). A sweep, a re-render, and a
+  return package now write `report.json` beside `index.md`, carrying counts of
+  every declared finding by tier, by dimension, by repository, and by
+  tier × dimension, plus the total they all sum to. The tiers are the
+  collectors' own `RED` / `AMBER` bands and the dimensions their own
+  `dependencies` / `license` / `secrets` / `churn` categories — nothing is
+  re-banded or re-labelled.
+  - `index.md` gains a "Technical debt by tier" table across repositories,
+    rendered from that one computed value rather than counting the findings a
+    second time, so the table and `report.json` cannot state different numbers.

--- a/crates/trusty-audit/src/debt_rollup.rs
+++ b/crates/trusty-audit/src/debt_rollup.rs
@@ -1,0 +1,582 @@
+//! The bundle-level technical-debt roll-up, and the `report.json` carrying it (#6781).
+//!
+//! Why: every assurance collector writes its rows into one repository's
+//! `[report].findings` (`crate::grounding::findings`), and nothing ever added
+//! them up. A consumer wanting "how many RED findings does this engagement
+//! have" had to open each repository's `manifest.toml`, parse the array, and
+//! count — once per consumer, each with its own idea of what an empty band or
+//! an unrecognised one means. Two consumers counting the same array their own
+//! way is how two numbers describing one engagement start to disagree.
+//!
+//! What: [`DebtRollup`], the counts by tier, by dimension, by repository, and by
+//! tier × dimension, plus their shared [`DebtRollup::total`]. It is computed
+//! ONCE per run — [`from_manifests`] reads each repository's manifest — and both
+//! consumers read that one value: `crate::index_report` renders its "Technical
+//! debt by tier" table from it, and [`write`] serialises it to `report.json`
+//! beside the index.
+//!
+//! ## The taxonomy is the producer's, not this module's
+//!
+//! - **tier** is a finding's `severity` — the RED / AMBER band vocabulary
+//!   `crate::grounding::cve::Severity` spells and the other three collectors
+//!   reuse, and the same vocabulary trusty-review's Assurance Scans table
+//!   renders verbatim. Nothing is invented here and nothing is re-banded.
+//! - **dimension** is a finding's `category` — `dependencies`, `license`,
+//!   `secrets`, `churn`, the four `CATEGORY` constants under
+//!   `crate::grounding`.
+//!
+//! A band or a category this crate does not recognise is counted under its own
+//! name rather than dropped, for the reason trusty-review renders one rather
+//! than erroring: the producer owns the vocabulary, and a collector added after
+//! this module was written must still reach the total.
+//!
+//! ## Fail-open reading
+//!
+//! A repository whose manifest is absent, unreadable, or not parseable
+//! contributes nothing and raises nothing. The index already states why a unit
+//! produced no report; a roll-up that refused to render because one repository
+//! failed would lose the counts for the ones that succeeded.
+//!
+//! Test: `debt_rollup_tests`.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AuditError;
+
+/// The bundle-level machine-readable report, beside `index.md`.
+///
+/// `report.json` is unclaimed at bundle level: `tga` writes one per repository,
+/// inside that repository's own directory, so the two never collide.
+pub const REPORT_FILE: &str = "report.json";
+
+/// The tier a finding is counted under when its producer left `severity` empty.
+///
+/// Counted rather than dropped: a finding with no band is still a finding, and
+/// silently discarding it would make the marginals disagree with the row count.
+pub const UNSPECIFIED_TIER: &str = "UNSPECIFIED";
+
+/// The dimension a finding is counted under when its producer left `category`
+/// empty — the same reading trusty-review's Assurance Scans section gives it.
+pub const UNCATEGORISED_DIMENSION: &str = "uncategorised";
+
+/// Counts of every declared finding, by tier, by dimension, and by repository.
+///
+/// Why: the one place an engagement's finding totals are derived, so a renderer
+/// and a JSON consumer cannot report different numbers for the same run.
+/// What: four cross-tabulations over the same population plus [`Self::total`],
+/// the population's size. Every marginal sums to `total` — `by_tier`,
+/// `by_dimension`, each repository's map summed over repositories, and
+/// `by_tier_dimension` summed over both axes. `BTreeMap` throughout, so the
+/// serialised key order is deterministic across runs.
+/// Test: `debt_rollup_tests::every_marginal_sums_to_the_total`,
+/// `debt_rollup_tests::the_json_carries_the_rollup_block`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct DebtRollup {
+    /// Findings per tier, e.g. `{"RED": 3, "AMBER": 11}`.
+    pub by_tier: BTreeMap<String, usize>,
+    /// Findings per dimension, e.g. `{"dependencies": 9, "secrets": 5}`.
+    pub by_dimension: BTreeMap<String, usize>,
+    /// Findings per repository, then per tier within it.
+    pub by_repo: BTreeMap<String, BTreeMap<String, usize>>,
+    /// Findings per tier, then per dimension within it.
+    pub by_tier_dimension: BTreeMap<String, BTreeMap<String, usize>>,
+    /// Every finding counted, across every repository.
+    pub total: usize,
+}
+
+impl DebtRollup {
+    /// Count one finding into every cross-tabulation at once.
+    ///
+    /// Why: the four maps and the total are one fact seen four ways. Updating
+    /// them from four call sites is how a marginal drifts from the total; this
+    /// is the only writer, so the invariant holds by construction.
+    /// What: normalises `tier` (trimmed, upper-cased, empty →
+    /// [`UNSPECIFIED_TIER`]) and `dimension` (trimmed, empty →
+    /// [`UNCATEGORISED_DIMENSION`]), then increments five counters.
+    ///
+    /// # Postconditions
+    /// `total` grows by exactly one, and so does exactly one bucket in each of
+    /// the four maps.
+    ///
+    /// Test: `debt_rollup_tests::every_marginal_sums_to_the_total`,
+    /// `debt_rollup_tests::an_unbanded_finding_is_counted_not_dropped`.
+    pub fn tally(&mut self, repo: &str, tier: &str, dimension: &str) {
+        let tier = normalised_tier(tier);
+        let dimension = normalised_dimension(dimension);
+        *self.by_tier.entry(tier.clone()).or_default() += 1;
+        *self.by_dimension.entry(dimension.clone()).or_default() += 1;
+        *self
+            .by_repo
+            .entry(repo.trim().to_owned())
+            .or_default()
+            .entry(tier.clone())
+            .or_default() += 1;
+        *self
+            .by_tier_dimension
+            .entry(tier)
+            .or_default()
+            .entry(dimension)
+            .or_default() += 1;
+        self.total += 1;
+    }
+
+    /// Whether this run declared no findings at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.total == 0
+    }
+
+    /// The tiers present, worst band first and then alphabetically.
+    ///
+    /// The order trusty-review's Assurance Scans table sorts its rows in — RED,
+    /// then AMBER, then every band neither crate recognises — so a reader
+    /// meeting both documents meets one ordering.
+    /// Test: `debt_rollup_tests::the_table_orders_red_before_amber`.
+    #[must_use]
+    pub fn tiers(&self) -> Vec<&str> {
+        let mut tiers: Vec<&str> = self.by_tier.keys().map(String::as_str).collect();
+        tiers.sort_by_key(|tier| (band_rank(tier), *tier));
+        tiers
+    }
+
+    /// The "Technical debt by tier" section, or `""` when nothing was found.
+    ///
+    /// Why: the index's one cross-repository view of the findings. It reads
+    /// every cell out of this value — including the grand total, which is
+    /// [`Self::total`] rather than a second sum over the rows — so the table and
+    /// `report.json` cannot state different numbers.
+    /// What: one row per repository, one column per tier present, plus a totals
+    /// row taken from [`Self::by_tier`]. An empty roll-up renders nothing at
+    /// all, for the reason trusty-review's Assurance Scans section does: a
+    /// heading over an empty table reads as a scan that found nothing, which is
+    /// a claim no collector made.
+    /// Test: `debt_rollup_tests::the_table_reads_its_totals_from_the_rollup`,
+    /// `debt_rollup_tests::an_empty_rollup_renders_nothing`.
+    #[must_use]
+    pub fn table(&self) -> String {
+        if self.is_empty() {
+            return String::new();
+        }
+        let tiers = self.tiers();
+        let mut out = String::from("## Technical debt by tier\n\n");
+        out.push_str(
+            "Counted once from every repository's `[report].findings` and written to \
+             `report.json` beside this file, which also carries the per-dimension and \
+             tier-by-dimension breakdowns. The bands are the collectors' own; nothing here \
+             re-bands a finding.\n\n",
+        );
+        out.push_str("| repository |");
+        for tier in &tiers {
+            out.push_str(&format!(" {tier} |"));
+        }
+        out.push_str(" total |\n| --- |");
+        for _ in &tiers {
+            out.push_str(" --- |");
+        }
+        out.push_str(" --- |\n");
+        for (repo, counts) in &self.by_repo {
+            out.push_str(&format!("| {repo} |"));
+            let mut row_total = 0;
+            for tier in &tiers {
+                let count = counts.get(*tier).copied().unwrap_or(0);
+                row_total += count;
+                out.push_str(&format!(" {count} |"));
+            }
+            out.push_str(&format!(" {row_total} |\n"));
+        }
+        out.push_str("| **all repositories** |");
+        for tier in &tiers {
+            out.push_str(&format!(
+                " **{}** |",
+                self.by_tier.get(*tier).copied().unwrap_or(0)
+            ));
+        }
+        out.push_str(&format!(" **{}** |\n\n", self.total));
+        out
+    }
+}
+
+/// Sort key: RED before AMBER before every band this crate does not recognise.
+///
+/// `crate::grounding::cve::Severity` spells only the first two; the third arm
+/// is what keeps a band a later collector introduces sorting last rather than
+/// panicking.
+fn band_rank(tier: &str) -> u8 {
+    match tier {
+        "RED" => 0,
+        "AMBER" => 1,
+        "GREEN" => 2,
+        _ => 3,
+    }
+}
+
+/// A finding's `severity`, trimmed and upper-cased, or [`UNSPECIFIED_TIER`].
+///
+/// Upper-casing matches how trusty-review's table ranks a band, so `Red` and
+/// `RED` from two collectors land in one bucket rather than two.
+fn normalised_tier(tier: &str) -> String {
+    let trimmed = tier.trim();
+    if trimmed.is_empty() {
+        return UNSPECIFIED_TIER.to_owned();
+    }
+    trimmed.to_ascii_uppercase()
+}
+
+/// A finding's `category`, trimmed, or [`UNCATEGORISED_DIMENSION`].
+///
+/// Trimmed but NOT case-folded: the four `CATEGORY` constants are lower-case
+/// literals, and case-folding a dimension would silently rename a collector's
+/// own label in the delivered JSON.
+fn normalised_dimension(dimension: &str) -> String {
+    let trimmed = dimension.trim();
+    if trimmed.is_empty() {
+        return UNCATEGORISED_DIMENSION.to_owned();
+    }
+    trimmed.to_owned()
+}
+
+/// Just enough of a manifest to read its findings, ignoring everything else.
+///
+/// Deliberately not `crate::manifest::AuditManifest`: that type models what
+/// this crate WRITES, and the findings array is a third party's — a collector
+/// adding a key (a CWE tag, an OSV identifier) must not make this reader fail.
+/// Every unknown key and every unknown section is dropped by serde.
+#[derive(Debug, Default, Deserialize)]
+struct FindingsDoc {
+    #[serde(default)]
+    report: FindingsBlock,
+}
+
+/// The `[report]` table's findings array, and nothing else from it.
+#[derive(Debug, Default, Deserialize)]
+struct FindingsBlock {
+    #[serde(default)]
+    findings: Vec<FindingRow>,
+}
+
+/// The two columns the roll-up counts on, out of a row that carries more.
+#[derive(Debug, Default, Deserialize)]
+struct FindingRow {
+    /// The producer's band — the roll-up's tier.
+    #[serde(default)]
+    severity: String,
+    /// The collector that produced it — the roll-up's dimension.
+    #[serde(default)]
+    category: String,
+}
+
+/// The `(tier, dimension)` of every finding one manifest declares.
+///
+/// Why: the manifest is the interface (owner ruling 2026-08-19). The roll-up
+/// reads what the collectors wrote rather than re-running any scan, so it
+/// describes the delivered artifact exactly.
+/// What: fail-open — an absent, unreadable, or unparseable manifest yields an
+/// empty list, because the index already states why that unit has no report and
+/// a roll-up that refused over one repository would lose the other repositories'
+/// counts.
+/// Test: `debt_rollup_tests::a_manifest_yields_its_findings`,
+/// `debt_rollup_tests::an_unreadable_manifest_contributes_nothing`.
+#[must_use]
+pub fn read_findings(manifest: &Path) -> Vec<(String, String)> {
+    let Ok(text) = std::fs::read_to_string(manifest) else {
+        return Vec::new();
+    };
+    let Ok(doc) = toml::from_str::<FindingsDoc>(&text) else {
+        return Vec::new();
+    };
+    doc.report
+        .findings
+        .into_iter()
+        .map(|row| (row.severity, row.category))
+        .collect()
+}
+
+/// Roll every unit's manifest up into one [`DebtRollup`].
+///
+/// Why: the ONE computation of these counts per run. Both consumers — the
+/// index's table and `report.json` — are handed its result rather than counting
+/// the findings again for themselves.
+/// What: takes `(repository name, manifest path)` pairs in the run's own order
+/// and reads each manifest exactly once. A repository that declares no findings
+/// is absent from [`DebtRollup::by_repo`] rather than carrying an all-zero row,
+/// so the table names only the repositories that contributed a finding.
+/// Test: `debt_rollup_tests::three_repositories_roll_up_into_one_block`.
+#[must_use]
+pub fn from_manifests<I>(units: I) -> DebtRollup
+where
+    I: IntoIterator<Item = (String, PathBuf)>,
+{
+    let mut rollup = DebtRollup::default();
+    for (repo, manifest) in units {
+        for (tier, dimension) in read_findings(&manifest) {
+            rollup.tally(&repo, &tier, &dimension);
+        }
+    }
+    rollup
+}
+
+/// The bundle-level `report.json` document.
+///
+/// Why: a named block rather than a bare roll-up at the document root, so a
+/// later run-level fact can join it without moving the counts a consumer has
+/// already wired to.
+/// What: the run's local timestamp — the same string the index states — and the
+/// `debt_rollup` block itself.
+/// Test: `debt_rollup_tests::the_json_carries_the_rollup_block`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct BundleReport<'a> {
+    /// Local time with its UTC offset, from `crate::index_report::local_now`.
+    pub generated_at: &'a str,
+    /// The counts, by tier, by dimension, by repository, and by tier × dimension.
+    pub debt_rollup: &'a DebtRollup,
+}
+
+/// The bundle report's JSON, pretty-printed.
+///
+/// Serialisation of `BTreeMap`s and `usize`s cannot fail, so the fallible arm is
+/// unreachable; it still yields an empty document rather than panicking, because
+/// a run that has just written every report must not die on its index.
+/// Test: `debt_rollup_tests::the_json_carries_the_rollup_block`.
+#[must_use]
+pub fn to_json(rollup: &DebtRollup, generated_at: &str) -> String {
+    let document = BundleReport {
+        generated_at,
+        debt_rollup: rollup,
+    };
+    serde_json::to_string_pretty(&document).unwrap_or_else(|_| "{}".to_owned())
+}
+
+/// Write `report.json` into `dir`, replacing any earlier one.
+///
+/// # Postconditions
+/// On `Ok`, `dir/report.json` carries this run's `debt_rollup` block. Nothing
+/// outside `dir` is written, which is what keeps `crate::rerender`'s "the source
+/// package is only read" postcondition true.
+///
+/// # Errors
+/// [`AuditError::WorkDir`] when the file cannot be written — propagated for the
+/// reason `crate::index_report::write` propagates its own: the roll-up is a
+/// member of the deliverable, not a cosmetic extra.
+///
+/// Test: `debt_rollup_tests::the_json_lands_beside_the_index`.
+pub fn write(rollup: &DebtRollup, generated_at: &str, dir: &Path) -> Result<(), AuditError> {
+    let path = dir.join(REPORT_FILE);
+    std::fs::write(&path, to_json(rollup, generated_at))
+        .map_err(|source| AuditError::WorkDir { path, source })
+}
+
+#[cfg(test)]
+mod debt_rollup_tests {
+    use super::*;
+
+    /// A manifest carrying the rows the collectors write, plus keys this reader
+    /// does not model — the shape a CWE-tagging or OSV collector produces.
+    fn manifest(dir: &Path, name: &str, rows: &[(&str, &str)]) -> PathBuf {
+        let path = dir.join(name);
+        let mut text = String::from("[report]\ntitle = \"Acme\"\nfindings = [\n");
+        for (severity, category) in rows {
+            text.push_str(&format!(
+                "  {{ category = \"{category}\", id = \"X\", package = \"p\", version = \"1\", \
+                 severity = \"{severity}\", title = \"t\", cwe = \"CWE-1\" }},\n"
+            ));
+        }
+        text.push_str("]\n");
+        std::fs::write(&path, text).expect("write manifest");
+        path
+    }
+
+    /// The fixture the arithmetic tests count: three repositories, four
+    /// dimensions, both bands the collectors emit.
+    fn three_repositories() -> (tempfile::TempDir, DebtRollup) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let api = manifest(
+            tmp.path(),
+            "api.toml",
+            &[
+                ("RED", "dependencies"),
+                ("AMBER", "dependencies"),
+                ("RED", "secrets"),
+            ],
+        );
+        let web = manifest(
+            tmp.path(),
+            "web.toml",
+            &[("AMBER", "license"), ("AMBER", "churn")],
+        );
+        let ops = manifest(tmp.path(), "ops.toml", &[("RED", "secrets")]);
+        let rollup = from_manifests([
+            ("acme-api".to_owned(), api),
+            ("acme-web".to_owned(), web),
+            ("acme-ops".to_owned(), ops),
+        ]);
+        (tmp, rollup)
+    }
+
+    #[test]
+    fn a_manifest_yields_its_findings() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = manifest(
+            tmp.path(),
+            "manifest.toml",
+            &[("RED", "dependencies"), ("AMBER", "license")],
+        );
+        assert_eq!(
+            read_findings(&path),
+            vec![
+                ("RED".to_owned(), "dependencies".to_owned()),
+                ("AMBER".to_owned(), "license".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_unreadable_manifest_contributes_nothing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("nope.toml");
+        assert!(read_findings(&missing).is_empty(), "absent is fine");
+
+        let malformed = tmp.path().join("bad.toml");
+        std::fs::write(&malformed, "this is not toml = = =").expect("write");
+        assert!(read_findings(&malformed).is_empty(), "malformed is fine");
+
+        let rollup = from_manifests([("acme".to_owned(), missing)]);
+        assert!(rollup.is_empty(), "a failed unit does not sink the roll-up");
+    }
+
+    #[test]
+    fn three_repositories_roll_up_into_one_block() {
+        let (_tmp, rollup) = three_repositories();
+        assert_eq!(rollup.total, 6);
+        assert_eq!(rollup.by_tier["RED"], 3);
+        assert_eq!(rollup.by_tier["AMBER"], 3);
+        assert_eq!(rollup.by_dimension["dependencies"], 2);
+        assert_eq!(rollup.by_dimension["secrets"], 2);
+        assert_eq!(rollup.by_dimension["license"], 1);
+        assert_eq!(rollup.by_dimension["churn"], 1);
+        assert_eq!(rollup.by_repo["acme-api"]["RED"], 2);
+        assert_eq!(rollup.by_repo["acme-web"]["AMBER"], 2);
+        assert_eq!(rollup.by_repo["acme-ops"]["RED"], 1);
+        assert_eq!(rollup.by_tier_dimension["RED"]["secrets"], 2);
+        assert_eq!(rollup.by_tier_dimension["AMBER"]["churn"], 1);
+        assert!(
+            !rollup.by_tier_dimension["RED"].contains_key("license"),
+            "a cell nothing landed in is absent, not zero"
+        );
+    }
+
+    /// The invariant the whole block exists to make checkable: no consumer can
+    /// pick a marginal that disagrees with the total.
+    #[test]
+    fn every_marginal_sums_to_the_total() {
+        let (_tmp, rollup) = three_repositories();
+        let sum = |m: &BTreeMap<String, usize>| m.values().sum::<usize>();
+        assert_eq!(sum(&rollup.by_tier), rollup.total, "by_tier");
+        assert_eq!(sum(&rollup.by_dimension), rollup.total, "by_dimension");
+        assert_eq!(
+            rollup.by_repo.values().map(sum).sum::<usize>(),
+            rollup.total,
+            "by_repo"
+        );
+        assert_eq!(
+            rollup.by_tier_dimension.values().map(sum).sum::<usize>(),
+            rollup.total,
+            "by_tier_dimension"
+        );
+        // The two two-dimensional tables agree on their shared axis as well.
+        for (tier, count) in &rollup.by_tier {
+            assert_eq!(sum(&rollup.by_tier_dimension[tier]), *count, "{tier}");
+        }
+    }
+
+    #[test]
+    fn an_unbanded_finding_is_counted_not_dropped() {
+        let mut rollup = DebtRollup::default();
+        rollup.tally("acme", "  ", "");
+        rollup.tally("acme", " red ", " secrets ");
+        assert_eq!(rollup.total, 2);
+        assert_eq!(rollup.by_tier[UNSPECIFIED_TIER], 1);
+        assert_eq!(rollup.by_dimension[UNCATEGORISED_DIMENSION], 1);
+        assert_eq!(rollup.by_tier["RED"], 1, "a band is folded to upper case");
+        assert_eq!(rollup.by_dimension["secrets"], 1, "a dimension is trimmed");
+    }
+
+    #[test]
+    fn the_table_orders_red_before_amber() {
+        let mut rollup = DebtRollup::default();
+        rollup.tally("acme", "AMBER", "license");
+        rollup.tally("acme", "ZEBRA", "license");
+        rollup.tally("acme", "RED", "secrets");
+        assert_eq!(rollup.tiers(), vec!["RED", "AMBER", "ZEBRA"]);
+        let table = rollup.table();
+        let red = table.find("RED").expect("RED column");
+        let amber = table.find("AMBER").expect("AMBER column");
+        assert!(red < amber, "{table}");
+    }
+
+    /// The renderer reads the roll-up rather than re-counting: mutate the block
+    /// and the rendered totals follow it.
+    #[test]
+    fn the_table_reads_its_totals_from_the_rollup() {
+        let (_tmp, mut rollup) = three_repositories();
+        let before = rollup.table();
+        assert!(
+            before.contains("| **all repositories** | **3** | **3** | **6** |"),
+            "{before}"
+        );
+        assert!(before.contains("| acme-api | 2 | 1 | 3 |"), "{before}");
+
+        rollup.tally("acme-api", "RED", "dependencies");
+        let after = rollup.table();
+        assert!(
+            after.contains("| **all repositories** | **4** | **3** | **7** |"),
+            "{after}"
+        );
+        assert!(after.contains("| acme-api | 3 | 1 | 4 |"), "{after}");
+    }
+
+    #[test]
+    fn an_empty_rollup_renders_nothing() {
+        assert_eq!(DebtRollup::default().table(), "");
+    }
+
+    /// The closure condition's shape: a `debt_rollup` block carrying all five
+    /// fields, so a consumer can read a total without touching a finding.
+    #[test]
+    fn the_json_carries_the_rollup_block() {
+        let (_tmp, rollup) = three_repositories();
+        let text = to_json(&rollup, "2026-09-04 11:00:00 -04:00");
+        let parsed: serde_json::Value = serde_json::from_str(&text).expect("valid JSON");
+        assert_eq!(parsed["generated_at"], "2026-09-04 11:00:00 -04:00");
+        let block = &parsed["debt_rollup"];
+        for field in [
+            "by_tier",
+            "by_dimension",
+            "by_repo",
+            "by_tier_dimension",
+            "total",
+        ] {
+            assert!(!block[field].is_null(), "{field} must be present: {text}");
+        }
+        assert_eq!(block["total"], 6);
+        assert_eq!(block["by_tier"]["RED"], 3);
+        assert_eq!(block["by_dimension"]["churn"], 1);
+        assert_eq!(block["by_repo"]["acme-ops"]["RED"], 1);
+        assert_eq!(block["by_tier_dimension"]["RED"]["secrets"], 2);
+    }
+
+    #[test]
+    fn the_json_lands_beside_the_index() {
+        let (tmp, rollup) = three_repositories();
+        let out = tmp.path().join("out");
+        std::fs::create_dir(&out).expect("mkdir");
+        write(&rollup, "2026-09-04 11:00:00 -04:00", &out).expect("written");
+        let text = std::fs::read_to_string(out.join(REPORT_FILE)).expect("report.json");
+        assert!(text.contains("\"debt_rollup\""), "{text}");
+        assert!(text.contains("\"total\": 6"), "{text}");
+    }
+}

--- a/crates/trusty-audit/src/index_report.rs
+++ b/crates/trusty-audit/src/index_report.rs
@@ -241,6 +241,15 @@ pub struct IndexReport {
     pub entries: Vec<IndexEntry>,
     /// Wall clock around the whole run.
     pub total: Option<Duration>,
+    /// The findings every unit declared, counted once (#6781).
+    ///
+    /// Why: the index's "Technical debt by tier" table and the `report.json`
+    /// [`write`] leaves beside it are two views of ONE count. Carrying the
+    /// computed value here rather than letting each renderer walk the manifests
+    /// is what makes it impossible for them to disagree.
+    /// What: empty — which renders no table and an empty block — for a producer
+    /// that read no manifests, or a run whose repositories declared nothing.
+    pub debt: crate::debt_rollup::DebtRollup,
 }
 
 /// The current local time with its UTC offset, e.g. `2026-08-19 22:40:11 -04:00`.
@@ -299,7 +308,8 @@ fn strip_binary_name(binary: &Path, line: &str) -> String {
 ///
 /// # Postconditions
 /// On `Ok`, `dir/index.md` describes this run: the versions, the timestamp, the
-/// timings, and one link per report file that EXISTS at the moment of writing.
+/// timings, and one link per report file that EXISTS at the moment of writing,
+/// and `dir/report.json` carries the same run's `debt_rollup` block (#6781).
 /// Nothing outside `dir` is written — which is what keeps
 /// `crate::rerender`'s "the source package is only read" postcondition true when
 /// the re-render writes an index of its own.
@@ -313,7 +323,10 @@ fn strip_binary_name(binary: &Path, line: &str) -> String {
 pub fn write(report: &IndexReport, dir: &Path) -> Result<(), AuditError> {
     let path = dir.join(INDEX_FILE);
     std::fs::write(&path, render(report, dir))
-        .map_err(|source| AuditError::WorkDir { path, source })
+        .map_err(|source| AuditError::WorkDir { path, source })?;
+    // #6781: the machine-readable twin of the table `render` just wrote, from
+    // the same value, so a consumer never has to re-derive a total.
+    crate::debt_rollup::write(&report.debt, &report.generated_at, dir)
 }
 
 /// The index's Markdown, with every link relative to `dir`.
@@ -333,6 +346,9 @@ pub fn render(report: &IndexReport, dir: &Path) -> String {
          long each piece took, what every file here is, and where each report is.\n\n",
     );
     summary(report, &mut out);
+    // #6781: every cell comes out of `report.debt`, including the grand total,
+    // so this table and `report.json` state one number rather than two.
+    out.push_str(&report.debt.table());
     versions(report, &mut out);
     inference(report, &mut out);
     timings(report, &mut out);
@@ -538,6 +554,10 @@ impl Producer {
             Producer::Sweep => vec![
                 ("index.md", "this file"),
                 (
+                    "report.json",
+                    "the same run's technical-debt roll-up in machine-readable form — counts by tier, by dimension, by repository, and by tier x dimension, so a consumer never re-derives a total from the raw findings (#6781)",
+                ),
+                (
                     "<NN>-<repo>/",
                     "one directory per selected repository, numbered by its place in the selection",
                 ),
@@ -561,6 +581,10 @@ impl Producer {
             Producer::Render => vec![
                 ("index.md", "this file"),
                 (
+                    "report.json",
+                    "the re-rendered manifests' technical-debt roll-up in machine-readable form — counts by tier, by dimension, by repository, and by tier x dimension (#6781)",
+                ),
+                (
                     "<name>/",
                     "one directory per manifest re-rendered, named after the directory the manifest came from",
                 ),
@@ -577,6 +601,10 @@ impl Producer {
             // table and the links above it read in one frame.
             Producer::Package => vec![
                 ("index.md", "this file"),
+                (
+                    "report.json",
+                    "the packaged repositories' technical-debt roll-up in machine-readable form — counts by tier, by dimension, by repository, and by tier x dimension (#6781)",
+                ),
                 (
                     "<NN>-<repo>/manifest.toml",
                     "what `tga audit` collected for that repository — the interface `trusty-audit render` re-renders the report from",
@@ -784,6 +812,14 @@ pub fn write_sweep(
             search_evidence: !crate::grounding::search_tier_degraded(&run.gaps),
         })
         .collect();
+    // #6781: one read of each repository's manifest, feeding both the index's
+    // table and the `report.json` `write` leaves beside it.
+    let debt = crate::debt_rollup::from_manifests(report.repos.iter().map(|run| {
+        (
+            run.repo.name.clone(),
+            run.output.join(crate::manifest::AuditManifest::FILE_NAME),
+        )
+    }));
     let index = IndexReport {
         producer: Producer::Sweep,
         generated_at: local_now(),
@@ -792,6 +828,7 @@ pub fn write_sweep(
         inference: inference.map(InferenceRecord::of),
         entries,
         total: Some(total),
+        debt,
     };
     write(&index, &work.path(crate::workdir::Area::Output))
 }
@@ -848,6 +885,13 @@ pub fn write_render(
             search_evidence: !crate::grounding::search_tier_degraded(&rendered.gaps),
         })
         .collect();
+    // #6781: read from the manifest each report was rendered FROM — the
+    // re-render writes none of its own, and the source package is only read.
+    let debt = crate::debt_rollup::from_manifests(
+        reports
+            .iter()
+            .map(|rendered| (rendered.name.clone(), rendered.manifest.clone())),
+    );
     let index = IndexReport {
         producer: Producer::Render,
         generated_at: local_now(),
@@ -858,6 +902,7 @@ pub fn write_render(
         inference,
         entries,
         total: Some(total),
+        debt,
     };
     write(&index, out_dir)
 }
@@ -893,7 +938,69 @@ mod index_tests {
             inference: None,
             entries,
             total: Some(Duration::from_secs(3_723)),
+            // #6781: no findings, so the fixture's index renders no debt table
+            // and every earlier assertion over it still reads the same page.
+            debt: crate::debt_rollup::DebtRollup::default(),
         }
+    }
+
+    /// The index renders the roll-up it is handed rather than counting the
+    /// findings again — mutate the block and the rendered totals follow.
+    ///
+    /// Against `origin/main` at aec14c919 this does not compile: neither
+    /// `IndexReport.debt` nor `crate::debt_rollup` exists.
+    #[test]
+    fn the_index_states_the_debt_rollup_it_is_handed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut index = report(Producer::Sweep, vec![]);
+        assert!(
+            !render(&index, tmp.path()).contains("Technical debt by tier"),
+            "an empty roll-up renders no table"
+        );
+
+        index.debt.tally("acme-api", "RED", "dependencies");
+        index.debt.tally("acme-api", "AMBER", "secrets");
+        index.debt.tally("acme-web", "RED", "license");
+        let rendered = render(&index, tmp.path());
+        assert!(
+            rendered.contains("| **all repositories** | **2** | **1** | **3** |"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("| acme-web | 1 | 0 | 1 |"), "{rendered}");
+
+        index.debt.tally("acme-web", "RED", "churn");
+        let after = render(&index, tmp.path());
+        assert!(
+            after.contains("| **all repositories** | **3** | **1** | **4** |"),
+            "the table follows the roll-up: {after}"
+        );
+    }
+
+    /// `write` leaves the machine-readable twin beside the index, carrying the
+    /// same counts the table states (#6781).
+    #[test]
+    fn the_index_write_leaves_a_report_json_beside_it() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut index = report(Producer::Sweep, vec![]);
+        index.debt.tally("acme-api", "RED", "dependencies");
+        write(&index, tmp.path()).expect("written");
+
+        let json = std::fs::read_to_string(tmp.path().join(crate::debt_rollup::REPORT_FILE))
+            .expect("report.json");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(parsed["debt_rollup"]["total"], 1);
+        assert_eq!(parsed["debt_rollup"]["by_tier"]["RED"], 1);
+        assert_eq!(parsed["generated_at"], "2026-08-19 22:40:11 -04:00");
+
+        let markdown = std::fs::read_to_string(tmp.path().join(INDEX_FILE)).expect("index.md");
+        assert!(
+            markdown.contains("| **all repositories** | **1** | **1** |"),
+            "{markdown}"
+        );
+        assert!(
+            markdown.contains("| `report.json` |"),
+            "the contents table names the new file: {markdown}"
+        );
     }
 
     /// 🔴 #6080's requirement in one assertion: a run over ONE repository still

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -78,6 +78,10 @@ pub mod chain;
 pub mod cli;
 pub mod clone;
 pub mod config;
+// #6781: the bundle-level technical-debt roll-up — counts by tier, dimension,
+// repository, and tier x dimension, computed once per run and read by BOTH the
+// index's table and `report.json`, so the two cannot disagree.
+pub mod debt_rollup;
 pub mod discover;
 // #5825: the INBOUND package, built on the auditor's machine. `package` is the
 // outbound one built on the recipient's. Two modules, opposite directions,

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -131,6 +131,15 @@ pub const REPORTS_PREFIX: &str = "reports";
 /// Test: `super::package_tests::the_package_index_links_resolve_inside_the_zip`.
 pub const INDEX_ENTRY: &str = "reports/index.md";
 
+/// The generated member carrying the index's counts, machine-readable (#6781).
+///
+/// Why: beside [`INDEX_ENTRY`] and in the same frame, because it states the same
+/// facts for a different reader. Its `debt_rollup` block is what a downstream
+/// consumer reads instead of re-deriving totals from each manifest's raw
+/// findings, which is the whole point of computing them once.
+/// Test: `super::package_tests::the_package_carries_the_debt_rollup`.
+pub const DEBT_ENTRY: &str = "reports/report.json";
+
 /// Directory inside the zip holding the tga extract databases (#5479).
 pub const EXTRACT_PREFIX: &str = "extract";
 
@@ -362,13 +371,17 @@ pub fn assemble(
     // asks of it — what is NOT in here — and because silence about an ignored
     // request is indistinguishable from a request never made.
     excluded.extend(config.unsupported_declaration());
+    // #6781: one render, two members — the index and its machine-readable twin
+    // come out of one `IndexReport`, so they share a timestamp and a roll-up.
+    let (index, debt) = render_index(work, report, &collected);
     let generated = Generated {
         metadata: render_metadata(work, config, report, &audited, unattempted)?,
         readme: render_readme(config, &audited, &excluded),
         // #6080: built from `collected`, so the index links the members that are
         // actually going into this archive rather than the files the sweep left
         // on disk. Before `fill_archive`, because it is one of the members.
-        index: render_index(work, report, &collected),
+        index,
+        debt,
         // #6245: `None` on a clean sweep — a `failures/` directory holding an
         // index that says "none" is worse than no directory.
         failures: render_failures(report, &collected),
@@ -674,6 +687,10 @@ fn fill_archive(
         (README_ENTRY, Some(generated.readme)),
         (METADATA_ENTRY, Some(generated.metadata)),
         (INDEX_ENTRY, Some(generated.index)),
+        // #6781: written unconditionally, exactly as the index is — a run whose
+        // repositories declared no findings ships a roll-up whose total is 0,
+        // which is a statement, where an absent file would be a question.
+        (DEBT_ENTRY, Some(generated.debt)),
         // #6245: absent on a clean sweep — see `Generated::failures`.
         (FAILURES_ENTRY, generated.failures),
     ];
@@ -988,6 +1005,69 @@ trusty-review = "0.15.1"
         assert!(index.contains("| acme-api | 12m 32s |"), "{index}");
         // And no log is offered, because the archive carries none.
         assert!(!index.contains("- log:"), "{index}");
+    }
+
+    /// Declare `[report].findings` on a repository the sweep already audited.
+    fn declares_findings(run: &RepoRun, rows: &[(&str, &str)]) {
+        let mut text = String::from("[report]\ntitle = \"Acme\"\nfindings = [\n");
+        for (severity, category) in rows {
+            text.push_str(&format!(
+                "  {{ category = \"{category}\", id = \"X\", severity = \"{severity}\" }},\n"
+            ));
+        }
+        text.push_str("]\n\n[[repositories]]\nname = \"acme\"\npath = \"/r\"\n");
+        std::fs::write(run.output.join("manifest.toml"), text).expect("write manifest");
+    }
+
+    /// 🔴 #6781: the delivered package carries the roll-up as a member, so the
+    /// recipient's consumers read one total instead of re-deriving it from every
+    /// manifest's raw findings — and the index's table states the same numbers.
+    ///
+    /// Against `origin/main` at aec14c919 this fails on the first assertion:
+    /// `reports/report.json` was not a member of the archive.
+    #[test]
+    fn the_package_carries_the_debt_rollup() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let api = audited(&work, "00-acme-api", "acme-api");
+        let web = audited(&work, "01-acme-web", "acme-web");
+        declares_findings(&api, &[("RED", "dependencies"), ("AMBER", "secrets")]);
+        declares_findings(&web, &[("RED", "license")]);
+        let report = RunReport::of(vec![api, web]);
+        let destination = default_destination(&work);
+
+        let package =
+            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assert!(
+            package.files.iter().any(|f| f.entry == DEBT_ENTRY),
+            "the roll-up must be reported as a member: {:?}",
+            package.files
+        );
+
+        let json = read_entry(&destination, DEBT_ENTRY);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        let block = &parsed["debt_rollup"];
+        assert_eq!(block["total"], 3, "{json}");
+        assert_eq!(block["by_tier"]["RED"], 2, "{json}");
+        assert_eq!(block["by_dimension"]["secrets"], 1, "{json}");
+        assert_eq!(block["by_repo"]["acme-web"]["RED"], 1, "{json}");
+        assert_eq!(block["by_tier_dimension"]["AMBER"]["secrets"], 1, "{json}");
+
+        let index = read_entry(&destination, INDEX_ENTRY);
+        assert!(
+            index.contains("| **all repositories** | **2** | **1** | **3** |"),
+            "{index}"
+        );
+        // One render, so both members carry one timestamp.
+        assert_eq!(
+            parsed["generated_at"].as_str().expect("a timestamp"),
+            index
+                .lines()
+                .find_map(|l| l.strip_prefix("- Generated: "))
+                .expect("the index states one"),
+            "{index}"
+        );
     }
 
     /// 🔴 Every link the packaged index writes must name a member that is

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -41,6 +41,12 @@ pub(super) struct Generated {
     pub(super) metadata: String,
     /// [`super::INDEX_ENTRY`] — what the reports are, and a link to each.
     pub(super) index: String,
+    /// [`super::DEBT_ENTRY`] — the index's counts, machine-readable (#6781).
+    ///
+    /// Rendered from the same [`crate::index_report::IndexReport`] the index is,
+    /// so the table a recipient reads and the block a consumer parses are the
+    /// same numbers rather than two derivations of them.
+    pub(super) debt: String,
     /// [`super::FAILURES_ENTRY`] — every repository that failed, and why.
     ///
     /// `None` when the sweep had no failures: a `failures/` directory holding
@@ -120,13 +126,19 @@ struct PackagedRepo {
 /// [`crate::index_report::Producer::Package`]. Rendered against
 /// [`REPORTS_PREFIX`], which is where the member lands, so `<stem>/report.md`
 /// and `../extract/<stem>.db` both resolve inside the archive.
+///
+/// Returns the index AND its machine-readable twin, `reports/report.json`
+/// (#6781), because both are rendered from one [`crate::index_report::IndexReport`]
+/// — one timestamp and one roll-up, so the two members cannot disagree about
+/// either.
 /// Test: `super::package_tests::the_package_carries_an_index_of_its_reports`,
-/// `super::package_tests::the_package_index_links_resolve_inside_the_zip`.
+/// `super::package_tests::the_package_index_links_resolve_inside_the_zip`,
+/// `super::package_tests::the_package_carries_the_debt_rollup`.
 pub(super) fn render_index(
     work: &WorkDir,
     report: &RunReport,
     collected: &[(String, PathBuf)],
-) -> String {
+) -> (String, String) {
     let entries = report
         .repos
         .iter()
@@ -170,8 +182,20 @@ pub(super) fn render_index(
         inference: declared_inference(report),
         entries,
         total: (measured > 0).then(|| std::time::Duration::from_millis(measured)),
+        // #6781: read from the sweep's own manifests on disk, not the zip
+        // members — the counts describe the same repositories either way, and
+        // the archive is still being written when this renders.
+        debt: crate::debt_rollup::from_manifests(report.repos.iter().map(|run| {
+            (
+                run.repo.name.clone(),
+                run.output.join(crate::manifest::AuditManifest::FILE_NAME),
+            )
+        })),
     };
-    crate::index_report::render(&index, Path::new(REPORTS_PREFIX))
+    (
+        crate::index_report::render(&index, Path::new(REPORTS_PREFIX)),
+        crate::debt_rollup::to_json(&index.debt, &index.generated_at),
+    )
 }
 
 /// The inference identity the packaged manifests declare (#6135).

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -1201,6 +1201,89 @@ trusty-review = "0.15.1"
         assert!(index.contains("../extract/<NN>-<repo>.db"), "{index}");
     }
 
+    /// A stub `tga` whose manifest declares `[report].findings` in both bands
+    /// and two dimensions — what the assurance collectors leave behind.
+    fn writes_findings() -> String {
+        r#"#!/bin/sh
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in --output) out="$2"; shift;; esac
+  shift
+done
+mkdir -p "$out"
+cat > "$out/manifest.toml" <<'MANIFEST'
+[report]
+title = "Acme"
+findings = [
+  { category = "dependencies", id = "RUSTSEC-1", severity = "RED" },
+  { category = "dependencies", id = "RUSTSEC-2", severity = "AMBER" },
+  { category = "secrets", id = "leak", severity = "RED" },
+]
+
+[[repositories]]
+name = "acme"
+path = "/r"
+MANIFEST
+exit 0
+"#
+        .to_owned()
+    }
+
+    /// 🔴 #6781: the sweep rolls its repositories' findings up ONCE and delivers
+    /// the counts two ways — `out/report.json` for machine consumers, and the
+    /// index's own table — so neither has to re-derive a total.
+    ///
+    /// Against `origin/main` at aec14c919 this fails on its first read: `out/`
+    /// carried no `report.json` at all.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_sweep_rolls_its_findings_up_into_report_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_findings());
+        make_repo(&work, "acme-api");
+        make_repo(&work, "acme-web");
+        select(
+            &work,
+            &[
+                ("acme-api", "repos/acme-api"),
+                ("acme-web", "repos/acme-web"),
+            ],
+        );
+
+        let report = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect("the sweep completes");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+
+        let json = std::fs::read_to_string(
+            work.path(Area::Output)
+                .join(crate::debt_rollup::REPORT_FILE),
+        )
+        .expect("the sweep writes report.json beside its index");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        let block = &parsed["debt_rollup"];
+        assert_eq!(block["total"], 6, "{json}");
+        assert_eq!(block["by_tier"]["RED"], 4, "{json}");
+        assert_eq!(block["by_tier"]["AMBER"], 2, "{json}");
+        assert_eq!(block["by_dimension"]["dependencies"], 4, "{json}");
+        assert_eq!(block["by_dimension"]["secrets"], 2, "{json}");
+        assert_eq!(block["by_repo"]["acme-api"]["RED"], 2, "{json}");
+        assert_eq!(
+            block["by_tier_dimension"]["AMBER"]["dependencies"], 2,
+            "{json}"
+        );
+
+        // The index states the same counts, taken from the same value.
+        let index = index_of(&work);
+        assert!(index.contains("## Technical debt by tier"), "{index}");
+        assert!(
+            index.contains("| **all repositories** | **4** | **2** | **6** |"),
+            "{index}"
+        );
+        assert!(index.contains("| acme-api | 2 | 1 | 3 |"), "{index}");
+    }
+
     /// #6080: the checkpoint records how long each repository took, so a resumed
     /// sweep can report the run that did the work rather than the second it took
     /// to verify the output.


### PR DESCRIPTION
Every assurance collector writes its rows into one repository's `[report].findings` and nothing added them up, so a consumer wanting an engagement's RED count opened each `manifest.toml` and counted for itself.

`debt_rollup` computes those counts once per run and hands the result to both consumers, so they cannot disagree:

- `index.md` gains a "Technical debt by tier" table across repositories.
- `report.json` beside it carries the same value verbatim, under a `debt_rollup` block.

The sweep, the re-render, and the return package (`reports/report.json`) all produce both. The package's two members come out of one `IndexReport`, so they share a timestamp as well as a roll-up.

## The axes, and where their values come from

Two axes, both the collectors' own vocabulary — nothing is re-banded or re-labelled.

| Axis | Field | Values | Source |
|---|---|---|---|
| tier | `severity` | `RED`, `AMBER` | `grounding::cve::Severity`, reused by the license, secrets and churn legs |
| dimension | `category` | `dependencies`, `license`, `secrets`, `churn` | the four `CATEGORY` constants under `grounding` |

An unrecognised band or category is counted under its own name rather than dropped — the producer owns the vocabulary, and a collector added later must still reach the total. A manifest that is absent or will not parse contributes nothing rather than failing the run; the index already states why that unit produced no report.

### No effort axis — read this before assuming one was missed

The issue asks for "effort tiers" and says each finding carries `cost_effort (low/medium/high)`. **No such field exists on the findings this roll-up counts.** `ManifestFinding` (`trusty-review/src/report/manifest.rs:300`) carries `category`, `id`, `package`, `version`, `severity`, `title`, `url` — and no effort of any kind.

A `cost_effort` field does exist, on a *different* population in a different crate: `trusty_review::report::investigate::analyze::Finding` (`analyze.rs:113`), the LLM's DD reading, serialised per repository to `investigation.json` (`trusty-review/src/report/run.rs:819`). Three things separate it from what is rolled up here:

1. It is a different population. Those are an LLM's readings of source files; these are deterministic scanner rows. Summing them into one `total` would make every marginal describe two things at once.
2. It is free text, not a tier. The schema says "Qualitative cost/effort framing; no invented figures. Empty string if unknown" — `low`/`medium`/`high` is a convention the model is not held to.
3. `investigation.json` is a best-effort recovery snapshot whose write failure is a warning, so it is not reliably present.

Adding `by_effort` / `by_effort_dimension` over that source is feasible — the snapshot sits in the same directory this roll-up already reads `manifest.toml` from. It is a deliberate second scope, not an oversight. Raised on #6781 for the owner to direct.

## The invariant

`DebtRollup::tally` is the only writer of all five counters, so the invariant holds by construction rather than by discipline. `every_marginal_sums_to_the_total` checks it on a fixture of findings across three repositories: `by_tier`, `by_dimension`, `by_repo` summed over repositories, and `by_tier_dimension` summed over both axes each equal `total`, and the two two-dimensional tables agree on their shared axis.

`the_table_reads_its_totals_from_the_rollup` and `the_index_states_the_debt_rollup_it_is_handed` mutate the block and assert the rendered totals follow, which is what proves the renderer reads the roll-up rather than counting again.

Nothing was replaced: no loop over findings computing a total existed anywhere in `trusty-audit`, and `trusty-review`'s Assurance Scans renderer emits per-category tables with no count. This roll-up is the first derivation of a total, not a second one.

## Gates — rung 3, `-p trusty-audit`

`cargo fmt --check`, `cargo check -p trusty-audit --all-targets`, `cargo clippy -p trusty-audit --all-targets -- -D warnings` — all exit 0.

`cargo test -p trusty-audit --no-fail-fast` — 931 passed, 0 failed, 7 ignored, across 9 targets plus doc-tests:

```
     Running unittests src/lib.rs
test result: ok. 898 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 33.03s
     Running tests/binary_names.rs
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/cli_end_to_end.rs
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/guided_launch.rs
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/install_fails_closed.rs
test result: ok. 4 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
     Running tests/render_zero_arg.rs
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/run_fails_closed.rs
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   Doc-tests trusty_audit
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

14 of those are new: 10 in `debt_rollup_tests`, 2 in `index_tests`, 1 in `run_tests`, 1 in `package_tests`. Each fails without the change — verified by neutering the two production hooks and keeping the tests, which produced `report.json: Os { code: 2, kind: NotFound }` on both write paths and a missing table on the render path.

Doc gates: `check_line_cap.sh` (0 violations), `check_test_pointers.sh` (0 dangling), `check_changelog_fragment.sh` (fragment present and valid), `check_sld.sh` (0 errors).

## Note

`grounding_tests::a_409_registration_conflict_clears_the_stale_row_and_retries` and `an_unresolvable_409_degrades_the_evidence_tier_out_loud` failed once mid-session and passed on every run since. This branch touches no `grounding/` file.

Refs #6781
milestone #71

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
