### PR TITLE
fix(trusty-search): split the #6822 changelog fragment so the assembler accepts it (Refs #6822)

### DIFF
--- a/crates/trusty-search/changelog.d/6822-f16-default.md
+++ b/crates/trusty-search/changelog.d/6822-f16-default.md
@@ -1,27 +1,5 @@
 Changed
 
-**Default behaviour change for newly built indexes.** `TRUSTY_VECTOR_QUANT` now
-defaults to `f16` instead of `f32`: every index created from this version on
-stores half-precision vectors, halving the vector bytes it holds in RAM and on
-disk. Recall@10 measures 1.00 — the same as f32 — on the `ooc_quick_wins`
-fixture's query set. Set `TRUSTY_VECTOR_QUANT=f32` to keep full precision;
-`i8` is unchanged and stays opt-in. An empty value now means "unset" and
-resolves to the default rather than to `f32`.
-
-Existing indexes are untouched: usearch records the scalar kind in the snapshot
-header and rebuilds the metric from it on every open, so opening an f32 index
-under the new default reads it as f32 and rewrites no bytes.
-
-Added
-
-`trusty-search quantize` (and `POST /indexes/:id/quantize`) converts an existing
-index's vectors to a different precision in place — the only way an index built
-before this change becomes quantized, since a forced reindex upserts into the
-store built at warm-boot and therefore re-embeds at the old precision. It
-reports before it writes (`--dry-run` names the index, root, chunk count, vector
-count and snapshot bytes), prompts unless `--yes`, is a no-op when the index is
-already at the target, and refuses while a reindex is in flight.
-
-`GET /indexes/:id/status` gained `semantic_coverage.vector_quant`: the precision
-the LIVE index holds, which for any index built before this change differs from
-what `TRUSTY_VECTOR_QUANT` would suggest.
+- **Default behaviour change for newly built indexes.** `TRUSTY_VECTOR_QUANT` now defaults to `f16` instead of `f32`, so every index created from this version on stores half-precision vectors — half the vector bytes in RAM and on disk. Recall@10 measures 1.00, the same as f32, on the `ooc_quick_wins` fixture's query set. Set `TRUSTY_VECTOR_QUANT=f32` to keep full precision; `i8` is unchanged and stays opt-in. An empty value now means "unset" and resolves to the default rather than to `f32`.
+- Existing indexes are untouched by the flip: usearch records the scalar kind in the snapshot header and rebuilds the metric from it on every open, so opening an f32 index under the new default reads it as f32 and rewrites no bytes. Converting one is the explicit `trusty-search quantize` backfill.
+- Corrected the `TRUSTY_VECTOR_QUANT` memory-tuning entry, which claimed a forced reindex adopts a new precision. It does not — the vector store is built once at warm-boot and a reindex upserts into it, so `reindex --force` re-embeds at the old precision.

--- a/crates/trusty-search/changelog.d/6822-quantize-backfill.md
+++ b/crates/trusty-search/changelog.d/6822-quantize-backfill.md
@@ -1,0 +1,4 @@
+Added
+
+- `trusty-search quantize` (and `POST /indexes/:id/quantize`) re-encodes an existing index's vectors at a different scalar precision in place. This is the only way an index built before the `f16` default becomes quantized, since a forced reindex upserts into the store built at warm-boot and therefore re-embeds at the old precision. It reports before it writes (`--dry-run` names the index, root, chunk count, vector count and snapshot bytes), prompts unless `--yes`, is a no-op when the index already holds the target precision, and refuses while a reindex is in flight.
+- `GET /indexes/:id/status` reports `semantic_coverage.vector_quant`: the precision the LIVE index holds, which for any index built before the default flip differs from what `TRUSTY_VECTOR_QUANT` would suggest.


### PR DESCRIPTION
Refs #6822. Fixes the one red required check on `main` after #6843.

`scripts/check_changelog_fragment.sh` failed on #6843's head: the assembler
requires at least one `- ` bullet under the category line, and one fragment
holds one category. The merged fragment had prose plus a second category
heading in a single file.

This splits it: `6822-f16-default.md` keeps `Changed`,
`6822-quantize-backfill.md` carries `Added`. Fragment content is otherwise
unchanged.

## How this reached main

The split was written before #6843 merged, but it was staged and never
committed, so the pushed head still carried the invalid fragment. I then merged
#6843 while that check was red — my error, and the reason this follow-up exists
rather than the fix having shipped in the original PR.

## Gate

```
bash scripts/check_changelog_fragment.sh
changelog-fragment gate: scanned 2 changed path(s); attributed 0 crate-source
path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
```

Changelog-fragment-only change: no crate source is touched, so the Rust ladder
does not apply.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools