### PR TITLE
docs(trusty-audit): fix the two ambiguous write intra-doc links (Refs #6780)

### DIFF
--- a/crates/trusty-audit/src/debt_rollup.rs
+++ b/crates/trusty-audit/src/debt_rollup.rs
@@ -12,7 +12,7 @@
 //! tier × dimension, plus their shared [`DebtRollup::total`]. It is computed
 //! ONCE per run — [`from_manifests`] reads each repository's manifest — and both
 //! consumers read that one value: `crate::index_report` renders its "Technical
-//! debt by tier" table from it, and [`write`] serialises it to `report.json`
+//! debt by tier" table from it, and [`write()`] serialises it to `report.json`
 //! beside the index.
 //!
 //! ## The taxonomy is the producer's, not this module's

--- a/crates/trusty-audit/src/index_report.rs
+++ b/crates/trusty-audit/src/index_report.rs
@@ -254,9 +254,10 @@ pub struct IndexReport {
     /// The findings every unit declared, counted once (#6781).
     ///
     /// Why: the index's "Technical debt by tier" table and the `report.json`
-    /// [`write`] leaves beside it are two views of ONE count. Carrying the
-    /// computed value here rather than letting each renderer walk the manifests
-    /// is what makes it impossible for them to disagree.
+    /// [`debt_rollup::write`](crate::debt_rollup::write) leaves beside it are
+    /// two views of ONE count. Carrying the computed value here rather than
+    /// letting each renderer walk the manifests is what makes it impossible for
+    /// them to disagree.
     /// What: empty — which renders no table and an empty block — for a producer
     /// that read no manifests, or a run whose repositories declared nothing.
     pub debt: crate::debt_rollup::DebtRollup,


### PR DESCRIPTION
## Outcome

Lands the rustdoc fix commit (45c1ef590) from PR #6781 as its own docs-only PR. PR #6801 merged before this fix reached its branch, leaving the commit orphaned on `origin/feat/6780-osv-lookup`. This PR re-applies it to main.

Refs #6780, #6781

## Changes

Fixed two ambiguous intra-doc links in `debt_rollup.rs` and `index_report.rs` that rustdoc rejected as ambiguous between the module function and the `write!` macro. Lines only; no source code changes.

Out of scope: none.

## Risk

Doc comment changes only. No runtime behavior impact. Blast radius: zero.

## Tests

Doc lines only; rung 1 per the test ladder. `scripts/check_rustdoc_links.sh` reports 0 broken links across the workspace.

## Baseline

No pre-existing failures in the baseline.

## Docs

This is the changelog-fragment-skipped docs-only work. Doc comment updates only in `debt_rollup.rs` and `index_report.rs`.

## Review

No functional changes. Rustdoc fix commit from #6781, landed after #6801 merged.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
