### PR TITLE
feat(trusty-review)!: CWE weakness-class tags on investigation findings, trusty-review 0.34.0 (Refs #6779)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11998,7 +11998,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 #      this line existed. Both consumers name what they need: trusty-analyze's
 #      `review` feature pulls `trusty-review/mcp`; trusty-mpm's dev-dependency
 #      only touches `integrations`, which is unconditional.
-trusty-review = { path = "crates/trusty-review", version = "0.33", default-features = false }
+trusty-review = { path = "crates/trusty-review", version = "0.34", default-features = false }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -92,7 +92,13 @@ name        = "trusty-review"
 # to `report::index_registry` under #6677), and `trait_method_added` for
 # `SearchClient::index_status` (src/integrations/search_client.rs:229), which an
 # out-of-tree implementor of the trait would have to add.
-version     = "0.33.1"
+# 0.33.1 -> 0.34.0 (#6779): MINOR, the breaking position for a 0.x crate. The
+# weakness-class tag adds a public field to `report::investigate::VerifiedFinding`
+# and to `report::synthesize::FindingProse`, both of which have public fields and
+# neither of which is `#[non_exhaustive]` — an out-of-tree struct literal for
+# either stops compiling. `cargo-semver-checks` reports this as
+# `struct_missing_field`-class breakage against the 0.33.1 baseline.
+version     = "0.34.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6779-cwe-tagging.md
+++ b/crates/trusty-review/changelog.d/6779-cwe-tagging.md
@@ -1,0 +1,7 @@
+Added
+
+- Investigation findings can now carry a CWE weakness class, so a consumer counting ISO-5055-style structural flaws no longer has to infer one from prose ([#6779](https://github.com/bobmatnyc/trusty-tools/issues/6779)).
+  - **Schema:** the investigation response schema declares an optional `cwe_id` and names the weakness classes the crate reads back, so the model picks from a known vocabulary rather than inventing a spelling.
+  - **Ingestion:** `report::investigate::cwe::resolve` admits a well-formed `CWE-<number>` id (upper-casing it) or a class NAME from one table of 12 weakness classes. Anything else — a malformed id, an unknown class, an empty field — resolves to nothing and is dropped; a finding is never rejected for it, and an id is never repaired into a neighbouring one.
+  - **Serialisation:** `cwe_id` is skipped when absent, so a finding with no identifiable weakness class carries no field at all in `investigation.json`. A GREEN finding names a strength, so it carries no weakness class either.
+  - **Report:** a classified finding renders its id next to the title as `SQL injection [CWE-89]`; an unclassified one renders exactly as before.

--- a/crates/trusty-review/changelog.d/6779-cwe-tagging.md
+++ b/crates/trusty-review/changelog.d/6779-cwe-tagging.md
@@ -1,7 +1,8 @@
 Added
 
-- Investigation findings can now carry a CWE weakness class, so a consumer counting ISO-5055-style structural flaws no longer has to infer one from prose ([#6779](https://github.com/bobmatnyc/trusty-tools/issues/6779)).
-  - **Schema:** the investigation response schema declares an optional `cwe_id` and names the weakness classes the crate reads back, so the model picks from a known vocabulary rather than inventing a spelling.
-  - **Ingestion:** `report::investigate::cwe::resolve` admits a well-formed `CWE-<number>` id (upper-casing it) or a class NAME from one table of 12 weakness classes. Anything else — a malformed id, an unknown class, an empty field — resolves to nothing and is dropped; a finding is never rejected for it, and an id is never repaired into a neighbouring one.
-  - **Serialisation:** `cwe_id` is skipped when absent, so a finding with no identifiable weakness class carries no field at all in `investigation.json`. A GREEN finding names a strength, so it carries no weakness class either.
-  - **Report:** a classified finding renders its id next to the title as `SQL injection [CWE-89]`; an unclassified one renders exactly as before.
+- Investigation findings can now carry CWE weakness classes, so a consumer counting ISO-5055-style structural flaws no longer has to infer them from prose ([#6779](https://github.com/bobmatnyc/trusty-tools/issues/6779)).
+  - **Schema:** the investigation response schema declares an optional `cwe_id` array and names the weakness classes the crate reads back, so the model picks from a known vocabulary rather than inventing a spelling.
+  - **Ingestion:** `report::investigate::cwe::resolve_all` admits, per entry, a well-formed `CWE-<number>` id (upper-casing it) or a class NAME from one table of 12 weakness classes, then de-duplicates. Anything else — a malformed id, an unknown class, an empty entry — is dropped; one bad entry never costs a good one, a finding is never rejected for this field, and an id is never repaired into a neighbouring one.
+  - **Serialisation:** `cwe_id` is skipped when empty, so a finding with no identifiable weakness class carries no field at all in `investigation.json`. A GREEN finding names a strength, so it carries no weakness class either.
+  - **Report:** a classified finding renders its ids next to the title as `SQL injection [CWE-89]`, or `[CWE-798, CWE-532]` where several apply; an unclassified one renders exactly as before.
+  - **Breaking:** `VerifiedFinding` and `FindingProse` each gain a public field, so an out-of-tree struct literal for either needs it. Hence the 0.34.0 MINOR bump.

--- a/crates/trusty-review/src/report/investigate/analyze.rs
+++ b/crates/trusty-review/src/report/investigate/analyze.rs
@@ -111,14 +111,15 @@ pub struct RawFinding {
     /// Qualitative cost/effort framing.
     #[serde(default)]
     pub cost_effort: String,
-    /// The weakness class this finding maps to, as an id or a class name (#6779).
+    /// The weakness classes this finding maps to, as ids or class names (#6779).
     ///
-    /// Raw and untrusted, exactly like every other field here: `None` when the
-    /// model omits it, and whatever string it emitted otherwise. Verification
-    /// runs it through [`super::cwe::resolve`], which drops anything it cannot
-    /// read mechanically.
+    /// Raw and untrusted, exactly like every other field here. `None` covers
+    /// both a missing key and an explicit `null`, which the nullable schema
+    /// property permits; the entries themselves are whatever strings the model
+    /// emitted. Verification runs the list through [`super::cwe::resolve_all`],
+    /// which drops every entry it cannot read mechanically.
     #[serde(default)]
-    pub cwe_id: Option<String>,
+    pub cwe_id: Option<Vec<String>>,
 }
 
 /// The raw investigation response (a `findings` array).
@@ -183,9 +184,10 @@ pub fn investigation_schema(max_findings: usize) -> ResponseSchema {
                             // `cwe::WEAKNESS_CLASSES` so the vocabulary the model
                             // is offered is the one ingestion reads back.
                             "cwe_id": {
-                                "type": ["string", "null"],
+                                "type": ["array", "null"],
+                                "items": {"type": "string"},
                                 "description": format!(
-                                    "The CWE id for this finding's weakness class, as CWE-<number> (e.g. CWE-89). null when the finding maps to no known weakness class — NEVER guess one. Known classes: {}.",
+                                    "Every CWE id this finding's weakness classes map to, each as CWE-<number> (e.g. [\"CWE-89\"]). Most findings have exactly one; give several only when the finding genuinely violates several. Empty array or null when the finding maps to no known weakness class — NEVER guess one. Known classes: {}.",
                                     super::cwe::class_checklist()
                                 )
                             }

--- a/crates/trusty-review/src/report/investigate/analyze.rs
+++ b/crates/trusty-review/src/report/investigate/analyze.rs
@@ -111,6 +111,14 @@ pub struct RawFinding {
     /// Qualitative cost/effort framing.
     #[serde(default)]
     pub cost_effort: String,
+    /// The weakness class this finding maps to, as an id or a class name (#6779).
+    ///
+    /// Raw and untrusted, exactly like every other field here: `None` when the
+    /// model omits it, and whatever string it emitted otherwise. Verification
+    /// runs it through [`super::cwe::resolve`], which drops anything it cannot
+    /// read mechanically.
+    #[serde(default)]
+    pub cwe_id: Option<String>,
 }
 
 /// The raw investigation response (a `findings` array).
@@ -166,7 +174,21 @@ pub fn investigation_schema(max_findings: usize) -> ResponseSchema {
                             "description": {"type": "string", "description": "One concise sentence."},
                             "business_impact": {"type": "string", "description": "One concise sentence. Empty string if the code does not support one — never invent an impact to fill this field."},
                             "remediation": {"type": "string", "description": "One concise sentence."},
-                            "cost_effort": {"type": "string", "description": "Qualitative cost/effort framing; no invented figures. Empty string if unknown."}
+                            "cost_effort": {"type": "string", "description": "Qualitative cost/effort framing; no invented figures. Empty string if unknown."},
+                            // #6779: nullable for the same reason `line` is —
+                            // strict mode requires every property in `required`,
+                            // and "no identifiable weakness class" is a real
+                            // answer that an empty string would not distinguish
+                            // from a lazy one. The enumeration comes from
+                            // `cwe::WEAKNESS_CLASSES` so the vocabulary the model
+                            // is offered is the one ingestion reads back.
+                            "cwe_id": {
+                                "type": ["string", "null"],
+                                "description": format!(
+                                    "The CWE id for this finding's weakness class, as CWE-<number> (e.g. CWE-89). null when the finding maps to no known weakness class — NEVER guess one. Known classes: {}.",
+                                    super::cwe::class_checklist()
+                                )
+                            }
                         }
                     }
                 }

--- a/crates/trusty-review/src/report/investigate/batch_tests.rs
+++ b/crates/trusty-review/src/report/investigate/batch_tests.rs
@@ -90,7 +90,7 @@ fn empty_input_yields_no_batches() {
 fn finding(file: &str, title: &str, severity: Severity, description: &str) -> VerifiedFinding {
     VerifiedFinding {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         title: title.to_string(),
         severity,
         dimension: "authentication & secrets".to_string(),

--- a/crates/trusty-review/src/report/investigate/batch_tests.rs
+++ b/crates/trusty-review/src/report/investigate/batch_tests.rs
@@ -90,6 +90,7 @@ fn empty_input_yields_no_batches() {
 fn finding(file: &str, title: &str, severity: Severity, description: &str) -> VerifiedFinding {
     VerifiedFinding {
         trace_verdict: String::new(),
+        cwe_id: None,
         title: title.to_string(),
         severity,
         dimension: "authentication & secrets".to_string(),

--- a/crates/trusty-review/src/report/investigate/cwe.rs
+++ b/crates/trusty-review/src/report/investigate/cwe.rs
@@ -8,17 +8,21 @@
 //! them. Deriving a CWE id from the dimension alone would be a guess, and #6779
 //! says never guess.
 //!
-//! So the weakness class comes from the model, which is the only party that saw
+//! So the weakness classes come from the model, which is the only party that saw
 //! the code, and this module is the ingestion gate on that field: an id the model
 //! emits is admitted only when it is well formed, and a class NAME the model
-//! emits instead of an id is resolved through [`WEAKNESS_CLASSES`]. Anything
-//! else resolves to `None`, and a `None` never reaches the serialised finding at
-//! all.
+//! emits instead of an id is resolved through [`WEAKNESS_CLASSES`]. Everything
+//! else is dropped, and an all-dropped list leaves the finding with an empty
+//! `cwe_id` that never reaches `investigation.json` at all.
 //!
-//! What: [`resolve`], the one entry point both branches run through;
-//! [`class_checklist`], which renders the same table into the prompt so the
-//! model chooses from the set this module can read back rather than inventing a
-//! spelling. One table, two consumers, no drift.
+//! The field is a LIST because one finding can violate more than one weakness
+//! class — a hardcoded credential logged on the error path is CWE-798 and
+//! CWE-532 at once, and picking one of the two would discard a real fact.
+//!
+//! What: [`resolve_all`], the entry point ingestion calls; [`class_checklist`],
+//! which renders the same table into the prompt so the model chooses from the
+//! set this module can read back rather than inventing a spelling. One table,
+//! two consumers, no drift.
 //!
 //! Test: `super::cwe_tests`.
 
@@ -94,11 +98,41 @@ const WEAKNESS_CLASSES: &[(&str, &str)] = &[
     ("unchecked error condition", "CWE-390"),
 ];
 
-/// Resolve what the model put in `cwe_id` into a CWE id, or `None`.
+/// Resolve every weakness class the model declared, dropping what it cannot.
 ///
-/// Why: this is the single gate #6779's "never guessed" rule is enforced at. A
-/// caller that gets `None` omits the field entirely, so an unidentifiable
-/// weakness class costs the finding nothing and states nothing.
+/// Why: this is the single gate #6779's "never guessed" rule is enforced at, and
+/// it is per element so one unreadable entry costs only itself — a list of
+/// `["CWE-798", "not a class"]` still tags the finding CWE-798 rather than
+/// losing both. The finding itself is never rejected for this field.
+///
+/// What: [`resolve`] on each entry, dropping every `None`, then de-duplicating
+/// while keeping first-seen order (two spellings of one class — `cwe-79` and
+/// `Cross-Site Scripting` — must not render as two tags). A list whose every
+/// entry drops returns empty, which the caller serialises as no field at all.
+///
+/// # Postconditions
+/// Every returned id matches `^CWE-\d+$` and appears once. The result is never
+/// longer than `raw`.
+///
+/// Test: `super::cwe_tests::{several_classes_survive_together,
+/// duplicate_spellings_collapse_to_one_tag,
+/// an_all_unresolvable_list_becomes_empty}`.
+pub fn resolve_all(raw: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for entry in raw {
+        if let Some(id) = resolve(entry)
+            && !out.contains(&id)
+        {
+            out.push(id);
+        }
+    }
+    out
+}
+
+/// Resolve ONE declared weakness class into a CWE id, or `None`.
+///
+/// Why: the per-element half of [`resolve_all`], kept separate because the two
+/// admission branches are the part worth testing directly.
 ///
 /// What: two branches, in order. A well-formed `CWE-<digits>` id is admitted and
 /// upper-cased, whatever case the model used. Otherwise the text is reduced by
@@ -114,7 +148,7 @@ const WEAKNESS_CLASSES: &[(&str, &str)] = &[
 /// Test: `super::cwe_tests::{a_well_formed_id_is_admitted_and_upper_cased,
 /// a_malformed_id_is_dropped, the_class_table_round_trips_a_sample,
 /// every_table_id_is_well_formed}`.
-pub fn resolve(raw: &str) -> Option<String> {
+fn resolve(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return None;

--- a/crates/trusty-review/src/report/investigate/cwe.rs
+++ b/crates/trusty-review/src/report/investigate/cwe.rs
@@ -1,0 +1,199 @@
+//! CWE weakness-class tagging for investigation findings (#6779).
+//!
+//! Why: findings in `investigation.json` carry a DD `dimension`, a severity and
+//! prose, and nothing that names a weakness CLASS. ISO-5055-style structural-flaw
+//! counting needs one, and the six dimensions cannot supply it — "authentication
+//! & secrets" covers hardcoded credentials (CWE-798), missing authentication
+//! (CWE-306) and weak crypto (CWE-327), and nothing in the finding picks between
+//! them. Deriving a CWE id from the dimension alone would be a guess, and #6779
+//! says never guess.
+//!
+//! So the weakness class comes from the model, which is the only party that saw
+//! the code, and this module is the ingestion gate on that field: an id the model
+//! emits is admitted only when it is well formed, and a class NAME the model
+//! emits instead of an id is resolved through [`WEAKNESS_CLASSES`]. Anything
+//! else resolves to `None`, and a `None` never reaches the serialised finding at
+//! all.
+//!
+//! What: [`resolve`], the one entry point both branches run through;
+//! [`class_checklist`], which renders the same table into the prompt so the
+//! model chooses from the set this module can read back rather than inventing a
+//! spelling. One table, two consumers, no drift.
+//!
+//! Test: `super::cwe_tests`.
+
+/// Weakness classes this crate can name a CWE id for, and the id for each.
+///
+/// Why: the model is asked for a `cwe_id`, and models answer that field with a
+/// class name ("hardcoded credentials") about as readily as with an id. Both
+/// spellings are the same claim, so both are accepted — the table is what makes
+/// the name branch deterministic instead of a second guess. It is also the
+/// enumeration the prompt shows (see [`class_checklist`]), which is what keeps
+/// the model's vocabulary and this reader's vocabulary the same one.
+///
+/// What: the left column is the canonical class key — lower case, spaces, the
+/// shape [`canonical_key`] reduces an incoming label to. The right column is the
+/// CWE id. Several keys map to one id on purpose: they are alternate names for
+/// one class, not distinct classes.
+///
+/// Coverage is the classes #6779 named, plus CWE-390 from the issue's own
+/// missing-error-handling example. It is deliberately not the full CWE corpus:
+/// a class absent here still reaches the finding when the model spells the id
+/// itself, because [`resolve`] admits any well-formed id.
+const WEAKNESS_CLASSES: &[(&str, &str)] = &[
+    // Injection.
+    ("injection", "CWE-74"),
+    ("sql injection", "CWE-89"),
+    ("command injection", "CWE-78"),
+    ("os command injection", "CWE-78"),
+    ("template injection", "CWE-1336"),
+    ("cross site scripting", "CWE-79"),
+    ("xss", "CWE-79"),
+    ("cross site scripting xss", "CWE-79"),
+    // Path handling.
+    ("path traversal", "CWE-22"),
+    ("directory traversal", "CWE-22"),
+    // Credentials and secrets.
+    ("hardcoded credentials", "CWE-798"),
+    ("hardcoded credential", "CWE-798"),
+    ("hardcoded secret", "CWE-798"),
+    ("hardcoded secrets", "CWE-798"),
+    // Deserialization.
+    ("insecure deserialization", "CWE-502"),
+    ("unsafe deserialization", "CWE-502"),
+    // Access control.
+    ("missing authentication", "CWE-306"),
+    ("missing authorization", "CWE-862"),
+    ("improper authorization", "CWE-285"),
+    // Request forgery.
+    ("ssrf", "CWE-918"),
+    ("server side request forgery", "CWE-918"),
+    ("server side request forgery ssrf", "CWE-918"),
+    // Cryptography.
+    ("weak crypto", "CWE-327"),
+    ("weak cryptography", "CWE-327"),
+    ("broken cryptographic algorithm", "CWE-327"),
+    // Input handling.
+    ("improper input validation", "CWE-20"),
+    ("missing input validation", "CWE-20"),
+    // Concurrency.
+    ("race condition", "CWE-362"),
+    ("toctou", "CWE-367"),
+    ("time of check time of use", "CWE-367"),
+    // Resource limits.
+    ("resource exhaustion", "CWE-400"),
+    ("uncontrolled resource consumption", "CWE-400"),
+    ("unbounded allocation", "CWE-789"),
+    // Information exposure.
+    ("information exposure through logs", "CWE-532"),
+    ("sensitive information in logs", "CWE-532"),
+    ("information exposure through an error message", "CWE-209"),
+    ("information exposure through error messages", "CWE-209"),
+    // Error handling (the issue's own worked example).
+    ("missing error handling", "CWE-390"),
+    ("unchecked error condition", "CWE-390"),
+];
+
+/// Resolve what the model put in `cwe_id` into a CWE id, or `None`.
+///
+/// Why: this is the single gate #6779's "never guessed" rule is enforced at. A
+/// caller that gets `None` omits the field entirely, so an unidentifiable
+/// weakness class costs the finding nothing and states nothing.
+///
+/// What: two branches, in order. A well-formed `CWE-<digits>` id is admitted and
+/// upper-cased, whatever case the model used. Otherwise the text is reduced by
+/// [`canonical_key`] and looked up in [`WEAKNESS_CLASSES`]. Empty, malformed
+/// (`CWE-`, `cwe89`, `SQL-89`) and unknown-class input all return `None` —
+/// dropped, never repaired into a neighbouring id.
+///
+/// # Postconditions
+/// A `Some` value always matches `^CWE-\d+$`: the id branch checks that shape
+/// directly and the class branch returns a [`WEAKNESS_CLASSES`] value, which
+/// `every_table_id_is_well_formed` holds to the same shape.
+///
+/// Test: `super::cwe_tests::{a_well_formed_id_is_admitted_and_upper_cased,
+/// a_malformed_id_is_dropped, the_class_table_round_trips_a_sample,
+/// every_table_id_is_well_formed}`.
+pub fn resolve(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(id) = well_formed_id(trimmed) {
+        return Some(id);
+    }
+    let key = canonical_key(trimmed);
+    WEAKNESS_CLASSES
+        .iter()
+        .find(|(class, _)| *class == key)
+        .map(|(_, id)| (*id).to_string())
+}
+
+/// `Some("CWE-<digits>")` when `raw` already IS an id, else `None`.
+///
+/// The `^CWE-\d+$` check, spelled without the `regex` crate — the shape is three
+/// conditions and pulling a dependency in for it would be the heavier answer.
+/// The prefix match is case-insensitive because models write `cwe-79` freely;
+/// the returned id is always upper-case so two spellings never render as two
+/// different tags.
+fn well_formed_id(raw: &str) -> Option<String> {
+    let (prefix, digits) = raw.split_at_checked(4)?;
+    if !prefix.eq_ignore_ascii_case("CWE-") {
+        return None;
+    }
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some(format!("CWE-{digits}"))
+}
+
+/// Reduce a class label to the spelling [`WEAKNESS_CLASSES`] keys use.
+///
+/// Lower case, every non-alphanumeric run collapsed to one space, trimmed — so
+/// `"Cross-Site Scripting (XSS)"`, `"cross-site scripting (xss)"` and
+/// `"Cross Site Scripting XSS"` are one key, and punctuation the model adds
+/// cannot miss a row that is present. Words are NOT dropped: a parenthesised
+/// acronym is part of the label, so that key is its own row in the table rather
+/// than something this function guesses away.
+fn canonical_key(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut pending_space = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_space && !out.is_empty() {
+                out.push(' ');
+            }
+            pending_space = false;
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            pending_space = true;
+        }
+    }
+    out
+}
+
+/// The class enumeration the investigation prompt shows the model.
+///
+/// Why: a model told only "emit a CWE id" invents both ids and spellings. Naming
+/// the classes this crate reads back — from the same table it reads them back
+/// WITH — makes the field mechanically resolvable instead of hopefully so.
+/// What: one `class (CWE-n)` entry per DISTINCT id, in table order, comma
+/// separated. Alternate names for an id are omitted: they exist so an incoming
+/// label resolves, and repeating them in the prompt would only spend tokens.
+/// Test: `super::cwe_tests::the_checklist_names_each_id_once`.
+pub fn class_checklist() -> String {
+    let mut seen: Vec<&str> = Vec::new();
+    let mut out: Vec<String> = Vec::new();
+    for (class, id) in WEAKNESS_CLASSES {
+        if seen.contains(id) {
+            continue;
+        }
+        seen.push(id);
+        out.push(format!("{class} ({id})"));
+    }
+    out.join(", ")
+}
+
+#[cfg(test)]
+#[path = "cwe_tests.rs"]
+mod cwe_tests;

--- a/crates/trusty-review/src/report/investigate/cwe_tests.rs
+++ b/crates/trusty-review/src/report/investigate/cwe_tests.rs
@@ -1,14 +1,19 @@
 //! Tests for CWE weakness-class tagging (#6779).
 //!
-//! Why: the field is only trustworthy if it is dropped whenever the model's
-//! answer is not mechanically readable — a repaired or guessed id would be
-//! exactly the fabrication #6779 forbids. These cases pin both halves: what is
-//! admitted, and what is silently dropped.
-//! What: covers id validation, the class table, the prompt checklist, and the
+//! Why: the field is only trustworthy if an entry is dropped whenever the
+//! model's answer is not mechanically readable — a repaired or guessed id would
+//! be exactly the fabrication #6779 forbids. These cases pin both halves: what
+//! is admitted, and what is silently dropped.
+//! What: covers per-entry id validation, the class table, list assembly
+//! (several classes, de-duplication, all-dropped), the prompt checklist, and the
 //! end-to-end serialisation shape through `verify_findings`.
 //! Test: included as `#[cfg(test)] mod cwe_tests` from `cwe.rs`.
 
 use super::*;
+
+fn list(entries: &[&str]) -> Vec<String> {
+    entries.iter().map(|e| (*e).to_string()).collect()
+}
 
 /// Why: models write `cwe-79` as readily as `CWE-79`; one class must not render
 /// as two tags.
@@ -71,6 +76,45 @@ fn every_table_id_is_well_formed() {
     }
 }
 
+// ── List assembly ────────────────────────────────────────────────────────────
+
+/// Why: the field is a list because one finding can violate several classes at
+/// once — a hardcoded credential logged on the error path is CWE-798 and
+/// CWE-532. Both must survive, in the order the model gave them, and the id and
+/// class-name branches must mix freely within one list.
+#[test]
+fn several_classes_survive_together() {
+    assert_eq!(
+        resolve_all(&list(&["CWE-798", "information exposure through logs"])),
+        vec!["CWE-798".to_string(), "CWE-532".to_string()]
+    );
+}
+
+/// Why: `cwe-79` and `Cross-Site Scripting` are one claim written twice. Two
+/// tags for one class would inflate any structural-flaw count built on this
+/// field.
+#[test]
+fn duplicate_spellings_collapse_to_one_tag() {
+    assert_eq!(
+        resolve_all(&list(&["cwe-79", "Cross-Site Scripting", "CWE-79"])),
+        vec!["CWE-79".to_string()]
+    );
+}
+
+/// Why: one unreadable entry must cost only itself. The finding keeps the tags
+/// that did resolve, and a list where nothing resolves becomes empty — which is
+/// what makes the field vanish from the serialised finding.
+#[test]
+fn an_all_unresolvable_list_becomes_empty() {
+    assert!(resolve_all(&list(&["SQL-89", "not a weakness class", ""])).is_empty());
+    assert!(resolve_all(&[]).is_empty());
+    assert_eq!(
+        resolve_all(&list(&["not a weakness class", "CWE-22"])),
+        vec!["CWE-22".to_string()],
+        "a bad entry must not take a good one with it"
+    );
+}
+
 /// Why: the prompt spends tokens per entry, and the alternate spellings exist
 /// for ingestion, not for the model to read back.
 #[test]
@@ -126,9 +170,9 @@ fn parse(findings_json: &str) -> Vec<crate::report::investigate::analyze::RawFin
         .findings
 }
 
-/// Why: this is #6779's closure condition end to end — a declared weakness class
-/// reaches `investigation.json`, and a finding without one carries NO field at
-/// all rather than a null or an empty string.
+/// Why: this is #6779's closure condition end to end — declared weakness classes
+/// reach `investigation.json`, and a finding without one carries NO field at all
+/// rather than a null or an empty array.
 ///
 /// This is the case that fails on `main`: the serialised finding there has no
 /// `cwe_id` key for either input, because nothing in the pipeline carries one.
@@ -138,12 +182,12 @@ fn a_declared_weakness_class_reaches_the_serialised_finding() {
     let sel = selection("auth.rs", content);
     let raw = parse(
         r#"{"findings": [
-            {"title": "Hardcoded token", "severity": "red",
+            {"title": "Hardcoded token logged on the error path", "severity": "red",
              "dimension": "authentication & secrets", "file": "auth.rs",
              "evidence_quote": "let token = \"hunter2\";",
              "description": "d", "business_impact": "b",
              "remediation": "r", "cost_effort": "low",
-             "cwe_id": "CWE-798"},
+             "cwe_id": ["CWE-798", "information exposure through logs"]},
             {"title": "Unclear query construction", "severity": "amber",
              "dimension": "state management", "file": "auth.rs",
              "evidence_quote": "let q = build(input);",
@@ -153,11 +197,14 @@ fn a_declared_weakness_class_reaches_the_serialised_finding() {
     );
     let out = verify_findings(raw, &sel);
     assert_eq!(out.verified.len(), 2, "notes: {:?}", out.notes);
-    assert_eq!(out.verified[0].cwe_id.as_deref(), Some("CWE-798"));
-    assert_eq!(out.verified[1].cwe_id, None);
+    assert_eq!(out.verified[0].cwe_id, vec!["CWE-798", "CWE-532"]);
+    assert!(out.verified[1].cwe_id.is_empty());
 
     let tagged = serde_json::to_string(&out.verified[0]).expect("serialises");
-    assert!(tagged.contains(r#""cwe_id":"CWE-798""#), "{tagged}");
+    assert!(
+        tagged.contains(r#""cwe_id":["CWE-798","CWE-532"]"#),
+        "{tagged}"
+    );
     let untagged = serde_json::to_string(&out.verified[1]).expect("serialises");
     assert!(
         !untagged.contains("cwe_id"),
@@ -167,10 +214,11 @@ fn a_declared_weakness_class_reaches_the_serialised_finding() {
 
 /// Why: a malformed id must not survive ingestion, and it must not reject the
 /// finding either — the weakness class is an addition to a finding, never a
-/// precondition for it.
+/// precondition for it. An explicit `null` is the other shape the nullable
+/// schema property permits, and it must parse rather than error.
 #[test]
 fn a_malformed_declared_id_is_dropped_and_the_finding_survives() {
-    let content = "let token = \"hunter2\";\n";
+    let content = "let token = \"hunter2\";\nlet q = build(input);\n";
     let sel = selection("auth.rs", content);
     let raw = parse(
         r#"{"findings": [
@@ -179,18 +227,26 @@ fn a_malformed_declared_id_is_dropped_and_the_finding_survives() {
              "evidence_quote": "let token = \"hunter2\";",
              "description": "d", "business_impact": "b",
              "remediation": "r", "cost_effort": "low",
-             "cwe_id": "SQL-89"}
+             "cwe_id": ["SQL-89"]},
+            {"title": "Unclear query construction", "severity": "amber",
+             "dimension": "state management", "file": "auth.rs",
+             "evidence_quote": "let q = build(input);",
+             "description": "d", "business_impact": "b",
+             "remediation": "r", "cost_effort": "low",
+             "cwe_id": null}
         ]}"#,
     );
     let out = verify_findings(raw, &sel);
-    assert_eq!(out.verified.len(), 1, "notes: {:?}", out.notes);
-    assert_eq!(out.verified[0].cwe_id, None);
-    let json = serde_json::to_string(&out.verified[0]).expect("serialises");
-    assert!(!json.contains("cwe_id"), "{json}");
+    assert_eq!(out.verified.len(), 2, "notes: {:?}", out.notes);
+    for f in &out.verified {
+        assert!(f.cwe_id.is_empty(), "{}", f.title);
+        let json = serde_json::to_string(f).expect("serialises");
+        assert!(!json.contains("cwe_id"), "{json}");
+    }
 }
 
 /// Why: a GREEN finding names a strength. A strength has no weakness class, so
-/// the tag is blanked on that band exactly as its prose is (#6080).
+/// the tags are blanked on that band exactly as its prose is (#6080).
 #[test]
 fn a_green_finding_carries_no_weakness_class() {
     let content = "let token = read_secret();\n";
@@ -200,22 +256,27 @@ fn a_green_finding_carries_no_weakness_class() {
             {"title": "Secrets read from the environment", "severity": "green",
              "dimension": "authentication & secrets", "file": "auth.rs",
              "evidence_quote": "let token = read_secret();",
-             "cwe_id": "CWE-798"}
+             "cwe_id": ["CWE-798"]}
         ]}"#,
     );
     let out = verify_findings(raw, &sel);
     assert_eq!(out.verified.len(), 1, "notes: {:?}", out.notes);
-    assert_eq!(out.verified[0].cwe_id, None);
+    assert!(out.verified[0].cwe_id.is_empty());
 }
 
 /// Why: the schema is what makes the field reachable at all, and strict mode
 /// requires the property to be declared nullable rather than merely omitted
-/// (the `line` precedent, #5675).
+/// (the `line` precedent, #5675). It is an ARRAY of strings, not a string.
 #[test]
-fn the_schema_declares_a_nullable_cwe_id() {
+fn the_schema_declares_a_nullable_cwe_id_array() {
     let schema = crate::report::investigate::analyze::investigation_schema(8);
     let json = serde_json::to_value(&schema).expect("schema serialises");
-    let text = json.to_string();
-    assert!(text.contains("cwe_id"), "{text}");
-    assert!(text.contains("hardcoded credentials (CWE-798)"), "{text}");
+    let property = &json["schema"]["properties"]["findings"]["items"]["properties"]["cwe_id"];
+    assert_eq!(property["type"], serde_json::json!(["array", "null"]));
+    assert_eq!(property["items"]["type"], "string");
+    let description = property["description"].as_str().expect("description");
+    assert!(
+        description.contains("hardcoded credentials (CWE-798)"),
+        "{description}"
+    );
 }

--- a/crates/trusty-review/src/report/investigate/cwe_tests.rs
+++ b/crates/trusty-review/src/report/investigate/cwe_tests.rs
@@ -1,0 +1,221 @@
+//! Tests for CWE weakness-class tagging (#6779).
+//!
+//! Why: the field is only trustworthy if it is dropped whenever the model's
+//! answer is not mechanically readable — a repaired or guessed id would be
+//! exactly the fabrication #6779 forbids. These cases pin both halves: what is
+//! admitted, and what is silently dropped.
+//! What: covers id validation, the class table, the prompt checklist, and the
+//! end-to-end serialisation shape through `verify_findings`.
+//! Test: included as `#[cfg(test)] mod cwe_tests` from `cwe.rs`.
+
+use super::*;
+
+/// Why: models write `cwe-79` as readily as `CWE-79`; one class must not render
+/// as two tags.
+#[test]
+fn a_well_formed_id_is_admitted_and_upper_cased() {
+    assert_eq!(resolve("CWE-79").as_deref(), Some("CWE-79"));
+    assert_eq!(resolve("cwe-79").as_deref(), Some("CWE-79"));
+    assert_eq!(resolve("  Cwe-1336  ").as_deref(), Some("CWE-1336"));
+}
+
+/// Why: #6779's "never guessed" rule. Every one of these is a shape the model
+/// has produced for an id field, and every one must be DROPPED rather than
+/// repaired into the nearest plausible id.
+#[test]
+fn a_malformed_id_is_dropped() {
+    for raw in [
+        "", "   ", "CWE-", "CWE", "cwe89", "SQL-89", "CWE-79a", "CWE-7 9", "unknown", "CW",
+    ] {
+        assert_eq!(resolve(raw), None, "{raw:?} should not resolve");
+    }
+}
+
+/// Why: the class-name branch is the fallback for a model that answers the field
+/// with a weakness class instead of an id. A sample across the table proves the
+/// lookup, the punctuation reduction, and the case folding together.
+#[test]
+fn the_class_table_round_trips_a_sample() {
+    let sample = [
+        ("SQL Injection", "CWE-89"),
+        ("Cross-Site Scripting (XSS)", "CWE-79"),
+        ("path traversal", "CWE-22"),
+        ("Hardcoded Credentials", "CWE-798"),
+        ("insecure deserialization", "CWE-502"),
+        ("Missing Authentication", "CWE-306"),
+        ("SSRF", "CWE-918"),
+        ("weak cryptography", "CWE-327"),
+        ("Improper Input Validation", "CWE-20"),
+        ("TOCTOU", "CWE-367"),
+        ("resource exhaustion", "CWE-400"),
+        ("information exposure through logs", "CWE-532"),
+        ("missing error handling", "CWE-390"),
+    ];
+    for (class, id) in sample {
+        assert_eq!(resolve(class).as_deref(), Some(id), "class {class:?}");
+    }
+}
+
+/// Why: `resolve`'s postcondition says every `Some` matches `^CWE-\d+$`. The id
+/// branch checks that itself; this holds the table's own values to it, so a row
+/// added with a typo cannot smuggle a malformed tag onto a finding.
+#[test]
+fn every_table_id_is_well_formed() {
+    for (class, id) in WEAKNESS_CLASSES {
+        assert_eq!(
+            well_formed_id(id).as_deref(),
+            Some(*id),
+            "table row {class:?} carries a malformed id {id:?}"
+        );
+        assert_eq!(canonical_key(class).as_str(), *class, "key {class:?}");
+    }
+}
+
+/// Why: the prompt spends tokens per entry, and the alternate spellings exist
+/// for ingestion, not for the model to read back.
+#[test]
+fn the_checklist_names_each_id_once() {
+    let checklist = class_checklist();
+    assert!(checklist.contains("sql injection (CWE-89)"), "{checklist}");
+    assert!(checklist.contains("ssrf (CWE-918)"), "{checklist}");
+    assert_eq!(
+        checklist.matches("CWE-798").count(),
+        1,
+        "one entry per id: {checklist}"
+    );
+    assert_eq!(
+        checklist.matches("CWE-327").count(),
+        1,
+        "one entry per id: {checklist}"
+    );
+}
+
+// ── End-to-end through verification and serialisation ────────────────────────
+
+use crate::report::investigate::select::{SelectedFile, Selection};
+use crate::report::investigate::verify::verify_findings;
+
+fn selection(path: &str, content: &str) -> Selection {
+    Selection {
+        files: vec![SelectedFile {
+            path: path.to_string(),
+            content: content.to_string(),
+            truncated: false,
+            dimensions: vec![],
+            selected_by: None,
+            hotspot: None,
+            declared_for: None,
+        }],
+        total_files: 1,
+        skipped: 0,
+        bytes_sent: content.len(),
+        dimensions_covered: vec![],
+        dimensions_absent: vec![],
+        per_dimension: vec![],
+        test_census: Default::default(),
+        attributed_files: 0,
+        attributed_only: false,
+    }
+}
+
+/// The model's batch response, parsed the way the live path parses it — so this
+/// case exercises the schema field's `#[serde(default)]` too.
+fn parse(findings_json: &str) -> Vec<crate::report::investigate::analyze::RawFinding> {
+    serde_json::from_str::<crate::report::investigate::analyze::RawInvestigation>(findings_json)
+        .expect("investigation parses")
+        .findings
+}
+
+/// Why: this is #6779's closure condition end to end — a declared weakness class
+/// reaches `investigation.json`, and a finding without one carries NO field at
+/// all rather than a null or an empty string.
+///
+/// This is the case that fails on `main`: the serialised finding there has no
+/// `cwe_id` key for either input, because nothing in the pipeline carries one.
+#[test]
+fn a_declared_weakness_class_reaches_the_serialised_finding() {
+    let content = "line one\nlet token = \"hunter2\";\nlet q = build(input);\n";
+    let sel = selection("auth.rs", content);
+    let raw = parse(
+        r#"{"findings": [
+            {"title": "Hardcoded token", "severity": "red",
+             "dimension": "authentication & secrets", "file": "auth.rs",
+             "evidence_quote": "let token = \"hunter2\";",
+             "description": "d", "business_impact": "b",
+             "remediation": "r", "cost_effort": "low",
+             "cwe_id": "CWE-798"},
+            {"title": "Unclear query construction", "severity": "amber",
+             "dimension": "state management", "file": "auth.rs",
+             "evidence_quote": "let q = build(input);",
+             "description": "d", "business_impact": "b",
+             "remediation": "r", "cost_effort": "low"}
+        ]}"#,
+    );
+    let out = verify_findings(raw, &sel);
+    assert_eq!(out.verified.len(), 2, "notes: {:?}", out.notes);
+    assert_eq!(out.verified[0].cwe_id.as_deref(), Some("CWE-798"));
+    assert_eq!(out.verified[1].cwe_id, None);
+
+    let tagged = serde_json::to_string(&out.verified[0]).expect("serialises");
+    assert!(tagged.contains(r#""cwe_id":"CWE-798""#), "{tagged}");
+    let untagged = serde_json::to_string(&out.verified[1]).expect("serialises");
+    assert!(
+        !untagged.contains("cwe_id"),
+        "a finding with no identifiable weakness class must carry no field: {untagged}"
+    );
+}
+
+/// Why: a malformed id must not survive ingestion, and it must not reject the
+/// finding either — the weakness class is an addition to a finding, never a
+/// precondition for it.
+#[test]
+fn a_malformed_declared_id_is_dropped_and_the_finding_survives() {
+    let content = "let token = \"hunter2\";\n";
+    let sel = selection("auth.rs", content);
+    let raw = parse(
+        r#"{"findings": [
+            {"title": "Hardcoded token", "severity": "red",
+             "dimension": "authentication & secrets", "file": "auth.rs",
+             "evidence_quote": "let token = \"hunter2\";",
+             "description": "d", "business_impact": "b",
+             "remediation": "r", "cost_effort": "low",
+             "cwe_id": "SQL-89"}
+        ]}"#,
+    );
+    let out = verify_findings(raw, &sel);
+    assert_eq!(out.verified.len(), 1, "notes: {:?}", out.notes);
+    assert_eq!(out.verified[0].cwe_id, None);
+    let json = serde_json::to_string(&out.verified[0]).expect("serialises");
+    assert!(!json.contains("cwe_id"), "{json}");
+}
+
+/// Why: a GREEN finding names a strength. A strength has no weakness class, so
+/// the tag is blanked on that band exactly as its prose is (#6080).
+#[test]
+fn a_green_finding_carries_no_weakness_class() {
+    let content = "let token = read_secret();\n";
+    let sel = selection("auth.rs", content);
+    let raw = parse(
+        r#"{"findings": [
+            {"title": "Secrets read from the environment", "severity": "green",
+             "dimension": "authentication & secrets", "file": "auth.rs",
+             "evidence_quote": "let token = read_secret();",
+             "cwe_id": "CWE-798"}
+        ]}"#,
+    );
+    let out = verify_findings(raw, &sel);
+    assert_eq!(out.verified.len(), 1, "notes: {:?}", out.notes);
+    assert_eq!(out.verified[0].cwe_id, None);
+}
+
+/// Why: the schema is what makes the field reachable at all, and strict mode
+/// requires the property to be declared nullable rather than merely omitted
+/// (the `line` precedent, #5675).
+#[test]
+fn the_schema_declares_a_nullable_cwe_id() {
+    let schema = crate::report::investigate::analyze::investigation_schema(8);
+    let json = serde_json::to_value(&schema).expect("schema serialises");
+    let text = json.to_string();
+    assert!(text.contains("cwe_id"), "{text}");
+    assert!(text.contains("hardcoded credentials (CWE-798)"), "{text}");
+}

--- a/crates/trusty-review/src/report/investigate/mod.rs
+++ b/crates/trusty-review/src/report/investigate/mod.rs
@@ -22,6 +22,7 @@
 
 pub mod analyze;
 mod batch;
+pub mod cwe;
 pub mod deps;
 pub mod exposure;
 mod regions;
@@ -693,6 +694,9 @@ fn scrubbed_prose(slug: &str, band: &str, f: &VerifiedFinding, secrets: &[String
         // is this crate's own composed text, not model prose over repository
         // content.
         trace_verdict: f.trace_verdict.clone(),
+        // #6779: mechanical too — an id resolved at ingestion, never prose, so
+        // the scrub below has nothing to find in it.
+        cwe_id: f.cwe_id.clone(),
     };
     super::redact::scrub_prose(&mut prose, secrets);
     prose
@@ -877,6 +881,7 @@ mod coverage_tests {
     fn green(dimension: &str) -> VerifiedFinding {
         VerifiedFinding {
             trace_verdict: String::new(),
+            cwe_id: None,
             title: "Clean signal".to_string(),
             severity: Severity::Green,
             dimension: dimension.to_string(),

--- a/crates/trusty-review/src/report/investigate/mod.rs
+++ b/crates/trusty-review/src/report/investigate/mod.rs
@@ -881,7 +881,7 @@ mod coverage_tests {
     fn green(dimension: &str) -> VerifiedFinding {
         VerifiedFinding {
             trace_verdict: String::new(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             title: "Clean signal".to_string(),
             severity: Severity::Green,
             dimension: dimension.to_string(),

--- a/crates/trusty-review/src/report/investigate/regions_tests.rs
+++ b/crates/trusty-review/src/report/investigate/regions_tests.rs
@@ -40,6 +40,7 @@ fn finding(description: &str, line: u64) -> VerifiedFinding {
         remediation: String::new(),
         cost_effort: String::new(),
         trace_verdict: String::new(),
+        cwe_id: None,
     }
 }
 

--- a/crates/trusty-review/src/report/investigate/regions_tests.rs
+++ b/crates/trusty-review/src/report/investigate/regions_tests.rs
@@ -40,7 +40,7 @@ fn finding(description: &str, line: u64) -> VerifiedFinding {
         remediation: String::new(),
         cost_effort: String::new(),
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
     }
 }
 

--- a/crates/trusty-review/src/report/investigate/render_tests.rs
+++ b/crates/trusty-review/src/report/investigate/render_tests.rs
@@ -53,7 +53,7 @@ fn dep(name: &str, locked: Option<&str>) -> Dependency {
 fn finding() -> VerifiedFinding {
     VerifiedFinding {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         title: "Hardcoded secret".to_string(),
         severity: Severity::Red,
         dimension: "authentication & secrets".to_string(),

--- a/crates/trusty-review/src/report/investigate/render_tests.rs
+++ b/crates/trusty-review/src/report/investigate/render_tests.rs
@@ -53,6 +53,7 @@ fn dep(name: &str, locked: Option<&str>) -> Dependency {
 fn finding() -> VerifiedFinding {
     VerifiedFinding {
         trace_verdict: String::new(),
+        cwe_id: None,
         title: "Hardcoded secret".to_string(),
         severity: Severity::Red,
         dimension: "authentication & secrets".to_string(),

--- a/crates/trusty-review/src/report/investigate/trace_tests.rs
+++ b/crates/trusty-review/src/report/investigate/trace_tests.rs
@@ -28,6 +28,7 @@ pub(super) const SHRINK_GUARD_RATIO_DIVISOR: usize = 2;\n";
 fn finding(title: &str, severity: Severity, line: Option<u64>) -> VerifiedFinding {
     VerifiedFinding {
         trace_verdict: String::new(),
+        cwe_id: None,
         title: title.to_string(),
         severity,
         dimension: "scalability".to_string(),

--- a/crates/trusty-review/src/report/investigate/trace_tests.rs
+++ b/crates/trusty-review/src/report/investigate/trace_tests.rs
@@ -28,7 +28,7 @@ pub(super) const SHRINK_GUARD_RATIO_DIVISOR: usize = 2;\n";
 fn finding(title: &str, severity: Severity, line: Option<u64>) -> VerifiedFinding {
     VerifiedFinding {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         title: title.to_string(),
         severity,
         dimension: "scalability".to_string(),

--- a/crates/trusty-review/src/report/investigate/verdict_tests.rs
+++ b/crates/trusty-review/src/report/investigate/verdict_tests.rs
@@ -37,6 +37,7 @@ fn finding(severity: Severity) -> VerifiedFinding {
         remediation: "r".to_string(),
         cost_effort: "low".to_string(),
         trace_verdict: String::new(),
+        cwe_id: None,
     }
 }
 

--- a/crates/trusty-review/src/report/investigate/verdict_tests.rs
+++ b/crates/trusty-review/src/report/investigate/verdict_tests.rs
@@ -37,7 +37,7 @@ fn finding(severity: Severity) -> VerifiedFinding {
         remediation: "r".to_string(),
         cost_effort: "low".to_string(),
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
     }
 }
 

--- a/crates/trusty-review/src/report/investigate/verify.rs
+++ b/crates/trusty-review/src/report/investigate/verify.rs
@@ -62,6 +62,16 @@ pub struct VerifiedFinding {
     /// — keeps this empty and renders exactly as it did before the pass existed.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub trace_verdict: String,
+    /// The CWE id for this finding's weakness class, when one is identifiable
+    /// (#6779).
+    ///
+    /// `None` — and so ABSENT from `investigation.json` — whenever the model
+    /// named no weakness class, named one this crate cannot read mechanically,
+    /// or the finding is GREEN (a strength has no weakness class). The field
+    /// only ever appears when it says something, which is what keeps a
+    /// structural-flaw count off findings that were never classified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwe_id: Option<String>,
 }
 
 /// The outcome of verifying one repository's raw findings.
@@ -220,6 +230,14 @@ pub fn verify_findings(raw: Vec<RawFinding>, selection: &Selection) -> VerifyOut
                 cost_effort: green_blank(green, &f.cost_effort),
                 // #6166 leg 2: the verdict pass writes this, never verification.
                 trace_verdict: String::new(),
+                // #6779: a GREEN names a strength, so it carries no weakness
+                // class — the same blanking its prose gets. Every other band
+                // keeps whatever `resolve` can read, and nothing else.
+                cwe_id: if green {
+                    None
+                } else {
+                    super::cwe::resolve(f.cwe_id.as_deref().unwrap_or_default())
+                },
             }),
             None => {
                 out.rejected += 1;

--- a/crates/trusty-review/src/report/investigate/verify.rs
+++ b/crates/trusty-review/src/report/investigate/verify.rs
@@ -62,16 +62,17 @@ pub struct VerifiedFinding {
     /// — keeps this empty and renders exactly as it did before the pass existed.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub trace_verdict: String,
-    /// The CWE id for this finding's weakness class, when one is identifiable
-    /// (#6779).
+    /// The CWE ids for this finding's weakness classes, when any are
+    /// identifiable (#6779).
     ///
-    /// `None` — and so ABSENT from `investigation.json` — whenever the model
-    /// named no weakness class, named one this crate cannot read mechanically,
-    /// or the finding is GREEN (a strength has no weakness class). The field
-    /// only ever appears when it says something, which is what keeps a
-    /// structural-flaw count off findings that were never classified.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cwe_id: Option<String>,
+    /// EMPTY — and so ABSENT from `investigation.json` — whenever the model
+    /// named no weakness class, named only ones this crate cannot read
+    /// mechanically, or the finding is GREEN (a strength has no weakness
+    /// class). The field only ever appears when it says something, which is what
+    /// keeps a structural-flaw count off findings that were never classified.
+    /// A list, not one id: a finding can violate several classes at once.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cwe_id: Vec<String>,
 }
 
 /// The outcome of verifying one repository's raw findings.
@@ -234,9 +235,9 @@ pub fn verify_findings(raw: Vec<RawFinding>, selection: &Selection) -> VerifyOut
                 // class — the same blanking its prose gets. Every other band
                 // keeps whatever `resolve` can read, and nothing else.
                 cwe_id: if green {
-                    None
+                    Vec::new()
                 } else {
-                    super::cwe::resolve(f.cwe_id.as_deref().unwrap_or_default())
+                    super::cwe::resolve_all(f.cwe_id.as_deref().unwrap_or_default())
                 },
             }),
             None => {

--- a/crates/trusty-review/src/report/investigate/verify_tests.rs
+++ b/crates/trusty-review/src/report/investigate/verify_tests.rs
@@ -45,6 +45,10 @@ fn raw(severity: &str, file: &str, quote: &str, line: Option<u64>) -> RawFinding
         business_impact: "impact".to_string(),
         remediation: "fix".to_string(),
         cost_effort: "low".to_string(),
+        // #6779: the weakness-class cases live in `cwe_tests`; every case here
+        // predates the field and must stay untagged so it still proves what it
+        // was written to prove.
+        cwe_id: None,
     }
 }
 

--- a/crates/trusty-review/src/report/redact_tests.rs
+++ b/crates/trusty-review/src/report/redact_tests.rs
@@ -262,7 +262,7 @@ fn leaky_investigation(slug: &str) -> Investigation {
             status: InvestigationStatus::Unavailable(format!("provider rejected {FAKE_TOKEN}")),
             findings: vec![VerifiedFinding {
                 trace_verdict: String::new(),
-                cwe_id: None,
+                cwe_id: Vec::new(),
                 title: format!("hardcoded {FAKE_TOKEN}"),
                 severity: Severity::Red,
                 dimension: format!("authentication & secrets {FAKE_TOKEN}"),
@@ -381,7 +381,7 @@ fn investigation_credentials_never_reach_the_rendered_report() {
 fn scrub_prose_covers_evidence_and_every_narrative_field() {
     let mut prose = crate::report::synthesize::FindingProse {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         app_slug: "northwind".to_string(),
         title: format!("t {FAKE_TOKEN}"),
         severity: "RED".to_string(),

--- a/crates/trusty-review/src/report/redact_tests.rs
+++ b/crates/trusty-review/src/report/redact_tests.rs
@@ -262,6 +262,7 @@ fn leaky_investigation(slug: &str) -> Investigation {
             status: InvestigationStatus::Unavailable(format!("provider rejected {FAKE_TOKEN}")),
             findings: vec![VerifiedFinding {
                 trace_verdict: String::new(),
+                cwe_id: None,
                 title: format!("hardcoded {FAKE_TOKEN}"),
                 severity: Severity::Red,
                 dimension: format!("authentication & secrets {FAKE_TOKEN}"),
@@ -380,6 +381,7 @@ fn investigation_credentials_never_reach_the_rendered_report() {
 fn scrub_prose_covers_evidence_and_every_narrative_field() {
     let mut prose = crate::report::synthesize::FindingProse {
         trace_verdict: String::new(),
+        cwe_id: None,
         app_slug: "northwind".to_string(),
         title: format!("t {FAKE_TOKEN}"),
         severity: "RED".to_string(),

--- a/crates/trusty-review/src/report/reporter_findings.rs
+++ b/crates/trusty-review/src/report/reporter_findings.rs
@@ -53,6 +53,11 @@ struct FindingRow {
     /// the verifier decided, so it carries no `inferred` tag and is never
     /// punctuation-deduped.
     trace_verdict: String,
+    /// The CWE id for this finding's weakness class (#6779), or `None`. Rendered
+    /// as a `[CWE-89]` suffix on the title; absent when the investigation could
+    /// identify no weakness class, so an untagged finding renders exactly as it
+    /// did before the tag existed.
+    cwe_id: Option<String>,
     business_impact: Option<String>,
     remediation: Option<String>,
     cost_effort: Option<String>,
@@ -108,6 +113,7 @@ impl FindingRow {
             evidence_quote: raw_evidence(&f.evidence),
             evidence_measured: f.evidence_measured,
             trace_verdict: f.trace_verdict.clone(),
+            cwe_id: f.cwe_id.clone(),
             business_impact: prose_field(&f.business_impact),
             remediation: prose_field(&f.remediation),
             cost_effort: prose_field(&f.cost_effort),
@@ -129,6 +135,7 @@ impl FindingRow {
         self.evidence_quote = raw_evidence(&f.evidence);
         self.evidence_measured = f.evidence_measured;
         self.trace_verdict = f.trace_verdict.clone();
+        self.cwe_id = f.cwe_id.clone();
         self.business_impact = prose_field(&f.business_impact);
         self.remediation = prose_field(&f.remediation);
         self.cost_effort = prose_field(&f.cost_effort);
@@ -143,7 +150,17 @@ impl FindingRow {
     fn into_scope(self, index: usize) -> Scope {
         let mut s = Scope::new();
         s.set("finding_index", index.to_string());
-        s.set("finding_title", self.title);
+        // #6779: the weakness class rides on the title so a reader scanning the
+        // finding list sees it without opening the evidence block. Appended
+        // HERE and not earlier: `push_finding_band` pairs a narrative with a row
+        // by exact title match, and a suffixed title would match nothing.
+        s.set(
+            "finding_title",
+            match &self.cwe_id {
+                Some(id) => format!("{} [{id}]", self.title),
+                None => self.title.clone(),
+            },
+        );
         s.set_opt("finding_category", self.category);
         s.set_opt("finding_description", self.description);
         s.set_opt("finding_business_impact", self.business_impact);

--- a/crates/trusty-review/src/report/reporter_findings.rs
+++ b/crates/trusty-review/src/report/reporter_findings.rs
@@ -53,11 +53,11 @@ struct FindingRow {
     /// the verifier decided, so it carries no `inferred` tag and is never
     /// punctuation-deduped.
     trace_verdict: String,
-    /// The CWE id for this finding's weakness class (#6779), or `None`. Rendered
-    /// as a `[CWE-89]` suffix on the title; absent when the investigation could
-    /// identify no weakness class, so an untagged finding renders exactly as it
-    /// did before the tag existed.
-    cwe_id: Option<String>,
+    /// The CWE ids for this finding's weakness classes (#6779), or empty.
+    /// Rendered as a `[CWE-89, CWE-20]` suffix on the title; empty when the
+    /// investigation could identify no weakness class, so an untagged finding
+    /// renders exactly as it did before the tag existed.
+    cwe_id: Vec<String>,
     business_impact: Option<String>,
     remediation: Option<String>,
     cost_effort: Option<String>,
@@ -156,9 +156,10 @@ impl FindingRow {
         // by exact title match, and a suffixed title would match nothing.
         s.set(
             "finding_title",
-            match &self.cwe_id {
-                Some(id) => format!("{} [{id}]", self.title),
-                None => self.title.clone(),
+            if self.cwe_id.is_empty() {
+                self.title.clone()
+            } else {
+                format!("{} [{}]", self.title, self.cwe_id.join(", "))
             },
         );
         s.set_opt("finding_category", self.category);

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -466,6 +466,7 @@ fn reporter_injects_synthesis_prose() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
+            cwe_id: None,
             app_slug: slug,
             title: "Injection risk".to_string(),
             severity: "RED".to_string(),
@@ -751,6 +752,7 @@ fn render_with_finding(f: crate::report::synthesize::FindingProse) -> String {
 fn restating_finding() -> crate::report::synthesize::FindingProse {
     crate::report::synthesize::FindingProse {
         trace_verdict: String::new(),
+        cwe_id: None,
         app_slug: String::new(),
         title: "Extract method — hnsw_store".to_string(),
         severity: "AMBER".to_string(),
@@ -886,6 +888,7 @@ fn evidence_renders_as_fenced_block() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
+            cwe_id: None,
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -942,6 +945,7 @@ fn a_trace_verdict_renders_under_the_evidence_fence() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: "cleared-by-trace: the query is parameterised at line 61".to_string(),
+            cwe_id: None,
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -971,6 +975,60 @@ fn a_trace_verdict_renders_under_the_evidence_fence() {
     );
 }
 
+/// Why (#6779): the weakness class has to be visible where a reader scans, not
+/// only in `investigation.json`. It rides on the title, and a finding with no
+/// identifiable class must render EXACTLY as it did before the tag existed —
+/// no empty brackets, no placeholder.
+/// What: two findings through one render; the tagged one gains a ` [CWE-89]`
+/// suffix on its title and the untagged one gains nothing.
+/// Test: this test itself.
+#[test]
+fn a_weakness_class_renders_next_to_the_finding_title() {
+    use crate::report::synthesize::{FindingProse, Synthesis};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let mut model = fixture_model(tmp.path());
+    let slug = model.repositories[0].slug.clone();
+    let prose = |title: &str, cwe_id: Option<String>| FindingProse {
+        trace_verdict: String::new(),
+        cwe_id,
+        app_slug: slug.clone(),
+        title: title.to_string(),
+        severity: "RED".to_string(),
+        description: "Unsanitised query parameters".to_string(),
+        evidence: "let query = `SELECT * FROM users WHERE id = ${id}`;".to_string(),
+        component: "lib/auth/session.ts:58".to_string(),
+        business_impact: "customer data exposure".to_string(),
+        remediation: "use parameterised queries".to_string(),
+        cost_effort: "low".to_string(),
+        evidence_measured: true,
+    };
+    model.synthesis = Some(Synthesis {
+        code_quality_summary: None,
+        security_summary: None,
+        authorship_summary: None,
+        executive_summary: None,
+        top_risks: vec![],
+        findings: vec![
+            prose("SQL injection", Some("CWE-89".to_string())),
+            prose("Unclear session lifetime", None),
+        ],
+        notes: vec![],
+    });
+
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd")
+        .expect("bundled template");
+    let md = Reporter::new(tmp.path()).render(&model, &template);
+
+    assert!(md.contains("SQL injection [CWE-89]"), "md:\n{md}");
+    assert!(md.contains("Unclear session lifetime"), "md:\n{md}");
+    assert!(
+        !md.contains("Unclear session lifetime ["),
+        "an unclassified finding must carry no bracket; md:\n{md}"
+    );
+}
+
 /// Why: this is the direct regression test for defect #3 — a blank line
 /// inside the evidence quote must never be read as a section boundary and
 /// must never splice a "No data available" line mid-quote.
@@ -995,6 +1053,7 @@ fn evidence_with_blank_line_fences_cleanly() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
+            cwe_id: None,
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -1054,6 +1113,7 @@ fn evidence_containing_triple_backticks_uses_longer_fence() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
+            cwe_id: None,
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -1132,6 +1192,7 @@ fn evidence_with_adjacent_hash_comment_lines_renders_byte_identical() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
+            cwe_id: None,
             app_slug: slug,
             title: "ALLOWED_OAUTH_DOMAINS fails closed but is undocumented".to_string(),
             severity: "RED".to_string(),
@@ -1199,6 +1260,7 @@ fn evidence_with_blank_line_full_render_has_no_fenced_splice() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
+            cwe_id: None,
             app_slug: slug,
             title: "AI Gateway secrets".to_string(),
             severity: "RED".to_string(),
@@ -1377,6 +1439,7 @@ fn reporter_merges_synthesis_prose_onto_deterministic_finding() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
+            cwe_id: None,
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -3120,6 +3183,7 @@ fn amber_prose(
 ) -> crate::report::synthesize::FindingProse {
     crate::report::synthesize::FindingProse {
         trace_verdict: String::new(),
+        cwe_id: None,
         app_slug: String::new(),
         title: title.to_string(),
         severity: "AMBER".to_string(),

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -466,7 +466,7 @@ fn reporter_injects_synthesis_prose() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             app_slug: slug,
             title: "Injection risk".to_string(),
             severity: "RED".to_string(),
@@ -752,7 +752,7 @@ fn render_with_finding(f: crate::report::synthesize::FindingProse) -> String {
 fn restating_finding() -> crate::report::synthesize::FindingProse {
     crate::report::synthesize::FindingProse {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         app_slug: String::new(),
         title: "Extract method — hnsw_store".to_string(),
         severity: "AMBER".to_string(),
@@ -888,7 +888,7 @@ fn evidence_renders_as_fenced_block() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -945,7 +945,7 @@ fn a_trace_verdict_renders_under_the_evidence_fence() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: "cleared-by-trace: the query is parameterised at line 61".to_string(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -979,8 +979,9 @@ fn a_trace_verdict_renders_under_the_evidence_fence() {
 /// only in `investigation.json`. It rides on the title, and a finding with no
 /// identifiable class must render EXACTLY as it did before the tag existed —
 /// no empty brackets, no placeholder.
-/// What: two findings through one render; the tagged one gains a ` [CWE-89]`
-/// suffix on its title and the untagged one gains nothing.
+/// What: three findings through one render; the single-class one gains a
+/// ` [CWE-89]` suffix, the multi-class one a comma-separated ` [CWE-798,
+/// CWE-532]`, and the untagged one gains nothing.
 /// Test: this test itself.
 #[test]
 fn a_weakness_class_renders_next_to_the_finding_title() {
@@ -989,7 +990,7 @@ fn a_weakness_class_renders_next_to_the_finding_title() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let mut model = fixture_model(tmp.path());
     let slug = model.repositories[0].slug.clone();
-    let prose = |title: &str, cwe_id: Option<String>| FindingProse {
+    let prose = |title: &str, cwe_id: Vec<String>| FindingProse {
         trace_verdict: String::new(),
         cwe_id,
         app_slug: slug.clone(),
@@ -1010,8 +1011,12 @@ fn a_weakness_class_renders_next_to_the_finding_title() {
         executive_summary: None,
         top_risks: vec![],
         findings: vec![
-            prose("SQL injection", Some("CWE-89".to_string())),
-            prose("Unclear session lifetime", None),
+            prose("SQL injection", vec!["CWE-89".to_string()]),
+            prose(
+                "Hardcoded token logged on the error path",
+                vec!["CWE-798".to_string(), "CWE-532".to_string()],
+            ),
+            prose("Unclear session lifetime", Vec::new()),
         ],
         notes: vec![],
     });
@@ -1022,6 +1027,10 @@ fn a_weakness_class_renders_next_to_the_finding_title() {
     let md = Reporter::new(tmp.path()).render(&model, &template);
 
     assert!(md.contains("SQL injection [CWE-89]"), "md:\n{md}");
+    assert!(
+        md.contains("Hardcoded token logged on the error path [CWE-798, CWE-532]"),
+        "md:\n{md}"
+    );
     assert!(md.contains("Unclear session lifetime"), "md:\n{md}");
     assert!(
         !md.contains("Unclear session lifetime ["),
@@ -1053,7 +1062,7 @@ fn evidence_with_blank_line_fences_cleanly() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -1113,7 +1122,7 @@ fn evidence_containing_triple_backticks_uses_longer_fence() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -1192,7 +1201,7 @@ fn evidence_with_adjacent_hash_comment_lines_renders_byte_identical() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             app_slug: slug,
             title: "ALLOWED_OAUTH_DOMAINS fails closed but is undocumented".to_string(),
             severity: "RED".to_string(),
@@ -1260,7 +1269,7 @@ fn evidence_with_blank_line_full_render_has_no_fenced_splice() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             app_slug: slug,
             title: "AI Gateway secrets".to_string(),
             severity: "RED".to_string(),
@@ -1439,7 +1448,7 @@ fn reporter_merges_synthesis_prose_onto_deterministic_finding() {
         top_risks: vec![],
         findings: vec![FindingProse {
             trace_verdict: String::new(),
-            cwe_id: None,
+            cwe_id: Vec::new(),
             app_slug: slug,
             title: "SQL injection".to_string(),
             severity: "RED".to_string(),
@@ -3183,7 +3192,7 @@ fn amber_prose(
 ) -> crate::report::synthesize::FindingProse {
     crate::report::synthesize::FindingProse {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         app_slug: String::new(),
         title: title.to_string(),
         severity: "AMBER".to_string(),

--- a/crates/trusty-review/src/report/run_tests.rs
+++ b/crates/trusty-review/src/report/run_tests.rs
@@ -472,7 +472,7 @@ fn snapshot_fixture() -> Investigation {
             status: InvestigationStatus::Available,
             findings: vec![VerifiedFinding {
                 trace_verdict: String::new(),
-                cwe_id: None,
+                cwe_id: Vec::new(),
                 title: "Hardcoded credential".to_string(),
                 severity: crate::report::metrics::Severity::Red,
                 dimension: "security".to_string(),

--- a/crates/trusty-review/src/report/run_tests.rs
+++ b/crates/trusty-review/src/report/run_tests.rs
@@ -472,6 +472,7 @@ fn snapshot_fixture() -> Investigation {
             status: InvestigationStatus::Available,
             findings: vec![VerifiedFinding {
                 trace_verdict: String::new(),
+                cwe_id: None,
                 title: "Hardcoded credential".to_string(),
                 severity: crate::report::metrics::Severity::Red,
                 dimension: "security".to_string(),

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -285,6 +285,14 @@ pub struct FindingProse {
     /// travel with it to reach the rendered evidence block.
     #[serde(default)]
     pub trace_verdict: String,
+    /// The CWE id for this finding's weakness class, or `None` (#6779).
+    ///
+    /// Never LLM-authored HERE: synthesis has no schema field for it, so every
+    /// synthesis response deserialises with `None`. It travels on this row
+    /// because the investigation's prose is the row that wins for a verified
+    /// finding, and the tag has to reach the rendered title with it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwe_id: Option<String>,
 }
 
 // ─── Synthesizer ────────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/report/synthesize.rs
+++ b/crates/trusty-review/src/report/synthesize.rs
@@ -285,14 +285,14 @@ pub struct FindingProse {
     /// travel with it to reach the rendered evidence block.
     #[serde(default)]
     pub trace_verdict: String,
-    /// The CWE id for this finding's weakness class, or `None` (#6779).
+    /// The CWE ids for this finding's weakness classes, or empty (#6779).
     ///
     /// Never LLM-authored HERE: synthesis has no schema field for it, so every
-    /// synthesis response deserialises with `None`. It travels on this row
-    /// because the investigation's prose is the row that wins for a verified
-    /// finding, and the tag has to reach the rendered title with it.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cwe_id: Option<String>,
+    /// synthesis response deserialises empty. It travels on this row because the
+    /// investigation's prose is the row that wins for a verified finding, and
+    /// the tags have to reach the rendered title with it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cwe_id: Vec<String>,
 }
 
 // ─── Synthesizer ────────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -76,6 +76,7 @@ fn model_with(repos: Vec<RepositoryReport>, investigation: Option<Investigation>
 fn verified_finding(title: &str, file: &str, line: u64, description: &str) -> VerifiedFinding {
     VerifiedFinding {
         trace_verdict: String::new(),
+        cwe_id: None,
         title: title.to_string(),
         severity: Severity::Red,
         dimension: "authentication & secrets".to_string(),

--- a/crates/trusty-review/src/report/synthesize_digest_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_digest_tests.rs
@@ -76,7 +76,7 @@ fn model_with(repos: Vec<RepositoryReport>, investigation: Option<Investigation>
 fn verified_finding(title: &str, file: &str, line: u64, description: &str) -> VerifiedFinding {
     VerifiedFinding {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         title: title.to_string(),
         severity: Severity::Red,
         dimension: "authentication & secrets".to_string(),

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -403,6 +403,7 @@ fn control_routes_investigation() -> Investigation {
             status: InvestigationStatus::Available,
             findings: vec![VerifiedFinding {
                 trace_verdict: String::new(),
+                cwe_id: None,
                 title: "Control-plane HTTP handlers have no authentication or authorization"
                     .to_string(),
                 severity: Severity::Red,
@@ -505,6 +506,7 @@ fn network_claim_investigation() -> Investigation {
     inv.repos[0].findings[0].business_impact = LIVE_NETWORK_IMPACT.to_string();
     inv.repos[0].findings.push(VerifiedFinding {
         trace_verdict: String::new(),
+        cwe_id: None,
         title: "Admin stop endpoint trusts every caller with no authentication".to_string(),
         severity: Severity::Amber,
         dimension: "authentication & secrets".to_string(),

--- a/crates/trusty-review/src/report/synthesize_grounding_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_grounding_tests.rs
@@ -403,7 +403,7 @@ fn control_routes_investigation() -> Investigation {
             status: InvestigationStatus::Available,
             findings: vec![VerifiedFinding {
                 trace_verdict: String::new(),
-                cwe_id: None,
+                cwe_id: Vec::new(),
                 title: "Control-plane HTTP handlers have no authentication or authorization"
                     .to_string(),
                 severity: Severity::Red,
@@ -506,7 +506,7 @@ fn network_claim_investigation() -> Investigation {
     inv.repos[0].findings[0].business_impact = LIVE_NETWORK_IMPACT.to_string();
     inv.repos[0].findings.push(VerifiedFinding {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         title: "Admin stop endpoint trusts every caller with no authentication".to_string(),
         severity: Severity::Amber,
         dimension: "authentication & secrets".to_string(),

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -2618,6 +2618,7 @@ fn two_findings_on_one_file_model() -> ReportModel {
 fn grounded_finding(business_impact: &str) -> super::FindingProse {
     super::FindingProse {
         trace_verdict: String::new(),
+        cwe_id: None,
         app_slug: "acme-web".to_string(),
         title: "Run handler executes an arbitrary caller-supplied executable".to_string(),
         severity: "RED".to_string(),
@@ -2840,6 +2841,7 @@ fn control_routes_investigation() -> crate::report::investigate::Investigation {
             status: InvestigationStatus::Available,
             findings: vec![VerifiedFinding {
                 trace_verdict: String::new(),
+                cwe_id: None,
                 title: "Control-plane HTTP handlers have no authentication or authorization"
                     .to_string(),
                 severity: Severity::Red,

--- a/crates/trusty-review/src/report/synthesize_tests.rs
+++ b/crates/trusty-review/src/report/synthesize_tests.rs
@@ -2618,7 +2618,7 @@ fn two_findings_on_one_file_model() -> ReportModel {
 fn grounded_finding(business_impact: &str) -> super::FindingProse {
     super::FindingProse {
         trace_verdict: String::new(),
-        cwe_id: None,
+        cwe_id: Vec::new(),
         app_slug: "acme-web".to_string(),
         title: "Run handler executes an arbitrary caller-supplied executable".to_string(),
         severity: "RED".to_string(),
@@ -2841,7 +2841,7 @@ fn control_routes_investigation() -> crate::report::investigate::Investigation {
             status: InvestigationStatus::Available,
             findings: vec![VerifiedFinding {
                 trace_verdict: String::new(),
-                cwe_id: None,
+                cwe_id: Vec::new(),
                 title: "Control-plane HTTP handlers have no authentication or authorization"
                     .to_string(),
                 severity: Severity::Red,


### PR DESCRIPTION
## Summary

Findings in `investigation.json` gain `cwe_id`, a list of CWE weakness-class
identifiers, omitted when the list is empty. The model declares the class
against an enumerated checklist; `report/investigate/cwe.rs` validates and
resolves the declared values through one table, drops malformed entries, and
collapses duplicates. GREEN findings carry no `cwe_id`. Rendered output shows
the tags after the title, e.g. `[CWE-798, CWE-532]`.

A dimension-to-CWE guess was deliberately not implemented — tagging comes only
from the model's own declaration against the checklist.

`trusty-review` is the crate that writes `investigation.json`, not
`trusty-audit`. The per-CWE count roll-up is left to #6781.

## Version

`trusty-review` 0.33.1 -> 0.34.0 (public field added to a serialized struct).
Root workspace pin `0.33` -> `0.34`. The engagement template's
`[tools] trusty-review = "0.33.0"` pin is intentionally untouched until
0.34.0 is published (#6772).

## Test plan

Rung 4 — cross-crate change (trusty-review is a workspace-shared crate).

- `cargo fmt --check`, `cargo check -p trusty-review`, `cargo clippy -p
  trusty-review --all-targets -- -D warnings`, `cargo test -p trusty-review
  --no-fail-fast`: 14 targets, 2170 lib tests, 12 new CWE tests, all green.
- `cargo check --workspace --all-targets`: clean.
- `cargo test -p trusty-analyze --no-fail-fast`: 11 targets, green (direct
  dependent).
- Doc gates clean (`check_line_cap.sh`, `check_changelog_fragment.sh`,
  `check_test_pointers.sh`).
- `scripts/check-pr-version-bump.sh`: clear.

Refs #6779. milestone #71

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
