### PR TITLE
fix(workspace): internal dependency version requirements must accept their crate (#6776)

### DIFF
--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -79,6 +79,8 @@ on:
       - "scripts/check_source_class_selftest.sh"
       - "scripts/check_scan_floor_selftest.sh"
       - "scripts/check_version_bump_verdict_selftest.sh"
+      - "scripts/check_workspace_dep_versions.sh"
+      - "scripts/check_workspace_dep_versions_selftest.sh"
       - ".github/workflows/version-parity.yml"
   # Every three hours. Fine-grained enough that a publish is caught in one
   # working session, coarse enough to stay well inside crates.io's API-usage
@@ -246,6 +248,25 @@ jobs:
       - name: Source-classification selftest (both gates share one definition)
         if: github.event_name == 'pull_request'
         run: bash scripts/check_source_class_selftest.sh
+
+      # Internal `[workspace.dependencies]` requirement drift (#6776). A
+      # DIFFERENT question from this job's own gate: not "is this version
+      # already live on crates.io" but "does the root table's requirement even
+      # accept the member crate's own version". No cargo command in-tree can
+      # answer it — the row's `path` wins over its `version`, so the drift is
+      # invisible until `cargo publish` or an external consumer resolves the
+      # crate from the registry (`trusty-console` sat at `^0.9.0` against a
+      # 0.11.0 crate; `tga` at `^6.0.1` against 7.1.0). It lives in this job
+      # because this is the publish-safety job that runs unconditionally on
+      # every PR. Pure shell over two manifests: no cargo, no network, well
+      # under a second. Selftest first, for the same reason as the gates above.
+      - name: Workspace-dep version selftest (must reject a drifted row)
+        if: github.event_name == 'pull_request'
+        run: bash scripts/check_workspace_dep_versions_selftest.sh
+
+      - name: Check internal workspace.dependencies version requirements
+        if: github.event_name == 'pull_request'
+        run: bash scripts/check_workspace_dep_versions.sh
 
       # #4688: diff against the base branch AS IT IS NOW, not the frozen
       # `base.sha` snapshot. checkout leaves refs/remotes/origin/<base> at

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,9 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.11", defau
 # manifest edge (#5236, DOC-67 §6). One in-tree Cargo edge exists again: #6294
 # made `tga` a dev-dependency of trusty-analyze, which is why tga no longer has
 # a row in scripts/semver-checks-crate-exclusions.tsv (#6300).
-tga = { path = "crates/trusty-git-analytics", version = "6.0.1" }
+# #6776: same drift as trusty-console, surfaced by the new gate — `^6.0.1`
+# cannot accept the crate's own 7.1.0.
+tga = { path = "crates/trusty-git-analytics", version = "7.1" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
@@ -167,7 +169,11 @@ trusty-review = { path = "crates/trusty-review", version = "0.34", default-featu
 # (de-bundled from the host crates for single-owner-per-binary). It is still a
 # published library crate; the path entry remains so any local lib consumers
 # resolve in-tree.
-trusty-console = { path = "crates/trusty-console", version = "0.9.0" }
+# #6776: the requirement tracks the crate's current MINOR, not a pinned patch.
+# `^0.9.0` excluded the crate's own 0.11.0 — in-tree the path override hid it, so
+# only a crates.io consumer (or `cargo publish`) resolved wrong. Guarded now by
+# scripts/check_workspace_dep_versions.sh.
+trusty-console = { path = "crates/trusty-console", version = "0.11" }
 # trusty-progress: shared rustup/cargo-style progress + status display (#1315).
 # Consumed by trusty-installer for install/upgrade component rows; published library crate.
 trusty-progress = { path = "crates/trusty-progress", version = "0.3.0" }

--- a/docs/reference/ci-scripts.md
+++ b/docs/reference/ci-scripts.md
@@ -2,7 +2,7 @@
 
 (Plus two operator scripts no workflow runs at all — see the last section.)
 
-Eight scripts in `scripts/` run in a GitHub Actions workflow and nowhere else —
+Nine scripts in `scripts/` run in a GitHub Actions workflow and nowhere else —
 no pre-commit hook, no `Makefile` target, no other doc page. Each was written
 for a specific failure and none of them announced itself anywhere a reader
 would look, so a change to one of the workflows below could drop it with
@@ -27,11 +27,12 @@ what it stops; the header says why it exists.
 | `classify-ci-results.sh` | `ci.yml`, `red-main-notify.yml` | Turns a set of job conclusions into the red-main verdict. `cancelled` is not `failure`, so the previous `contains(needs.*.result, 'failure')` test let an all-cancelled run report main verified (#4179). |
 | `ci-create-local-main.sh` | `ci.yml`, `pre-publish.yml` | Creates the local `main` branch the `trusty-agents` git tests need, and fails the step when creation genuinely fails. The `git fetch origin main:main \|\| true` it replaced swallowed a GitHub 500 and produced an unrelated test failure eleven minutes later (#5693). |
 | `detect-embedder-cuda-relevant.sh` | `ci.yml` | Decides whether a change can affect the `trusty-common` `embedder-cuda` build, so the CUDA leg runs when it is relevant and is skipped when it is not. |
+| `check_workspace_dep_versions.sh` | `version-parity.yml` (`pr-version-bump`) | Asserts every internal `[workspace.dependencies]` row's `version` requirement actually accepts the member crate's own version, under Cargo's caret rules. The row's `path` wins in-tree, so no cargo command in the workspace can see the drift — `trusty-console` sat at `^0.9.0` against a 0.11.0 crate and `tga` at `^6.0.1` against 7.1.0, both invisible until `cargo publish` or an external consumer resolved from the registry (#6776, same class as #4088). |
 | `check_token_drift.mjs` | `token-drift.yml` | Compares each Tailwind app's hand-transcribed `--color-*` RGB triples against the canonical Foundry `tokens.css`. `ci.yml` deliberately does NOT duplicate it (`ci.yml`, `ui-checks` job): `token-drift.yml` already runs it across all seven crates directly rather than through each `package.json`. |
 
 ## Self-tests
 
-Six of the eight have a companion test that proves the gate can still fail — a
+Seven of the nine have a companion test that proves the gate can still fail — a
 gate that cannot fail makes its own green meaningless:
 
 | Script | Its test |
@@ -42,6 +43,7 @@ gate that cannot fail makes its own green meaningless:
 | `classify-ci-results.sh` | `scripts/check-ci-helpers-selftest.sh` |
 | `detect-embedder-cuda-relevant.sh` | `scripts/check-ci-helpers-selftest.sh` |
 | `check_token_drift.mjs` | `scripts/check_token_drift.test.mjs`, a `node:test` suite `token-drift.yml` runs before the gate |
+| `check_workspace_dep_versions.sh` | `scripts/check_workspace_dep_versions_selftest.sh`, run as the step before the gate in the same job |
 
 `check_deny_duplicates.sh` and `ci-create-local-main.sh` have no test of their
 own. Both carry a frozen baseline or a fetch that can fail open, which is the
@@ -49,9 +51,11 @@ shape a self-test exists to pin, so both are candidates if either is edited.
 
 ## Which of these block a merge
 
-None of these workflows appear in `main`'s required-status-check contexts as of
-2026-09-02. Read the list live before relying on any of them to stop a merge —
-a hand-copied list already cost
+One does: `check_workspace_dep_versions.sh` runs as a step of `version-parity.yml`'s
+`pr-version-bump` job, whose context `PR version bump vs crates.io (issue #4421)`
+is required, so a drifted workspace row fails a required check (#6776). The rest
+did not appear in `main`'s required contexts as of 2026-09-04. Read the list live
+before relying on any of them to stop a merge — a hand-copied list already cost
 [#5836](https://github.com/bobmatnyc/trusty-tools/pull/5836) a merge:
 
 ```bash

--- a/scripts/check_workspace_dep_versions.sh
+++ b/scripts/check_workspace_dep_versions.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+#
+# check_workspace_dep_versions.sh — every internal `[workspace.dependencies]`
+# row's version requirement must accept the member crate's own version (#6776).
+#
+# Why: a row in the root `[workspace.dependencies]` table carries BOTH a `path`
+#   and a `version`. In-tree the path wins, so cargo never evaluates the version
+#   requirement and `cargo build` / `cargo check` / `cargo test` all stay green
+#   no matter how far the two drift. The requirement is only consulted when the
+#   crate is resolved from crates.io — i.e. at publish time, and by any external
+#   consumer. #6776 found `trusty-console = { path = …, version = "0.9.0" }`
+#   against a crate at `0.11.0`: `^0.9.0` excludes `0.11.0`, so a published
+#   consumer resolves a version that does not exist or an ancient one. Same
+#   class as #4088, where the path override likewise hid a break a workspace
+#   `cargo check` structurally cannot see.
+#
+# What: reads the root `Cargo.toml`, takes every `[workspace.dependencies]` row
+#   that declares `path = "crates/<dir>"` AND a `version`, reads that member's
+#   own `[package] version`, and asserts the member version SATISFIES the row's
+#   requirement under Cargo's caret rules (including the 0.x rule, where the
+#   minor is the breaking component). A row with a `path` and no `version` is
+#   in-tree-only resolution and is reported as SKIP, not silently ignored.
+#
+#   Fails CLOSED. A member manifest that cannot be read, a version that is not a
+#   plain `X.Y.Z[-pre]`, and a requirement operator this script does not model
+#   (anything but a bare or `^` requirement) are all failures naming the row —
+#   an unverifiable row is never a silent pass. It also enforces a SCAN FLOOR
+#   (#4618): examining zero rows exits non-zero rather than reporting success
+#   over nothing.
+#
+# Usage:
+#   bash scripts/check_workspace_dep_versions.sh
+#
+# Env: WS_DEP_MANIFEST overrides the root manifest scanned (fixtures only).
+#   WS_DEP_MIN_ROWS overrides the scan floor (fixtures only; default 8).
+#
+# Exit: 0 when every internal row's requirement accepts its member's version;
+#   1 on the first drift, unverifiable row, or vacuous scan, naming the row and
+#   the exact edit that closes it.
+#
+# Test: scripts/check_workspace_dep_versions_selftest.sh drives this script over
+#   fixture manifests — satisfied rows, the #6776 `^0.9.0` vs `0.11.0` drift,
+#   the 0.x minor rule, a `1.x` row, an alias key whose directory differs from
+#   the row name, a missing member manifest, an unsupported operator, and an
+#   empty table (scan floor) — and asserts the live repo scan passes.
+#
+# Portability: bash 3.2 (macOS) and bash 5 (Linux CI). POSIX tools only, no
+#   cargo and no network, so it runs in a toolchain-less shell job.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MANIFEST="${WS_DEP_MANIFEST:-${REPO_ROOT}/Cargo.toml}"
+MIN_ROWS="${WS_DEP_MIN_ROWS:-8}"
+
+# The member manifests are resolved relative to the manifest's own directory so
+# a fixture root is self-contained.
+MANIFEST_DIR="$(cd "$(dirname "${MANIFEST}")" && pwd)"
+
+failures=0
+examined=0
+
+fail() {
+  printf '[FAIL] %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+# ---------------------------------------------------------------------------
+# rows — emit `name<TAB>path<TAB>version` for every `[workspace.dependencies]`
+# row declaring a `path`. `version` is empty when the row has none. The awk
+# arms on the section header and disarms on the next top-level table, so a
+# `path = ` in some other section is never picked up.
+# ---------------------------------------------------------------------------
+rows() {
+  awk '
+    /^\[workspace\.dependencies\]/ { inside = 1; next }
+    /^\[/                          { inside = 0 }
+    !inside                        { next }
+    # Skip full-line comments and blanks.
+    /^[[:space:]]*#/               { next }
+    /^[[:space:]]*$/               { next }
+    # A row must name a key and carry a crates/ path.
+    !/path[[:space:]]*=[[:space:]]*"/ { next }
+    {
+      line = $0
+      name = line
+      sub(/[[:space:]]*=.*$/, "", name)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", name)
+
+      path = line
+      sub(/^.*path[[:space:]]*=[[:space:]]*"/, "", path)
+      sub(/".*$/, "", path)
+
+      ver = ""
+      if (line ~ /version[[:space:]]*=[[:space:]]*"/) {
+        ver = line
+        sub(/^.*version[[:space:]]*=[[:space:]]*"/, "", ver)
+        sub(/".*$/, "", ver)
+      }
+      printf "%s\t%s\t%s\n", name, path, ver
+    }
+  ' "${MANIFEST}"
+}
+
+# ---------------------------------------------------------------------------
+# member_version <member-dir> — the member's `[package] version`, or empty when
+# the manifest is unreadable or declares none.
+# ---------------------------------------------------------------------------
+member_version() {
+  local dir="$1"
+  local file="${MANIFEST_DIR}/${dir}/Cargo.toml"
+  [ -f "${file}" ] || return 0
+  awk '
+    /^\[package\]/            { inside = 1; next }
+    /^\[/                     { inside = 0 }
+    inside && /^[[:space:]]*version[[:space:]]*=/ {
+      v = $0
+      sub(/^.*=[[:space:]]*"/, "", v)
+      sub(/".*$/, "", v)
+      print v
+      exit
+    }
+  ' "${file}"
+}
+
+# ---------------------------------------------------------------------------
+# Caret-requirement satisfaction, Cargo semantics.
+#
+# `satisfies <req> <version>` exits 0 when <version> is inside the caret range
+# <req> denotes, 1 when it is outside, and 2 when either side is a shape this
+# script does not model (the caller turns that into a fail-closed error).
+#
+# Upper bound increments the LEFTMOST NONZERO component of the requirement as
+# written, which is what makes the minor the breaking component for `0.y.z`:
+#   ^1.2.3 -> <2.0.0    ^0.2.3 -> <0.3.0    ^0.0.3 -> <0.0.4
+#   ^1.2   -> <2.0.0    ^0.2   -> <0.3.0    ^0.0   -> <0.1.0
+#   ^1     -> <2.0.0    ^0     -> <1.0.0
+# ---------------------------------------------------------------------------
+satisfies() {
+  local req="$1" ver="$2"
+
+  # Only a bare or explicitly-caret requirement is modelled. Anything else
+  # (`=`, `~`, `>=`, `*`, a comma-separated set) is unverifiable here.
+  case "${req}" in
+    ^*) req="${req#^}" ;;
+    [0-9]*) ;;
+    *) return 2 ;;
+  esac
+  case "${req}" in *[!0-9.]*) return 2 ;; esac
+  case "${req}" in *..*|.*|*.) return 2 ;; esac
+
+  # A prerelease/build version is not modelled; the workspace has none.
+  case "${ver}" in *[!0-9.]*) return 2 ;; esac
+  case "${ver}" in *..*|.*|*.) return 2 ;; esac
+
+  local r_major r_minor r_patch r_minor_set r_patch_set
+  r_major="${req%%.*}"
+  r_minor=0
+  r_patch=0
+  r_minor_set=0
+  r_patch_set=0
+  case "${req}" in
+    *.*.*)
+      r_minor_set=1
+      r_patch_set=1
+      r_minor="${req#*.}"
+      r_minor="${r_minor%%.*}"
+      r_patch="${req##*.}"
+      ;;
+    *.*)
+      r_minor_set=1
+      r_minor="${req#*.}"
+      ;;
+  esac
+  [ -n "${r_major}" ] || return 2
+  [ -n "${r_minor}" ] || return 2
+  [ -n "${r_patch}" ] || return 2
+
+  local v_major v_minor v_patch
+  v_major="${ver%%.*}"
+  v_minor=0
+  v_patch=0
+  case "${ver}" in
+    *.*.*)
+      v_minor="${ver#*.}"
+      v_minor="${v_minor%%.*}"
+      v_patch="${ver##*.}"
+      ;;
+    *.*)
+      v_minor="${ver#*.}"
+      ;;
+  esac
+  [ -n "${v_major}" ] && [ -n "${v_minor}" ] && [ -n "${v_patch}" ] || return 2
+
+  # Lower bound: >= r_major.r_minor.r_patch
+  local lo hi
+  lo=$(printf '%d%03d%03d' "${r_major}" "${r_minor}" "${r_patch}")
+
+  # Upper bound (exclusive), per the leftmost-nonzero rule above.
+  if [ "${r_major}" -ne 0 ]; then
+    hi=$(printf '%d%03d%03d' "$((r_major + 1))" 0 0)
+  elif [ "${r_minor_set}" -eq 0 ]; then
+    hi=$(printf '%d%03d%03d' 1 0 0)
+  elif [ "${r_minor}" -ne 0 ]; then
+    hi=$(printf '%d%03d%03d' 0 "$((r_minor + 1))" 0)
+  elif [ "${r_patch_set}" -eq 0 ]; then
+    hi=$(printf '%d%03d%03d' 0 1 0)
+  elif [ "${r_patch}" -ne 0 ]; then
+    hi=$(printf '%d%03d%03d' 0 0 "$((r_patch + 1))")
+  else
+    hi=$(printf '%d%03d%03d' 0 0 1)
+  fi
+
+  local v
+  v=$(printf '%d%03d%03d' "${v_major}" "${v_minor}" "${v_patch}")
+  # 10#… so a zero-padded component is never read as octal.
+  if [ "$((10#${v}))" -ge "$((10#${lo}))" ] && [ "$((10#${v}))" -lt "$((10#${hi}))" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main scan
+# ---------------------------------------------------------------------------
+if [ ! -f "${MANIFEST}" ]; then
+  printf '[FAIL] root manifest not found: %s\n' "${MANIFEST}" >&2
+  exit 1
+fi
+
+printf 'Checking internal [workspace.dependencies] version requirements in %s\n' \
+  "${MANIFEST}"
+
+while IFS="$(printf '\t')" read -r name path req; do
+  [ -n "${name}" ] || continue
+
+  if [ -z "${req}" ]; then
+    printf '[SKIP] %-22s %s — path-only row, no version requirement to check\n' \
+      "${name}" "${path}"
+    continue
+  fi
+
+  crate_ver="$(member_version "${path}")"
+  if [ -z "${crate_ver}" ]; then
+    fail "$(printf '%s: cannot read [package] version from %s/Cargo.toml — row is unverifiable' \
+      "${name}" "${path}")"
+    examined=$((examined + 1))
+    continue
+  fi
+
+  examined=$((examined + 1))
+
+  set +e
+  satisfies "${req}" "${crate_ver}"
+  verdict=$?
+  set -e
+
+  case "${verdict}" in
+    0)
+      printf '[ OK ] %-22s req %-8s accepts crate %s\n' "${name}" "${req}" "${crate_ver}"
+      ;;
+    1)
+      suggest="$(printf '%s' "${crate_ver}" | awk -F. '{ print $1"."$2 }')"
+      # The 0.x note only applies when the member really is a 0.y.z crate.
+      if [ "${crate_ver%%.*}" = "0" ]; then
+        note=' (for 0.y.z the MINOR is the breaking component)'
+      else
+        note=''
+      fi
+      fail "$(printf '%s: root Cargo.toml requires version = "%s" but %s is %s.\n         ^%s does not accept %s%s.\n         Fix: set the row to version = "%s" in [workspace.dependencies].' \
+        "${name}" "${req}" "${path}" "${crate_ver}" \
+        "${req}" "${crate_ver}" "${note}" "${suggest}")"
+      ;;
+    *)
+      fail "$(printf '%s: unmodelled version shape (req "%s", crate "%s"). Extend %s rather than skipping the row.' \
+        "${name}" "${req}" "${crate_ver}" "$(basename "$0")")"
+      ;;
+  esac
+done <<EOF
+$(rows)
+EOF
+
+# Scan floor (#4618): a run that examined nothing must not report success.
+if [ "${examined}" -lt "${MIN_ROWS}" ]; then
+  printf '[FAIL] SCAN FLOOR: examined %d internal row(s), expected at least %d.\n' \
+    "${examined}" "${MIN_ROWS}" >&2
+  printf '       Either [workspace.dependencies] lost its internal rows or the\n' >&2
+  printf '       parser stopped matching them. A vacuous scan is not a pass.\n' >&2
+  exit 1
+fi
+
+if [ "${failures}" -gt 0 ]; then
+  printf '\n%d internal [workspace.dependencies] row(s) drifted from their member crate.\n' \
+    "${failures}" >&2
+  exit 1
+fi
+
+printf '\nAll %d internal row(s) accept their member crate version.\n' "${examined}"

--- a/scripts/check_workspace_dep_versions_selftest.sh
+++ b/scripts/check_workspace_dep_versions_selftest.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# check_workspace_dep_versions_selftest.sh — mutation self-test for the internal
+# `[workspace.dependencies]` version-requirement gate (#6776).
+#
+# Why: the gate it tests is the only thing standing between a drifted workspace
+#   row and a publish-time resolution break, because no cargo command in-tree
+#   can see the drift at all (the `path` override wins). A gate in that position
+#   is untested code unless something re-proves it can still FAIL — the #4618
+#   lesson, and the reason every case below is a manifest that must be rejected.
+#
+# What: builds throwaway fixture workspaces under a temp dir, points the gate at
+#   each via `WS_DEP_MANIFEST`, and asserts the exit status and (where it
+#   matters) the reason. Cases:
+#     satisfied            every row's requirement accepts its member  -> PASS
+#     drift_0x             the real #6776 shape, ^0.9.0 vs 0.11.0      -> FAIL
+#     drift_major          ^6.0.1 vs 7.1.0 (major bump)                -> FAIL
+#     ok_0x_patch          ^0.5.0 vs 0.5.1 (patch inside the range)    -> PASS
+#     ok_partial_req       ^0.47 vs 0.47.3 (two-component requirement) -> PASS
+#     ok_major_range       ^1.0.0 vs 1.5.17 (1.x caret is wide)        -> PASS
+#     alias_key            row key differs from its directory          -> FAIL
+#     missing_member       member Cargo.toml absent                    -> FAIL
+#     bad_operator         a requirement shape the gate does not model -> FAIL
+#     scan_floor           table present but zero internal rows        -> FAIL
+#   Plus a final case asserting the LIVE repo manifest passes, so the gate and
+#   the tree it guards cannot disagree silently.
+#
+# Usage:
+#   bash scripts/check_workspace_dep_versions_selftest.sh          # every case
+#   bash scripts/check_workspace_dep_versions_selftest.sh drift_0x # one by name
+#
+# Exit: 0 when every case reaches its expected verdict; 1 naming the first case
+#   that did not.
+#
+# Portability: bash 3.2 (macOS) and bash 5 (Linux CI). POSIX tools only.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="${SCRIPT_DIR}/check_workspace_dep_versions.sh"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+failures=0
+only="${1:-}"
+
+pass() { printf '  ok   %s\n' "$1"; }
+bad() {
+  printf '  FAIL %s: %s\n' "$1" "$2" >&2
+  failures=$((failures + 1))
+}
+
+# want_case <name> <expect: pass|fail> <fixture-dir> [expected-substring]
+want_case() {
+  local name="$1" expect="$2" dir="$3" needle="${4:-}"
+  if [ -n "${only}" ] && [ "${only}" != "${name}" ]; then
+    return 0
+  fi
+  local out status
+  # The floor is lowered for fixtures: they carry a handful of rows, not the
+  # workspace's full set. The scan_floor case overrides it back up.
+  out="$(WS_DEP_MANIFEST="${dir}/Cargo.toml" WS_DEP_MIN_ROWS="${WS_DEP_MIN_ROWS_CASE:-1}" \
+    bash "${GATE}" 2>&1)"
+  status=$?
+
+  if [ "${expect}" = "pass" ] && [ "${status}" -ne 0 ]; then
+    bad "${name}" "expected exit 0, got ${status}. Output: ${out}"
+    return 0
+  fi
+  if [ "${expect}" = "fail" ] && [ "${status}" -eq 0 ]; then
+    bad "${name}" "expected NON-ZERO exit, got 0 — the gate accepted a bad manifest. Output: ${out}"
+    return 0
+  fi
+  if [ -n "${needle}" ] && ! printf '%s' "${out}" | grep -qF "${needle}"; then
+    bad "${name}" "output missing expected text '${needle}'. Output: ${out}"
+    return 0
+  fi
+  pass "${name}"
+}
+
+# member <fixture-dir> <crate-dir> <name> <version>
+member() {
+  local dir="$1" sub="$2" pkg="$3" ver="$4"
+  mkdir -p "${dir}/crates/${sub}"
+  cat >"${dir}/crates/${sub}/Cargo.toml" <<EOF
+[package]
+name    = "${pkg}"
+version = "${ver}"
+edition = "2021"
+EOF
+}
+
+# ── satisfied / ok_* cases: one fixture covering every accepting shape ────────
+ok_dir="${TMPROOT}/satisfied"
+mkdir -p "${ok_dir}"
+member "${ok_dir}" trusty-code     trusty-code     0.5.1
+member "${ok_dir}" trusty-common   trusty-common   0.47.3
+member "${ok_dir}" trusty-mpm      trusty-mpm      1.5.17
+cat >"${ok_dir}/Cargo.toml" <<'EOF'
+[workspace]
+members = ["crates/*"]
+
+[workspace.dependencies]
+# A comment row must not be parsed as a dependency.
+trusty-code = { path = "crates/trusty-code", version = "0.5.0" }
+trusty-common = { path = "crates/trusty-common", version = "0.47" }
+trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
+serde = { version = "1", features = ["derive"] }
+
+[profile.release]
+lto = true
+EOF
+want_case satisfied      pass "${ok_dir}" "All 3 internal row(s)"
+want_case ok_0x_patch    pass "${ok_dir}" "trusty-code            req 0.5.0"
+want_case ok_partial_req pass "${ok_dir}" "trusty-common          req 0.47"
+want_case ok_major_range pass "${ok_dir}" "trusty-mpm             req 1.0.0"
+
+# ── drift_0x: the exact #6776 shape ──────────────────────────────────────────
+d0="${TMPROOT}/drift_0x"
+mkdir -p "${d0}"
+member "${d0}" trusty-console trusty-console 0.11.0
+cat >"${d0}/Cargo.toml" <<'EOF'
+[workspace.dependencies]
+trusty-console = { path = "crates/trusty-console", version = "0.9.0" }
+EOF
+want_case drift_0x fail "${d0}" 'version = "0.11"'
+
+# ── drift_major: a major-version bump left behind ────────────────────────────
+dm="${TMPROOT}/drift_major"
+mkdir -p "${dm}"
+member "${dm}" trusty-git-analytics tga 7.1.0
+cat >"${dm}/Cargo.toml" <<'EOF'
+[workspace.dependencies]
+tga = { path = "crates/trusty-git-analytics", version = "6.0.1" }
+EOF
+# The 0.y.z note must NOT appear for a 7.x crate.
+want_case drift_major fail "${dm}" 'version = "7.1"'
+if [ -z "${only}" ] || [ "${only}" = "drift_major_no_0x_note" ]; then
+  out="$(WS_DEP_MANIFEST="${dm}/Cargo.toml" WS_DEP_MIN_ROWS=1 bash "${GATE}" 2>&1)"
+  if printf '%s' "${out}" | grep -qF '0.y.z'; then
+    bad drift_major_no_0x_note "the 0.y.z hint leaked onto a 7.x crate: ${out}"
+  else
+    pass drift_major_no_0x_note
+  fi
+fi
+
+# ── alias_key: the row key is an alias; the DIRECTORY decides the member ─────
+# `tga` -> crates/trusty-git-analytics is the real shape in this workspace. A
+# parser that derived the member from the row NAME would read no manifest here
+# and must not silently pass.
+ak="${TMPROOT}/alias_key"
+mkdir -p "${ak}"
+member "${ak}" trusty-git-analytics tga 7.1.0
+cat >"${ak}/Cargo.toml" <<'EOF'
+[workspace.dependencies]
+tga = { path = "crates/trusty-git-analytics", version = "6.0.1" }
+EOF
+want_case alias_key fail "${ak}" 'crates/trusty-git-analytics is 7.1.0'
+
+# ── missing_member: unverifiable row must fail closed ────────────────────────
+mm="${TMPROOT}/missing_member"
+mkdir -p "${mm}"
+cat >"${mm}/Cargo.toml" <<'EOF'
+[workspace.dependencies]
+trusty-gone = { path = "crates/trusty-gone", version = "0.1.0" }
+EOF
+want_case missing_member fail "${mm}" 'cannot read [package] version'
+
+# ── bad_operator: a requirement shape the gate does not model ────────────────
+bo="${TMPROOT}/bad_operator"
+mkdir -p "${bo}"
+member "${bo}" trusty-thing trusty-thing 0.4.0
+cat >"${bo}/Cargo.toml" <<'EOF'
+[workspace.dependencies]
+trusty-thing = { path = "crates/trusty-thing", version = ">=0.1, <0.5" }
+EOF
+want_case bad_operator fail "${bo}" 'unmodelled version shape'
+
+# ── scan_floor: a table with no internal rows must not report success ────────
+sf="${TMPROOT}/scan_floor"
+mkdir -p "${sf}"
+cat >"${sf}/Cargo.toml" <<'EOF'
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+EOF
+want_case scan_floor fail "${sf}" 'SCAN FLOOR'
+
+# ── the live repo must pass its own gate ─────────────────────────────────────
+if [ -z "${only}" ] || [ "${only}" = "live_repo" ]; then
+  out="$(cd "${REPO_ROOT}" && bash "${GATE}" 2>&1)"
+  status=$?
+  if [ "${status}" -ne 0 ]; then
+    bad live_repo "the live workspace manifest does not pass. Output: ${out}"
+  else
+    pass live_repo
+  fi
+fi
+
+if [ "${failures}" -gt 0 ]; then
+  printf '\n%d selftest case(s) failed.\n' "${failures}" >&2
+  exit 1
+fi
+printf '\nAll selftest cases passed.\n'


### PR DESCRIPTION
## What

Two internal `[workspace.dependencies]` rows required a version range that
excluded the member crate's own version:

| Row | Requirement | Crate | `^req` accepts it? |
|---|---|---|---|
| `trusty-console` | `0.9.0` | `0.11.0` | no — `^0.9.0` is `>=0.9.0, <0.10.0` |
| `tga` (`crates/trusty-git-analytics`) | `6.0.1` | `7.1.0` | no — `^6.0.1` is `>=6.0.1, <7.0.0` |

Both now track the crate's current minor (`0.11`, `7.1`), matching how the
`trusty-common` (`0.47`), `trusty-review` (`0.34`), and `trusty-installer`
(`0.13`) rows are already written.

The issue reports `trusty-console` only. `tga` is the same defect in the same
table, found by the guard below; shipping the guard without it would land a red
required check.

## Why it was invisible

Each row carries both a `path` and a `version`. In-tree the path wins, so cargo
never evaluates the requirement — `cargo build`, `cargo check`, and
`cargo test` are all green no matter how far the two drift. The requirement is
consulted only when the crate resolves from crates.io: at `cargo publish`, and
by any external consumer. Same class as #4088.

`Cargo.lock` is unchanged, which is the point: nothing in-tree resolves
differently.

## The guard

`scripts/check_workspace_dep_versions.sh` reads every internal row and asserts
the member's version satisfies the requirement under Cargo's caret rules,
including the 0.x rule where the minor is the breaking component.

- Resolves the member from the row's **`path`**, not its key — the `tga` row
  points at `crates/trusty-git-analytics`, so a name-derived lookup would read
  no manifest and pass silently. Covered by the `alias_key` case.
- Fails closed on an unreadable member manifest, a requirement operator it does
  not model, and a scan floor violation (#4618). An unverifiable row is never a
  silent pass.
- A `path` row with no `version` (`trusty-audit`) reports `[SKIP]` rather than
  being dropped quietly.
- Pure shell over two manifests: no cargo, no network, well under a second.

`scripts/check_workspace_dep_versions_selftest.sh` is the paired mutation
battery — 12 cases, every failing one a manifest that must be rejected,
including the exact `^0.9.0` vs `0.11.0` shape from this issue and a case
asserting the live repo manifest passes.

## Wiring

Runs as a step of `version-parity.yml`'s `pr-version-bump` job rather than in a
new workflow. That job is the required context
`PR version bump vs crates.io (issue #4421)`, runs unconditionally on every PR,
needs no Rust toolchain, and asks the adjacent publish-safety question. Reusing
it also avoids a new push-to-main workflow and the `red-main-notify.yml`
coverage entry one would require.

Both steps carry exactly `if: github.event_name == 'pull_request'`, which is
what `check_version_bump_verdict_selftest.sh` permits — that selftest passes
(`EXIT=0`), so the job still cannot report success without running its checks.

## Test ladder

**Rung 1 → 3.** No crate source changed (`check_changelog_fragment.sh` confirms:
`attributed 0 crate-source path(s)`), so no changelog fragment is required. The
root manifest is a workspace-wide file, so `trusty-console` gates were run
anyway rather than claimed unnecessary.

```
SKIP_UI_BUILD=1 cargo fmt --check && cargo check -p trusty-console --all-targets   # EXIT=0
SKIP_UI_BUILD=1 cargo clippy -p trusty-console --all-targets -- -D warnings        # EXIT=0
SKIP_UI_BUILD=1 cargo test -p trusty-console --no-fail-fast                        # EXIT=0
```

`cargo test -p trusty-console --no-fail-fast`, all 6 targets:

```
test result: ok. 404 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 30.42s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.77s
test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

`cargo metadata --no-deps` exits 0, so every member manifest still parses and
the workspace resolves.

### The new gate, reproducing the bug then passing

Pre-fix, against the unmodified `Cargo.toml`:

```
[FAIL] tga: root Cargo.toml requires version = "6.0.1" but crates/trusty-git-analytics is 7.1.0.
         ^6.0.1 does not accept 7.1.0.
         Fix: set the row to version = "7.1" in [workspace.dependencies].
[FAIL] trusty-console: root Cargo.toml requires version = "0.9.0" but crates/trusty-console is 0.11.0.
         ^0.9.0 does not accept 0.11.0 (for 0.y.z the MINOR is the breaking component).
         Fix: set the row to version = "0.11" in [workspace.dependencies].

2 internal [workspace.dependencies] row(s) drifted from their member crate.
GATE_EXIT=1
```

Post-fix:

```
[ OK ] tga                    req 7.1      accepts crate 7.1.0
[ OK ] trusty-console         req 0.11     accepts crate 0.11.0
[SKIP] trusty-audit           crates/trusty-audit — path-only row, no version requirement to check

All 12 internal row(s) accept their member crate version.
GATE_EXIT=0
```

Selftest:

```
  ok   satisfied
  ok   ok_0x_patch
  ok   ok_partial_req
  ok   ok_major_range
  ok   drift_0x
  ok   drift_major
  ok   drift_major_no_0x_note
  ok   alias_key
  ok   missing_member
  ok   bad_operator
  ok   scan_floor
  ok   live_repo

All selftest cases passed.
SELFTEST_EXIT=0
```

### Repo gates

```
bash scripts/check_workspace_dep_versions.sh          # EXIT=0
bash scripts/check_workspace_dep_versions_selftest.sh # EXIT=0
bash scripts/check_version_bump_verdict_selftest.sh   # EXIT=0
bash scripts/check-red-main-coverage.sh               # EXIT=0 — 20 push-to-main workflow(s), all covered
bash scripts/check_line_cap.sh                        # EXIT=0 — 4472 files, 0 violations
bash scripts/check_changelog_fragment.sh              # EXIT=0 — no crate source changed
bash scripts/check_test_pointers.sh                   # EXIT=0 — 30528 citations, 0 dangling
bash scripts/check_doc_numbers.sh                     # EXIT=0 — 131 claims, 0 violations
```

## Closure conditions

- [x] The workspace row's requirement matches the crate's current minor (`0.11`)
- [x] A check fails when an internal row's version no longer accepts its member
      crate's version — new sibling script, wired into a required PR context,
      with its own mutation battery

Refs #6776

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
