### PR TITLE
fix(tga): fetch SSH-scheme remotes and surface a stale-history headline (Refs #6782)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10439,7 +10439,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "7.0.0"
+version = "7.1.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-audit/changelog.d/6782-stale-history-index.md
+++ b/crates/trusty-audit/changelog.d/6782-stale-history-index.md
@@ -1,0 +1,7 @@
+Fixed
+
+- The run index and the return package's `reports/index.md` now state, in a
+  repository's own section, that its git history is stale because the fetch
+  failed. The fact reached the recipient only as one bullet inside section 9 of
+  that repository's report, which is read after its commit and pull-request
+  figures rather than before them (#6782).

--- a/crates/trusty-audit/src/index_report.rs
+++ b/crates/trusty-audit/src/index_report.rs
@@ -206,6 +206,16 @@ pub struct IndexEntry {
     pub log: Option<PathBuf>,
     /// Why this unit produced no report, or `None` when it produced one.
     pub failure: Option<String>,
+    /// Gap lines saying this unit's git history is stale (#6782), verbatim.
+    ///
+    /// Why: a repository whose fetch failed produces a report that looks
+    /// complete and is quietly describing a clone of unknown age. It reaches
+    /// the index because the index is what a reader opens first — a caveat
+    /// buried in section 9 of the report itself is read too late, if at all.
+    /// What: empty for every unit whose remotes were reached, which is every
+    /// unit of a producer that runs no fetch. A re-render and a package carry
+    /// none: neither fetches, and neither re-reads the sweep's manifests.
+    pub stale: Vec<String>,
     /// Whether an earlier run did this work and this one carried it over.
     pub carried_over: bool,
     /// Wall clock around this unit, or `None` when this run did not measure it.
@@ -477,6 +487,11 @@ fn reports(report: &IndexReport, dir: &Path, out: &mut String) {
         out.push_str(&format!("### {}\n\n", entry.name));
         if let Some(reason) = &entry.failure {
             out.push_str(&format!("No report — {reason}\n\n"));
+        }
+        // #6782: before the links, because the point is to be read before the
+        // report is opened.
+        for line in &entry.stale {
+            out.push_str(&format!("> {line}\n\n"));
         }
         if entry.files.is_empty() && entry.failure.is_none() {
             out.push_str(&format!(
@@ -805,6 +820,14 @@ pub fn write_sweep(
                 crate::run::RepoResult::Failed { reason } => Some(reason.clone()),
                 crate::run::RepoResult::Succeeded => None,
             },
+            // #6782: promoted out of the manifest's gap list so the index
+            // states it beside the repository's own links.
+            stale: run
+                .gaps
+                .iter()
+                .filter(|gap| gap.contains(crate::run::STALE_FETCH_MARKER))
+                .cloned()
+                .collect(),
             carried_over: run.resumed,
             duration: run.duration_ms.map(Duration::from_millis),
             // #6783: read off the gaps this repository actually stated, which a
@@ -878,6 +901,9 @@ pub fn write_render(
                 crate::rerender::RenderResult::Failed { reason } => Some(reason.clone()),
                 crate::rerender::RenderResult::Succeeded => None,
             },
+            // A re-render fetches nothing and reads no manifest gaps, so it has
+            // no stale-history fact of its own to state (#6782).
+            stale: Vec::new(),
             carried_over: false,
             duration: rendered.duration_ms.map(Duration::from_millis),
             // #6783: a re-render indexes any checkout present on this machine,
@@ -920,10 +946,44 @@ mod index_tests {
             dir,
             log: None,
             failure: None,
+            stale: Vec::new(),
             carried_over: false,
             duration: Some(Duration::from_millis(1_500)),
             search_evidence: true,
         }
+    }
+
+    /// Why (#6782): a repository fetched from nothing renders a full report,
+    /// so the index is where a reader has to see that its history is stale —
+    /// #5321's mid-list Gaps bullet is read after the figures, if at all.
+    /// What: an entry carrying a stale gap line renders it in that
+    /// repository's own section, and a clean entry adds nothing.
+    /// Test: this is the test.
+    #[test]
+    fn a_stale_repository_is_named_in_its_index_section() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("01-acme");
+        std::fs::create_dir_all(&dir).expect("create dir");
+
+        let mut stale = entry("acme/api", dir.clone());
+        stale.stale = vec![format!(
+            "**{} (unsupported URL protocol; class=Net (12))** — repository `acme/api` \
+             could not be fetched from remote `origin`.",
+            crate::run::STALE_FETCH_MARKER
+        )];
+        let clean = entry("acme/web", dir);
+
+        let text = render(&report(Producer::Sweep, vec![stale, clean]), tmp.path());
+
+        assert!(
+            text.contains("> **git history is stale: fetch failed"),
+            "the index does not headline the stale repository:\n{text}"
+        );
+        assert_eq!(
+            text.matches("git history is stale").count(),
+            1,
+            "the clean repository picked up a stale line:\n{text}"
+        );
     }
 
     fn report(producer: Producer, entries: Vec<IndexEntry>) -> IndexReport {

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -161,6 +161,15 @@ pub(super) fn render_index(
                     crate::run::RepoResult::Failed { reason } => Some(reason.clone()),
                     crate::run::RepoResult::Succeeded => None,
                 },
+                // #6782: the recipient's copy of the same headline. This index
+                // is the one they open, so leaving it to the sweep's `out/`
+                // index would state it only to the operator.
+                stale: run
+                    .gaps
+                    .iter()
+                    .filter(|gap| gap.contains(crate::run::STALE_FETCH_MARKER))
+                    .cloned()
+                    .collect(),
                 carried_over: run.resumed,
                 duration: run.duration_ms.map(std::time::Duration::from_millis),
                 // #6783: the recipient's copy of the coverage count, read off

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -140,6 +140,9 @@ use approve::approve_for_indexing;
 use child::spawn_tga;
 use pins::{PinnedBinaries, pinned_binaries};
 use verify::{mark_complete, verify_output};
+// #6782: the index states a stale-history repository, and verify.rs owns the
+// marker it recognises.
+pub(crate) use verify::STALE_FETCH_MARKER;
 
 // Re-exported at its historical path: `crate::rerender`, `crate::distribute`,
 // `crate::session` and both `cli` submodules name it as `crate::run::…`.

--- a/crates/trusty-audit/src/run/verify.rs
+++ b/crates/trusty-audit/src/run/verify.rs
@@ -27,6 +27,21 @@ use crate::manifest::AuditManifest;
 /// only way this client can tell "assessed" from "assessed nothing".
 const COLLECT_FAILED_MARKER: &str = "stage `collect` did not complete";
 
+/// The words `tga` opens a stale-refs gap line with (`tga::audit::gaps`'s
+/// `STALE_FETCH_HEADLINE`, #6782).
+///
+/// Why: a repository fetched from nothing still produces a full report — every
+/// section populated, every figure describing whatever the clone held when it
+/// was made. That is worse than an empty section, because nothing on the page
+/// looks wrong. The index states it per repository so a reader sees it before
+/// they open the report.
+/// What: matched against the gap lines [`verify_output`] returns, the same
+/// textual seam and the same brittleness as [`COLLECT_FAILED_MARKER`] — this
+/// crate does not depend on `tga`, so its prose is the only channel. A reworded
+/// marker stops the headline, never the gap line itself, which is rendered
+/// either way.
+pub(crate) const STALE_FETCH_MARKER: &str = "git history is stale: fetch failed";
+
 /// What a zero exit is allowed to mean.
 ///
 /// Why: the finding that made this necessary. `tga audit` returns `Ok` whenever

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -59,7 +59,7 @@ name = "tga"
 # new config table; nothing existing is removed or changed. `src/**` changed
 # while 6.0.0 was already live on crates.io, so the `PR version bump vs
 # crates.io` gate (#4421) requires the bump.
-version = "7.0.0"
+version = "7.1.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -142,16 +142,21 @@ toml_edit = { workspace = true }
 # is the documented way to extend a shared dep without cloning the version.
 rusqlite = { workspace = true, features = ["chrono"] }
 # Git
-# Local pin retained: the workspace `git2` entry turns on default ssh+https
-# features and `vendored-openssl`; tga explicitly disables defaults to drop
-# the libssh2 system dependency. The `https` and `vendored-openssl` features
-# are added here (#337) so `tga collect` can fetch from https:// remotes
-# without an external system git:
+# Local pin retained: the workspace `git2` entry turns on git2's defaults; tga
+# disables them and names exactly the transports it needs, so the feature set
+# is stated here rather than inherited.
+# The `https` and `vendored-openssl` features are here (#337) so `tga collect`
+# can fetch from https:// remotes without an external system git:
 #   - macOS: uses the native Security framework (no openssl runtime dep)
 #   - Linux: vendors openssl statically (portable binaries, no system libssl)
 #   - Windows: uses Schannel (no openssl runtime dep)
-# SSH transport remains disabled (out of scope for this fix).
-git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2", "https", "vendored-openssl"] }
+# #6782: `ssh` links libssh2, without which libgit2 rejects every
+# `git@host:org/repo.git` / `ssh://` origin with `unsupported URL protocol;
+# class=Net (12)` — 59 of 59 repositories in a client audit — and the sweep
+# then walks clone-time refs. libssh2-sys vendors libssh2 from its own bundled
+# source, and `vendored-openssl` already propagates to it, so this adds no
+# system library and no new runtime dependency.
+git2 = { version = "0.20", default-features = false, features = ["vendored-libgit2", "https", "ssh", "vendored-openssl"] }
 # HTTP client — workspace entry already declares
 # `default-features = false, features = ["json", "stream", "rustls-tls"]`
 # which is a superset of what tga needs. The `stream` extra is harmless

--- a/crates/trusty-git-analytics/changelog.d/6782-ssh-fetch.md
+++ b/crates/trusty-git-analytics/changelog.d/6782-ssh-fetch.md
@@ -8,6 +8,11 @@ Fixed
   collected from clone-time refs. Adding the feature links libssh2 from its own
   vendored source and reuses the openssl this crate already vendors, so no new
   system library or runtime dependency (#6782).
+- The non-interactive credential chain now offers each source at most once per
+  fetch instead of answering from the top every time libgit2 re-enters the
+  callback. `ssh-agent` running with no identities loaded reports success, so
+  the old behaviour re-offered the empty agent until libgit2 gave up — 120
+  seconds per repository — and never reached `~/.ssh/id_ed25519` (#6782).
 - A repository collected from stale local refs now leads the report's Gaps &
   Caveats section with **git history is stale: fetch failed (…)**, ahead of the
   failed stages, and is named on stderr during the run. It was one unemphasised

--- a/crates/trusty-git-analytics/changelog.d/6782-ssh-fetch.md
+++ b/crates/trusty-git-analytics/changelog.d/6782-ssh-fetch.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `tga collect` and `tga audit` can now fetch from an SSH-scheme `origin`. The
+  `git2` dependency was built without the `ssh` feature, so libgit2 had no
+  libssh2 transport and rejected every `git@host:org/repo.git` or `ssh://`
+  remote with `unsupported URL protocol; class=Net (12)` before the fetch's
+  credential callback ran — 59 of 59 repositories in a client audit, each
+  collected from clone-time refs. Adding the feature links libssh2 from its own
+  vendored source and reuses the openssl this crate already vendors, so no new
+  system library or runtime dependency (#6782).
+- A repository collected from stale local refs now leads the report's Gaps &
+  Caveats section with **git history is stale: fetch failed (…)**, ahead of the
+  failed stages, and is named on stderr during the run. It was one unemphasised
+  sentence mid-list, which a reader taking the commit and pull-request figures
+  at face value could pass over (#6782).

--- a/crates/trusty-git-analytics/src/audit/gaps.rs
+++ b/crates/trusty-git-analytics/src/audit/gaps.rs
@@ -62,8 +62,21 @@ pull-request, and ticket metadata; it stores no file content, diffs, patches, hu
 Free-text fields it does store — commit messages, pull-request and ticket titles — are retained \
 verbatim and carry whatever their authors wrote into them.";
 
-/// One Gaps & Caveats line per stage that did not complete, then one per
-/// repository collected from stale local refs.
+/// The words a stale-refs gap line opens with (#6782).
+///
+/// Why: #5321 put the fallback on the page, but as one mid-list sentence in a
+/// section a reader skims, so a due-diligence reader taking commit and PR
+/// figures at face value had nothing to stop them. Leading with the verdict is
+/// what makes it visible; exporting the phrase is what lets a downstream
+/// consumer — `trusty-audit`'s run index — recognise the line instead of
+/// re-deriving the wording.
+/// What: the literal prefix every stale-refs line starts with, before the
+/// parenthesised reason.
+/// Test: `super::tests::a_stale_fetch_line_leads_with_the_headline`.
+pub const STALE_FETCH_HEADLINE: &str = "git history is stale: fetch failed";
+
+/// One Gaps & Caveats line per repository collected from stale local refs, then
+/// one per stage that did not complete.
 ///
 /// Why: a stage that failed took a whole class of data with it — no `dora` run
 /// means no delivery-health figures, no `jira sync` means no ticket
@@ -73,10 +86,11 @@ verbatim and carry whatever their authors wrote into them.";
 /// here. A stale-refs fallback (#5321) is the same obligation one step
 /// further in: the stage SUCCEEDED, so nothing about the data's age is visible
 /// anywhere on the page unless it is stated here.
-/// What: for each failure in execution order, a line naming the stage, a
-/// redacted excerpt of the reason, and the fact that the affected area is
-/// unassessed; then, for each unreachable remote, a line naming the repository,
-/// the remote, and that its figures may be behind the true remote state; then,
+/// What: for each unreachable remote FIRST (#6782), a line opening with
+/// [`STALE_FETCH_HEADLINE`] and naming the repository, the remote, and that its
+/// figures may be behind the true remote state; then, for each failure in
+/// execution order, a line naming the stage, a redacted excerpt of the reason,
+/// and the fact that the affected area is unassessed; then,
 /// for each leg the config declared absent (#6130), a line naming the leg and
 /// why it was never attempted. Returns an empty vec when every stage succeeded,
 /// every remote was reached, and every leg ran — a clean run adds no line.
@@ -90,7 +104,8 @@ verbatim and carry whatever their authors wrote into them.";
 /// credential was embedded in it.
 /// Test: `super::tests::{sweep_gap_lines_name_each_failed_stage,
 /// sweep_gap_lines_are_empty_for_a_clean_run,
-/// a_repo_that_fell_back_to_stale_local_refs_is_named_in_the_gap_lines}`, and
+/// a_repo_that_fell_back_to_stale_local_refs_is_named_in_the_gap_lines,
+/// a_stale_fetch_line_leads_with_the_headline}`, and
 /// `crate::report::dd_manifest_tests::a_token_straddling_the_excerpt_boundary_leaves_no_fragment`.
 pub fn sweep_gap_lines<S: AsRef<str>>(stats: &AuditSweepStats, secrets: &[S]) -> Vec<String> {
     let failed_stages = stats.failures().map(|outcome| {
@@ -108,12 +123,16 @@ pub fn sweep_gap_lines<S: AsRef<str>>(stats: &AuditSweepStats, secrets: &[S]) ->
 
     // #5321: worded from the collector's own log line, because an operator who
     // has the run log needs to match the two up without translating.
+    // #6782: the verdict leads, and the line is emitted ahead of the stage
+    // failures below — a reader who stops after the first bullet has still read
+    // the one fact that invalidates the commit and PR figures.
     let stale = stats.stale_fetches.iter().map(|fetch| {
         let reason = redacted_excerpt(&fetch.error, secrets);
         format!(
-            "Repository `{}` could not be fetched from remote `{}` ({reason}) — collection \
-             continued on stale local refs, so its data may be behind the true remote state. \
-             Read its figures as a snapshot of the local clone, not of the remote.",
+            "**{STALE_FETCH_HEADLINE} ({reason})** — repository `{}` could not be fetched \
+             from remote `{}`, so collection continued on stale local refs and its data may \
+             be behind the true remote state. Read its figures as a snapshot of the local \
+             clone, not of the remote.",
             fetch.repo, fetch.remote
         )
     });
@@ -132,7 +151,10 @@ pub fn sweep_gap_lines<S: AsRef<str>>(stats: &AuditSweepStats, secrets: &[S]) ->
         )
     });
 
-    failed_stages.chain(stale).chain(declared).collect()
+    // #6782: stale-refs lines first. A failed stage leaves an EMPTY section,
+    // which a reader notices; a stale fetch leaves a full one that is quietly
+    // wrong, which they do not.
+    stale.chain(failed_stages).chain(declared).collect()
 }
 
 /// One Gaps & Caveats line per distinct reason a repository could not be

--- a/crates/trusty-git-analytics/src/audit/mod.rs
+++ b/crates/trusty-git-analytics/src/audit/mod.rs
@@ -49,7 +49,7 @@ pub use analyze::{
 /// of a copy that can drift away from it (#5308 review).
 #[cfg(test)]
 pub(crate) use gaps::MAX_REASON_CHARS;
-pub use gaps::{index_gap_lines, sweep_gap_lines, DATA_HANDLING_NOTE};
+pub use gaps::{index_gap_lines, sweep_gap_lines, DATA_HANDLING_NOTE, STALE_FETCH_HEADLINE};
 pub use repo_index::{
     ensure_repositories_indexed, index_id_for, resolve_search_binary, RepoIndexOutcome,
     RepoIndexStatus, DEFAULT_SEARCH_BIN, ENV_SEARCH_BIN,

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -593,8 +593,10 @@ fn init_repo_with_dead_origin(path: &std::path::Path, remote_url: &str) {
 /// The stale-refs line travels the same redaction path a stage message does,
 /// and it needs to: git2 quotes the remote URL back in the error, so an HTTPS
 /// remote with an embedded token puts that token in the manifest and the
-/// delivered report. Also pins the ordering — failed stages first, then the
-/// repositories that were collected anyway.
+/// delivered report. Also pins the ordering — since #6782 the repositories
+/// collected on stale refs come FIRST, ahead of the failed stages, because a
+/// failed stage leaves an empty section a reader notices and a stale fetch
+/// leaves a full one that is quietly wrong.
 #[test]
 fn a_credential_in_a_fetch_error_never_reaches_the_gap_line() {
     let mut stats = AuditSweepStats::default();
@@ -613,12 +615,43 @@ fn a_credential_in_a_fetch_error_never_reaches_the_gap_line() {
     let lines = crate::audit::sweep_gap_lines(&stats, &["ghp_SECRETVALUE"]);
 
     assert_eq!(lines.len(), 2, "{lines:#?}");
-    assert!(lines[0].contains("`dora`"), "{}", lines[0]);
-    assert!(lines[1].contains("acme-service"), "{}", lines[1]);
+    assert!(lines[0].contains("acme-service"), "{}", lines[0]);
+    assert!(lines[1].contains("`dora`"), "{}", lines[1]);
     assert!(
-        !lines[1].contains("ghp_SECRETVALUE"),
+        !lines[0].contains("ghp_SECRETVALUE"),
         "the token survived into the report: {}",
-        lines[1]
+        lines[0]
+    );
+}
+
+/// Why (#6782): #5321 put the stale-refs fallback on the page as one sentence
+/// mid-list, phrased as a repository fact — a due-diligence reader taking the
+/// commit and PR figures at face value had nothing to stop them.
+/// What: the line opens with [`crate::audit::STALE_FETCH_HEADLINE`], carries
+/// the fetch error, and is emphasised, so it reads as a verdict rather than as
+/// one more caveat.
+/// Test: this is the test.
+#[test]
+fn a_stale_fetch_line_leads_with_the_headline() {
+    let mut stats = AuditSweepStats::default();
+    stats.record_stale_fetch(crate::audit::StaleFetch {
+        repo: "acme-service".to_string(),
+        remote: "origin".to_string(),
+        error: "unsupported URL protocol; class=Net (12)".to_string(),
+    });
+
+    let lines = crate::audit::sweep_gap_lines(&stats, NO_SECRETS);
+
+    assert_eq!(lines.len(), 1, "{lines:#?}");
+    assert!(
+        lines[0].starts_with(&format!("**{}", crate::audit::STALE_FETCH_HEADLINE)),
+        "the line does not lead with the headline: {}",
+        lines[0]
+    );
+    assert!(
+        lines[0].contains("unsupported URL protocol"),
+        "the line must carry the fetch error: {}",
+        lines[0]
     );
 }
 

--- a/crates/trusty-git-analytics/src/collect/git/fetch.rs
+++ b/crates/trusty-git-analytics/src/collect/git/fetch.rs
@@ -315,4 +315,71 @@ mod tests {
             prf.outcome
         );
     }
+
+    /// The error libgit2 returns when it has no transport for a URL's scheme.
+    ///
+    /// #6782: this is the string 59 client repositories hit, and the one thing
+    /// an SSH remote must never produce — it means libssh2 was never linked in,
+    /// so no credential this module offers was ever consulted.
+    const NO_TRANSPORT: &str = "unsupported URL protocol";
+
+    /// A loopback port with nothing listening, so a connect attempt is refused
+    /// immediately rather than waiting out a TCP timeout.
+    fn closed_loopback_port() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+        port
+    }
+
+    /// Run a tracked fetch against `url` and return the recorded failure text.
+    fn fetch_error_for(url: &str) -> String {
+        let td = tempfile::tempdir().expect("tempdir");
+        let repo = git2::Repository::init(td.path()).expect("init");
+        repo.remote("origin", url).expect("add remote origin");
+        match fetch_remote_with_outcome(&repo, "origin").expect("soft-fail returns Ok") {
+            FetchOutcome::Failed { error, .. } => error,
+            other => panic!("expected Failed for unreachable {url}, got {other:?}"),
+        }
+    }
+
+    /// Why (#6782): tga's `git2` was built without the `ssh` feature, so
+    /// libgit2 rejected every `ssh://` remote before the credential callback
+    /// above ran. The audit then walked whatever the clone-time refs held and
+    /// reported success.
+    /// What: points `origin` at an `ssh://` URL on a closed loopback port and
+    /// asserts the recorded failure is a connect/auth failure, not libgit2
+    /// declining the scheme. Pre-fix this asserts against `unsupported URL
+    /// protocol; class=Net (12)`.
+    /// Test: this is the test.
+    #[test]
+    fn an_ssh_url_reaches_the_ssh_transport() {
+        let url = format!(
+            "ssh://git@127.0.0.1:{}/org/repo.git",
+            closed_loopback_port()
+        );
+        let error = fetch_error_for(&url);
+        assert!(
+            !error.contains(NO_TRANSPORT),
+            "ssh:// remote was rejected for want of a transport, not for want of a \
+             reachable host: {error}"
+        );
+    }
+
+    /// Why (#6782): the scp-style spelling `git@host:org/repo.git` is what
+    /// `git clone` writes for a GitHub SSH remote, so it is the form the client
+    /// audit actually carried. libgit2 parses it into the same SSH transport,
+    /// which means it fails the same way when that transport is absent.
+    /// What: points `origin` at a scp-style URL on loopback and asserts the
+    /// failure is not the missing-transport error.
+    /// Test: this is the test.
+    #[test]
+    fn an_scp_style_remote_reaches_the_ssh_transport() {
+        let error = fetch_error_for("git@127.0.0.1:org/repo.git");
+        assert!(
+            !error.contains(NO_TRANSPORT),
+            "scp-style remote was rejected for want of a transport, not for want of a \
+             reachable host: {error}"
+        );
+    }
 }

--- a/crates/trusty-git-analytics/src/collect/git/fetch.rs
+++ b/crates/trusty-git-analytics/src/collect/git/fetch.rs
@@ -17,6 +17,10 @@
 //! 4. Git credential helper (falls through to the platform keychain, e.g.
 //!    `osxkeychain`, `store`, or `manager-core`)
 //!
+//! Each is offered at most once per fetch, in that order: libgit2 re-enters
+//! the credential callback after every rejection, so a callback that answered
+//! from the top each time would re-offer source 1 forever (#6782).
+//!
 //! **No interactive prompts** — SSH BatchMode-equivalent. We never ask
 //! for a password or passphrase, because the binary is typically run
 //! in CI / background tasks where stdin is unavailable.
@@ -72,9 +76,21 @@ pub fn fetch_remote_with_outcome(repo: &Repository, remote_name: &str) -> Result
 
     info!("Fetching from remote '{}'", remote_name);
 
+    // #6782: libgit2 calls this callback again after every credential the
+    // remote rejects, so one that answers with the same source each time never
+    // reaches the next one. That is not hypothetical: `Cred::ssh_key_from_agent`
+    // succeeds against an `ssh-agent` holding no identities, so a host whose
+    // key lives in a file — the ordinary macOS 1Password/keychain setup — spent
+    // two minutes re-offering an empty agent to github.com and then reported
+    // `Auth (-16)`, never trying `~/.ssh/id_ed25519` at all. The cursor is what
+    // advances the chain.
+    let cursor = std::cell::Cell::new(0usize);
     let mut callbacks = RemoteCallbacks::new();
-    callbacks.credentials(|url, username_from_url, allowed_types| {
-        non_interactive_credentials(url, username_from_url, allowed_types)
+    callbacks.credentials(move |_url, username_from_url, allowed_types| {
+        let (next, cred) =
+            non_interactive_credentials(cursor.get(), username_from_url, allowed_types)?;
+        cursor.set(next);
+        Ok(cred)
     });
 
     let mut fetch_options = FetchOptions::new();
@@ -136,70 +152,86 @@ pub fn fetch_and_record(repo: &Repository, repo_name: &str, remote_name: &str) -
     }
 }
 
-/// Build a credential without prompting the user.
+/// One non-interactive place a credential can come from.
 ///
-/// Tries, in order:
-/// 1. SSH agent (if `allowed_types` permits)
-/// 2. `~/.ssh/id_ed25519` then `~/.ssh/id_rsa`
-/// 3. `GITHUB_TOKEN` / `GH_TOKEN` env var as an HTTPS PAT
-///    (username `x-access-token`, password = token value)
-/// 4. Default credential helper (falls through to platform keychain:
-///    `osxkeychain`, `store`, `manager-core`, etc.)
+/// Why (#6782): the chain used to be `if` arms inside one function, which is
+/// only expressible as "the first source that yields anything". libgit2 asks
+/// again after each rejection, so what it actually needs is an ordered list it
+/// can be walked through — the same order, addressable by position.
+#[derive(Clone, Copy)]
+enum CredSource {
+    /// A key held by a running `ssh-agent`.
+    Agent,
+    /// A private key file under `~/.ssh/`, by basename.
+    KeyFile(&'static str),
+    /// `GITHUB_TOKEN` / `GH_TOKEN` as an HTTPS password.
+    GithubToken,
+    /// The platform credential helper (`osxkeychain`, `store`, …).
+    Helper,
+}
+
+/// The sources tried, in order, most specific first.
+const CRED_CHAIN: [CredSource; 5] = [
+    CredSource::Agent,
+    CredSource::KeyFile("id_ed25519"),
+    CredSource::KeyFile("id_rsa"),
+    CredSource::GithubToken,
+    CredSource::Helper,
+];
+
+/// The next usable credential at or after `from` in [`CRED_CHAIN`], and the
+/// position the caller should resume from.
 ///
-/// Returns a git2 error if none of these succeed — the caller records it
-/// as a `FetchOutcome::Failed` and (by default since 2.6.0) exits
-/// non-zero so stale data is never silently served.
+/// Why: `RemoteCallbacks::credentials` is re-entered after every credential the
+/// remote rejects. Answering from a cursor rather than from the top is what
+/// turns the chain into a real fallback sequence — before #6782 it was a loop,
+/// because `Cred::ssh_key_from_agent` succeeds against an agent holding no
+/// identities and so was re-offered until libgit2 gave up.
+/// What: scans forward for the first source whose `allowed_types` the remote
+/// permits and that can actually build a `Cred`, and returns it with the index
+/// after it. Sources that cannot apply are skipped without consuming a turn.
+/// Never prompts: a key file is passed with no passphrase, so an encrypted one
+/// fails here rather than blocking on stdin.
+/// Test: `tests::the_credential_chain_advances_rather_than_repeating`.
 fn non_interactive_credentials(
-    _url: &str,
+    from: usize,
     username_from_url: Option<&str>,
     allowed_types: CredentialType,
-) -> std::result::Result<Cred, git2::Error> {
+) -> std::result::Result<(usize, Cred), git2::Error> {
     let username = username_from_url.unwrap_or("git");
 
-    if allowed_types.contains(CredentialType::SSH_KEY) {
-        // 1. SSH agent first.
-        if let Ok(cred) = Cred::ssh_key_from_agent(username) {
-            return Ok(cred);
-        }
-
-        // 2. Explicit key files (ed25519 preferred, rsa fallback).
-        if let Some(home) = home_dir() {
-            for key_name in &["id_ed25519", "id_rsa"] {
-                let private_key = home.join(".ssh").join(key_name);
-                if private_key.exists() {
-                    // git2 needs a passphrase parameter even for unencrypted
-                    // keys; we pass None to force non-interactive behavior.
-                    if let Ok(cred) = Cred::ssh_key(username, None, private_key.as_path(), None) {
-                        return Ok(cred);
-                    }
-                }
+    for (index, source) in CRED_CHAIN.iter().enumerate().skip(from) {
+        let cred = match source {
+            CredSource::Agent if allowed_types.contains(CredentialType::SSH_KEY) => {
+                Cred::ssh_key_from_agent(username).ok()
             }
-        }
-    }
-
-    // 3. HTTPS token from GITHUB_TOKEN / GH_TOKEN env var.
-    //    These are the standard names used by GitHub Actions, gh CLI,
-    //    and most CI systems.  The token is used as the password with
-    //    the canonical `x-access-token` username that GitHub expects for
-    //    PAT / GitHub App token authentication over HTTPS.
-    if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
-        let token = std::env::var(trusty_common::env_vars::ENV_GITHUB_TOKEN)
-            .or_else(|_| std::env::var("GH_TOKEN"))
-            .ok();
-        if let Some(tok) = token {
-            if let Ok(cred) = Cred::userpass_plaintext("x-access-token", &tok) {
-                return Ok(cred);
+            CredSource::KeyFile(name) if allowed_types.contains(CredentialType::SSH_KEY) => {
+                home_dir()
+                    .map(|home| home.join(".ssh").join(name))
+                    .filter(|key| key.exists())
+                    .and_then(|key| {
+                        // git2 needs a passphrase parameter even for unencrypted
+                        // keys; None forces non-interactive behaviour.
+                        Cred::ssh_key(username, None, key.as_path(), None).ok()
+                    })
             }
-        }
-    }
-
-    // 4. Default credential helper (platform keychain, credential store,
-    //    etc.).  This covers the common macOS / Windows / Linux cases where
-    //    the user has already authenticated via `gh auth login` or
-    //    `git credential approve`.
-    if allowed_types.contains(CredentialType::DEFAULT) {
-        if let Ok(cred) = Cred::default() {
-            return Ok(cred);
+            // The canonical `x-access-token` username GitHub expects for PAT /
+            // GitHub App token authentication over HTTPS.
+            CredSource::GithubToken
+                if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) =>
+            {
+                std::env::var(trusty_common::env_vars::ENV_GITHUB_TOKEN)
+                    .or_else(|_| std::env::var("GH_TOKEN"))
+                    .ok()
+                    .and_then(|token| Cred::userpass_plaintext("x-access-token", &token).ok())
+            }
+            CredSource::Helper if allowed_types.contains(CredentialType::DEFAULT) => {
+                Cred::default().ok()
+            }
+            _ => None,
+        };
+        if let Some(cred) = cred {
+            return Ok((index + 1, cred));
         }
     }
 
@@ -341,6 +373,42 @@ mod tests {
             FetchOutcome::Failed { error, .. } => error,
             other => panic!("expected Failed for unreachable {url}, got {other:?}"),
         }
+    }
+
+    /// Why (#6782): with the SSH transport linked, the credential chain ran for
+    /// the first time and looped. `Cred::ssh_key_from_agent` succeeds against an
+    /// `ssh-agent` holding no identities, and the callback answered from the top
+    /// of the chain every time libgit2 re-entered it, so `~/.ssh/id_ed25519` was
+    /// never reached — a real fetch spent 120 s re-offering an empty agent to
+    /// github.com and then reported `class=Ssh (23); code=Auth (-16)`.
+    /// What: walks the chain from every position and asserts each answer
+    /// advances the cursor, so the sequence is finite whatever this machine
+    /// happens to hold. Environment-independent by construction: it asserts the
+    /// advance, never which source answered.
+    /// Test: this is the test.
+    #[test]
+    fn the_credential_chain_advances_rather_than_repeating() {
+        let allowed =
+            CredentialType::SSH_KEY | CredentialType::USER_PASS_PLAINTEXT | CredentialType::DEFAULT;
+
+        let mut cursor = 0usize;
+        let mut answers = 0usize;
+        while let Ok((next, _cred)) = non_interactive_credentials(cursor, Some("git"), allowed) {
+            assert!(
+                next > cursor,
+                "the callback answered without advancing: cursor {cursor} -> {next}"
+            );
+            cursor = next;
+            answers += 1;
+            assert!(
+                answers <= CRED_CHAIN.len(),
+                "the chain answered more times than it has sources"
+            );
+        }
+        assert!(
+            cursor <= CRED_CHAIN.len(),
+            "the cursor ran past the chain: {cursor}"
+        );
     }
 
     /// Why (#6782): tga's `git2` was built without the `ssh` feature, so

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -686,6 +686,25 @@ fn write_stage_report(
     }
     writeln!(out, "\n{}", stats.summary())?;
 
+    // #6782: one named line per stale repository, ahead of the stage failures.
+    // `stage_mark` renders `ok (N stale)` in the table, which says how many but
+    // never which, and an operator watching a 59-repository sweep cannot act on
+    // a count.
+    if !stats.stale_fetches.is_empty() {
+        writeln!(
+            err,
+            "\n{} — these repositories were collected from stale local refs:",
+            tga::audit::STALE_FETCH_HEADLINE
+        )?;
+        for fetch in &stats.stale_fetches {
+            writeln!(
+                err,
+                "  {}: remote `{}` ({})",
+                fetch.repo, fetch.remote, fetch.error
+            )?;
+        }
+    }
+
     if stats.any_failed() {
         writeln!(
             err,
@@ -902,6 +921,44 @@ mod tests {
         assert!(
             stale_row.contains("ok (2 stale)"),
             "the row must count the repositories that fell back: {stale_row}"
+        );
+    }
+
+    /// Why (#6782): `ok (2 stale)` says how many repositories fell back and
+    /// never which, so an operator watching a 59-repository sweep cannot act on
+    /// it — and the report that would name them is written hours later.
+    /// What: the stale repositories are named on stderr under the same headline
+    /// the report leads its Gaps section with; a clean run writes nothing.
+    /// Test: this is the test.
+    #[test]
+    fn stale_repositories_are_named_on_stderr() {
+        let render_err = |stats: &AuditSweepStats| {
+            let mut out = Vec::new();
+            let mut err = Vec::new();
+            write_stage_report(stats, &mut out, &mut err).expect("write to an in-memory buffer");
+            String::from_utf8(err).expect("stderr is UTF-8")
+        };
+
+        let mut clean = AuditSweepStats::default();
+        clean.record(SweepStage::Collect, Instant::now(), Ok(()));
+        assert_eq!(render_err(&clean), "", "a clean run writes no stderr");
+
+        let mut stale = AuditSweepStats::default();
+        stale.record(SweepStage::Collect, Instant::now(), Ok(()));
+        stale.record_stale_fetch(StaleFetch {
+            repo: "acme-service".to_string(),
+            remote: "origin".to_string(),
+            error: "unsupported URL protocol; class=Net (12)".to_string(),
+        });
+
+        let text = render_err(&stale);
+        assert!(
+            text.contains(tga::audit::STALE_FETCH_HEADLINE),
+            "the block must carry the report's own headline: {text}"
+        );
+        assert!(
+            text.contains("acme-service") && text.contains("unsupported URL protocol"),
+            "the block must name the repository and the fetch error: {text}"
         );
     }
 


### PR DESCRIPTION
Two defects, one root and one it uncovered.

**1. No SSH transport.** `crates/trusty-git-analytics/Cargo.toml` pinned `git2` with `default-features = false` and only `https`, so libgit2 had no libssh2. Every `git@host:org/repo.git` and `ssh://` origin failed with `unsupported URL protocol; class=Net (12)` before the fetch's credential callback ran — 59 of 59 repositories in a client audit — and the sweep collected whatever the clone-time refs held. (The issue points at the root `Cargo.toml`; the effective pin is tga's own local one, which overrides it.)

**2. The credential chain looped.** With the transport actually running, `Cred::ssh_key_from_agent` succeeds against an `ssh-agent` holding no identities, and the callback answered from the top of the chain every time libgit2 re-entered it after a rejection — so `~/.ssh/id_ed25519` was never reached. The chain is now an ordered `CRED_CHAIN` walked by a cursor the callback carries: each source offered at most once, inapplicable sources skipped without consuming a turn.

## Why the `ssh` feature, not shelling out to system `git`

- The SSH credential path already existed and was written for this. `collect/git/fetch.rs` has offered ssh-agent, `~/.ssh/id_ed25519` and `~/.ssh/id_rsa` since #337; only the transport was missing.
- Shelling out would replace a working layer. `is_auth_or_transport_error` classifies on `git2::ErrorClass`, and `FetchOutcome::Failed` carries the git2 error string that `StaleFetch` and the report's gap line quote. It would also add a runtime `git` binary requirement the release tarball does not ship.
- **No new dependency, statically linked.** `ssh` → `libgit2-sys/ssh` → `libssh2-sys`, which vendors libssh2 from bundled source; the `vendored-openssl` already on the pin propagates to it. `libssh2-sys` was already in `Cargo.lock` (the workspace `git2` entry keeps its defaults), so the lock carries no new package. `otool -L target/release/tga` shows no `libssh2`, `libssl` or `libcrypto` row.
- **Portable.** `release.yml` builds every target natively — `macos-14` for `aarch64-apple-darwin`, `ubuntu-latest` and `ubuntu-24.04-arm` for the two linux-gnu legs (#2533 / PR #4822). There is no cross-compile leg to hit the pkg-config problem the workflow header describes. `SKIP_UI_BUILD=1 cargo build --release -p tga` links clean.

## Live before/after

A throwaway integration test against `git@github.com:octocat/Hello-World.git`, since removed:

```
before: Failed { error: "remote rejected authentication: Failed getting response;
        class=Ssh (23); code=Auth (-16)" }        120.22s
after:  Success { remote: "origin" }
        origin/master = 7fd1a60b01f91b314f59955a4e4d4e80d8edf11d      0.74s
```

## Where the headline appears

`git history is stale: fetch failed (<error>)`, from one exported constant (`tga::audit::STALE_FETCH_HEADLINE`):

- `audit/gaps.rs` — the line leads with the bolded headline, and stale entries come **first** in the gaps vec, ahead of the failed stages. A failed stage leaves an empty section a reader notices; a stale fetch leaves a full one that is quietly wrong.
- `commands/audit.rs` — each stale repository and its error is named on stderr during the run. `ok (2 stale)` said how many, never which.
- `trusty-audit/src/index_report.rs` + `package/generated.rs` — `IndexEntry.stale` renders in that repository's own section of both the sweep's `out/index.md` and the return package's `reports/index.md`. Matched via `run::STALE_FETCH_MARKER`, following the documented `COLLECT_FAILED_MARKER` precedent — trusty-audit does not depend on tga, so the manifest prose is the only channel.

## Gates — rung 4

```
cargo fmt --check                                         EXIT=0
cargo clippy -p tga --all-targets -- -D warnings          EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings EXIT=0
cargo check --workspace                                   EXIT=0
SKIP_UI_BUILD=1 cargo build --release -p tga              EXIT=0
scripts/check_line_cap.sh                                 EXIT=0
scripts/check_changelog_fragment.sh                       EXIT=0
scripts/check_test_pointers.sh                            EXIT=0  (30427 citations, 0 dangling)
scripts/check_sld.sh                                      EXIT=0
```

`cargo test -p tga --no-fail-fast` — EXIT=0, every target:

```
unittests src/lib.rs   ok. 1566 passed; 0 failed; 7 ignored
unittests src/main.rs  ok.    0 passed; 0 failed; 0 ignored
agentic_detection_corpus              ok. 0 passed; 0 failed; 1 ignored
agentic_detection_corpus_configured   ok. 0 passed; 0 failed; 1 ignored
ai_markers_bad_file        ok. 1 passed; 0 failed; 0 ignored
ai_markers_operator_file   ok. 1 passed; 0 failed; 0 ignored
bitbucket_live             ok. 1 passed; 0 failed; 0 ignored
config_mount               ok. 2 passed; 0 failed; 0 ignored
config_serialize_redaction ok. 8 passed; 0 failed; 0 ignored
integration_test           ok. 1 passed; 0 failed; 0 ignored
Doc-tests tga              ok. 10 passed; 0 failed; 0 ignored
```

`cargo test -p trusty-audit --no-fail-fast` — EXIT=0:

```
unittests src/lib.rs   ok. 885 passed; 0 failed; 5 ignored
binary_names           ok.   3 passed; 0 failed; 0 ignored
cli_end_to_end         ok.   5 passed; 0 failed; 0 ignored
guided_launch          ok.   4 passed; 0 failed; 0 ignored
install_fails_closed   ok.   4 passed; 0 failed; 2 ignored
render_zero_arg        ok.   8 passed; 0 failed; 0 ignored
run_fails_closed       ok.   9 passed; 0 failed; 0 ignored
```

New tests. The first two fail on `main` with `unsupported URL protocol; class=Net (12)`:

```
collect::git::fetch::tests::an_ssh_url_reaches_the_ssh_transport ... ok
collect::git::fetch::tests::an_scp_style_remote_reaches_the_ssh_transport ... ok
collect::git::fetch::tests::the_credential_chain_advances_rather_than_repeating ... ok
audit::tests::a_stale_fetch_line_leads_with_the_headline ... ok
commands::audit::tests::stale_repositories_are_named_on_stderr ... ok
index_report::index_tests::a_stale_repository_is_named_in_its_index_section ... ok
```

## Known red, by coordination

`pr-version-bump` fails on `trusty-audit`: this branch changes its `src/**` under the published 0.13.3 and does not bump it. That is deliberate — #6785 (#6783) lands trusty-audit 0.14.0 first, and this branch rebases onto it. `tga` passes the same check, bumped 7.0.0 → 7.1.0 (minor: `tga::audit::STALE_FETCH_HEADLINE` is a new public export).

```
[FAIL] trusty-audit 0.13.3 — src/** changed under a version that is ALREADY published
[ OK ] tga — version bumped 7.0.0 -> 7.1.0
```

Refs #6782
milestone #71

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
