### PR TITLE
fix(trusty-audit): hold the engagement template's pins at the release versions (Refs #6772)

### DIFF
--- a/.claude/skills/cargo-publish/SKILL.md
+++ b/.claude/skills/cargo-publish/SKILL.md
@@ -200,7 +200,11 @@ assuming you're mid-publish — this is the Step 2b pre-tag gate above, MANDATOR
 before `git tag`, not just a status preview. `--help` documents the rare,
 logged `PREFLIGHT_ALLOW_DETACHED=1` override for check 1 (validated release
 worktrees only — misuse of it is exactly how the incident happened). No
-override exists for the identity check.
+override exists for the identity check. Publishing `trusty-audit` has one extra
+obligation: run `scripts/refresh-engagement-pins.sh` and commit the result before
+the bump, because CHECK 10 fails the release when a `[tools]` pin in
+`crates/trusty-audit/templates/engagement.template.toml` lags a sibling whose
+workspace version this same train is about to publish (#6772).
 
 ## Step 6: Version-Parity Guard (MANDATORY, issue #3366)
 

--- a/crates/trusty-audit/changelog.d/6772-template-pins-at-release.md
+++ b/crates/trusty-audit/changelog.d/6772-template-pins-at-release.md
@@ -1,0 +1,10 @@
+Fixed
+
+- The engagement template's `[tools]` pins now name the versions this release
+  train ships. `scripts/refresh-engagement-pins.sh` sets each pin to its crate's
+  current workspace version and `--check` reports the stale ones;
+  `scripts/preflight-publish.sh` CHECK 10 runs that check when publishing
+  trusty-audit and fails the release when a pin lags a sibling whose workspace
+  version is not yet on crates.io, so the copy compiled into
+  `instructions::ENGAGEMENT_TEMPLATE` and written out by `taudit distribute`
+  can no longer ship a version behind the one that just published (#6772).

--- a/crates/trusty-audit/src/distribute.rs
+++ b/crates/trusty-audit/src/distribute.rs
@@ -1274,6 +1274,76 @@ api_key = "lin_api_client_a"
         assert!(text.contains("name_with_owner = \"acme/web\""), "{text}");
     }
 
+    /// The constant `taudit distribute` ships is the file on disk, not a copy.
+    ///
+    /// Why: #6772 — `scripts/refresh-engagement-pins.sh` and its
+    /// `preflight-publish.sh` CHECK 10 both edit and read the FILE, while every
+    /// packaged copy comes from the CONSTANT. `include_str!` already makes
+    /// those the same bytes at compile time, so this assertion is close to
+    /// tautological; what it actually guards is the provenance, catching a
+    /// future edit that replaces the `include_str!` with an inline literal and
+    /// puts the release gate back to checking a file nothing ships.
+    #[test]
+    fn the_compiled_engagement_template_is_the_file_on_disk() {
+        // #6772: the release gate edits this path; the binary ships the constant.
+        let on_disk = std::fs::read_to_string(Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/templates/engagement.template.toml"
+        )))
+        .expect("the template is a tracked file in this crate");
+
+        assert_eq!(
+            instructions::ENGAGEMENT_TEMPLATE,
+            on_disk,
+            "ENGAGEMENT_TEMPLATE no longer comes from \
+             templates/engagement.template.toml, so refreshing that file would \
+             leave the packaged copy stale (#6772)"
+        );
+    }
+
+    /// Every `[tools]` pin the shipped reference carries is a version triple.
+    ///
+    /// Why: #6772 left the template pinning tga 6.0.0 while the same release
+    /// train published 7.0.0. `scripts/refresh-engagement-pins.sh` rewrites
+    /// these literals with an awk substitution, so a mangled rewrite would
+    /// otherwise ship a pin like `7.1.0"` that no download can resolve. This
+    /// asserts the shape the client's own installer needs, on the constant the
+    /// client actually gets.
+    #[test]
+    fn every_tool_pin_in_the_shipped_template_is_a_semver_triple() {
+        // #6772: refresh-engagement-pins.sh rewrites these literals in place.
+        let loaded = EngagementConfig::from_toml(
+            instructions::ENGAGEMENT_TEMPLATE,
+            Path::new("engagement.template.toml"),
+        )
+        .expect("the shipped reference loads");
+
+        let pins = [
+            ("tga", loaded.tools.tga.version()),
+            ("trusty-search", loaded.tools.trusty_search.version()),
+            ("trusty-analyze", loaded.tools.trusty_analyze.version()),
+            ("trusty-review", loaded.tools.trusty_review.version()),
+        ];
+
+        for (name, version) in pins {
+            assert!(
+                is_version_triple(version),
+                "the {name} pin is not a version triple: {version:?}"
+            );
+        }
+    }
+
+    /// `MAJOR.MINOR.PATCH`, with SemVer's optional `-pre` and `+build` tails.
+    fn is_version_triple(version: &str) -> bool {
+        let core = version.split('+').next().unwrap_or_default();
+        let core = core.split('-').next().unwrap_or_default();
+        let parts: Vec<&str> = core.split('.').collect();
+        parts.len() == 3
+            && parts
+                .iter()
+                .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+    }
+
     #[test]
     fn a_missing_binary_is_refused_and_leaves_no_file() {
         let fixture = Fixture::new(TEMPLATE);

--- a/crates/trusty-audit/src/distribute.rs
+++ b/crates/trusty-audit/src/distribute.rs
@@ -1274,15 +1274,20 @@ api_key = "lin_api_client_a"
         assert!(text.contains("name_with_owner = \"acme/web\""), "{text}");
     }
 
-    /// The constant `taudit distribute` ships is the file on disk, not a copy.
+    /// The constant `taudit distribute` ships still matches the file on disk.
     ///
     /// Why: #6772 — `scripts/refresh-engagement-pins.sh` and its
     /// `preflight-publish.sh` CHECK 10 both edit and read the FILE, while every
-    /// packaged copy comes from the CONSTANT. `include_str!` already makes
-    /// those the same bytes at compile time, so this assertion is close to
-    /// tautological; what it actually guards is the provenance, catching a
-    /// future edit that replaces the `include_str!` with an inline literal and
-    /// puts the release gate back to checking a file nothing ships.
+    /// packaged copy comes from the CONSTANT. While the `include_str!` is
+    /// there this assertion is tautological: the two are the same bytes by
+    /// construction at compile time.
+    ///
+    /// What it catches is the NEXT DIVERGENCE after someone freezes a copy.
+    /// An inline literal replacing the `include_str!` passes for as long as it
+    /// holds the bytes it was copied from, so this test does not fire on the
+    /// edit itself. It fires the first time the file moves out from under that
+    /// copy — the next `refresh-engagement-pins.sh` run — which is when the
+    /// release gate would otherwise go back to checking a file nothing ships.
     #[test]
     fn the_compiled_engagement_template_is_the_file_on_disk() {
         // #6772: the release gate edits this path; the binary ships the constant.

--- a/crates/trusty-audit/src/distribute/instructions.rs
+++ b/crates/trusty-audit/src/distribute/instructions.rs
@@ -44,7 +44,15 @@ const README_TEMPLATE: &str = include_str!("../../templates/instructions-README.
 /// It is a LOADABLE config as well as a reference — required keys present,
 /// optional ones commented — so an auditor can copy it, fill in the pins, and
 /// hand it straight back to `taudit distribute --config`.
-/// Test: `super::distribute_tests::the_shipped_config_reference_is_itself_loadable`.
+///
+/// The `[tools]` pins inside it are held at the workspace versions by
+/// `scripts/refresh-engagement-pins.sh`, which edits the FILE — and this
+/// constant is what `taudit distribute` ships, so a build older than the last
+/// refresh packages stale pins (#6772). `scripts/preflight-publish.sh` CHECK 10
+/// is the release-time gate.
+/// Test: `super::distribute_tests::the_shipped_config_reference_is_itself_loadable`,
+/// `super::distribute_tests::the_compiled_engagement_template_is_the_file_on_disk`,
+/// `super::distribute_tests::every_tool_pin_in_the_shipped_template_is_a_semver_triple`.
 pub const ENGAGEMENT_TEMPLATE: &str = include_str!("../../templates/engagement.template.toml");
 
 /// What the recipient is told about obtaining the OpenRouter key.

--- a/crates/trusty-audit/templates/engagement.template.toml
+++ b/crates/trusty-audit/templates/engagement.template.toml
@@ -47,10 +47,10 @@ engagement = "2026-Q3"
 #
 # Replace these with the versions your auditor pinned for this engagement.
 [tools]
-tga = "6.0.0"
+tga = "7.1.0"
 trusty-search = "0.52.0"
-trusty-analyze = "0.12.5"
-trusty-review = "0.33.0"
+trusty-analyze = "0.12.6"
+trusty-review = "0.34.0"
 
 # A pin may name the artifact's digest as well as its version, in which case a
 # download whose bytes do not match is refused:

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -76,6 +76,11 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
    trusty-common 0.46.1 and 0.46.3 in one week. Full rationale and the
    `--check-only`/full-mode split:
    [`.claude/skills/cargo-publish/SKILL.md`, "Step 2b"](../../.claude/skills/cargo-publish/SKILL.md#step-2b-pre-tag-gate-mandatory-issue-6508).
+4c. Releasing `trusty-audit`? Run `scripts/refresh-engagement-pins.sh` first and
+   commit the result, so `crates/trusty-audit/templates/engagement.template.toml`
+   pins the sibling versions this train ships rather than the previous ones —
+   `preflight-publish.sh` CHECK 10 fails the release when a pin lags a sibling
+   whose workspace version is not yet published (#6772).
 5. Create the tag: `git tag <crate-name>-v<version>`.
 6. Push the tag: `git push origin <crate-name>-v<version>`.
 7. Run `scripts/check-publish-ready.sh <crate-name>` (or

--- a/scripts/preflight-check10-selftest.sh
+++ b/scripts/preflight-check10-selftest.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+#
+# preflight-check10-selftest.sh — the decision half of preflight CHECK 10
+# (#6772).
+#
+# Why: CHECK 10 delegates the comparison to refresh-engagement-pins.sh and then
+#   decides what its output means. refresh-engagement-pins-selftest.sh covers
+#   the comparison; nothing covered the decision, and the decision had a
+#   fail-open arm. On exit 1 the check parsed the stale pins out of
+#   `grep '^STALE '`, and when that grep matched nothing all three buckets
+#   stayed empty, both guards were skipped, and control reached an
+#   unconditional `[WARN] … return 0` — so a stale-pins result passed the gate
+#   over an empty list. One drift in how the two scripts spell that line, and
+#   the check that exists to stop #6772 stops nothing while printing a WARN
+#   that names no pin.
+#
+#   That is CHECK 5's #5620 failure in a new place: a gate reading exit 0 out of
+#   a run that concluded nothing. It gets CHECK 5's treatment — fixtures over
+#   the decision, not the delegated gate.
+#
+# What: drives check10_engagement_pins() — extracted out of
+#   preflight-publish.sh by the same awk PATTERN preflight-check5-selftest.sh
+#   and preflight-check8-selftest.sh use — over a fixture repo whose
+#   scripts/refresh-engagement-pins.sh is a stub with a scripted exit and
+#   stdout, and a shell function shadowing `curl` in place of crates.io. No
+#   network, no cargo, no real template; the file runs in well under a second.
+#
+# THE GOVERNING ASSERTION, which every case is a special case of: this check
+#   permits a publish only when it can name what it concluded. A pass needs
+#   either "every pin is current" from the delegated gate, or a stale pin whose
+#   sibling crates.io says is already published. Nothing else — least of all an
+#   exit 1 it could not parse — earns exit 0.
+#
+#   Cases, and the arm each pins:
+#
+#     1. wrong crate            -> [PASS], n/a (the check is trusty-audit only)
+#     2. gate exits 0           -> [PASS], every pin current
+#     3. gate exits 2           -> [FAIL], pins unreadable
+#     4. exit 1, no STALE line  -> [FAIL]  <- THE REGRESSION; was [WARN]/exit 0
+#     5. exit 1, STALE + 404    -> [FAIL], sibling ships in this train
+#     6. exit 1, STALE + 200    -> [WARN], sibling already published
+#     7. exit 1, STALE + curl   -> [FAIL], crates.io gave no answer
+#        failure
+#
+#   Cases 5-7 are here so the fail-closed arm of case 4 is shown NOT to have
+#   swallowed the three verdicts that were already right.
+#
+# Test: this IS the test. Run directly:
+#   bash scripts/preflight-check10-selftest.sh
+#
+#   PREFLIGHT_SELFTEST_SCRIPT points this at a different preflight-publish.sh.
+#
+# Portability: POSIX tools plus bash 3.2 (macOS) and bash 5 (Linux CI).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_TOP="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+UNDER_TEST="${PREFLIGHT_SELFTEST_SCRIPT:-${REPO_TOP}/scripts/preflight-publish.sh}"
+
+if [ ! -r "$UNDER_TEST" ]; then
+  echo "preflight-check10-selftest: cannot read ${UNDER_TEST}" >&2
+  exit 1
+fi
+
+FAILURES=0
+CASES=0
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/preflight-check10-selftest.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $*"
+}
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  CASES=$((CASES + 1))
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %-52s -> %s\n' "$1" "$3"
+  else
+    fail "$1: expected '$2', got '$3'"
+  fi
+}
+
+# assert_contains <label> <needle> <haystack>
+assert_contains() {
+  CASES=$((CASES + 1))
+  case "$3" in
+    *"$2"*) printf '  ok   %-52s -> contains %s\n' "$1" "$2" ;;
+    *) fail "$1: output does not contain '$2'. Got: $3" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# stub_gate <exit> [stdout line...] — write the fixture repo's
+# scripts/refresh-engagement-pins.sh. CHECK 10 invokes it as
+# `bash "${REPO_ROOT}/scripts/refresh-engagement-pins.sh" --check`, so a plain
+# script on that path is the whole seam; no --refresh-script flag is needed.
+# ---------------------------------------------------------------------------
+FIXTURE_REPO="${WORK}/repo"
+mkdir -p "${FIXTURE_REPO}/scripts"
+
+STUB_STDOUT="${FIXTURE_REPO}/stub-stdout.txt"
+
+stub_gate() {
+  local rc="$1"; shift
+  printf '%s\n' "$@" > "$STUB_STDOUT"
+  cat > "${FIXTURE_REPO}/scripts/refresh-engagement-pins.sh" <<EOF
+#!/usr/bin/env bash
+cat "${STUB_STDOUT}"
+exit ${rc}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# run_check [PKG_NAME] — drive check10_engagement_pins in a clean subshell with
+# the shipped function extracted into it. Prints "<exit>|<stderr collapsed>".
+#
+# PKG_NAME, REPO_ROOT, CRATE_UA, TMP_PINS and TMP_PIN_BODY are the globals the
+# extracted function reads; they are declared here exactly as the shipped
+# script declares them. CURL_HTTP scripts the stub curl: a bare HTTP code is
+# echoed as crates.io's status, and the empty string is a transport failure
+# (nonzero exit), which is what makes the shipped `|| http="000"` fire. It is
+# assigned per case rather than prefixed onto the call: bash leaves a prefix
+# assignment to a function call SET afterwards, which would leak case 6's 200
+# into case 7.
+# ---------------------------------------------------------------------------
+run_check() {
+  local pkg="${1:-trusty-audit}"
+  local out rc
+  # Every global below is read only by the eval'd function, which shellcheck
+  # cannot see into.
+  # shellcheck disable=SC2034
+  out="$(
+    set +e
+    PKG_NAME="$pkg"
+    REPO_ROOT="$FIXTURE_REPO"
+    CRATE_UA="preflight-check10-selftest"
+    TMP_PINS="${WORK}/pins.log"
+    TMP_PIN_BODY="${WORK}/pinbody"
+
+    # Shadows the real curl. Honours -o so the shipped invocation's body file
+    # is written, and returns the scripted status on stdout the way
+    # `-w '%{http_code}'` does.
+    curl() {
+      local body=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -o) body="$2"; shift 2 ;;
+          *) shift ;;
+        esac
+      done
+      [ -n "$body" ] && : > "$body"
+      [ -n "${CURL_HTTP:-}" ] || return 7
+      printf '%s' "$CURL_HTTP"
+    }
+
+    eval "$(awk '/^check10_engagement_pins\(\) \{/,/^\}/' "$UNDER_TEST")"
+    check10_engagement_pins 2>&1 >/dev/null
+    printf '\nEXIT=%s' "$?"
+  )"
+  rc="$(printf '%s' "$out" | sed -n 's/^EXIT=//p' | tail -n1)"
+  out="$(printf '%s' "$out" | grep -v '^EXIT=' | tr '\n' ' ' | tr -s ' ')"
+  printf '%s|%s' "${rc:-?}" "$out"
+}
+
+status_of() { printf '%s' "$1" | cut -d'|' -f1; }
+text_of() { printf '%s' "$1" | cut -d'|' -f2-; }
+
+echo "check10_engagement_pins — the arms that were already right:"
+
+# --- 1. not trusty-audit: nothing to check ----------------------------------
+stub_gate 1
+CURL_HTTP="404"
+r="$(run_check trusty-search)"
+assert_eq       "1 wrong crate: permits"   "0"        "$(status_of "$r")"
+assert_contains "1 wrong crate: says n/a"  "[PASS]"   "$(text_of "$r")"
+assert_contains "1 wrong crate: names why" "n/a"      "$(text_of "$r")"
+
+# --- 2. every pin current ----------------------------------------------------
+stub_gate 0 "refresh-engagement-pins: OK — every [tools] pin is current."
+CURL_HTTP="404"
+r="$(run_check)"
+assert_eq       "2 pins current: permits" "0"      "$(status_of "$r")"
+assert_contains "2 pins current: PASS"    "[PASS]" "$(text_of "$r")"
+
+# --- 3. the delegated gate could not read the pins ---------------------------
+# Exit 2 is refresh-engagement-pins.sh's usage/unreadable code. An unreadable
+# table is exactly the state a silent pass would hide.
+stub_gate 2 "refresh-engagement-pins: ERROR: no readable pins in a [tools] table."
+CURL_HTTP="404"
+r="$(run_check)"
+assert_eq       "3 unreadable pins: stops"    "1"                 "$(status_of "$r")"
+assert_contains "3 unreadable pins: FAIL"     "[FAIL]"            "$(text_of "$r")"
+assert_contains "3 unreadable pins: names rc" "rc=2"              "$(text_of "$r")"
+assert_contains "3 unreadable pins: replays"  "no readable pins"  "$(text_of "$r")"
+
+echo
+echo "check10_engagement_pins — THE REGRESSION (#6772):"
+
+# --- 4. exit 1 with no STALE line the check can parse ------------------------
+# The delegated gate says stale pins EXIST. The line naming them does not match
+# what this check greps for, so all three buckets stay empty. Before the fix
+# this printed `[WARN] … pin(s) lag a sibling` over an empty list and returned
+# 0, letting a publish carry the exact stale template #6772 is about.
+stub_gate 1 \
+  "STALE-PIN tga pinned 6.0.0 workspace 7.1.0" \
+  "refresh-engagement-pins: 1 stale pin(s)."
+CURL_HTTP="404"
+r="$(run_check)"
+assert_eq       "4 unparsable stale result: stops"      "1"        "$(status_of "$r")"
+assert_contains "4 unparsable stale result: FAIL"       "[FAIL]"   "$(text_of "$r")"
+assert_contains "4 unparsable stale result: not a WARN" "exit 1"   "$(text_of "$r")"
+assert_contains "4 unparsable stale result: replays"    "STALE-PIN tga" "$(text_of "$r")"
+
+# The WARN wording is the fail-open path's fingerprint. Reaching it here is the
+# defect itself, so assert it is gone by name.
+CASES=$((CASES + 1))
+case "$(text_of "$r")" in
+  *"[WARN]"*) fail "4 unparsable stale result: still reached the WARN arm" ;;
+  *) printf '  ok   %-52s -> no WARN\n' "4 unparsable stale result: no WARN" ;;
+esac
+
+echo
+echo "check10_engagement_pins — the verdicts case 4 must not swallow:"
+
+# --- 5. stale pin whose sibling is NOT published: ships in this train --------
+stub_gate 1 "STALE tga pinned=6.0.0 workspace=7.1.0"
+CURL_HTTP="404"
+r="$(run_check)"
+assert_eq       "5 sibling unpublished: stops"    "1"       "$(status_of "$r")"
+assert_contains "5 sibling unpublished: FAIL"     "[FAIL]"  "$(text_of "$r")"
+assert_contains "5 sibling unpublished: names it" "tga"     "$(text_of "$r")"
+
+# --- 6. stale pin whose sibling IS published: a legitimate lag ---------------
+stub_gate 1 "STALE tga pinned=6.0.0 workspace=7.1.0"
+CURL_HTTP="200"
+r="$(run_check)"
+assert_eq       "6 sibling published: permits"  "0"       "$(status_of "$r")"
+assert_contains "6 sibling published: WARN"     "[WARN]"  "$(text_of "$r")"
+assert_contains "6 sibling published: names it" "tga"     "$(text_of "$r")"
+
+# --- 7. crates.io gave no answer --------------------------------------------
+# CURL_HTTP unset makes the stub exit nonzero, so the shipped `|| http="000"`
+# fires — the same landing as an unexpected status.
+stub_gate 1 "STALE tga pinned=6.0.0 workspace=7.1.0"
+CURL_HTTP=""
+r="$(run_check)"
+assert_eq       "7 crates.io silent: stops"     "1"        "$(status_of "$r")"
+assert_contains "7 crates.io silent: FAIL"      "[FAIL]"   "$(text_of "$r")"
+assert_contains "7 crates.io silent: names 000" "HTTP 000" "$(text_of "$r")"
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "preflight-check10-selftest: ${CASES} assertion(s) passed."
+  exit 0
+fi
+echo "preflight-check10-selftest: ${FAILURES} of ${CASES} assertion(s) FAILED." >&2
+exit 1

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -254,6 +254,13 @@
 #     published tga 7.0.0 / 0.12.6 / 0.33.1, with every other check green
 #     (#6772; PR #6723 was the previous instance).
 #
+#     FAILS CLOSED ON A RESULT IT CANNOT READ. Any exit but 0 or 1 means the
+#     pins could not be read at all. Exit 1 means stale pins EXIST, so at least
+#     one `STALE <pkg> pinned=<x> workspace=<y>` line must parse out of the
+#     output; if none does, the two scripts disagree about that line's format
+#     and this check has no idea which pins are stale — a FAIL, not the WARN the
+#     empty-list path used to reach.
+#
 #     No override flag. The remedy is one command:
 #     `scripts/refresh-engagement-pins.sh`, then commit the template.
 #
@@ -292,11 +299,12 @@
 #   half a four-minute rustdoc run had kept untested. Check 6 has
 #   scripts/check-tag-publish-parity-selftest.sh and check 7 has
 #   scripts/check-ui-bundle-freshness-selftest.sh; both drive every failure
-#   branch of the delegated script against fixtures. Check 10 has
-#   scripts/refresh-engagement-pins-selftest.sh, which drives the delegated
-#   comparison over synthetic workspaces; THIS script's published/unpublished
-#   decision over that comparison's output is bound to the live crates.io
-#   registry, like checks 1-4, and is exercised by running the script.
+#   branch of the delegated script against fixtures. Check 10 has TWO, for the
+#   same reason check 5 does: scripts/refresh-engagement-pins-selftest.sh drives
+#   the delegated comparison over synthetic workspaces, and
+#   scripts/preflight-check10-selftest.sh drives THIS script's decision over
+#   that comparison's output — every arm including the fail-closed one, with a
+#   stub gate on REPO_ROOT and a stub curl standing in for crates.io.
 #   Verified by construction:
 #     (a) FAIL mode — run from an unmerged feature branch (HEAD != origin/main)
 #         to demonstrate check 1 failing.
@@ -1589,6 +1597,22 @@ check10_engagement_pins() {
         ;;
     esac
   done < <(grep '^STALE ' "$log" || true)
+
+  # #6772: rc=1 is refresh-engagement-pins.sh saying "stale pins exist", so at
+  # least one STALE line MUST have parsed. All three buckets empty means the
+  # grep matched nothing — the two scripts disagree about that line's format —
+  # and every guard below is skipped, landing on the unconditional WARN with an
+  # empty list. Fail closed instead: a stale-pins result must never pass.
+  if [ -z "$blocking" ] && [ -z "$lagging" ] && [ -z "$unverified" ]; then
+    echo "[FAIL] engagement-pins: refresh-engagement-pins.sh --check reported stale" >&2
+    echo "       pins (exit 1), but no 'STALE <pkg> pinned=<x> workspace=<y>' line" >&2
+    echo "       parsed out of its output, so this gate cannot say WHICH pins are" >&2
+    echo "       stale or whether their siblings ship in this train." >&2
+    echo "       The two scripts disagree about that line's format. Full output" >&2
+    echo "       (${log}):" >&2
+    sed 's/^/       /' "$log" >&2
+    return 1
+  fi
 
   if [ -n "$unverified" ]; then
     echo "[FAIL] engagement-pins: crates.io would not say whether a stale pin's sibling" >&2

--- a/scripts/preflight-publish.sh
+++ b/scripts/preflight-publish.sh
@@ -233,6 +233,30 @@
 #     the assembler for you, or assemble directly at the version you intend to
 #     ship (`scripts/assemble-changelog.sh <crate-dir> <version>`).
 #
+#   CHECK 10 (the engagement template's sibling pins, #6772): trusty-audit only.
+#     Runs `scripts/refresh-engagement-pins.sh --check`, which compares each
+#     `[tools]` pin in `crates/trusty-audit/templates/engagement.template.toml`
+#     with that package's current workspace version, then decides per stale pin
+#     by asking crates.io whether the workspace version is published.
+#
+#     THE RULE: a pin must equal the sibling's current workspace version when
+#     that version is NOT yet on crates.io — the sibling is shipping in this
+#     same release train, so the pin is stale the moment the binary is built.
+#     When the sibling's workspace version IS already published, the sibling is
+#     not part of this train and a pin naming an older published version is a
+#     legitimate engagement choice: reported as a WARN, never a block.
+#
+#     WHY THIS IS NOT ALREADY COVERED: the template is `include_str!`-ed into
+#     `instructions::ENGAGEMENT_TEMPLATE` and written out verbatim by `taudit
+#     distribute`, so the packaged copy is only as fresh as the binary — and
+#     nothing in checks 1-9 reads it. At 7cfeda52d the template pinned tga
+#     6.0.0 / trusty-analyze 0.12.5 / trusty-review 0.33.0 while that same train
+#     published tga 7.0.0 / 0.12.6 / 0.33.1, with every other check green
+#     (#6772; PR #6723 was the previous instance).
+#
+#     No override flag. The remedy is one command:
+#     `scripts/refresh-engagement-pins.sh`, then commit the template.
+#
 # Crate + version resolution: accepts EITHER
 #     scripts/preflight-publish.sh <crate-name-or-dir> [version]
 #   or, when [version] is omitted, reads the version from that crate's
@@ -247,7 +271,7 @@
 #   check-publish-ready.sh does, to avoid a second, divergent lookup
 #   convention in this workspace.
 #
-#   --check-only     run all 9 checks unconditionally (never short-circuits)
+#   --check-only     run all 10 checks unconditionally (never short-circuits)
 #                     and print one [PASS]/[FAIL] line per check, then a
 #                     one-line summary. Useful to preview status without
 #                     assuming you are mid-publish. Exit code is still
@@ -268,7 +292,11 @@
 #   half a four-minute rustdoc run had kept untested. Check 6 has
 #   scripts/check-tag-publish-parity-selftest.sh and check 7 has
 #   scripts/check-ui-bundle-freshness-selftest.sh; both drive every failure
-#   branch of the delegated script against fixtures.
+#   branch of the delegated script against fixtures. Check 10 has
+#   scripts/refresh-engagement-pins-selftest.sh, which drives the delegated
+#   comparison over synthetic workspaces; THIS script's published/unpublished
+#   decision over that comparison's output is bound to the live crates.io
+#   registry, like checks 1-4, and is exercised by running the script.
 #   Verified by construction:
 #     (a) FAIL mode — run from an unmerged feature branch (HEAD != origin/main)
 #         to demonstrate check 1 failing.
@@ -1512,6 +1540,90 @@ check9_changelog_assembled() {
   return 1
 }
 
+# ===========================================================================
+# CHECK 10 — the engagement template's sibling pins (#6772), trusty-audit only
+# ===========================================================================
+# The comparison is delegated to scripts/refresh-engagement-pins.sh, which has
+# its own self-test; what lives HERE is the one judgement that needs the
+# network — whether a stale pin names a sibling that is shipping in this same
+# release train. See the header comment for the rule and the #6772 history.
+check10_engagement_pins() {
+  if [ "$PKG_NAME" != "trusty-audit" ]; then
+    echo "[PASS] engagement-pins: n/a — only trusty-audit compiles the engagement template." >&2
+    return 0
+  fi
+
+  local log="${TMP_PINS}" rc=0
+  bash "${REPO_ROOT}/scripts/refresh-engagement-pins.sh" --check > "$log" 2>&1 || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    echo "[PASS] engagement-pins: every [tools] pin names its crate's workspace version." >&2
+    return 0
+  fi
+
+  # Any exit but 1 means the gate could not READ the pins (missing template,
+  # unreadable [tools] table, cargo metadata failure). Fail closed — an
+  # unreadable table is exactly the state a silent pass would hide.
+  if [ "$rc" -ne 1 ]; then
+    echo "[FAIL] engagement-pins: could not read the template's [tools] pins (rc=${rc}):" >&2
+    sed 's/^/       /' "$log" >&2
+    return 1
+  fi
+
+  local blocking="" lagging="" unverified=""
+  local name pinned wanted http url
+  while read -r _tag name pinned_kv wanted_kv; do
+    pinned="${pinned_kv#pinned=}"
+    wanted="${wanted_kv#workspace=}"
+    url="https://crates.io/api/v1/crates/${name}/${wanted}"
+    http="$(curl -sS -A "$CRATE_UA" -o "$TMP_PIN_BODY" -w "%{http_code}" "$url")" || http="000"
+    case "$http" in
+      404)
+        blocking="${blocking}         ${name}: pinned ${pinned}, workspace ${wanted} — ${wanted} is NOT published, so it ships with this train"$'\n'
+        ;;
+      200)
+        lagging="${lagging}         ${name}: pinned ${pinned}, workspace ${wanted} — ${wanted} is already published, so this pin may lag"$'\n'
+        ;;
+      *)
+        unverified="${unverified}         ${name}: HTTP ${http} from ${url}"$'\n'
+        ;;
+    esac
+  done < <(grep '^STALE ' "$log" || true)
+
+  if [ -n "$unverified" ]; then
+    echo "[FAIL] engagement-pins: crates.io would not say whether a stale pin's sibling" >&2
+    echo "       is shipping in this train:" >&2
+    printf '%s' "$unverified" >&2
+    echo "       Cannot verify pin freshness — refusing to pass this check." >&2
+    return 1
+  fi
+
+  if [ -n "$blocking" ]; then
+    echo "[FAIL] engagement-pins: crates/trusty-audit/templates/engagement.template.toml" >&2
+    echo "       pins a sibling BEHIND the version shipping in this same release train:" >&2
+    printf '%s' "$blocking" >&2
+    echo "       THE RULE: a [tools] pin must equal the sibling's current workspace" >&2
+    echo "       version when that version is not yet on crates.io — the sibling is" >&2
+    echo "       about to ship beside this publish, so the pin is stale the moment the" >&2
+    echo "       binary is built. When the sibling's workspace version IS already" >&2
+    echo "       published it is not part of this train, and a pin naming an older" >&2
+    echo "       published version is a legitimate engagement choice (WARN, not FAIL)." >&2
+    echo "       This matters because the template is include_str!-ed into" >&2
+    echo "       instructions::ENGAGEMENT_TEMPLATE and written out verbatim by" >&2
+    echo "       'taudit distribute', so a stale pin ships inside the binary (#6772)." >&2
+    echo "       Fix: scripts/refresh-engagement-pins.sh, then commit the template and" >&2
+    echo "       rebuild." >&2
+    return 1
+  fi
+
+  echo "[WARN] engagement-pins: pin(s) lag a sibling that is NOT in this release train:" >&2
+  printf '%s' "$lagging" >&2
+  echo "       Permitted — each named version is already published, so the pin is a" >&2
+  echo "       deliberate engagement choice rather than release drift. Run" >&2
+  echo "       scripts/refresh-engagement-pins.sh if you meant to track the workspace." >&2
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # Scratch temp file for check 4's curl response body. Created once up front
 # and cleaned up via a script-scoped EXIT trap (matches check_line_cap.sh's
@@ -1522,10 +1634,12 @@ TMP_SEMVER="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.semver.XXXXXX")"
 TMP_PARITY="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.parity.XXXXXX")"
 TMP_UIBUNDLE="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.uibundle.XXXXXX")"
 TMP_CHANGELOG="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.changelog.XXXXXX")"
-trap 'rm -f "$TMP_BODY" "$TMP_SEMVER" "$TMP_PARITY" "$TMP_UIBUNDLE" "$TMP_CHANGELOG"' EXIT
+TMP_PINS="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.pins.XXXXXX")"
+TMP_PIN_BODY="$(mktemp "${TMPDIR:-/tmp}/preflight-publish.pinbody.XXXXXX")"
+trap 'rm -f "$TMP_BODY" "$TMP_SEMVER" "$TMP_PARITY" "$TMP_UIBUNDLE" "$TMP_CHANGELOG" "$TMP_PINS" "$TMP_PIN_BODY"' EXIT
 
 # ---------------------------------------------------------------------------
-# Run all 9 checks. Always run every check (rather than short-circuiting) so
+# Run all 10 checks. Always run every check (rather than short-circuiting) so
 # --check-only and normal mode share one code path and a single run always
 # reports the full picture — a partial preflight is how gaps get missed.
 # ---------------------------------------------------------------------------
@@ -1540,6 +1654,7 @@ check6_tag_parity;          [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check7_ui_bundle;           [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check8_prepublish_gate;     [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 check9_changelog_assembled; [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
+check10_engagement_pins;    [ $? -eq 0 ] || FAILURES=$((FAILURES + 1))
 set -e
 
 if [ "$FAILURES" -gt 0 ]; then
@@ -1551,18 +1666,18 @@ if [ -n "${SEMVER_NOT_VERIFIED:-}" ]; then
   # #5620: "passed all 7 checks" must not absorb a check-5 outcome that verified
   # nothing. The same distinction the check line draws, drawn again at the line
   # an operator is most likely to read on its own.
-  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 9 checks, but the" >&2
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 10 checks, but the" >&2
   echo "  public API was NOT VERIFIED: ${SEMVER_NOT_VERIFIED}. See the check 5 line above." >&2
 elif [ -n "${SEMVER_TYPES_ADVISORY:-}" ]; then
   # The type differ blocks nothing, so without this the summary would say
   # "safe to publish" over a listed set of type changes nobody has confirmed.
-  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 9 checks." >&2
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 10 checks." >&2
   echo "  ADVISORY, not blocking: ${SEMVER_TYPES_ADVISORY}. See the semver-types line above." >&2
 else
-  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 9 checks. Safe to publish." >&2
+  echo "preflight-publish: OK — ${PKG_NAME} ${VERSION} passed all 10 checks. Safe to publish." >&2
 fi
 if [ -n "${GATE_NOT_VERIFIED:-}" ]; then
-  # Same reasoning as the SEMVER_NOT_VERIFIED line above: "passed all 9 checks"
+  # Same reasoning as the SEMVER_NOT_VERIFIED line above: "passed all 10 checks"
   # must not absorb a check-8 outcome that read nothing.
   echo "preflight-publish: NOTE — ${GATE_NOT_VERIFIED}. See the check 8 line above." >&2
 fi

--- a/scripts/refresh-engagement-pins-selftest.sh
+++ b/scripts/refresh-engagement-pins-selftest.sh
@@ -14,8 +14,9 @@
 #   engagement.template.toml`, and runs the gate against them with `--repo`.
 #   Asserts exit status and output for both modes, that a rewrite is
 #   idempotent to the byte, that the commented `# [tools]` digest example is
-#   never rewritten, and that an unreadable table fails closed. The last case
-#   runs `--check` against the REAL checked-out template.
+#   never rewritten, and that an unreadable table — or an unreadable
+#   `cargo metadata` — fails closed. The last case runs `--check` against the
+#   REAL checked-out template.
 #
 # Test: this IS the test. Run directly:
 #   bash scripts/refresh-engagement-pins-selftest.sh
@@ -220,6 +221,18 @@ run_case "missing [tools] table" 2 "no readable pins" "$repo" --check
 repo="$(mkrepo notemplate tga=7.1.0)"
 rm -f "$(template_path "$repo")"
 run_case "missing template file" 2 "no template at" "$repo" --check
+
+# `cargo metadata` is the only source of workspace versions, so a run that
+# cannot get one has nothing to compare a pin against. The template here is
+# readable and its pins parse — the failure is downstream of that, which is the
+# arm a fixture with a broken template would never reach.
+repo="$(mkrepo badmetadata tga=7.1.0)"
+cat > "$(template_path "$repo")" <<'EOF'
+[tools]
+tga = "7.1.0"
+EOF
+printf '[workspace\nmembers = [\n' > "${repo}/Cargo.toml"
+run_case "unreadable cargo metadata" 2 "'cargo metadata --no-deps' failed" "$repo" --check
 
 # ===========================================================================
 # 7. THE LIVE REPO. Proves the checked-out template is current, rather than

--- a/scripts/refresh-engagement-pins-selftest.sh
+++ b/scripts/refresh-engagement-pins-selftest.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# refresh-engagement-pins-selftest.sh — fixtures for
+# scripts/refresh-engagement-pins.sh.
+#
+# Why: the gate this drives is the only mechanical answer to #6772, and its
+#   failing branches are the half that matters — a gate that always exits 0
+#   looks identical to one that checks something, which is how three stale
+#   pins shipped compiled into trusty-audit at 7cfeda52d with every other
+#   release check green.
+#
+# What: builds synthetic single-file cargo workspaces under a scratch
+#   directory, each with its own `crates/trusty-audit/templates/
+#   engagement.template.toml`, and runs the gate against them with `--repo`.
+#   Asserts exit status and output for both modes, that a rewrite is
+#   idempotent to the byte, that the commented `# [tools]` digest example is
+#   never rewritten, and that an unreadable table fails closed. The last case
+#   runs `--check` against the REAL checked-out template.
+#
+# Test: this IS the test. Run directly:
+#   bash scripts/refresh-engagement-pins-selftest.sh
+#
+# Portability: POSIX tools plus cargo and python3, bash 3.2 (macOS) and
+#   bash 5 (Linux CI).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+GATE="${SCRIPT_DIR}/refresh-engagement-pins.sh"
+
+PASSED=0
+FAILED=0
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/refresh-engagement-pins-selftest.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+pass_case() { echo "  ok  $1"; PASSED=$((PASSED + 1)); }
+fail_case() {
+  echo "SELF-TEST FAIL: $1" >&2
+  shift
+  printf '%s\n' "$@" | sed 's/^/       /' >&2
+  FAILED=$((FAILED + 1))
+}
+
+# mkrepo <name> <pkg=version>... -> prints the repo path. A minimal cargo
+# workspace: enough for `cargo metadata --no-deps` to report each package's
+# version, plus the template directory the gate reads. No external
+# dependencies, so metadata resolves offline in milliseconds.
+mkrepo() {
+  local name="$1"; shift
+  local repo="${WORK}/${name}" spec pkg version i=0
+  mkdir -p "${repo}/crates/trusty-audit/templates"
+  printf '[workspace]\nmembers = ["crates/*"]\nresolver = "2"\n' > "${repo}/Cargo.toml"
+  printf '[package]\nname = "trusty-audit"\nversion = "0.14.0"\nedition = "2021"\n' \
+    > "${repo}/crates/trusty-audit/Cargo.toml"
+  mkdir -p "${repo}/crates/trusty-audit/src"
+  : > "${repo}/crates/trusty-audit/src/lib.rs"
+  for spec in "$@"; do
+    pkg="${spec%%=*}"
+    version="${spec#*=}"
+    i=$((i + 1))
+    mkdir -p "${repo}/crates/dep${i}/src"
+    printf '[package]\nname = "%s"\nversion = "%s"\nedition = "2021"\n' "$pkg" "$version" \
+      > "${repo}/crates/dep${i}/Cargo.toml"
+    : > "${repo}/crates/dep${i}/src/lib.rs"
+  done
+  echo "$repo"
+}
+
+template_path() { echo "$1/crates/trusty-audit/templates/engagement.template.toml"; }
+
+# run_case <label> <expect-exit> <expect-substring|-> <repo> [gate args...]
+run_case() {
+  local label="$1" want_exit="$2" want_sub="$3" repo="$4"
+  shift 4
+  local out rc=0
+  out="$(bash "$GATE" --repo "$repo" "$@" 2>&1)" || rc=$?
+  if [ "$rc" -ne "$want_exit" ]; then
+    fail_case "${label}: expected exit ${want_exit}, got ${rc}" "$out"
+    return
+  fi
+  if [ "$want_sub" != "-" ] && ! grep -qF -- "$want_sub" <<< "$out"; then
+    fail_case "${label}: exit ${rc} but output never said '${want_sub}'" "$out"
+    return
+  fi
+  pass_case "${label} -> exit ${rc}${want_sub:+, reported ${want_sub}}"
+}
+
+# ===========================================================================
+# 1. Every pin already at its workspace version. --check exits 0, and the
+#    default mode leaves the file byte-identical.
+# ===========================================================================
+repo="$(mkrepo current tga=7.1.0 trusty-review=0.34.0)"
+cat > "$(template_path "$repo")" <<'EOF'
+client = "Acme"
+
+[tools]
+tga = "7.1.0"
+trusty-review = "0.34.0"
+
+[report]
+template = "cast"
+EOF
+before="$(cat "$(template_path "$repo")")"
+run_case "current pins: --check" 0 "OK" "$repo" --check
+run_case "current pins: rewrite" 0 "no change" "$repo"
+if [ "$before" = "$(cat "$(template_path "$repo")")" ]; then
+  pass_case "current pins: rewrite left the file byte-identical"
+else
+  fail_case "current pins: rewrite modified an already-current template" \
+    "$(diff <(printf '%s\n' "$before") "$(template_path "$repo")" || true)"
+fi
+
+# ===========================================================================
+# 2. THE REGRESSION — the #6772 shape. Two pins lag the workspace versions
+#    they are about to ship beside. --check names each one and exits 1; the
+#    rewrite fixes exactly those and a re-check goes clean.
+# ===========================================================================
+repo="$(mkrepo stale tga=7.1.0 trusty-search=0.52.0 trusty-review=0.34.0)"
+cat > "$(template_path "$repo")" <<'EOF'
+[tools]
+tga = "6.0.0"
+trusty-search = "0.52.0"
+trusty-review = "0.33.0"
+EOF
+run_case "stale pins: --check names tga" 1 "STALE tga pinned=6.0.0 workspace=7.1.0" "$repo" --check
+run_case "stale pins: --check names trusty-review" 1 \
+  "STALE trusty-review pinned=0.33.0 workspace=0.34.0" "$repo" --check
+out="$(bash "$GATE" --repo "$repo" --check 2>&1)" || true
+if grep -qF "STALE trusty-search" <<< "$out"; then
+  fail_case "stale pins: --check falsely reported the already-current trusty-search" "$out"
+else
+  pass_case "stale pins: --check left the already-current trusty-search alone"
+fi
+run_case "stale pins: rewrite" 0 "tga: 6.0.0 -> 7.1.0" "$repo"
+run_case "stale pins: --check after rewrite" 0 "OK" "$repo" --check
+
+# ===========================================================================
+# 3. Idempotence — a second rewrite over the just-refreshed template reports
+#    no change and produces the same bytes.
+# ===========================================================================
+after_first="$(cat "$(template_path "$repo")")"
+run_case "idempotence: second rewrite" 0 "no change" "$repo"
+if [ "$after_first" = "$(cat "$(template_path "$repo")")" ]; then
+  pass_case "idempotence: second rewrite left the file byte-identical"
+else
+  fail_case "idempotence: second rewrite changed the file" \
+    "$(diff <(printf '%s\n' "$after_first") "$(template_path "$repo")" || true)"
+fi
+
+# ===========================================================================
+# 4. The inline-table digest spelling the template documents. The version is
+#    refreshed; the sha256 beside it survives untouched.
+# ===========================================================================
+repo="$(mkrepo digest trusty-review=0.34.0)"
+cat > "$(template_path "$repo")" <<'EOF'
+[tools]
+trusty-review = { version = "0.32.0", sha256 = "deadbeef" }
+EOF
+run_case "digest spelling: --check" 1 "STALE trusty-review pinned=0.32.0 workspace=0.34.0" \
+  "$repo" --check
+run_case "digest spelling: rewrite" 0 "0.32.0 -> 0.34.0" "$repo"
+if grep -qF 'trusty-review = { version = "0.34.0", sha256 = "deadbeef" }' "$(template_path "$repo")"; then
+  pass_case "digest spelling: version refreshed, sha256 preserved"
+else
+  fail_case "digest spelling: rewrite mangled the inline table" "$(cat "$(template_path "$repo")")"
+fi
+
+# ===========================================================================
+# 5. The commented `# [tools]` example further down the file is documentation,
+#    not a pin — a rewrite must never touch it, and it must never be read as a
+#    pin either.
+# ===========================================================================
+repo="$(mkrepo commented tga=7.1.0)"
+cat > "$(template_path "$repo")" <<'EOF'
+[tools]
+tga = "6.0.0"
+
+# [tools]
+# tga = "1.0.0"
+# trusty-review = { version = "0.32.0", sha256 = "…" }
+EOF
+run_case "commented example: rewrite" 0 "tga: 6.0.0 -> 7.1.0" "$repo"
+if grep -qF '# tga = "1.0.0"' "$(template_path "$repo")"; then
+  pass_case "commented example: left verbatim"
+else
+  fail_case "commented example: the rewrite edited a comment" "$(cat "$(template_path "$repo")")"
+fi
+
+# ===========================================================================
+# 6. Fail-closed cases. Each of these would otherwise report success over a
+#    table the gate never actually read.
+# ===========================================================================
+repo="$(mkrepo unknown tga=7.1.0)"
+cat > "$(template_path "$repo")" <<'EOF'
+[tools]
+tga = "7.1.0"
+not-a-workspace-crate = "1.0.0"
+EOF
+run_case "unknown package pin" 2 "not-a-workspace-crate" "$repo" --check
+
+repo="$(mkrepo emptytable tga=7.1.0)"
+cat > "$(template_path "$repo")" <<'EOF'
+[tools]
+
+[report]
+template = "cast"
+EOF
+run_case "empty [tools] table" 2 "no readable pins" "$repo" --check
+
+repo="$(mkrepo notable tga=7.1.0)"
+cat > "$(template_path "$repo")" <<'EOF'
+client = "Acme"
+
+[report]
+template = "cast"
+EOF
+run_case "missing [tools] table" 2 "no readable pins" "$repo" --check
+
+repo="$(mkrepo notemplate tga=7.1.0)"
+rm -f "$(template_path "$repo")"
+run_case "missing template file" 2 "no template at" "$repo" --check
+
+# ===========================================================================
+# 7. THE LIVE REPO. Proves the checked-out template is current, rather than
+#    only the fixtures built to make the gate pass.
+# ===========================================================================
+run_case "live repo: checked-out template" 0 "OK" "$REPO_ROOT" --check
+
+echo
+echo "refresh-engagement-pins-selftest: ${PASSED} passed, ${FAILED} failed."
+[ "$FAILED" -eq 0 ]

--- a/scripts/refresh-engagement-pins.sh
+++ b/scripts/refresh-engagement-pins.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# refresh-engagement-pins.sh — hold the engagement template's sibling-tool pins
+# at the workspace versions (#6772).
+#
+# Why: `crates/trusty-audit/templates/engagement.template.toml` pins the four
+#   sibling tools an engagement runs (`tga`, `trusty-search`, `trusty-analyze`,
+#   `trusty-review`) as literal versions, and nothing bumps them. The file is
+#   also `include_str!`-ed into `instructions::ENGAGEMENT_TEMPLATE` and written
+#   out verbatim by `taudit distribute`, so a stale pin ships inside the binary
+#   and into every client package built from it. At 7cfeda52d the template
+#   pinned tga 6.0.0 / trusty-analyze 0.12.5 / trusty-review 0.33.0 while the
+#   same release train published tga 7.0.0 / 0.12.6 / 0.33.1 (#6772; PR #6723
+#   was the previous instance of the same drift).
+#
+# What: reads the ACTIVE `[tools]` table out of the template, asks
+#   `cargo metadata --no-deps` for each pinned package's current workspace
+#   version, and either rewrites the pins to match (default) or reports the
+#   mismatches and exits nonzero (`--check`). Both modes touch only the version
+#   literal on a pin line inside the `[tools]` table — comments, the commented
+#   `# [tools]` digest example, key order and every other byte are preserved,
+#   so a second run over an already-refreshed template is a no-op.
+#
+#   Both pin spellings the template documents are handled:
+#
+#       tga = "7.1.0"
+#       trusty-review = { version = "0.34.0", sha256 = "…" }
+#
+#   Fails closed: a `[tools]` table that is missing, empty, or names a package
+#   this workspace does not build is a usage error (exit 2), never a silent
+#   pass. A gate that reports success over a table it could not read is the
+#   failure mode this script exists to remove.
+#
+#   NOT what this decides: whether a lagging pin is ACCEPTABLE. A pin may
+#   legitimately lag when the sibling crate is not part of the release train.
+#   That judgement lives in `scripts/preflight-publish.sh` CHECK 10, which
+#   consults crates.io; this script only answers "does the pin equal the
+#   workspace version".
+#
+# Usage:
+#   scripts/refresh-engagement-pins.sh [--check] [--repo <dir>]
+#
+#   --check        report stale pins instead of rewriting them. One
+#                  `STALE <pkg> pinned=<x> workspace=<y>` line per mismatch on
+#                  stdout, then exit 1. Exit 0 and a single OK line when every
+#                  pin is current.
+#   --repo <dir>   operate on a different repo root (self-test only).
+#   -h|--help      print this header and exit 0.
+#
+# Exit codes: 0 = pins are current (`--check`), or were rewritten/left alone
+#   (default). 1 = at least one stale pin (`--check` only). 2 = usage error,
+#   unreadable template, unreadable metadata, or a pin naming a package that is
+#   not a workspace member.
+#
+# Test: scripts/refresh-engagement-pins-selftest.sh drives both modes over
+#   synthetic single-file workspaces — a current table, a stale table, the
+#   inline-table digest spelling, an unknown package, an empty table, a missing
+#   `[tools]` header, and an idempotence case that reruns the rewrite and
+#   diffs the bytes. It also runs `--check` against the REAL checked-out
+#   template so the live repo is proven, not only a fixture.
+#
+# Portability: POSIX tools plus python3 (already required by check_semver.sh),
+#   bash 3.2 (macOS) and bash 5 (Linux CI).
+
+set -euo pipefail
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+  esac
+done
+
+usage() {
+  echo "usage: scripts/refresh-engagement-pins.sh [--check] [--repo <dir>]" >&2
+  exit 2
+}
+
+CHECK_ONLY=0
+REPO_ARG=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check) CHECK_ONLY=1; shift ;;
+    --repo)
+      [ "$#" -ge 2 ] || usage
+      REPO_ARG="$2"
+      shift 2
+      ;;
+    *)
+      echo "refresh-engagement-pins: unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [ -n "$REPO_ARG" ]; then
+  REPO_ROOT="$(cd "$REPO_ARG" && pwd)"
+else
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+fi
+
+TEMPLATE_REL="crates/trusty-audit/templates/engagement.template.toml"
+TEMPLATE="${REPO_ROOT}/${TEMPLATE_REL}"
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "refresh-engagement-pins: ERROR: no template at ${TEMPLATE}" >&2
+  exit 2
+fi
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/refresh-engagement-pins.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+# ---------------------------------------------------------------------------
+# Read the ACTIVE [tools] table: `pkg<TAB>pinned-version` per line.
+#
+# `in_tools` flips only on a bare `[header]` at column 0, so the commented
+# `# [tools]` digest example further down the file is never entered, and the
+# table ends at the next real header.
+# ---------------------------------------------------------------------------
+PINS="${SCRATCH}/pins.tsv"
+awk '
+  /^\[/ { in_tools = ($0 == "[tools]"); next }
+  !in_tools { next }
+  /^[[:space:]]*#/ { next }
+  match($0, /^[A-Za-z0-9_.-]+/) {
+    name = substr($0, RSTART, RLENGTH)
+    rest = substr($0, RSTART + RLENGTH)
+    if (rest !~ /^[[:space:]]*=/) next
+    # Inline-table spelling: narrow to the inner `version` key first, so a
+    # sha256 digest that follows it is never mistaken for the version.
+    if (rest ~ /^[[:space:]]*=[[:space:]]*\{/) {
+      if (!match(rest, /version[[:space:]]*=[[:space:]]*"[^"]*"/)) next
+      rest = substr(rest, RSTART, RLENGTH)
+    }
+    sub(/^[^"]*"/, "", rest)
+    sub(/".*$/, "", rest)
+    if (rest != "") printf "%s\t%s\n", name, rest
+  }
+' "$TEMPLATE" > "$PINS"
+
+if [ ! -s "$PINS" ]; then
+  echo "refresh-engagement-pins: ERROR: ${TEMPLATE_REL} has no readable pins in a" >&2
+  echo "       [tools] table. The table is REQUIRED (see the template's own note:" >&2
+  echo "       there is no \"latest\"), so an empty or missing one is a defect in the" >&2
+  echo "       template, not a state this gate may pass over." >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Workspace versions. `cargo metadata` is the single source of truth here — it
+# resolves the package name directly (crates/trusty-git-analytics/ is package
+# `tga`), which a crates/<dir>/Cargo.toml scan would have to special-case.
+# ---------------------------------------------------------------------------
+META="${SCRATCH}/metadata.json"
+if ! cargo metadata --no-deps --format-version 1 --manifest-path "${REPO_ROOT}/Cargo.toml" \
+     > "$META" 2> "${SCRATCH}/meta-err.txt"; then
+  echo "refresh-engagement-pins: ERROR: 'cargo metadata --no-deps' failed:" >&2
+  sed 's/^/       /' "${SCRATCH}/meta-err.txt" >&2
+  exit 2
+fi
+
+WANTED="${SCRATCH}/wanted.tsv"
+WANTED_ERR="${SCRATCH}/wanted.err"
+if ! python3 - "$META" "$PINS" > "$WANTED" 2> "$WANTED_ERR" <<'PY'
+import json
+import sys
+
+meta_path, pins_path = sys.argv[1], sys.argv[2]
+with open(meta_path, encoding="utf-8") as fh:
+    versions = {p["name"]: p["version"] for p in json.load(fh)["packages"]}
+
+missing = []
+out = []
+with open(pins_path, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        name, pinned = line.split("\t", 1)
+        if name not in versions:
+            missing.append(name)
+            continue
+        out.append(f"{name}\t{pinned}\t{versions[name]}")
+
+if missing:
+    print("MISSING\t" + ",".join(missing), file=sys.stderr)
+    raise SystemExit(3)
+
+print("\n".join(out))
+PY
+then
+  echo "refresh-engagement-pins: ERROR: ${TEMPLATE_REL}'s [tools] table pins a package" >&2
+  echo "       this workspace does not build:" >&2
+  sed 's/^/       /' "$WANTED_ERR" >&2
+  echo "       Every pin must name a workspace package, so the release train can" >&2
+  echo "       keep it current. Fix the pin name in the template." >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# --check: report, never write.
+# ---------------------------------------------------------------------------
+if [ "$CHECK_ONLY" -eq 1 ]; then
+  STALE=0
+  while IFS=$'\t' read -r name pinned wanted; do
+    [ -n "$name" ] || continue
+    if [ "$pinned" != "$wanted" ]; then
+      echo "STALE ${name} pinned=${pinned} workspace=${wanted}"
+      STALE=$((STALE + 1))
+    fi
+  done < "$WANTED"
+
+  if [ "$STALE" -gt 0 ]; then
+    echo "refresh-engagement-pins: ${STALE} stale pin(s) in ${TEMPLATE_REL}." >&2
+    echo "       Refresh them: scripts/refresh-engagement-pins.sh" >&2
+    exit 1
+  fi
+
+  echo "refresh-engagement-pins: OK — every [tools] pin in ${TEMPLATE_REL} names the"
+  echo "  crate's current workspace version."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Default: rewrite the version literal on each stale pin line, in place.
+# ---------------------------------------------------------------------------
+UPDATED="${SCRATCH}/engagement.template.toml"
+awk -v want_file="$WANTED" '
+  BEGIN {
+    while ((getline line < want_file) > 0) {
+      n = split(line, f, "\t")
+      if (n >= 3) want[f[1]] = f[3]
+    }
+  }
+  /^\[/ { in_tools = ($0 == "[tools]"); print; next }
+  !in_tools || /^[[:space:]]*#/ { print; next }
+  {
+    if (!match($0, /^[A-Za-z0-9_.-]+/)) { print; next }
+    name = substr($0, RSTART, RLENGTH)
+    if (!(name in want)) { print; next }
+    head = substr($0, 1, RSTART + RLENGTH - 1)
+    rest = substr($0, RSTART + RLENGTH)
+    if (rest !~ /^[[:space:]]*=/) { print; next }
+    # Replace the FIRST quoted literal after `=` for the plain spelling, and
+    # the one belonging to the inner `version` key for the inline-table
+    # spelling — never a sha256 digest that follows it.
+    if (rest ~ /^[[:space:]]*=[[:space:]]*\{/) {
+      if (!match(rest, /version[[:space:]]*=[[:space:]]*"[^"]*"/)) { print; next }
+      pre = substr(rest, 1, RSTART - 1)
+      mid = substr(rest, RSTART, RLENGTH)
+      post = substr(rest, RSTART + RLENGTH)
+      sub(/"[^"]*"$/, "\"" want[name] "\"", mid)
+      print head pre mid post
+    } else {
+      if (!match(rest, /"[^"]*"/)) { print; next }
+      pre = substr(rest, 1, RSTART - 1)
+      post = substr(rest, RSTART + RLENGTH)
+      print head pre "\"" want[name] "\"" post
+    }
+  }
+' "$TEMPLATE" > "$UPDATED"
+
+if cmp -s "$TEMPLATE" "$UPDATED"; then
+  echo "refresh-engagement-pins: no change — every [tools] pin already names the"
+  echo "  crate's current workspace version."
+  exit 0
+fi
+
+cp "$UPDATED" "$TEMPLATE"
+echo "refresh-engagement-pins: rewrote ${TEMPLATE_REL}:"
+while IFS=$'\t' read -r name pinned wanted; do
+  [ -n "$name" ] || continue
+  [ "$pinned" = "$wanted" ] && continue
+  echo "  ${name}: ${pinned} -> ${wanted}"
+done < "$WANTED"
+echo "  Rebuild trusty-audit so instructions::ENGAGEMENT_TEMPLATE picks the new"
+echo "  bytes up — 'taudit distribute' ships the compiled copy, not this file."
+exit 0


### PR DESCRIPTION
Refs #6772

Adds `scripts/refresh-engagement-pins.sh` (rewrites or `--check`s the engagement template's `[tools]` pins against workspace versions) with a self-test, CHECK 10 in `scripts/preflight-publish.sh` (FAIL when a pin lags a sibling shipping in this train, WARN when the lagging version is already published, FAIL on any crates.io reply other than 200/404), and moves the template pins to tga 7.1.0 / trusty-analyze 0.12.6 / trusty-review 0.34.0. Two tests in `distribute.rs` guard the include_str! provenance and that every shipped pin is a semver triple.

Test ladder: rung 5 (release tooling); code-critic round in progress. `cargo fmt --check`, `cargo check -p trusty-audit --all-targets`, `cargo clippy -p trusty-audit --all-targets -- -D warnings`, `cargo test -p trusty-audit --no-fail-fast` (915 passed, 0 failed). `refresh-engagement-pins-selftest.sh`: 20 passed. Doc gates: sld, line-cap, test-pointers, changelog fragment all OK; shellcheck clean.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
