### PR TITLE
docs(trusty-mpm): qualify the picker doc links the module split broke (Refs #6753)

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -874,13 +874,13 @@ pub(crate) fn parse_picker_choice(
 /// without requiring the operator to remember session names or UUIDs. After a
 /// detach, the picker is redisplayed rather than exiting to the shell — the
 /// common "pick → Ctrl-b d → pick again" flow stays in one command.
-/// What: loops: derive the render state through [`prepare_menu`], print menu,
+/// What: loops: derive the render state through [`prepare_menu`](super::session_picker_order::prepare_menu), print menu,
 /// read one line, dispatch, then re-fetch the session list (via
 /// [`fetch_live_sessions`], honoring the scope) so the next iteration shows
 /// current state. Exits cleanly on `Quit`, EOF (Ctrl-D), or unrecognised input;
 /// propagates attach/launch errors.
 ///
-/// **The caller need not pre-sort (#6753).** [`prepare_menu`] runs at the top of
+/// **The caller need not pre-sort (#6753).** [`prepare_menu`](super::session_picker_order::prepare_menu) runs at the top of
 /// the loop and owns the order, so the FIRST menu is ordered exactly like every
 /// later one whatever order the caller hands in. Normalization used to run at the
 /// bottom only, which left the bare-`tm` path rendering its first menu in the

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_order.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_order.rs
@@ -46,7 +46,7 @@ pub(crate) fn filter_sessions_by_term(
 /// Put a freshly-obtained session list into the order and scope the picker
 /// renders (#6753).
 ///
-/// Why: [`run_tty_picker`] applied [`filter_sessions_by_term`] and
+/// Why: [`run_tty_picker`](super::session_picker::run_tty_picker) applied [`filter_sessions_by_term`] and
 /// [`sort_sessions`] at the BOTTOM of its loop only, so its FIRST menu showed
 /// the daemon's ascending-slot order while every later menu showed the scope's
 /// order. The attached session — usually the highest slot — printed last, bare
@@ -73,7 +73,7 @@ pub(crate) fn normalize_for_scope(
 /// Everything one render of the picker menu is decided by (#6753).
 ///
 /// Why: the three values below were computed inline at the top of
-/// [`run_tty_picker`]'s loop, from whatever order `sessions` happened to be in.
+/// [`run_tty_picker`](super::session_picker::run_tty_picker)'s loop, from whatever order `sessions` happened to be in.
 /// That made the ORDER an input nothing named and nothing could test, which is
 /// how the first render came to disagree with every later one. Naming the
 /// prepared list and its derived values together means a render cannot be
@@ -96,7 +96,7 @@ pub(crate) struct Menu {
 ///
 /// Why: this is the ONE place a menu is derived, so the first menu and every
 /// later one are the same computation rather than two that must be kept in step.
-/// [`run_tty_picker`] used to normalize at the BOTTOM of its loop only: its first
+/// [`run_tty_picker`](super::session_picker::run_tty_picker) used to normalize at the BOTTOM of its loop only: its first
 /// menu therefore printed the daemon's ascending-slot order, in which the
 /// attached session — usually the highest slot — came LAST. Bare Enter targets
 /// position 0, so it aimed at the oldest session (usually stopped, so it fired
@@ -105,7 +105,7 @@ pub(crate) struct Menu {
 /// What: [`normalize_for_scope`] first, then [`slots_are_stale`],
 /// [`next_launch_slot`] and the `first_needs_restart` flag off the NORMALIZED
 /// list. A deleted position 0 is never `first_needs_restart`, because
-/// [`decide_for_index`] checks `deleted` ahead of this flag.
+/// [`decide_for_index`](super::session_picker::decide_for_index) checks `deleted` ahead of this flag.
 /// Test: `prepare_menu_orders_the_first_render_like_every_later_one`,
 /// `prepare_menu_bare_enter_targets_the_attached_session`,
 /// `prepare_menu_is_idempotent`, `prepare_menu_applies_the_scopes_term_filter`,


### PR DESCRIPTION
## What

PR #6829 moved `prepare_menu` into `session_picker_order.rs`, and six intra-doc links kept pointing at the module they used to share:

```
LINK  trusty-mpm  session_picker.rs:877        unresolved link to `prepare_menu`
LINK  trusty-mpm  session_picker.rs:883        unresolved link to `prepare_menu`
LINK  trusty-mpm  session_picker_order.rs:49   unresolved link to `run_tty_picker`
LINK  trusty-mpm  session_picker_order.rs:76   unresolved link to `run_tty_picker`
LINK  trusty-mpm  session_picker_order.rs:99   unresolved link to `run_tty_picker`
LINK  trusty-mpm  session_picker_order.rs:108  unresolved link to `decide_for_index`
```

`Rustdoc intra-doc links` failed on #6829's head. It is not a required context, so the merge went through and main is red on it. My change caused it.

## How

Each link now carries an explicit path to the sibling module. Verified with the gate itself:

```
$ bash scripts/check_rustdoc_links.sh
SUMMARY  26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0, 0 diagnostic(s) examined
EXIT=0
```

## Test ladder — rung 1 (docs and comments only)

No Cargo test required at this rung, but the crate gates were run anyway since the edits sit in source files:

```
bash scripts/check_rustdoc_links.sh                       # EXIT=0, 0 broken links
cargo fmt --check                                         # EXIT=0
cargo check -p trusty-mpm --all-targets                   # EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   # EXIT=0
bash scripts/check_test_pointers.sh                       # 30667 citations, 0 dangling — OK
bash scripts/check_line_cap.sh                            # 4483 files, 0 violations — OK
```

No changelog fragment: documentation only, no code or test change.

Refs #6753

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
