### PR TITLE
fix(trusty-review,trusty-audit): every total analyze-lane collapse emits the shared DID-NOT-RUN headline the coverage rollup keys on (Refs #6784)

### DIFF
--- a/crates/trusty-audit/changelog.d/6784-rollup-keys-on-shared-headline.md
+++ b/crates/trusty-audit/changelog.d/6784-rollup-keys-on-shared-headline.md
@@ -1,0 +1,7 @@
+Fixed
+
+- The run index's dead-analyze-lane count now keys on the shared
+  `trusty_common::review_gap_contract` headline instead of a literal of its own,
+  so it recognises every gap line `trusty-review` writes for a total collapse.
+  It previously missed the client-build-failure path and undercounted
+  `Rollup::analyze_lanes_dead()` (#6784).

--- a/crates/trusty-audit/src/grounding/coverage_rollup.rs
+++ b/crates/trusty-audit/src/grounding/coverage_rollup.rs
@@ -105,8 +105,17 @@ impl Rollup {
 /// Why: the same one-phrase-to-key-on contract
 /// [`super::SEARCH_TIER_HEADLINE`] establishes. `trusty-review` writes it at the
 /// head of the report's Gaps & Caveats and this module matches it; two spellings
-/// would mean a bundle whose index disagrees with the reports it indexes.
-pub const ANALYZE_LANE_DEAD_HEADLINE: &str = "trusty-analyze lane DID NOT RUN";
+/// would mean a bundle whose index disagrees with the reports it indexes — which
+/// is exactly what #6784 found, with `trusty-review`'s client-build-collapse path
+/// leading with a different phrase and rolling up here as a lane that ran.
+///
+/// #6784: the value now comes from `trusty-common`, the one crate both this
+/// crate and `trusty-review` already depend on. That is deliberately NOT a
+/// dependency on `trusty-review`: DOC-67 §5 keeps this seam at a file, and it
+/// stays there. What the shared definition removes is two spellings inside one
+/// build.
+pub const ANALYZE_LANE_DEAD_HEADLINE: &str =
+    trusty_common::review_gap_contract::ANALYZE_LANE_DEAD_HEADLINE;
 
 /// Roll up the investigation coverage of every report under `dirs`, in the run's
 /// own order.
@@ -172,19 +181,22 @@ fn report_jsons(dir: &Path) -> Vec<PathBuf> {
 /// report-level fact, so every row of one report carries the same value.
 /// Anything that is not JSON, or is JSON without that shape, yields no rows.
 /// Test: `super::coverage_rollup_tests::{the_rollup_reads_every_report,
-/// a_json_that_is_not_a_report_contributes_nothing}`.
+/// a_json_that_is_not_a_report_contributes_nothing,
+/// a_gap_leading_with_the_shared_headline_is_a_dead_lane}`.
 #[must_use]
 pub fn read_coverage(report_json: &str) -> Vec<RepoCoverage> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(report_json) else {
         return Vec::new();
     };
+    // #6784: the predicate is the shared one, so a writer that leads with the
+    // headline can never be read here as a lane that ran.
     let analyze_lane_dead = value
         .get("gaps")
         .and_then(|g| g.as_array())
         .is_some_and(|gaps| {
-            gaps.iter()
-                .filter_map(|g| g.as_str())
-                .any(|g| g.contains(ANALYZE_LANE_DEAD_HEADLINE))
+            trusty_common::review_gap_contract::analyze_lane_is_dead(
+                gaps.iter().filter_map(|g| g.as_str()),
+            )
         });
     let Some(repos) = value
         .get("investigation")

--- a/crates/trusty-audit/src/grounding/coverage_rollup_tests.rs
+++ b/crates/trusty-audit/src/grounding/coverage_rollup_tests.rs
@@ -139,3 +139,36 @@ fn a_bundle_with_no_coverage_records_says_so() {
         "a producer with no reports to read must claim nothing either way"
     );
 }
+
+/// #6784 regression, cross-crate. Both of `trusty-review`'s total-collapse paths
+/// lead their gap line with
+/// [`trusty_common::review_gap_contract::ANALYZE_LANE_DEAD_HEADLINE`] and append
+/// their own detail; the reader must recognise either. The client-build path
+/// used to lead with "trusty-analyze data unavailable" and rolled up here as a
+/// lane that RAN.
+///
+/// The producing half is `trusty-review`'s
+/// `run_tests::a_dead_analyze_client_reads_as_a_dead_lane_downstream`, which
+/// runs the real code path; the two halves are bound by the shared constant
+/// because the crates deliberately do not depend on each other (DOC-67 §5).
+#[test]
+fn a_gap_leading_with_the_shared_headline_is_a_dead_lane() {
+    let client_build = format!(
+        "{ANALYZE_LANE_DEAD_HEADLINE} — the analysis client could not be built, so no \
+         application in this report was assessed against trusty-analyze."
+    );
+    let walk = format!("{ANALYZE_LANE_DEAD_HEADLINE} — 0 of 59 application(s) assessed.");
+
+    for gap in [&client_build, &walk] {
+        let rows = read_coverage(&report_json("A", 10, 100, &[gap]));
+        assert_eq!(rows.len(), 1, "{gap}");
+        assert!(rows[0].analyze_lane_dead, "must roll up as dead: {gap}");
+    }
+
+    let partial = "trusty-analyze lane partially degraded — 58 of 59 application(s) assessed.";
+    let rows = read_coverage(&report_json("A", 10, 100, &[partial]));
+    assert!(
+        !rows[0].analyze_lane_dead,
+        "a partly degraded lane DID run: {partial}"
+    );
+}

--- a/crates/trusty-common/changelog.d/6784-review-gap-contract.md
+++ b/crates/trusty-common/changelog.d/6784-review-gap-contract.md
@@ -1,0 +1,7 @@
+Added
+
+- `review_gap_contract`: the one definition of the "trusty-analyze lane DID NOT
+  RUN" headline a `trusty-review` report leads a dead analyze lane with, plus the
+  `analyze_lane_is_dead` predicate its readers apply. `trusty-review` and
+  `trusty-audit` deliberately do not depend on each other (DOC-67 §5), so each
+  spelled the phrase as its own literal and they drifted (#6784).

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -140,6 +140,20 @@ pub mod codex_config;
 /// env_var_names_are_stable`.
 pub mod env_vars;
 
+/// The Gaps & Caveats phrases a `trusty-review` report states and its readers
+/// key on (#6784).
+///
+/// Why: `trusty-review` writes the phrase and `trusty-audit` matches it, across
+/// a seam DOC-67 §5 keeps free of a Cargo edge — so a literal on each side
+/// drifted, and a total analyze collapse rolled up as a lane that RAN. This is
+/// the [`env_vars`] pattern applied to report prose.
+/// What: exposes
+/// [`ANALYZE_LANE_DEAD_HEADLINE`](review_gap_contract::ANALYZE_LANE_DEAD_HEADLINE)
+/// and [`analyze_lane_is_dead`](review_gap_contract::analyze_lane_is_dead).
+/// Test: `cargo test -p trusty-common --features unconditional-only --
+/// review_gap_contract`.
+pub mod review_gap_contract;
+
 pub mod project_discovery;
 
 /// Shared graceful-shutdown signal helper for trusty-* daemons (issue #534).

--- a/crates/trusty-common/src/review_gap_contract.rs
+++ b/crates/trusty-common/src/review_gap_contract.rs
@@ -1,0 +1,85 @@
+//! The Gaps & Caveats phrases a `trusty-review` report states and its readers
+//! key on (#6784).
+//!
+//! Why: `trusty-review` writes a report's Gaps & Caveats list, and
+//! `trusty-audit` reads that list back off the report's JSON twin to say, in the
+//! bundle index, whether the static-analysis lane ran. The two crates must not
+//! depend on each other — DOC-67 §5 puts the seam at a FILE, not a Cargo edge —
+//! so the phrase they agree on was spelled as a literal on each side. It drifted
+//! immediately: `trusty-review` has TWO total-collapse paths, and the second one
+//! led with "trusty-analyze data unavailable" while the reader matched
+//! "trusty-analyze lane DID NOT RUN". A client-build collapse therefore rendered
+//! as a lane that RAN, and undercounted the index's dead-lane tally.
+//! What: [`ANALYZE_LANE_DEAD_HEADLINE`], which every writer leads its line with,
+//! and [`analyze_lane_is_dead`], the one predicate every reader applies to a
+//! report's `gaps` list. Zero dependencies — a `&str` and a `bool`.
+//!
+//! This is the [`crate::env_vars`] pattern applied to report prose rather than
+//! to environment-variable names, and for the same reason that module gives: a
+//! literal in each crate is the drift it exists to stop. Version skew across the
+//! file boundary is unchanged and still real — a `trusty-audit` built against an
+//! older `trusty-common` holds whatever value it was compiled with. What this
+//! removes is two spellings inside ONE build.
+//! Test: `the_headline_is_stable`, `a_dead_lane_line_is_recognised`,
+//! `a_live_lane_is_not_recognised_as_dead`.
+
+/// The phrase every total analyze-lane collapse leads its Gaps & Caveats line
+/// with (#6784, #6811).
+///
+/// Why: see the module doc — this is the one string the writer emits and the
+/// reader matches, so a report and the index that summarises it cannot disagree
+/// about whether static analysis ran.
+/// What: the literal phrase, with no trailing punctuation. A writer formats
+/// `"{ANALYZE_LANE_DEAD_HEADLINE} — <its own detail>"`; a reader tests
+/// containment through [`analyze_lane_is_dead`], never with its own literal.
+/// Test: `the_headline_is_stable`.
+pub const ANALYZE_LANE_DEAD_HEADLINE: &str = "trusty-analyze lane DID NOT RUN";
+
+/// Whether a report's Gaps & Caveats list says its analyze lane assessed
+/// nothing (#6784).
+///
+/// Why: containment, not equality — each writer appends its own detail after the
+/// headline (which repository count collapsed, or that the client never built),
+/// and a reader that matched whole lines would recognise neither.
+/// What: true when any gap line contains [`ANALYZE_LANE_DEAD_HEADLINE`]. A
+/// partially degraded lane leads with a different phrase and reads false, which
+/// is correct: some applications WERE assessed.
+/// Test: `a_dead_lane_line_is_recognised`, `a_live_lane_is_not_recognised_as_dead`.
+pub fn analyze_lane_is_dead<'a>(gaps: impl IntoIterator<Item = &'a str>) -> bool {
+    gaps.into_iter()
+        .any(|gap| gap.contains(ANALYZE_LANE_DEAD_HEADLINE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the literal so a rename here can never silently change what every
+    /// writer emits and every reader matches.
+    #[test]
+    fn the_headline_is_stable() {
+        assert_eq!(
+            ANALYZE_LANE_DEAD_HEADLINE,
+            "trusty-analyze lane DID NOT RUN"
+        );
+    }
+
+    /// The predicate matches a line that CONTAINS the headline, because every
+    /// writer appends its own detail after it.
+    #[test]
+    fn a_dead_lane_line_is_recognised() {
+        let line =
+            format!("{ANALYZE_LANE_DEAD_HEADLINE} — 0 of 59 application(s) assessed, 59 failed.");
+        assert!(analyze_lane_is_dead([line.as_str()]));
+        assert!(analyze_lane_is_dead(["unrelated gap", line.as_str()]));
+    }
+
+    /// A partially degraded lane, and an empty list, are not a dead lane.
+    #[test]
+    fn a_live_lane_is_not_recognised_as_dead() {
+        assert!(!analyze_lane_is_dead(std::iter::empty()));
+        assert!(!analyze_lane_is_dead([
+            "trusty-analyze lane partially degraded — 58 of 59 application(s) assessed, 1 failed."
+        ]));
+    }
+}

--- a/crates/trusty-common/src/review_gap_contract.rs
+++ b/crates/trusty-common/src/review_gap_contract.rs
@@ -10,8 +10,8 @@
 //! led with "trusty-analyze data unavailable" while the reader matched
 //! "trusty-analyze lane DID NOT RUN". A client-build collapse therefore rendered
 //! as a lane that RAN, and undercounted the index's dead-lane tally.
-//! What: [`ANALYZE_LANE_DEAD_HEADLINE`], which every writer leads its line with,
-//! and [`analyze_lane_is_dead`], the one predicate every reader applies to a
+//! What: `ANALYZE_LANE_DEAD_HEADLINE`, which every writer leads its line with,
+//! and `analyze_lane_is_dead`, the one predicate every reader applies to a
 //! report's `gaps` list. Zero dependencies — a `&str` and a `bool`.
 //!
 //! This is the [`crate::env_vars`] pattern applied to report prose rather than

--- a/crates/trusty-review/changelog.d/6784-shared-dead-lane-headline.md
+++ b/crates/trusty-review/changelog.d/6784-shared-dead-lane-headline.md
@@ -1,0 +1,7 @@
+Fixed
+
+- Both total analyze-lane collapses now lead their Gaps & Caveats line with the
+  same "trusty-analyze lane DID NOT RUN" headline. The client-build-failure path
+  led with "trusty-analyze data unavailable", which the audit bundle index does
+  not recognise, so under `--allow-degraded` a report whose static-analysis lane
+  never ran was indexed as one whose lane ran (#6784).

--- a/crates/trusty-review/src/report/analyze_adapter_tests.rs
+++ b/crates/trusty-review/src/report/analyze_adapter_tests.rs
@@ -1341,9 +1341,12 @@ async fn a_lane_that_failed_every_repository_is_recorded() {
 
     let gaps = enrich_with_analyze_gaps(&mut model, &source).await;
 
+    // #6784: matched with the shared predicate, not a literal — the walk's
+    // record and the client-build-failure gap have to be recognised by the same
+    // rule `trusty-audit`'s bundle index applies.
     let record = gaps
         .iter()
-        .find(|g| g.contains("trusty-analyze lane DID NOT RUN"))
+        .find(|g| trusty_common::review_gap_contract::analyze_lane_is_dead([g.as_str()]))
         .unwrap_or_else(|| {
             panic!("a lane that assessed nothing must record that as a fact: {gaps:?}")
         });

--- a/crates/trusty-review/src/report/analyze_enrich.rs
+++ b/crates/trusty-review/src/report/analyze_enrich.rs
@@ -121,11 +121,14 @@ impl AnalyzeLaneCoverage {
             return None;
         }
         if self.succeeded == 0 {
+            // #6784: the headline is the shared constant, not a literal — the
+            // bundle index's dead-lane tally matches on it.
             return Some(format!(
-                "trusty-analyze lane DID NOT RUN — 0 of {attempted} application(s) assessed, \
+                "{headline} — 0 of {attempted} application(s) assessed, \
                  {failed} failed. No static-analysis pass contributed to this report, so every \
                  finding count, complexity figure, and health factor in it is UNASSESSED, not \
                  clean. Treat the report as covering the repository scan only (issue #6811).",
+                headline = trusty_common::review_gap_contract::ANALYZE_LANE_DEAD_HEADLINE,
                 attempted = self.attempted,
                 failed = failed,
             ));

--- a/crates/trusty-review/src/report/run_analyze.rs
+++ b/crates/trusty-review/src/report/run_analyze.rs
@@ -18,6 +18,7 @@
 //! a_partial_analyze_degradation_is_a_warning_not_a_failure,
 //! an_unattempted_analyze_lane_is_not_a_failure,
 //! a_client_that_will_not_build_counts_every_eligible_repository,
+//! a_dead_analyze_client_reads_as_a_dead_lane_downstream,
 //! the_request_analyze_timeout_beats_the_manifest}`.
 
 use anyhow::Result;
@@ -89,12 +90,9 @@ pub(super) async fn enrich_from_analyze(
             );
             // #5239: the client never existed, so no repo was assessed — that is
             // a whole-report gap, not a per-repo one.
-            model.gaps.push(
-                "trusty-analyze data unavailable — the analysis client could not be built, so no \
-                 application in this report was assessed against trusty-analyze. Findings, \
-                 complexity, and health factors are not assessed, not clean."
-                    .to_string(),
-            );
+            // #6784: it leads with the shared headline, so the bundle index
+            // counts it as the dead lane it is.
+            model.gaps.push(client_build_failure_gap());
             // #6811: no client means no repository was assessed, which is the
             // same total collapse the walk reports — counted over the
             // repositories the walk WOULD have attempted, so the verdict below
@@ -102,6 +100,29 @@ pub(super) async fn enrich_from_analyze(
             crate::report::AnalyzeLaneCoverage::never_ran(analyze_eligible_repositories(model))
         }
     }
+}
+
+/// The Gaps & Caveats line a client that would not build earns (#6784).
+///
+/// Why: this is the second of `trusty-review`'s two total-collapse paths, and
+/// it used to lead with "trusty-analyze data unavailable" while the other led
+/// with the phrase `trusty-audit`'s bundle index matches on. Under
+/// `--allow-degraded` a client-build collapse therefore shipped a report the
+/// index counted as a lane that RAN. Both paths now lead with the same shared
+/// headline, and the detail that distinguishes them follows it.
+/// It is a named function rather than an inline `format!` so the regression test
+/// can assert on the string this path actually produces rather than on a copy of
+/// it.
+/// What: [`trusty_common::review_gap_contract::ANALYZE_LANE_DEAD_HEADLINE`],
+/// then what this particular collapse was.
+/// Test: `run_tests::a_dead_analyze_client_reads_as_a_dead_lane_downstream`.
+pub(super) fn client_build_failure_gap() -> String {
+    format!(
+        "{headline} — the analysis client could not be built, so no application in this report \
+         was assessed against trusty-analyze. Findings, complexity, and health factors are not \
+         assessed, not clean (issue #6784).",
+        headline = trusty_common::review_gap_contract::ANALYZE_LANE_DEAD_HEADLINE,
+    )
 }
 
 /// Repositories the analyze walk would attempt, counted without walking (#6811).

--- a/crates/trusty-review/src/report/run_tests.rs
+++ b/crates/trusty-review/src/report/run_tests.rs
@@ -431,6 +431,49 @@ fn a_client_that_will_not_build_counts_every_eligible_repository() {
     );
 }
 
+/// #6784 regression, cross-crate. `trusty-audit`'s bundle index decides whether
+/// a report's analyze lane ran by matching one phrase against the report JSON's
+/// `gaps` list. `trusty-review` has TWO total-collapse paths, and this one — the
+/// client that would not build — used to lead with "trusty-analyze data
+/// unavailable", so under `--allow-degraded` the index counted it as a lane that
+/// RAN and undercounted `Rollup::analyze_lanes_dead()`.
+///
+/// The gap string here is produced by the real code path, and it is serialized
+/// through the same `ReportModel.gaps` field the reader reads before the shared
+/// predicate — `trusty_common::review_gap_contract::analyze_lane_is_dead`, the
+/// one `trusty_audit::grounding::coverage_rollup::read_coverage` calls — is
+/// applied to it. The two crates cannot import each other (DOC-67 §5 keeps the
+/// seam at a file), so the shared predicate is what binds this half to the
+/// `trusty-audit` half, `coverage_rollup_tests::a_gap_leading_with_the_shared_
+/// headline_is_a_dead_lane`.
+///
+/// Against `origin/main` at 0239a5388 the equivalent assertion fails: feeding
+/// that revision's client-build gap string to `read_coverage` yields
+/// `analyze_lane_dead: false`.
+#[test]
+fn a_dead_analyze_client_reads_as_a_dead_lane_downstream() {
+    let gap = crate::report::run_analyze::client_build_failure_gap();
+
+    // The reader sees this string only after it has been through the report's
+    // JSON twin, so the round trip is part of what is asserted.
+    let json = serde_json::json!({ "gaps": [gap] });
+    let gaps: Vec<&str> = json["gaps"]
+        .as_array()
+        .expect("gaps array")
+        .iter()
+        .filter_map(|g| g.as_str())
+        .collect();
+
+    assert!(
+        trusty_common::review_gap_contract::analyze_lane_is_dead(gaps),
+        "a client-build collapse must read downstream as a dead lane: {gap}"
+    );
+    assert!(
+        gap.contains("the analysis client could not be built"),
+        "the headline does not displace the detail that names WHICH collapse: {gap}"
+    );
+}
+
 // ── #6784: the investigation budget scales with the repository ───────────────
 
 /// #6784. A cap no tier named is the DEFAULT, and the default is what


### PR DESCRIPTION
## The finding

Post-merge critic finding on PR #6859 (HIGH), recorded on #6784.

`trusty-review` has two total analyze-lane collapse paths, and they led their
Gaps & Caveats line with different phrases:

- the walk-based collapse (`report/analyze_enrich.rs`, `AnalyzeLaneCoverage::record`)
  led with `trusty-analyze lane DID NOT RUN`;
- the client-build failure (`report/run_analyze.rs`, the `AnalyzeLaneCoverage::never_ran`
  arm) led with `trusty-analyze data unavailable`.

`trusty-audit`'s `grounding::coverage_rollup::read_coverage` matches the first
phrase. So with `--allow-degraded` — which `tga audit` always passes — a
client-build collapse shipped a report the bundle index rendered as a lane that
**ran**, and `Rollup::analyze_lanes_dead()` undercounted.

## Where the shared constant lives, and why

`trusty-audit` does **not** depend on `trusty-review`, and DOC-67 §5 keeps that
seam at a file rather than a Cargo edge. No dependency edge is added here.

The headline now has one definition in `trusty-common::review_gap_contract`,
alongside `analyze_lane_is_dead`, the predicate every reader applies.
`trusty-common` is the only crate both `trusty-review` and `trusty-audit`
already depend on, so both consume the shared definition with no new edge. This
is the `trusty_common::env_vars` precedent applied to report prose — that module
already carries constants `trusty-audit` writes and `trusty-review` reads, for
the same stated reason: a literal in each crate is the drift it exists to stop.

Version skew across the file boundary is unchanged and still real. What the
shared definition removes is two spellings inside one build.

`trusty-audit`'s `coverage_rollup::ANALYZE_LANE_DEAD_HEADLINE` stays a `const`
at the same public path, valued from the shared one, so nothing downstream
changes shape.

## What changed

- `crates/trusty-common/src/review_gap_contract.rs` (new): the headline constant
  and the reader predicate.
- `crates/trusty-review/src/report/run_analyze.rs`: `client_build_failure_gap()`
  leads with the shared headline and keeps its own detail after it.
- `crates/trusty-review/src/report/analyze_enrich.rs`: `record()` formats the
  same headline from the constant.
- `crates/trusty-audit/src/grounding/coverage_rollup.rs`: `read_coverage` routes
  through the shared predicate.

## The pre-fix failure

The regression is proved through the real consumer. Against `origin/main` at
`0239a5388`, feeding that revision's client-build gap string (quoted verbatim
from `run_analyze.rs:92-97`) into `read_coverage`:

```
running 5 tests
test grounding::coverage_rollup_tests::a_bundle_with_no_coverage_records_says_so ... ok
test grounding::coverage_rollup_tests::the_index_section_states_the_estate_share ... ok
test grounding::coverage_rollup_tests::prefix_demo_a_client_build_collapse_is_a_dead_lane ... FAILED
test grounding::coverage_rollup_tests::a_json_that_is_not_a_report_contributes_nothing ... ok
test grounding::coverage_rollup_tests::the_rollup_reads_every_report ... ok

failures:

---- grounding::coverage_rollup_tests::prefix_demo_a_client_build_collapse_is_a_dead_lane stdout ----

thread '...' panicked at crates/trusty-audit/src/grounding/coverage_rollup_tests.rs:153:5:
a total analyze collapse must roll up as a dead lane; gap was: trusty-analyze data unavailable — the analysis client could not be built, so no application in this report was assessed against trusty-analyze. Findings, complexity, and health factors are not assessed, not clean.

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 950 filtered out; finished in 0.01s
```

The shipped coverage is two tests bound by the shared constant, because the two
crates cannot import each other:

- `trusty-review` `run_tests::a_dead_analyze_client_reads_as_a_dead_lane_downstream`
  takes the gap string from the real code path, serializes it through the
  `ReportModel.gaps` field the reader reads, and applies
  `analyze_lane_is_dead` — the predicate `read_coverage` calls.
- `trusty-audit` `coverage_rollup_tests::a_gap_leading_with_the_shared_headline_is_a_dead_lane`
  asserts `read_coverage` recognises both writers' lines and still reads a
  partly degraded lane as live.
- `trusty-review` `analyze_adapter_tests::a_lane_that_failed_every_repository_is_recorded`
  now matches with the shared predicate instead of its own literal, so the walk
  path is held to the same rule.

## Gate — rung 4

| Command | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo check -p trusty-review -p trusty-audit -p trusty-common --all-targets` | exit 0 |
| `cargo clippy -p trusty-review -p trusty-audit --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p trusty-common --features unconditional-only --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-review --no-fail-fast` | ok — 2198 + 78 + 6 + 3 + 3 + 3 + 2 + 5 + 4 + 3 + 3 + 2 passed; 0 failed; 5 ignored across 12 targets |
| `cargo test -p trusty-audit --no-fail-fast` | ok — 950 + 3 + 5 + 4 + 4 + 8 + 9 passed; 0 failed; 7 ignored across 9 targets |
| `cargo test -p trusty-common --features unconditional-only --no-fail-fast review_gap_contract` | ok — 3 passed; 0 failed |
| `cargo check --workspace --all-targets` | exit 0 (85m41s) |
| `cargo test -p tga --no-fail-fast` | ok — 1574 + 1 + 1 + 1 + 2 + 8 + 1 + 10 passed; 0 failed; 9 ignored |

`tga` does not consume either changed surface in code — its only mention of the
headline is a doc comment in `audit/review.rs:259` — but it is a direct
`trusty-common` dependent, so its suite is run anyway.

Doc gates: `check_line_cap.sh` (4497 files, 0 violations), `check_test_pointers.sh`
(30755 citations, 0 dangling), `check_changelog_fragment.sh` (3 crates recorded),
`check_sld.sh` (0 errors) — all exit 0.

`check-pr-version-bump.sh` clear with no bumps: `trusty-review 0.35.0`,
`trusty-audit 0.14.1` and `trusty-common 0.48.0` are each unpublished, which the
gate passes as "version unchanged, not live on crates.io".

Refs #6784

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
