### PR TITLE
feat(scripts): repeatable phys-footprint measurement for the search and memory daemons

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -41,6 +41,26 @@
 | `TRUSTY_SHUTDOWN_FLUSH_TIMEOUT_SECS` | `trusty-search` daemon (issues #874, #2922) | Explicit override for the graceful-shutdown per-index HNSW/corpus flush deadline, in seconds. When unset (the default), each index's deadline is instead scaled from its own on-disk HNSW snapshot size (`30s` floor + `1s` per 20 MB, capped at 20 minutes) so a multi-hundred-MB index gets a workable budget instead of the old flat `10s` — which was short enough to time out mid-write on large indexes before atomic tmp+rename hardening landed. Set this only to force an exact value (e.g. a constrained CI/test environment); any positive integer wins outright over size-based scaling for every index. `0` or unset falls back to size scaling. |
 | `TRUSTY_SHUTDOWN_FLUSH_CONCURRENCY` | `trusty-search` daemon (issue #2922) | Max number of indexes flushed concurrently during graceful shutdown. Default `4`. Previously all indexes flushed strictly sequentially, so total shutdown time was `N × per-index timeout`; running a bounded number in parallel keeps a fleet of small/fast indexes from queuing behind one large one while still bounding peak concurrent disk I/O. Must be a positive integer; `0` or unparseable falls back to the default. |
 
+### Measuring what these tune
+
+`scripts/measure-daemon-footprint.sh` is the one instrument for a before/after
+memory claim about either daemon — it prints one comparable phys-footprint
+number plus a category breakdown, the daemon's own `/health` `rss_mb`, its
+data-directory size, and its index or palace counts.
+
+```bash
+bash scripts/measure-daemon-footprint.sh search          # human table
+bash scripts/measure-daemon-footprint.sh memory --json   # stable key set
+bash scripts/measure-daemon-footprint.sh --pid 42054     # explicit pid
+```
+
+On macOS the number comes from `footprint -f bytes <pid>` (`vmmap -summary`
+when `footprint` is unavailable); on Linux from `/proc/<pid>/status`'s
+`RssAnon`, the same reading `TRUSTY_MEMORY_ENFORCE_MEASURE=anon` gates on,
+falling back to `VmRSS`. Never `ps` RSS — macOS undercounts it. Any path that
+cannot produce a number exits 2 instead of reporting 0. Fixtures:
+`scripts/measure-daemon-footprint_selftest.sh` ([#6819](https://github.com/bobmatnyc/trusty-tools/issues/6819)).
+
 ## trusty-audit
 
 | Variable | Required by | Purpose |

--- a/scripts/measure-daemon-footprint.sh
+++ b/scripts/measure-daemon-footprint.sh
@@ -1,0 +1,680 @@
+#!/usr/bin/env bash
+#
+# measure-daemon-footprint.sh — one comparable phys-footprint reading for the
+# trusty-search / trusty-memory daemons, plus a breakdown. (#6819)
+#
+# Why: every child issue of epic #6802 has to prove a before/after memory
+#   claim, and each one re-deriving the recipe by hand produces numbers that
+#   are not comparable. `ps` RSS is the trap this script exists to avoid: on
+#   macOS it undercounts a daemon's real footprint by orders of magnitude
+#   (see the `macos-phys-footprint-vs-ps-rss` note), so `phys_footprint` is
+#   the only reading worth quoting. The Linux side follows the precedent
+#   already in the tree: `RssAnon` from `/proc/<pid>/status`, which is what
+#   `TRUSTY_MEMORY_ENFORCE_MEASURE=anon` gates on
+#   (`core::memguard_enforce::anon_rss_mb_for_pid`,
+#   crates/trusty-search/src/core/memguard_enforce.rs:109).
+#
+# What: resolves ONE pid, produces ONE primary number, and surrounds it with
+#   context an operator can act on.
+#     primary   macOS: `footprint -f bytes <pid>` → `phys_footprint`.
+#               Falls back to `vmmap -summary <pid>` → `Physical footprint`
+#               (coarser: one decimal place, so ~0.5% granularity).
+#               Linux: `/proc/<pid>/status` → `RssAnon`, else `VmRSS`.
+#     breakdown macOS: the per-category dirty bytes from the same footprint
+#               run, plus `phys_footprint_peak`. Linux: RssAnon / RssFile /
+#               RssShmem / VmRSS.
+#     health    the daemon's own `rss_mb`. trusty-search serves `/health` over
+#               loopback TCP; trusty-memory is UDS-only since #6286, so its
+#               reading comes from one `memory.health` JSON-RPC frame over the
+#               socket. Supplementary — an unreachable daemon does not fail
+#               the run, because the pid-level number is the deliverable.
+#     disk      the data directory's size. Measured with `du -sk` (portable,
+#               machine-readable) and rendered human-readable here, rather
+#               than parsing `du -sh`'s locale-dependent output.
+#     units     trusty-search: index count, warm-booted (resident) count and
+#               total chunks from `/health`. trusty-memory: palace count,
+#               LRU-cached count and total drawers from `memory.status`. Every
+#               key is emitted for both daemons — `null` where it does not
+#               apply — so the JSON key set does not vary with the target.
+#
+#   Fail-closed: any path that cannot produce the primary number exits 2 with
+#   a message naming what was missing. It never prints 0 as if measured.
+#
+# Test: scripts/measure-daemon-footprint_selftest.sh
+#
+# Usage:
+#   bash scripts/measure-daemon-footprint.sh search
+#   bash scripts/measure-daemon-footprint.sh --daemon memory --json
+#   bash scripts/measure-daemon-footprint.sh --pid 42054
+#
+# Options:
+#   --daemon <search|memory|trusty-search|trusty-memory>
+#   --pid <n>        measure this pid; skips daemon discovery
+#   --json           machine-readable output with a stable key set
+#   --no-health      skip the daemon's own /health reading
+#   --no-disk        skip the data-directory `du` pass
+#   -h, --help       this text (exit 0)
+#
+# Exit: 0 measured. 2 anything else — bad usage, daemon not running, no
+#   footprint/vmmap and no /proc, or an unparseable reading.
+#
+# Environment (test seams, and the overrides the daemons themselves honor):
+#   TRUSTY_DATA_DIR_OVERRIDE   absolute data-dir base, as trusty_common::resolve_data_dir reads it
+#   TRUSTY_DATA_DIR            trusty-search's own app-dir override (issue #281)
+#   MEASURE_FOOTPRINT_PLATFORM force `macos` or `linux` (selftest only)
+#   MEASURE_DAEMON_FOOTPRINT_LIB=1 when sourced: define the functions and return
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux), same as the
+#   rest of scripts/.
+
+set -uo pipefail
+
+SCHEMA="trusty-footprint/1"
+BREAKDOWN_LIMIT=12
+HEALTH_TIMEOUT_SECS=5
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+die() {
+  echo "measure-daemon-footprint: $*" >&2
+  exit 2
+}
+
+usage() {
+  sed -n '3,66p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ---------------------------------------------------------------------------
+# Pure helpers — every one of these is exercised by the selftest
+# ---------------------------------------------------------------------------
+
+# detect_platform -> macos | linux | unsupported
+detect_platform() {
+  if [ -n "${MEASURE_FOOTPRINT_PLATFORM:-}" ]; then
+    echo "${MEASURE_FOOTPRINT_PLATFORM}"
+    return 0
+  fi
+  case "$(uname -s)" in
+    Darwin) echo macos ;;
+    Linux) echo linux ;;
+    *) echo unsupported ;;
+  esac
+}
+
+# canonical_daemon <name> -> trusty-search | trusty-memory; exit 1 if unknown
+canonical_daemon() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    search | trusty-search | ts) echo trusty-search ;;
+    memory | trusty-memory | tm-daemon) echo trusty-memory ;;
+    *) return 1 ;;
+  esac
+}
+
+# launchd_label <canonical-daemon> -> com.trusty.<short>
+launchd_label() {
+  case "$1" in
+    trusty-search) echo com.trusty.search ;;
+    trusty-memory) echo com.trusty.memory ;;
+    *) return 1 ;;
+  esac
+}
+
+# is_positive_int <string>
+is_positive_int() {
+  case "$1" in
+    '' | *[!0-9]*) return 1 ;;
+    0) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# to_bytes <number> <unit>  — unit is one of B K KB M MB G GB T TB (any case).
+# Accepts a fractional number (vmmap prints "9.3G"). Emits integer bytes.
+to_bytes() {
+  local num="$1" unit
+  unit="$(printf '%s' "${2:-B}" | tr '[:lower:]' '[:upper:]')"
+  local mult
+  case "$unit" in
+    B | BYTES) mult=1 ;;
+    K | KB | KIB) mult=1024 ;;
+    M | MB | MIB) mult=1048576 ;;
+    G | GB | GIB) mult=1073741824 ;;
+    T | TB | TIB) mult=1099511627776 ;;
+    *) return 1 ;;
+  esac
+  case "$num" in
+    '' | *[!0-9.]*) return 1 ;;
+  esac
+  awk -v n="$num" -v m="$mult" 'BEGIN { printf "%.0f\n", n * m }'
+}
+
+# mb_from_bytes <bytes> — MiB, truncating, matching /health's rss_mb.
+mb_from_bytes() {
+  awk -v b="$1" 'BEGIN { printf "%d\n", int(b / 1048576) }'
+}
+
+# human_bytes <bytes> — "8.5G"-style, the shape `du -sh` would print.
+human_bytes() {
+  awk -v b="$1" 'BEGIN {
+    split("B K M G T P", u, " ")
+    i = 1
+    v = b + 0
+    while (v >= 1024 && i < 6) { v /= 1024; i++ }
+    if (i == 1) printf "%dB\n", v
+    else if (v >= 100) printf "%d%s\n", v, u[i]
+    else printf "%.1f%s\n", v, u[i]
+  }'
+}
+
+# json_escape <string> — the only characters these values can carry that JSON
+# forbids are the backslash and the double quote (paths, category names).
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# ---------------------------------------------------------------------------
+# Parsers — each takes a FILE so the selftest can feed it a fixture
+# ---------------------------------------------------------------------------
+
+# parse_footprint_field <file> <field>  — "phys_footprint" or
+# "phys_footprint_peak" from `footprint`'s "Auxiliary data:" block. `-f bytes`
+# makes the unit always "B", but the unit is parsed rather than assumed so a
+# `formatted` run still works.
+parse_footprint_field() {
+  local file="$1" field="$2" line num unit
+  line="$(grep -E "^[[:space:]]*${field}:" "$file" 2>/dev/null | head -1)"
+  [ -n "$line" ] || return 1
+  num="$(printf '%s' "$line" | awk '{ print $2 }')"
+  unit="$(printf '%s' "$line" | awk '{ print $3 }')"
+  [ -n "$num" ] || return 1
+  to_bytes "$num" "${unit:-B}"
+}
+
+# parse_footprint_categories <file> — "<dirty-bytes>\t<category>", biggest
+# first, zero-dirty and the TOTAL row dropped. Only meaningful for a
+# `-f bytes` run, which is what this script always requests.
+parse_footprint_categories() {
+  awk '
+    $2 == "B" && $1 + 0 > 0 {
+      cat = $8
+      for (i = 9; i <= NF; i++) cat = cat " " $i
+      if (cat == "TOTAL" || cat == "") next
+      printf "%d\t%s\n", $1, cat
+    }
+  ' "$1" | sort -rn -k1,1
+}
+
+# parse_vmmap_footprint <file> — `vmmap -summary`'s "Physical footprint:".
+# Coarser than `footprint` (one decimal), used only when footprint is absent.
+parse_vmmap_footprint() {
+  local file="$1" want="${2:-Physical footprint}" raw num unit
+  # Literal prefix match, not a regex: the label this is asked for is
+  # "Physical footprint (peak)", whose parentheses an ERE would read as a
+  # group and silently match the wrong line.
+  raw="$(awk -v want="${want}:" 'index($0, want) == 1 { print $NF; exit }' \
+    "$file" 2>/dev/null)"
+  [ -n "$raw" ] || return 1
+  num="$(printf '%s' "$raw" | sed 's/[^0-9.]//g')"
+  unit="$(printf '%s' "$raw" | sed 's/[0-9.]//g')"
+  [ -n "$num" ] || return 1
+  to_bytes "$num" "${unit:-B}"
+}
+
+# parse_proc_status_kb <file> <field> — one kB field from /proc/<pid>/status.
+# `RssAnon` is the primary reading, per the same choice
+# `core::memguard_enforce::anon_rss_mb_for_pid` makes; `VmRSS` is the
+# fallback for a kernel or container that does not expose RssAnon.
+parse_proc_status_kb() {
+  local file="$1" field="$2" val
+  val="$(grep -E "^${field}:" "$file" 2>/dev/null | head -1 | awk '{ print $2 }')"
+  is_positive_int "$val" || return 1
+  echo "$val"
+}
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+pid_is_alive() {
+  is_positive_int "$1" || return 1
+  kill -0 "$1" 2>/dev/null
+}
+
+# resolve_pid_launchd <label>
+resolve_pid_launchd() {
+  local label="$1" pid
+  command -v launchctl >/dev/null 2>&1 || return 1
+  pid="$(launchctl print "gui/$(id -u)/${label}" 2>/dev/null |
+    awk -F'= ' '/^[[:space:]]*pid = /{ print $2; exit }')"
+  is_positive_int "$pid" || return 1
+  echo "$pid"
+}
+
+# resolve_pid_pgrep <canonical-daemon> — fail closed on ambiguity. On a
+# developer box `pgrep -f trusty-memory` also matches every MCP stdio client
+# and every worktree's debug build, so guessing among them would report the
+# wrong process's footprint as the daemon's.
+resolve_pid_pgrep() {
+  local daemon="$1" pids count
+  command -v pgrep >/dev/null 2>&1 || return 1
+  pids="$(pgrep -f "${daemon}.*--foreground" 2>/dev/null)"
+  count="$(printf '%s\n' "$pids" | grep -c '[0-9]' || true)"
+  if [ "$count" != "1" ]; then
+    pids="$(pgrep -x "$daemon" 2>/dev/null)"
+    count="$(printf '%s\n' "$pids" | grep -c '[0-9]' || true)"
+  fi
+  if [ "$count" = "1" ]; then
+    printf '%s\n' "$pids" | tr -d '[:space:]'
+    return 0
+  fi
+  PGREP_CANDIDATES="$(printf '%s' "$pids" | tr '\n' ' ')"
+  return 1
+}
+
+# data_dir_base — where trusty_common::resolve_data_dir puts an app's dir.
+data_dir_base() {
+  local platform="$1"
+  if [ -n "${TRUSTY_DATA_DIR_OVERRIDE:-}" ]; then
+    case "${TRUSTY_DATA_DIR_OVERRIDE}" in
+      /*)
+        echo "${TRUSTY_DATA_DIR_OVERRIDE}"
+        return 0
+        ;;
+    esac
+  fi
+  if [ "$platform" = "macos" ]; then
+    echo "${HOME}/Library/Application Support"
+  else
+    echo "${XDG_DATA_HOME:-${HOME}/.local/share}"
+  fi
+}
+
+# daemon_data_subdir <canonical-daemon> <platform> — the directory whose size
+# is the daemon's on-disk corpus: indexes for search, palaces for memory.
+daemon_data_subdir() {
+  local daemon="$1" platform="$2" base leaf
+  case "$daemon" in
+    trusty-search) leaf=indexes ;;
+    trusty-memory) leaf=palaces ;;
+    *) return 1 ;;
+  esac
+  if [ "$daemon" = "trusty-search" ] && [ -n "${TRUSTY_DATA_DIR:-}" ]; then
+    echo "${TRUSTY_DATA_DIR}/${leaf}"
+    return 0
+  fi
+  base="$(data_dir_base "$platform")"
+  echo "${base}/${daemon}/${leaf}"
+}
+
+# search_health_url — the address the running daemon published, else the
+# compiled-in default.
+search_health_url() {
+  local platform="$1" base addr f
+  base="$(data_dir_base "$platform")"
+  for f in "${TRUSTY_DATA_DIR:-${base}/trusty-search}/http_addr" "${HOME}/.trusty-search/http_addr"; do
+    if [ -r "$f" ]; then
+      addr="$(tr -d '[:space:]' <"$f")"
+      if [ -n "$addr" ]; then
+        echo "http://${addr}/health"
+        return 0
+      fi
+    fi
+  done
+  echo "http://127.0.0.1:7878/health"
+}
+
+# memory_socket_path <platform>
+memory_socket_path() {
+  local base
+  base="$(data_dir_base "$1")"
+  echo "${base}/trusty-memory/trusty-memory.sock"
+}
+
+# uds_rpc <socket> <method> — one newline-terminated JSON-RPC frame, which is
+# exactly what trusty_common::uds::server reads (crates/trusty-common/src/uds/
+# server/mod.rs). Prints the raw response frame.
+uds_rpc() {
+  local sock="$1" method="$2"
+  [ -S "$sock" ] || return 1
+  command -v nc >/dev/null 2>&1 || return 1
+  printf '{"jsonrpc":"2.0","id":1,"method":"%s","params":{}}\n' "$method" |
+    nc -U -w "$HEALTH_TIMEOUT_SECS" "$sock" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Measurement
+# ---------------------------------------------------------------------------
+
+# Outputs, set by measure_*: PRIMARY_BYTES, PEAK_BYTES ("" when unknown),
+# SOURCE, BREAKDOWN_FILE.
+measure_macos() {
+  local pid="$1" out
+  out="${WORKDIR}/footprint.txt"
+  if command -v footprint >/dev/null 2>&1 &&
+    footprint -f bytes "$pid" >"$out" 2>/dev/null &&
+    PRIMARY_BYTES="$(parse_footprint_field "$out" phys_footprint)"; then
+    SOURCE="footprint"
+    PEAK_BYTES="$(parse_footprint_field "$out" phys_footprint_peak || true)"
+    parse_footprint_categories "$out" | head -"$BREAKDOWN_LIMIT" >"$BREAKDOWN_FILE"
+    return 0
+  fi
+  out="${WORKDIR}/vmmap.txt"
+  if command -v vmmap >/dev/null 2>&1 &&
+    vmmap -summary "$pid" >"$out" 2>/dev/null &&
+    PRIMARY_BYTES="$(parse_vmmap_footprint "$out" "Physical footprint")"; then
+    SOURCE="vmmap-summary"
+    PEAK_BYTES="$(parse_vmmap_footprint "$out" "Physical footprint (peak)" || true)"
+    : >"$BREAKDOWN_FILE"
+    return 0
+  fi
+  return 1
+}
+
+measure_linux() {
+  local pid="$1" status kb
+  status="${MEASURE_FOOTPRINT_PROC_STATUS:-/proc/${pid}/status}"
+  [ -r "$status" ] || return 1
+  : >"$BREAKDOWN_FILE"
+  if kb="$(parse_proc_status_kb "$status" RssAnon)"; then
+    SOURCE="proc-status-rssanon"
+  elif kb="$(parse_proc_status_kb "$status" VmRSS)"; then
+    SOURCE="proc-status-vmrss"
+  else
+    return 1
+  fi
+  PRIMARY_BYTES="$((kb * 1024))"
+  PEAK_BYTES="$(parse_proc_status_kb "$status" VmHWM 2>/dev/null || true)"
+  [ -n "$PEAK_BYTES" ] && PEAK_BYTES="$((PEAK_BYTES * 1024))"
+  local field
+  for field in RssAnon RssFile RssShmem VmRSS; do
+    if kb="$(parse_proc_status_kb "$status" "$field")"; then
+      printf '%d\t%s\n' "$((kb * 1024))" "$field" >>"$BREAKDOWN_FILE"
+    fi
+  done
+  return 0
+}
+
+# read_health <canonical-daemon> <platform> — sets HEALTH_RSS_MB,
+# HEALTH_ENDPOINT and the UNIT_* counts. Every UNIT_* key is emitted for both
+# daemons, `null` where it does not apply, so the JSON key set never varies
+# with which daemon was measured.
+# Returns 1 when the daemon could not be reached, which is not fatal: the
+# pid-level phys_footprint is the deliverable, this is context around it.
+#
+# trusty-memory's counts come from `memory.status`, not `memory.palaces_list`.
+# The list call opens every palace and took ~9s on a 93-palace host, which is
+# both slower than the socket read deadline and more work than a measurement
+# pass should ask a live daemon to do; `memory.status` answers instantly.
+read_health() {
+  local daemon="$1" platform="$2" body sock
+  command -v jq >/dev/null 2>&1 || return 1
+  if [ "$daemon" = "trusty-search" ]; then
+    HEALTH_ENDPOINT="$(search_health_url "$platform")"
+    command -v curl >/dev/null 2>&1 || return 1
+    body="$(curl -sS --max-time "$HEALTH_TIMEOUT_SECS" "$HEALTH_ENDPOINT" 2>/dev/null)"
+    [ -n "$body" ] || return 1
+    HEALTH_RSS_MB="$(printf '%s' "$body" | jq -r '.rss_mb // empty' 2>/dev/null)"
+    UNIT_KIND="indexes"
+    UNIT_COUNT="$(printf '%s' "$body" | jq -r '.indexes // empty' 2>/dev/null)"
+    UNIT_CHUNKS="$(printf '%s' "$body" | jq -r '.total_chunks // empty' 2>/dev/null)"
+    UNIT_DRAWERS=""
+    UNIT_RESIDENT="$(printf '%s' "$body" |
+      jq -r '.warmboot_summary.indexes_loaded // empty' 2>/dev/null)"
+  else
+    sock="$(memory_socket_path "$platform")"
+    HEALTH_ENDPOINT="${sock} (memory.health)"
+    body="$(uds_rpc "$sock" memory.health)" || return 1
+    [ -n "$body" ] || return 1
+    HEALTH_RSS_MB="$(printf '%s' "$body" | jq -r '.result.rss_mb // empty' 2>/dev/null)"
+    UNIT_KIND="palaces"
+    body="$(uds_rpc "$sock" memory.status 2>/dev/null || true)"
+    UNIT_COUNT="$(printf '%s' "$body" | jq -r '.result.palace_count // empty' 2>/dev/null)"
+    UNIT_CHUNKS=""
+    UNIT_DRAWERS="$(printf '%s' "$body" | jq -r '.result.total_drawers // empty' 2>/dev/null)"
+    UNIT_RESIDENT="$(printf '%s' "$body" |
+      jq -r '.result.cached_palace_count // empty' 2>/dev/null)"
+  fi
+  is_positive_int "$HEALTH_RSS_MB" || HEALTH_RSS_MB=""
+  is_positive_int "$UNIT_COUNT" || UNIT_COUNT=""
+  is_positive_int "$UNIT_CHUNKS" || UNIT_CHUNKS=""
+  is_positive_int "$UNIT_DRAWERS" || UNIT_DRAWERS=""
+  is_positive_int "$UNIT_RESIDENT" || UNIT_RESIDENT=""
+  [ -n "$HEALTH_RSS_MB" ] || return 1
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+emit_human() {
+  printf '%s  pid %s  (%s, source=%s)\n\n' "$DAEMON" "$PID" "$PLATFORM" "$SOURCE"
+  printf '  %-24s %10s MB  (%s B)\n' "phys_footprint" \
+    "$(mb_from_bytes "$PRIMARY_BYTES")" "$PRIMARY_BYTES"
+  if [ -n "$PEAK_BYTES" ]; then
+    printf '  %-24s %10s MB\n' "phys_footprint_peak" "$(mb_from_bytes "$PEAK_BYTES")"
+  fi
+  if [ -n "$HEALTH_RSS_MB" ]; then
+    printf '  %-24s %10s MB  (%s)\n' "/health rss_mb" "$HEALTH_RSS_MB" "$HEALTH_ENDPOINT"
+  elif [ "$WANT_HEALTH" = "1" ]; then
+    printf '  %-24s %10s\n' "/health rss_mb" "unavailable"
+  fi
+  if [ -n "$DISK_KB" ]; then
+    printf '  %-24s %10s      %s\n' "data dir" \
+      "$(human_bytes "$((DISK_KB * 1024))")" "$DATA_DIR"
+  fi
+  if [ -n "$UNIT_COUNT" ]; then
+    printf '  %-24s %10s      resident %s\n' "$UNIT_KIND" "$UNIT_COUNT" \
+      "${UNIT_RESIDENT:-?}"
+  fi
+  if [ -n "$UNIT_CHUNKS" ]; then
+    printf '  %-24s %10s\n' "chunks" "$UNIT_CHUNKS"
+  fi
+  if [ -n "$UNIT_DRAWERS" ]; then
+    printf '  %-24s %10s\n' "drawers" "$UNIT_DRAWERS"
+  fi
+  if [ -s "$BREAKDOWN_FILE" ]; then
+    printf '\n  breakdown:\n'
+    while IFS="$(printf '\t')" read -r bytes cat; do
+      [ -n "$bytes" ] || continue
+      printf '    %-22s %10s MB\n' "$cat" "$(mb_from_bytes "$bytes")"
+    done <"$BREAKDOWN_FILE"
+  fi
+}
+
+# json_num <value> — a JSON number, or `null` when the reading is absent. A
+# missing reading must never render as 0.
+json_num() {
+  if [ -n "${1:-}" ]; then printf '%s' "$1"; else printf 'null'; fi
+}
+
+json_str() {
+  if [ -n "${1:-}" ]; then printf '"%s"' "$(json_escape "$1")"; else printf 'null'; fi
+}
+
+emit_json() {
+  local first=1 bytes cat
+  printf '{\n'
+  printf '  "schema": %s,\n' "$(json_str "$SCHEMA")"
+  printf '  "daemon": %s,\n' "$(json_str "$DAEMON")"
+  printf '  "pid": %s,\n' "$(json_num "$PID")"
+  printf '  "platform": %s,\n' "$(json_str "$PLATFORM")"
+  printf '  "measured_at": %s,\n' "$(json_str "$MEASURED_AT")"
+  printf '  "source": %s,\n' "$(json_str "$SOURCE")"
+  printf '  "phys_footprint_bytes": %s,\n' "$(json_num "$PRIMARY_BYTES")"
+  printf '  "phys_footprint_mb": %s,\n' "$(json_num "$(mb_from_bytes "$PRIMARY_BYTES")")"
+  if [ -n "$PEAK_BYTES" ]; then
+    printf '  "phys_footprint_peak_mb": %s,\n' "$(json_num "$(mb_from_bytes "$PEAK_BYTES")")"
+  else
+    printf '  "phys_footprint_peak_mb": null,\n'
+  fi
+  printf '  "health": { "rss_mb": %s, "endpoint": %s },\n' \
+    "$(json_num "$HEALTH_RSS_MB")" "$(json_str "$HEALTH_ENDPOINT")"
+  printf '  "data_dir": { "path": %s, "size_kb": %s, "size_human": %s },\n' \
+    "$(json_str "$DATA_DIR")" "$(json_num "$DISK_KB")" \
+    "$(if [ -n "$DISK_KB" ]; then json_str "$(human_bytes "$((DISK_KB * 1024))")"; else printf 'null'; fi)"
+  printf '  "units": { "kind": %s, "count": %s, "resident": %s, "chunks": %s, "drawers": %s },\n' \
+    "$(json_str "$UNIT_KIND")" "$(json_num "$UNIT_COUNT")" \
+    "$(json_num "$UNIT_RESIDENT")" "$(json_num "$UNIT_CHUNKS")" \
+    "$(json_num "$UNIT_DRAWERS")"
+  printf '  "breakdown": ['
+  if [ -s "$BREAKDOWN_FILE" ]; then
+    printf '\n'
+    while IFS="$(printf '\t')" read -r bytes cat; do
+      [ -n "$bytes" ] || continue
+      [ "$first" = "1" ] || printf ',\n'
+      first=0
+      printf '    { "category": %s, "bytes": %s, "mb": %s }' \
+        "$(json_str "$cat")" "$bytes" "$(mb_from_bytes "$bytes")"
+    done <"$BREAKDOWN_FILE"
+    printf '\n  '
+  fi
+  printf ']\n}\n'
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  local want_daemon="" want_pid="" as_json=0
+  WANT_HEALTH=1
+  local want_disk=1
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --daemon)
+        [ $# -ge 2 ] || die "--daemon needs a value"
+        want_daemon="$2"
+        shift 2
+        ;;
+      --daemon=*)
+        want_daemon="${1#--daemon=}"
+        shift
+        ;;
+      --pid)
+        [ $# -ge 2 ] || die "--pid needs a value"
+        want_pid="$2"
+        shift 2
+        ;;
+      --pid=*)
+        want_pid="${1#--pid=}"
+        shift
+        ;;
+      --json)
+        as_json=1
+        shift
+        ;;
+      --no-health)
+        WANT_HEALTH=0
+        shift
+        ;;
+      --no-disk)
+        want_disk=0
+        shift
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      -*) die "unknown option: $1 (see --help)" ;;
+      *)
+        [ -z "$want_daemon" ] || die "daemon named twice: '$want_daemon' and '$1'"
+        want_daemon="$1"
+        shift
+        ;;
+    esac
+  done
+
+  PLATFORM="$(detect_platform)"
+  case "$PLATFORM" in
+    macos | linux) ;;
+    *) die "unsupported platform '$(uname -s)': no footprint/vmmap and no /proc/<pid>/status" ;;
+  esac
+
+  if [ -n "$want_daemon" ]; then
+    DAEMON="$(canonical_daemon "$want_daemon")" ||
+      die "unknown daemon '$want_daemon' (expected search or memory)"
+  elif [ -n "$want_pid" ]; then
+    DAEMON="pid-${want_pid}"
+  else
+    die "name a daemon (search|memory) or pass --pid <n>; see --help"
+  fi
+
+  if [ -n "$want_pid" ]; then
+    is_positive_int "$want_pid" || die "--pid must be a positive integer, got '$want_pid'"
+    pid_is_alive "$want_pid" || die "pid ${want_pid} is not running (or not visible to this uid)"
+    PID="$want_pid"
+  else
+    PGREP_CANDIDATES=""
+    PID="$(resolve_pid_launchd "$(launchd_label "$DAEMON")" || true)"
+    if [ -z "$PID" ]; then
+      PID="$(resolve_pid_pgrep "$DAEMON" || true)"
+    fi
+    if [ -z "$PID" ]; then
+      if [ -n "${PGREP_CANDIDATES:-}" ]; then
+        die "could not pick ${DAEMON}'s daemon pid unambiguously; candidates:${PGREP_CANDIDATES% } — rerun with --pid <n>"
+      fi
+      die "${DAEMON} is not running (no launchd job and no matching process)"
+    fi
+    pid_is_alive "$PID" || die "${DAEMON} pid ${PID} is not running"
+  fi
+
+  WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/measure-footprint.XXXXXX")" ||
+    die "could not create a scratch directory"
+  trap 'rm -rf "${WORKDIR}"' EXIT
+  BREAKDOWN_FILE="${WORKDIR}/breakdown.tsv"
+  : >"$BREAKDOWN_FILE"
+
+  PRIMARY_BYTES=""
+  PEAK_BYTES=""
+  SOURCE=""
+  HEALTH_RSS_MB=""
+  HEALTH_ENDPOINT=""
+  UNIT_KIND=""
+  UNIT_COUNT=""
+  UNIT_RESIDENT=""
+  UNIT_CHUNKS=""
+  UNIT_DRAWERS=""
+  DISK_KB=""
+  DATA_DIR=""
+  MEASURED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  if [ "$PLATFORM" = "macos" ]; then
+    measure_macos "$PID" ||
+      die "neither footprint nor vmmap produced a phys_footprint for pid ${PID}"
+  else
+    measure_linux "$PID" ||
+      die "no RssAnon or VmRSS in /proc/${PID}/status"
+  fi
+  is_positive_int "$PRIMARY_BYTES" ||
+    die "phys-footprint reading for pid ${PID} came back empty or zero; refusing to report it"
+
+  case "$DAEMON" in
+    trusty-search | trusty-memory)
+      if [ "$WANT_HEALTH" = "1" ]; then
+        read_health "$DAEMON" "$PLATFORM" || true
+      fi
+      DATA_DIR="$(daemon_data_subdir "$DAEMON" "$PLATFORM")"
+      if [ "$want_disk" = "1" ] && [ -d "$DATA_DIR" ]; then
+        DISK_KB="$(du -sk "$DATA_DIR" 2>/dev/null | awk '{ print $1 }')"
+        is_positive_int "$DISK_KB" || DISK_KB=""
+      fi
+      ;;
+  esac
+
+  if [ "$as_json" = "1" ]; then
+    emit_json
+  else
+    emit_human
+  fi
+}
+
+# Library mode: `MEASURE_DAEMON_FOOTPRINT_LIB=1 . scripts/measure-daemon-footprint.sh`
+# defines every function above and returns without measuring anything, which is
+# how the selftest exercises the parsers with no live daemon. (#6819)
+if [ "${MEASURE_DAEMON_FOOTPRINT_LIB:-0}" != "1" ]; then
+  main "$@"
+fi

--- a/scripts/measure-daemon-footprint_selftest.sh
+++ b/scripts/measure-daemon-footprint_selftest.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+#
+# measure-daemon-footprint_selftest.sh — fixtures for
+# scripts/measure-daemon-footprint.sh (#6819).
+#
+# Why: the script it tests is the instrument every other child issue of epic
+#   #6802 quotes its before/after numbers from, and its whole value rests on
+#   two properties a live-daemon run cannot demonstrate. First, the Linux
+#   branch: this machine is macOS, so `/proc/<pid>/status` parsing would ship
+#   entirely unexercised without a fixture — and it is the branch CI would
+#   run. Second, fail-closed: an operator who cannot tell "measured 0 MB"
+#   from "could not measure" will publish the wrong number, so every path
+#   that cannot produce a reading has to exit 2 with nothing on stdout, and
+#   only a negative test proves that.
+#
+#   The `vmmap` case is pinned because the label it looks for, "Physical
+#   footprint (peak)", was matched with `grep -E` at first — which reads the
+#   parentheses as a group and silently matches the wrong line.
+#
+# What: five groups, all against fixtures — no daemon, no launchd, no network.
+#   helpers    to_bytes / mb_from_bytes / human_bytes / canonical_daemon /
+#              is_positive_int, including the units and the rejections
+#   parsers    footprint's auxiliary block and category table, and vmmap's
+#              summary line, against captured real output
+#   proc       the Linux RssAnon / VmRSS ladder against four /proc fixtures
+#   cli        argument parsing: --help, no args, bad option, bad daemon,
+#              bad pid, a dead pid, a daemon named twice
+#   closed     the fail-closed paths, each asserting exit 2 AND empty stdout
+#
+# Usage: bash scripts/measure-daemon-footprint_selftest.sh
+# Exit: 0 when every case matches; 1 listing each mismatch.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI), same as the
+#   script under test.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}" || exit 1
+
+SCRIPT="${REPO_ROOT}/scripts/measure-daemon-footprint.sh"
+[ -r "$SCRIPT" ] || {
+  echo "FAIL: ${SCRIPT} not found"
+  exit 1
+}
+
+# Source the script in library mode: it defines every function and runs
+# nothing, which is the seam that lets the parsers be tested directly.
+# shellcheck source=scripts/measure-daemon-footprint.sh disable=SC1091
+MEASURE_DAEMON_FOOTPRINT_LIB=1 . "$SCRIPT"
+
+FIXTURES="$(mktemp -d "${TMPDIR:-/tmp}/measure-footprint-selftest.XXXXXX")"
+trap 'rm -rf "${FIXTURES}"' EXIT
+
+FAILURES=0
+CASES=0
+
+# eq <label> <expected> <actual>
+eq() {
+  local label="$1" want="$2" got="$3"
+  CASES=$((CASES + 1))
+  if [ "$want" = "$got" ]; then
+    printf '  ok   %-56s -> %s\n' "$label" "$got"
+  else
+    FAILURES=$((FAILURES + 1))
+    printf '  FAIL %-56s -> expected %s, got %s\n' "$label" "$want" "$got"
+  fi
+}
+
+# rc <label> <expected-rc> <command...>
+rc() {
+  local label="$1" want="$2" got=0
+  shift 2
+  "$@" >/dev/null 2>&1 || got=$?
+  eq "$label" "$want" "$got"
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+cat >"${FIXTURES}/footprint.txt" <<'EOF'
+======================================================================
+trusty-search [42054]: 64-bit    Footprint: 9954533592 B (16384 bytes per page)
+======================================================================
+
+      Dirty         Clean   Reclaimable    Regions    Category
+        ---           ---           ---        ---    ---
+6342688768 B           0 B    99532800 B       6747    MALLOC_SMALL
+2223816704 B           0 B           0 B        135    untagged (VM_ALLOCATE)
+1230995456 B           0 B           0 B        322    MALLOC_LARGE
+        0 B   151814144 B           0 B         54    mapped file
+        0 B           0 B           0 B        157    __AUTH
+        ---           ---           ---        ---    ---
+9954500824 B   175489024 B    99549184 B      10327    TOTAL
+
+Auxiliary data:
+    phys_footprint: 9954533592 B
+    phys_footprint_peak: 29108756384 B
+EOF
+
+# The default `formatted` output, to pin that the unit is parsed and not
+# assumed to be bytes.
+cat >"${FIXTURES}/footprint-formatted.txt" <<'EOF'
+Auxiliary data:
+    phys_footprint: 9493 MB
+    phys_footprint_peak: 27 GB
+EOF
+
+cat >"${FIXTURES}/vmmap.txt" <<'EOF'
+Process:         trusty-search [42054]
+Physical footprint:         9.3G
+Physical footprint (peak):  27.1G
+ReadOnly portion of Libraries: Total=1.0G resident=379.9M
+EOF
+
+# RssAnon present — the primary reading on Linux, matching the choice
+# core::memguard_enforce::anon_rss_mb_for_pid makes.
+printf 'Name:\ttrusty-search\nState:\tS (sleeping)\nVmHWM:\t 9700000 kB\nVmRSS:\t 9500000 kB\nRssAnon:\t 9000000 kB\nRssFile:\t  480000 kB\nRssShmem:\t   20000 kB\n' \
+  >"${FIXTURES}/status-full"
+
+# A kernel or hardened container that exposes no RssAnon: must fall back to
+# VmRSS, not fail.
+printf 'Name:\ttrusty-search\nVmHWM:\t 9700000 kB\nVmRSS:\t 9500000 kB\n' \
+  >"${FIXTURES}/status-no-anon"
+
+# RssAnon reported as 0 — the exact shape that must NOT be published as a
+# measurement. Falls through to VmRSS.
+printf 'Name:\ttrusty-search\nVmRSS:\t 9500000 kB\nRssAnon:\t       0 kB\n' \
+  >"${FIXTURES}/status-zero-anon"
+
+# Neither field: unmeasurable, must exit 2.
+printf 'Name:\ttrusty-search\nState:\tS (sleeping)\n' \
+  >"${FIXTURES}/status-empty"
+
+# ---------------------------------------------------------------------------
+# 1. Helpers
+# ---------------------------------------------------------------------------
+
+echo "helpers:"
+eq "to_bytes 1 B" 1 "$(to_bytes 1 B)"
+eq "to_bytes 2 KB" 2048 "$(to_bytes 2 KB)"
+eq "to_bytes 1 MB" 1048576 "$(to_bytes 1 MB)"
+eq "to_bytes 27 GB" 28991029248 "$(to_bytes 27 GB)"
+eq "to_bytes 9.3 G (fractional)" 9985798963 "$(to_bytes 9.3 G)"
+eq "to_bytes lowercase unit" 1073741824 "$(to_bytes 1 g)"
+rc "to_bytes rejects a junk unit" 1 to_bytes 1 furlongs
+rc "to_bytes rejects a non-number" 1 to_bytes 12x MB
+eq "mb_from_bytes truncates" 9493 "$(mb_from_bytes 9954533592)"
+eq "human_bytes 1.5G" 1.5G "$(human_bytes 1639247872)"
+eq "human_bytes bytes stay bytes" 512B "$(human_bytes 512)"
+eq "canonical_daemon search" trusty-search "$(canonical_daemon search)"
+eq "canonical_daemon TRUSTY-SEARCH" trusty-search "$(canonical_daemon TRUSTY-SEARCH)"
+eq "canonical_daemon memory" trusty-memory "$(canonical_daemon memory)"
+rc "canonical_daemon rejects an unknown name" 1 canonical_daemon postgres
+eq "launchd_label search" com.trusty.search "$(launchd_label trusty-search)"
+rc "is_positive_int rejects 0" 1 is_positive_int 0
+rc "is_positive_int rejects empty" 1 is_positive_int ""
+rc "is_positive_int rejects 12abc" 1 is_positive_int 12abc
+rc "is_positive_int accepts 42054" 0 is_positive_int 42054
+
+# ---------------------------------------------------------------------------
+# 2. footprint / vmmap parsers
+# ---------------------------------------------------------------------------
+
+echo "parsers:"
+eq "footprint phys_footprint (bytes)" 9954533592 \
+  "$(parse_footprint_field "${FIXTURES}/footprint.txt" phys_footprint)"
+eq "footprint phys_footprint_peak (bytes)" 29108756384 \
+  "$(parse_footprint_field "${FIXTURES}/footprint.txt" phys_footprint_peak)"
+# The `formatted` default prints MB/GB, so the unit has to be honoured. This
+# also pins that a `phys_footprint` lookup is not satisfied by the
+# `phys_footprint_peak` line sitting right under it.
+eq "footprint formatted MB is converted" 9954131968 \
+  "$(parse_footprint_field "${FIXTURES}/footprint-formatted.txt" phys_footprint)"
+eq "footprint formatted GB peak is converted" 28991029248 \
+  "$(parse_footprint_field "${FIXTURES}/footprint-formatted.txt" phys_footprint_peak)"
+rc "footprint field absent -> failure" 1 \
+  parse_footprint_field "${FIXTURES}/vmmap.txt" phys_footprint
+
+eq "categories: biggest first" "6342688768	MALLOC_SMALL" \
+  "$(parse_footprint_categories "${FIXTURES}/footprint.txt" | head -1)"
+eq "categories: multi-word name kept whole" "2223816704	untagged (VM_ALLOCATE)" \
+  "$(parse_footprint_categories "${FIXTURES}/footprint.txt" | sed -n 2p)"
+eq "categories: TOTAL row dropped" 0 \
+  "$(parse_footprint_categories "${FIXTURES}/footprint.txt" | grep -c TOTAL || true)"
+eq "categories: zero-dirty rows dropped" 3 \
+  "$(parse_footprint_categories "${FIXTURES}/footprint.txt" | grep -c . || true)"
+
+eq "vmmap Physical footprint" 9985798963 \
+  "$(parse_vmmap_footprint "${FIXTURES}/vmmap.txt" "Physical footprint")"
+# The regression: "(peak)" read as an ERE group matched the non-peak line.
+eq "vmmap Physical footprint (peak)" 29098403430 \
+  "$(parse_vmmap_footprint "${FIXTURES}/vmmap.txt" "Physical footprint (peak)")"
+rc "vmmap label absent -> failure" 1 \
+  parse_vmmap_footprint "${FIXTURES}/footprint.txt" "Physical footprint"
+
+# ---------------------------------------------------------------------------
+# 3. Linux /proc/<pid>/status ladder
+# ---------------------------------------------------------------------------
+
+echo "proc:"
+eq "RssAnon kB" 9000000 "$(parse_proc_status_kb "${FIXTURES}/status-full" RssAnon)"
+eq "VmRSS kB" 9500000 "$(parse_proc_status_kb "${FIXTURES}/status-full" VmRSS)"
+eq "RssFile kB" 480000 "$(parse_proc_status_kb "${FIXTURES}/status-full" RssFile)"
+rc "RssAnon absent -> failure" 1 \
+  parse_proc_status_kb "${FIXTURES}/status-no-anon" RssAnon
+rc "RssAnon of 0 is not a reading" 1 \
+  parse_proc_status_kb "${FIXTURES}/status-zero-anon" RssAnon
+rc "empty status -> no VmRSS either" 1 \
+  parse_proc_status_kb "${FIXTURES}/status-empty" VmRSS
+
+# End to end in forced-Linux mode against each fixture. `--pid $$` is this
+# shell, so the liveness check passes without a daemon.
+run_linux() {
+  MEASURE_FOOTPRINT_PLATFORM=linux \
+    MEASURE_FOOTPRINT_PROC_STATUS="$1" \
+    bash "$SCRIPT" --pid "$$" --json --no-health --no-disk 2>/dev/null
+}
+
+FULL_JSON="$(run_linux "${FIXTURES}/status-full")"
+eq "linux e2e: bytes = RssAnon * 1024" 9216000000 \
+  "$(printf '%s' "$FULL_JSON" | sed -n 's/.*"phys_footprint_bytes": \([0-9]*\).*/\1/p')"
+eq "linux e2e: mb" 8789 \
+  "$(printf '%s' "$FULL_JSON" | sed -n 's/.*"phys_footprint_mb": \([0-9]*\).*/\1/p')"
+eq "linux e2e: source names the field used" '"source": "proc-status-rssanon",' \
+  "$(printf '%s' "$FULL_JSON" | grep '"source"' | sed 's/^ *//')"
+eq "linux e2e: peak from VmHWM" 9472 \
+  "$(printf '%s' "$FULL_JSON" | sed -n 's/.*"phys_footprint_peak_mb": \([0-9]*\).*/\1/p')"
+eq "linux e2e: breakdown lists RssAnon first" '"category": "RssAnon"' \
+  "$(printf '%s' "$FULL_JSON" | grep -o '"category": "[A-Za-z]*"' | head -1)"
+
+NOANON_JSON="$(run_linux "${FIXTURES}/status-no-anon")"
+eq "linux e2e: falls back to VmRSS" '"source": "proc-status-vmrss",' \
+  "$(printf '%s' "$NOANON_JSON" | grep '"source"' | sed 's/^ *//')"
+eq "linux e2e: VmRSS bytes" 9728000000 \
+  "$(printf '%s' "$NOANON_JSON" | sed -n 's/.*"phys_footprint_bytes": \([0-9]*\).*/\1/p')"
+
+ZERO_JSON="$(run_linux "${FIXTURES}/status-zero-anon")"
+eq "linux e2e: RssAnon 0 does not become the number" '"source": "proc-status-vmrss",' \
+  "$(printf '%s' "$ZERO_JSON" | grep '"source"' | sed 's/^ *//')"
+
+# ---------------------------------------------------------------------------
+# 4. JSON key set
+# ---------------------------------------------------------------------------
+
+echo "json:"
+if command -v jq >/dev/null 2>&1; then
+  eq "valid JSON" ok "$(printf '%s' "$FULL_JSON" | jq -e . >/dev/null 2>&1 && echo ok || echo bad)"
+  eq "top-level keys" \
+    "schema daemon pid platform measured_at source phys_footprint_bytes phys_footprint_mb phys_footprint_peak_mb health data_dir units breakdown" \
+    "$(printf '%s' "$FULL_JSON" | jq -r 'keys_unsorted | join(" ")')"
+  eq "health keys" "rss_mb endpoint" \
+    "$(printf '%s' "$FULL_JSON" | jq -r '.health | keys_unsorted | join(" ")')"
+  eq "data_dir keys" "path size_kb size_human" \
+    "$(printf '%s' "$FULL_JSON" | jq -r '.data_dir | keys_unsorted | join(" ")')"
+  eq "units keys" "kind count resident chunks drawers" \
+    "$(printf '%s' "$FULL_JSON" | jq -r '.units | keys_unsorted | join(" ")')"
+  eq "breakdown entry keys" "category bytes mb" \
+    "$(printf '%s' "$FULL_JSON" | jq -r '.breakdown[0] | keys_unsorted | join(" ")')"
+  eq "schema value" "trusty-footprint/1" \
+    "$(printf '%s' "$FULL_JSON" | jq -r '.schema')"
+  # An absent reading is null, never 0 — the whole point of the fail-closed
+  # contract carried into the machine-readable output.
+  eq "absent health is null, not 0" null \
+    "$(printf '%s' "$FULL_JSON" | jq -r '.health.rss_mb')"
+  eq "absent unit count is null, not 0" null \
+    "$(printf '%s' "$FULL_JSON" | jq -r '.units.count')"
+else
+  echo "  SKIP jq not installed — key-set assertions need it"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. CLI parsing and the fail-closed paths
+# ---------------------------------------------------------------------------
+
+echo "cli:"
+rc "--help exits 0" 0 bash "$SCRIPT" --help
+eq "--help prints the usage block" 1 \
+  "$(bash "$SCRIPT" --help 2>/dev/null | grep -c '^Usage:' || true)"
+rc "no arguments exits 2" 2 bash "$SCRIPT"
+rc "unknown option exits 2" 2 bash "$SCRIPT" --nope
+rc "unknown daemon exits 2" 2 bash "$SCRIPT" postgres
+rc "daemon named twice exits 2" 2 bash "$SCRIPT" search memory
+rc "--daemon with no value exits 2" 2 bash "$SCRIPT" --daemon
+rc "--pid with no value exits 2" 2 bash "$SCRIPT" --pid
+rc "--pid abc exits 2" 2 bash "$SCRIPT" --pid abc
+rc "--pid 0 exits 2" 2 bash "$SCRIPT" --pid 0
+# Above PID_MAX on macOS and Linux alike, so it can never be alive.
+rc "--pid of a dead process exits 2" 2 bash "$SCRIPT" --pid 4194304
+
+echo "fail-closed:"
+# stdout must be EMPTY on every refusal: a partial table or a bare 0 would be
+# read as a measurement.
+closed() {
+  local label="$1"
+  shift
+  local out rc_got=0
+  out="$("$@" 2>/dev/null)" || rc_got=$?
+  eq "${label}: exit 2" 2 "$rc_got"
+  eq "${label}: stdout empty" "" "$out"
+}
+
+closed "unmeasurable /proc" env \
+  MEASURE_FOOTPRINT_PLATFORM=linux \
+  MEASURE_FOOTPRINT_PROC_STATUS="${FIXTURES}/status-empty" \
+  bash "$SCRIPT" --pid "$$" --json --no-health --no-disk
+closed "missing /proc file" env \
+  MEASURE_FOOTPRINT_PLATFORM=linux \
+  MEASURE_FOOTPRINT_PROC_STATUS="${FIXTURES}/does-not-exist" \
+  bash "$SCRIPT" --pid "$$" --json --no-health --no-disk
+closed "unsupported platform" env \
+  MEASURE_FOOTPRINT_PLATFORM=plan9 \
+  bash "$SCRIPT" --pid "$$" --json
+closed "dead pid" bash "$SCRIPT" --pid 4194304 --json
+
+# ---------------------------------------------------------------------------
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "measure-daemon-footprint selftest: ${CASES} cases, all passed"
+  exit 0
+fi
+echo "measure-daemon-footprint selftest: ${FAILURES} of ${CASES} cases FAILED"
+exit 1


### PR DESCRIPTION
Refs #6819

Epic #6802's other seven children each have to prove a before/after memory
claim. Without one instrument they re-derive the recipe by hand and produce
numbers that are not comparable. This is that instrument.

## What lands

`scripts/measure-daemon-footprint.sh` resolves ONE pid and prints ONE
phys-footprint number, surrounded by the context needed to act on it.

- **pid discovery** — `launchctl print gui/<uid>/com.trusty.<name>` on macOS,
  a `pgrep` fallback that fails closed on ambiguity (on this box
  `pgrep -f trusty-memory` matches 60+ MCP clients and worktree debug builds,
  so guessing among them would report the wrong process), or `--pid <n>`.
- **primary number** — macOS: `footprint -f bytes <pid>` → `phys_footprint`,
  falling back to `vmmap -summary` → `Physical footprint`. Linux:
  `/proc/<pid>/status` → `RssAnon`, else `VmRSS`. The Linux choice follows the
  precedent already in the tree: `core::memguard_enforce::anon_rss_mb_for_pid`
  (`crates/trusty-search/src/core/memguard_enforce.rs:109`), which is what
  `TRUSTY_MEMORY_ENFORCE_MEASURE=anon` gates on. `ps` RSS is never read —
  macOS undercounts it by orders of magnitude.
- **breakdown** — per-category dirty bytes plus `phys_footprint_peak` on
  macOS; RssAnon / RssFile / RssShmem / VmRSS on Linux.
- **`/health` `rss_mb`** — over loopback TCP for trusty-search. trusty-memory
  has been UDS-only since #6286, so it sends one newline-terminated
  `memory.health` JSON-RPC frame over the socket. Its counts come from
  `memory.status`, not `memory.palaces_list`: the list call opens every palace
  and took ~9s on a 93-palace host.
- **disk + units** — `du -sk` on the indexes/palaces directory, and the
  index/palace counts. Every `units` key is emitted for both daemons, `null`
  where it does not apply, so the JSON key set never varies with the target.
- **fail closed** — every path that cannot produce a reading exits 2 with a
  message naming what was missing and prints nothing on stdout, so "could not
  measure" can never be read as "measured 0 MB".

`--json` for a stable key set, a human table by default.

## Acceptance criterion — within 5% of a manual reading

Live `trusty-search` daemon, pid 42054, three readings back to back:

```
manual footprint before : 10006274288 B (9542.7 MB)
script (--json)         : 10006274288 B (9542.7 MB)
manual footprint after  : 10006323440 B (9542.8 MB)

delta vs before : 0.000000%
delta vs after  : -0.000491%
```

The script reads the same `footprint` field, so the only difference is the
process's own drift between samples. Well inside 5%.

## Gates — rung 1/2 (scripts + docs, no crate `src/**`)

No Cargo gate applies: nothing under `crates/*/src/` changed, so
`check_changelog_fragment.sh` correctly reports no fragment is owed.

```
scripts/measure-daemon-footprint_selftest.sh   74 cases, all passed
shellcheck (0.11.0) both scripts               exit 0
check_sld.sh                                   0 errors, 0 warnings
check_line_cap.sh                              0 violations
check_test_pointers.sh                         30537 citations, 0 dangling
check_doc_numbers.sh                           0 violations
check_changelog_fragment.sh                    no crate source changed — OK
check_public_docs.sh                           27 pages resolve
```

The selftest is fixture-only — no daemon, no launchd, no network — and covers
the parsers, the Linux `/proc` ladder (the branch this macOS host would
otherwise never exercise), the JSON key set, argument parsing, and every
fail-closed path asserting exit 2 AND empty stdout. It was verified able to
fail: perturbing one expected value produced `1 of 74 cases FAILED`, exit 1.

It found one real bug on the way in: the `vmmap` fallback looked for
`Physical footprint (peak)` with `grep -E`, which reads the parentheses as a
group and silently matches the non-peak line. Fixed, and pinned as a case.

## Not in scope

No CI workflow wiring. Adding a required context wedges every open PR that
predates it (#5962), and this script needs a live daemon to be worth gating
on. The selftest runs on demand.

## Live daemons

Neither daemon was restarted, installed, or reconfigured — pids 42054 and
39940 are the same ones the epic's section-0 measurement used.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
