### PR TITLE
docs(threat-model,adr-0032): tailscale serve onto console's loopback port is an accepted tailnet exposure path (Refs #6857)

### DIFF
--- a/docs/adr/0018-loopback-only-doctrine.md
+++ b/docs/adr/0018-loopback-only-doctrine.md
@@ -173,3 +173,23 @@ Vetted against prior ADRs on 2026-07-19:
 
 No conflicts with any other Accepted ADR. Summary: consistent with, and a
 direct refinement of, ADR-0011; no silent contradictions.
+
+## Amendment 2026-09-05: host-level `tailscale serve` onto console's loopback port (#6857)
+
+**Amended, not superseded.** This ADR's own Decision is unchanged even though
+its Status is `Superseded by 0032`: console remains the sole off-loopback
+HTTP surface, and ADR-0032 carries that invariant forward.
+
+**Why:** `tailscaled` can terminate tailnet HTTPS itself and reverse-proxy to
+a loopback port, without going through console's own `--tailscale` bind flag.
+That path needs a ruling: an accepted equivalent, or a bypass of this
+doctrine.
+
+**What:** A host-level `tailscale serve` reverse proxy onto console's
+existing `127.0.0.1` bind (e.g. `tailscale serve --bg http://127.0.0.1:7788`)
+is an **accepted equivalent** to console's `--tailscale` flag — it satisfies
+the same invariants this ADR and ADR-0032 both require: console is still the
+only off-loopback trusty-\* surface, no sibling daemon is touched, console
+never binds `0.0.0.0`, and Funnel stays forbidden. Access control is tailnet
+membership, plus tailnet ACLs where configured. Operational detail and the
+rollback command live in `docs/reference/threat-model.md`'s console entry.

--- a/docs/reference/threat-model.md
+++ b/docs/reference/threat-model.md
@@ -120,6 +120,22 @@ resolves `/api/agents/*` to it. The `--bind` escape hatch remains for the case
 console cannot cover, which is why it is token-gated at startup rather than
 merely discouraged.
 
+**A host-level `tailscale serve` reverse proxy is a second, accepted path
+onto console's loopback port** (#6857), alongside console's own `--tailscale`
+bind flag — see
+[ADR-0018's 2026-09-05 amendment](../adr/0018-loopback-only-doctrine.md#amendment-2026-09-05-host-level-tailscale-serve-onto-consoles-loopback-port-6857).
+Mechanism: `tailscaled`, running on the host, terminates tailnet HTTPS at the
+host's tailnet DNS name and reverse-proxies to console's existing
+`127.0.0.1:7788` listener (`tailscale serve --bg http://127.0.0.1:7788`);
+console itself is unmodified — it still binds `127.0.0.1` only, never
+`0.0.0.0`, and no sibling daemon is touched. What's exposed: everything
+console serves — the dashboard SPA and every proxied `/api/{service}/*path`
+route — the same surface console's own `--tailscale` bind would expose.
+Access control: tailnet membership, plus tailnet ACLs where configured; no
+additional auth layer beyond what console's other bind modes already provide.
+**Funnel is forbidden** on this path exactly as it is on console's built-in
+bind modes. Rollback: `tailscale serve --https=443 off`.
+
 ## Why the guard fails open on a missing `Origin` header
 
 The shared guard (`trusty_common::server::guard_write_origin`,


### PR DESCRIPTION
Documents the host-level `tailscale serve` reverse proxy onto trusty-console's loopback port as an accepted equivalent to console's own `--tailscale` bind flag. Adds the operational entry (mechanism, exposure, access control, rollback) to threat-model.md and a dated Amendment to ADR-0018, the ADR whose Decision text defines console's Tailscale/Funnel bind path.

Docs-only, rung 1: check_sld.sh + check_line_cap.sh pass

Refs #6857

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools