### PR TITLE
fix(trusty-review): keep every dependency row in investigation.json; cap only the rendered table (Refs #6788)

### DIFF
--- a/crates/trusty-review/changelog.d/6788-uncap-deps-snapshot.md
+++ b/crates/trusty-review/changelog.d/6788-uncap-deps-snapshot.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `investigation.json` now carries every dependency a repository declares. The
+  inventory was truncated to 30 rows before it was serialised, so a machine
+  consumer reading `repos[].deps` — trusty-audit's OSV vulnerability lookup —
+  saw 30 packages for a workspace declaring 134 and reported partial coverage
+  as complete. The 30-row cap now applies only when the markdown Dependency
+  Inventory table is rendered, so the report page and its "and N more" line are
+  unchanged (#6788).

--- a/crates/trusty-review/src/report/investigate/deps.rs
+++ b/crates/trusty-review/src/report/investigate/deps.rs
@@ -17,6 +17,9 @@ use std::path::Path;
 use serde::Serialize;
 
 /// The maximum number of dependency rows rendered before an "and N more" line.
+///
+/// #6788: a RENDER cap only. [`DependencyInventory::deps`] holds every row;
+/// [`DependencyInventory::rendered`] applies this at table-build time.
 pub const MAX_ROWS: usize = 30;
 
 /// One declared dependency with its locked version when a lockfile resolved it.
@@ -42,17 +45,21 @@ pub struct Dependency {
 
 /// The deterministic dependency inventory for one repository.
 ///
-/// Why: the reporter renders this as a `measured` "Dependency Inventory" section;
-/// tracking the true total separately from the capped rows lets it print an
-/// honest "and N more" line rather than silently dropping dependencies.
-/// What: `deps` are the (capped) rows in stable order; `total` is the full count
-/// before the cap.
-/// Test: `deps_tests::caps_rows_with_overflow_count`.
+/// Why: the reporter renders this as a `measured` "Dependency Inventory"
+/// section, capped at [`MAX_ROWS`] for readability — but the same struct is
+/// serialised into `investigation.json`, which machine consumers read (#6788:
+/// trusty-audit's OSV lookup queried 30 of a 134-dependency workspace because
+/// the cap was applied before serialisation). Keeping the full inventory here
+/// and capping at render time serves both.
+/// What: `deps` holds EVERY discovered row in stable order; `total` is that
+/// same count; [`Self::rendered`] is the capped view the table draws.
+/// Test: `deps_tests::{inventory_keeps_every_row_past_the_render_cap,
+/// rendered_caps_at_max_rows}`.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct DependencyInventory {
-    /// Dependency rows, capped at [`MAX_ROWS`], stable-sorted.
+    /// Every dependency row discovered, stable-sorted and uncapped (#6788).
     pub deps: Vec<Dependency>,
-    /// Total dependencies discovered across all ecosystems (pre-cap).
+    /// Total dependencies discovered across all ecosystems.
     pub total: usize,
     /// The manifest filenames actually read at the checkout root (#6137).
     ///
@@ -72,9 +79,22 @@ impl DependencyInventory {
         self.total == 0
     }
 
-    /// The count of rows omitted by the [`MAX_ROWS`] cap (0 when all fit).
+    /// The rows the markdown table draws: the first [`MAX_ROWS`] of [`Self::deps`].
+    ///
+    /// Why: the table stays readable at 30 rows while the serialised inventory
+    /// keeps all of them (#6788).
+    /// What: a slice of at most [`MAX_ROWS`] rows, in the inventory's order.
+    /// Test: `deps_tests::rendered_caps_at_max_rows`.
+    pub fn rendered(&self) -> &[Dependency] {
+        &self.deps[..self.deps.len().min(MAX_ROWS)]
+    }
+
+    /// The count of rows the [`MAX_ROWS`] render cap omits (0 when all fit).
+    ///
+    /// #6788: measured against the RENDERED rows — `deps` now carries the
+    /// full inventory, so `total - deps.len()` would always be 0.
     pub fn overflow(&self) -> usize {
-        self.total.saturating_sub(self.deps.len())
+        self.total.saturating_sub(self.rendered().len())
     }
 }
 
@@ -85,10 +105,12 @@ impl DependencyInventory {
 /// for a local checkout.
 /// What: collects direct dependencies from package.json, Cargo.toml, pyproject.toml,
 /// and go.mod, enriches each with a locked version from the matching lockfile when
-/// one parses, sorts by (ecosystem, name), and caps to [`MAX_ROWS`]. Records which
-/// of those manifests existed in `manifests_examined` (#6137), so a zero total can
-/// be told apart from a root where nothing was read.
-/// Test: `deps_tests::{multi_ecosystem_inventory, records_the_manifests_it_examined}`.
+/// one parses, and sorts by (ecosystem, name). Every row is kept (#6788); the
+/// [`MAX_ROWS`] cap is applied by [`DependencyInventory::rendered`] at table-build
+/// time. Records which of those manifests existed in `manifests_examined` (#6137),
+/// so a zero total can be told apart from a root where nothing was read.
+/// Test: `deps_tests::{multi_ecosystem_inventory, records_the_manifests_it_examined,
+/// inventory_keeps_every_row_past_the_render_cap}`.
 pub fn build_inventory(root: &Path) -> DependencyInventory {
     let mut all: Vec<Dependency> = Vec::new();
     all.extend(npm_deps(root));
@@ -101,8 +123,8 @@ pub fn build_inventory(root: &Path) -> DependencyInventory {
             .cmp(&b.ecosystem)
             .then_with(|| a.name.cmp(&b.name))
     });
+    // #6788: no truncation here — the snapshot must carry every row.
     let total = all.len();
-    all.truncate(MAX_ROWS);
     DependencyInventory {
         deps: all,
         total,

--- a/crates/trusty-review/src/report/investigate/deps_tests.rs
+++ b/crates/trusty-review/src/report/investigate/deps_tests.rs
@@ -112,21 +112,48 @@ fn go_mod_requires() {
     assert!(inv.deps.iter().any(|d| d.name == "golang.org/x/sync"));
 }
 
-/// Why: the report caps rows and must report the overflow count honestly.
-/// What: 35 cargo deps → 30 rows + overflow 5.
-/// Test: this test itself.
-#[test]
-fn caps_rows_with_overflow_count() {
-    let tmp = tempfile::TempDir::new().unwrap();
+/// Write a Cargo.toml at `root` declaring `count` dependencies, `dep00`-up.
+fn cargo_manifest_with(root: &Path, count: usize) {
     let mut toml = String::from("[package]\nname = \"x\"\n[dependencies]\n");
-    for i in 0..35 {
+    for i in 0..count {
         toml.push_str(&format!("dep{i:02} = \"1.0\"\n"));
     }
-    write(tmp.path(), "Cargo.toml", &toml);
+    write(root, "Cargo.toml", &toml);
+}
+
+/// Why: the report caps rows and must report the overflow count honestly.
+/// What: 35 cargo deps → 30 rendered rows + overflow 5.
+/// Test: this test itself.
+#[test]
+fn rendered_caps_at_max_rows() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    cargo_manifest_with(tmp.path(), 35);
     let inv = build_inventory(tmp.path());
     assert_eq!(inv.total, 35);
-    assert_eq!(inv.deps.len(), MAX_ROWS);
+    assert_eq!(inv.rendered().len(), MAX_ROWS);
     assert_eq!(inv.overflow(), 35 - MAX_ROWS);
+}
+
+/// Why: #6788 — `build_inventory` truncated to [`MAX_ROWS`] before the
+/// inventory was serialised into `investigation.json`, so trusty-audit's OSV
+/// lookup saw 30 packages per repository however many the manifest declared.
+/// What: 35 cargo deps → every row is kept in `deps` and survives a serde
+/// round-trip, in order, while `total` still reports 35.
+/// Test: this test itself.
+#[test]
+fn inventory_keeps_every_row_past_the_render_cap() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    cargo_manifest_with(tmp.path(), 35);
+    let inv = build_inventory(tmp.path());
+
+    assert_eq!(inv.total, 35);
+    assert_eq!(inv.deps.len(), 35, "the inventory must not be truncated");
+
+    let json = serde_json::to_value(&inv).expect("inventory serialises");
+    let rows = json["deps"].as_array().expect("deps array");
+    assert_eq!(rows.len(), 35, "every row must reach the snapshot");
+    assert_eq!(rows[34]["name"], "dep34", "the last row is the 35th");
+    assert_eq!(json["total"], 35);
 }
 
 /// Why: an absent/malformed manifest must contribute nothing, never error.

--- a/crates/trusty-review/src/report/investigate/render.rs
+++ b/crates/trusty-review/src/report/investigate/render.rs
@@ -99,9 +99,14 @@ fn empty_inventory_line(inv: &Investigation) -> String {
 }
 
 /// Render one repository's dependency table (capped, with an "and N more" line).
+///
+/// #6788: the cap lives here, not in the inventory — `inv.deps` carries every
+/// row for `investigation.json`, and `rendered()` is the 30-row table view.
+/// Test: `render_tests::{dependency_table_caps_and_overflows,
+/// dependency_table_draws_only_max_rows_of_a_full_inventory}`.
 fn dependency_table(inv: &DependencyInventory) -> String {
     let mut out = String::from("| Package | Ecosystem | Declared | Locked |\n|---|---|---|---|\n");
-    for d in &inv.deps {
+    for d in inv.rendered() {
         let spec = if d.spec.is_empty() { "—" } else { &d.spec };
         let locked = d.locked.as_deref().unwrap_or("—");
         out.push_str(&format!(

--- a/crates/trusty-review/src/report/investigate/render_tests.rs
+++ b/crates/trusty-review/src/report/investigate/render_tests.rs
@@ -264,6 +264,34 @@ fn dependency_table_caps_and_overflows() {
     assert!(out.contains("and 3 more"));
 }
 
+/// Why: #6788 uncapped the stored inventory so `investigation.json` carries
+/// every dependency; the rendered table must still stop at `MAX_ROWS` rather
+/// than printing 134 rows into an acquirer's report.
+/// What: a 35-row inventory renders exactly 30 package rows plus "and 5 more",
+/// and the 31st package never appears.
+/// Test: this test itself.
+#[test]
+fn dependency_table_draws_only_max_rows_of_a_full_inventory() {
+    use crate::report::investigate::deps::MAX_ROWS;
+
+    let deps: Vec<_> = (0..35).map(|i| dep(&format!("dep{i:02}"), None)).collect();
+    let inv = DependencyInventory {
+        total: deps.len(),
+        deps,
+        manifests_examined: vec!["Cargo.toml".to_string()],
+    };
+    let out = dependency_table(&inv);
+
+    let rows = out.lines().filter(|l| l.contains("| cargo |")).count();
+    assert_eq!(rows, MAX_ROWS, "the table must stay capped: {out}");
+    assert!(out.contains("| dep29 | cargo |"), "last kept row: {out}");
+    assert!(
+        !out.contains("| dep30 | cargo |"),
+        "first dropped row: {out}"
+    );
+    assert!(out.contains("and 5 more"), "{out}");
+}
+
 /// Why: the coverage section is the honesty surface.
 /// What: asserts examined/total, a not-investigated dimension, and the rejected
 /// note in the exact `investigation: N finding(s) rejected` form.

--- a/crates/trusty-review/src/report/run_tests.rs
+++ b/crates/trusty-review/src/report/run_tests.rs
@@ -515,6 +515,41 @@ fn investigation_snapshot_is_written_and_reloadable() {
     assert_eq!(parsed["repos"][0]["findings"][0]["file"], "src/auth.rs");
 }
 
+/// Why: #6788 — the inventory was capped at 30 rows BEFORE this snapshot was
+/// written, so trusty-audit's OSV lookup read 30 packages from a repository
+/// declaring 134 and reported partial coverage as complete.
+/// What: builds a real inventory from a 35-dependency Cargo.toml, persists an
+/// investigation carrying it, and asserts all 35 rows reach
+/// `investigation.json` with the total intact.
+/// Test: this test itself.
+#[test]
+fn investigation_snapshot_carries_every_dependency_row() {
+    use crate::report::investigate::deps::build_inventory;
+
+    let repo = tempfile::tempdir().expect("repo dir");
+    let mut toml = String::from("[package]\nname = \"x\"\n[dependencies]\n");
+    for i in 0..35 {
+        toml.push_str(&format!("dep{i:02} = \"1.0\"\n"));
+    }
+    std::fs::write(repo.path().join("Cargo.toml"), toml).expect("manifest");
+
+    let mut inv = snapshot_fixture();
+    inv.repos[0].deps = build_inventory(repo.path());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    persist_investigation(dir.path(), &inv);
+
+    let raw = std::fs::read_to_string(dir.path().join(INVESTIGATION_SNAPSHOT_FILENAME))
+        .expect("the snapshot must exist");
+    let parsed: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON");
+    let rows = parsed["repos"][0]["deps"]["deps"]
+        .as_array()
+        .expect("deps array");
+    assert_eq!(rows.len(), 35, "the snapshot must carry the full inventory");
+    assert_eq!(rows[34]["name"], "dep34");
+    assert_eq!(parsed["repos"][0]["deps"]["total"], 35);
+}
+
 /// Why: a recovery aid must never turn a run that would have succeeded into a
 /// failure of its own.
 /// What: points the snapshot at a path that cannot be a directory (an existing


### PR DESCRIPTION
## The defect

`build_inventory` truncated the dependency inventory to `MAX_ROWS` (30) before the
`Investigation` was serialised, so `investigation.json` dropped every dependency past
the 30th. The cap suits the rendered markdown table; the snapshot is read by machines.
trusty-audit's OSV vulnerability lookup (#6780) reads `repos[].deps`, so a workspace
declaring 134 dependencies was scanned 30/134 and that partial scan reported as
complete coverage.

## The shape, and why not `deps.all`

The stored inventory is now uncapped and `DependencyInventory::rendered()` applies the
30-row cap at table-build time. Adding a second `deps.all` field would have left
`deps.deps` silently truncated beside it — the next consumer reading the obvious field
would hit the same bug. One uncapped inventory removes the trap instead of adding a
field next to it.

- `deps` holds every discovered row; `total` is unchanged and still accurate.
- `overflow()` measures against the rendered rows, so the "and N more" line is
  identical; the markdown Dependency Inventory section is byte-for-byte unchanged.
- `redact.rs` gains reach as a side effect: it now scrubs every row, not the first 30.
- No consumer relied on the cap except `dependency_table`, which now applies it itself.

## Tests

Three new, plus one rename:

- `deps_tests::inventory_keeps_every_row_past_the_render_cap` — 35 cargo deps survive a
  serde round-trip, in order, with `total` intact.
- `run_tests::investigation_snapshot_carries_every_dependency_row` — end-to-end through
  `persist_investigation`: all 35 rows reach `investigation.json`.
- `render_tests::dependency_table_draws_only_max_rows_of_a_full_inventory` — a 35-row
  inventory renders exactly 30 rows plus "and 5 more"; `dep30` never appears.
- `deps_tests::caps_rows_with_overflow_count` → `rendered_caps_at_max_rows`.

Pre-fix failure, with the truncation re-inserted and the tests otherwise identical:

```
panicked at deps_tests.rs:150: assertion `left == right` failed: the inventory must not be truncated
  left: 30
 right: 35
panicked at run_tests.rs:547: assertion `left == right` failed: the snapshot must carry the full inventory
  left: 30
 right: 35
test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 2163 filtered out
```

## Gates — rung 4

Run on this head after rebasing onto `e92e3c181` (trusty-review 0.34.0).

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo check --workspace --all-targets` | EXIT=0 |
| `cargo check -p trusty-review --all-targets` | EXIT=0 |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-review --no-fail-fast` | EXIT=0 |
| `cargo test -p trusty-analyze --no-fail-fast` (direct dependent) | EXIT=0 |
| `check_line_cap.sh` | 4463 files, 0 violations |
| `check_test_pointers.sh` | 30444 citations, 0 dangling |
| `check_changelog_fragment.sh` | fragment present and valid |
| `check-pr-version-bump.sh` | clear, 0 warnings |

`cargo test -p trusty-review --no-fail-fast` per-target:

```
unittests src/lib.rs            ok. 2173 passed; 0 failed; 5 ignored
unittests src/main.rs           ok.   78 passed; 0 failed
cast_template_golden            ok.    6 passed; 0 failed
citation_2881_regression        ok.    3 passed; 0 failed
citation_4042_regression        ok.    3 passed; 0 failed
citation_4999_regression        ok.    3 passed; 0 failed
config_mount                    ok.    2 passed; 0 failed
registry_claim_4081_regression  ok.    5 passed; 0 failed
report_analyze_e2e              ok.    4 passed; 0 failed
report_e2e                      ok.    3 passed; 0 failed
report_investigate              ok.    3 passed; 0 failed
report_methodology_6675         ok.    2 passed; 0 failed
```

`cargo test -p trusty-analyze --no-fail-fast`: lib 517, main 30, config_mount 2,
csharp_roslyn_integration 1, generated_docs 5, on_demand 8, stdio_harness 2 (1 ignored),
uds_consumer_contract 3, version_cli 2 — 0 failed across every target.

No version bump: 0.34.0 landed in #6790 and is unpublished.

For #6780: trusty-audit does not read `repos[].deps` yet — `grounding.rs` only checks
that `investigation.json` exists. The OSV stage will read `repos[].deps.deps` and get
the full list with no shape change on its side.

Refs #6788
milestone #71

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
