### PR TITLE
refactor(trusty-common): control_bus event types hoisted from trusty-agents-common (Refs #6846)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11397,6 +11397,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "trusty-common",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6606,7 +6606,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11379,7 +11379,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-common"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11618,7 +11618,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.5.0" }
 # epic #3411). Published as of #4713 so `trusty-code` can publish again; 0.1.0
 # is the first upload.
 trusty-code-tui = { path = "crates/trusty-code-tui", version = "0.1.0" }
-trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
+trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.7" }
 trusty-common = { path = "crates/trusty-common", version = "0.49" }
 # Shared JSON-RPC 2.0 / MCP protocol primitives, extracted from
 # `trusty_common::mcp` by ADR-0040 (#5803).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ trusty-code = { path = "crates/trusty-code", version = "0.5.0" }
 # is the first upload.
 trusty-code-tui = { path = "crates/trusty-code-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.6.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.48" }
+trusty-common = { path = "crates/trusty-common", version = "0.49" }
 # Shared JSON-RPC 2.0 / MCP protocol primitives, extracted from
 # `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { path = "crates/trusty-mcp", version = "0.1.2" }

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -12,11 +12,17 @@ name = "trusty-agents-common"
 # src/assets/agents/*.md (prose only — no item signature changed), which
 # scripts/check-pr-version-bump.sh requires be bumped in the same PR (#4421).
 #
-# PR #6846: patch bump. This PR moves the `events` envelope and lifecycle/filter
-# TYPES into `trusty_common::control_bus` and re-exports them from the same
-# `events` path. Every public item this crate exported still resolves at the
-# same path with the same shape, so no public item was removed or changed.
-version = "0.6.5"
+# 0.7.0 (#6846): minor — the breaking position for a 0.y.z crate. This PR moves
+# the `events` envelope and lifecycle/filter TYPES into
+# `trusty_common::control_bus` and re-exports them from the same `events` path.
+# Source-level that is compatible — `use trusty_agents_common::events::
+# HarnessEvent` still resolves, to the same type — but `cargo-semver-checks`
+# reports `enum_missing` / `struct_missing` for all five, because a cross-crate
+# re-export leaves no item definition in this crate's rustdoc. The crate also
+# gains a required `trusty-common ^0.49` dependency, which does change what a
+# published consumer resolves. The gate is never advisory (#5050), so the bump
+# goes to the position the gate names rather than being argued down.
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -11,7 +11,12 @@ name = "trusty-agents-common"
 # PR #6764: patch bump. 0.6.3 is live on crates.io and this PR edits
 # src/assets/agents/*.md (prose only — no item signature changed), which
 # scripts/check-pr-version-bump.sh requires be bumped in the same PR (#4421).
-version = "0.6.4"
+#
+# PR #6846: patch bump. This PR moves the `events` envelope and lifecycle/filter
+# TYPES into `trusty_common::control_bus` and re-exports them from the same
+# `events` path. Every public item this crate exported still resolves at the
+# same path with the same shape, so no public item was removed or changed.
+version = "0.6.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -36,6 +41,12 @@ serde_yaml = { workspace = true }
 # Wave 1 (issue #862): session_registry.rs needs anyhow + chrono.
 anyhow = { workspace = true }
 chrono = { workspace = true }
+# #6846: the `events` envelope and lifecycle/filter TYPES moved to
+# `trusty_common::control_bus`, so trusty-console (the one event bus, owner
+# ruling 2026-09-05) can consume them without depending on this producer.
+# `events` re-exports them; the in-process channel and stderr relay stay here
+# until slice 9 (#6854).
+trusty-common = { workspace = true }
 # adapters/patterns.rs uses regex for pattern compilation.
 regex = { workspace = true }
 # Wave 3 P0 (issue #875): events::bus uses tokio::sync::broadcast for the

--- a/crates/trusty-agents-common/changelog.d/6846-events-types-reexported.md
+++ b/crates/trusty-agents-common/changelog.d/6846-events-types-reexported.md
@@ -3,6 +3,9 @@ Changed
 - `events` now re-exports `HarnessEvent`, `HarnessPayload`, `LifecycleEvent`,
   `HarnessSource` and `Filter` from the new `trusty_common::control_bus` instead
   of declaring them. Every name resolves at the same `events::*` path with the
-  same shape, so no consumer changes. The process-global broadcast channel, the
-  `__OMPM_EVENT__` stderr relay, `Lag`, `BusClosed` and `CHANNEL_CAPACITY` stay
-  here — the transport is not the type. (#6846)
+  same shape, so no source change is needed in a consumer. The process-global
+  broadcast channel, the `__OMPM_EVENT__` stderr relay, `Lag`, `BusClosed` and
+  `CHANNEL_CAPACITY` stay here — the transport is not the type. Shipped as
+  `0.7.0`: `cargo-semver-checks` reports the five as removed, because a
+  cross-crate re-export leaves no item definition in this crate's rustdoc, and
+  the crate now requires `trusty-common ^0.49`. (#6846)

--- a/crates/trusty-agents-common/changelog.d/6846-events-types-reexported.md
+++ b/crates/trusty-agents-common/changelog.d/6846-events-types-reexported.md
@@ -1,0 +1,8 @@
+Changed
+
+- `events` now re-exports `HarnessEvent`, `HarnessPayload`, `LifecycleEvent`,
+  `HarnessSource` and `Filter` from the new `trusty_common::control_bus` instead
+  of declaring them. Every name resolves at the same `events::*` path with the
+  same shape, so no consumer changes. The process-global broadcast channel, the
+  `__OMPM_EVENT__` stderr relay, `Lag`, `BusClosed` and `CHANNEL_CAPACITY` stay
+  here — the transport is not the type. (#6846)

--- a/crates/trusty-agents-common/src/events/bus.rs
+++ b/crates/trusty-agents-common/src/events/bus.rs
@@ -1,34 +1,32 @@
-//! Process-global event bus, the `HarnessEvent` envelope, and the
-//! lagged-receiver helper for the unified harness event stream (ADR-0005).
+//! Process-global event bus and the lagged-receiver helper for the unified
+//! harness event stream (ADR-0005).
 //!
 //! Why: Threading a `broadcast::Sender<HarnessEvent>` through every code path
 //!      that might emit telemetry (workflow engine, agent runners, hooks,
 //!      ctrl) would touch hundreds of function signatures. A `OnceLock` mirrors
 //!      how `tracing` solves the same problem — emit-from-anywhere with zero
-//!      overhead when no one is listening. The envelope wraps the per-domain
-//!      payload with cross-cutting metadata (source, session, monotonic seq,
-//!      timestamp) so any subscriber can order, correlate, and route events
-//!      without inspecting the payload.
-//! What: Defines `HarnessPayload` (the domain-tagged inner union),
-//!       `HarnessEvent` (the envelope), the process-global `EVENT_BUS`, a
-//!       monotonic `SEQ` counter, `bus`/`subscribe`/`publish`/`emit` helpers,
-//!       the `__OMPM_EVENT__` stderr relay prefix, and a `Lag` notice with
-//!       `recv_with_lag` so a lagged subscriber is told how many events it
-//!       skipped and can resume instead of tearing down its stream. A closed
-//!       channel ends that stream with the terminal `BusClosed` error.
-//! Test: `super::tests` covers serde round-trips of each payload arm, seq
-//!       monotonicity, lagged handling against a constructible test bus, and
-//!       the emit-line formatting helper.
+//!      overhead when no one is listening.
+//! What: Defines the process-global `EVENT_BUS`, a monotonic `SEQ` counter,
+//!       `bus`/`subscribe`/`publish`/`emit` helpers, the `__OMPM_EVENT__`
+//!       stderr relay prefix, and a `Lag` notice with `recv_with_lag` so a
+//!       lagged subscriber is told how many events it skipped and can resume
+//!       instead of tearing down its stream. A closed channel ends that stream
+//!       with the terminal `BusClosed` error. The envelope this transports —
+//!       `HarnessEvent`, `HarnessPayload`, and the lifecycle taxonomy — lives
+//!       in `trusty_common::control_bus`.
+//! Test: `super::tests` covers seq monotonicity, lagged handling against a
+//!       constructible test bus, and the emit-line formatting helper.
+
+// #6846: the envelope and lifecycle/filter TYPES moved to
+// `trusty_common::control_bus`; this file keeps the transport that moves them.
+// The in-process channel itself is removed in slice 9 (#6854).
 
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use chrono::Utc;
 use tokio::sync::broadcast;
-
-use super::lifecycle::{HarnessSource, LifecycleEvent};
+use trusty_common::control_bus::{HarnessEvent, HarnessPayload, HarnessSource};
 
 /// Stderr line prefix used to relay events from a child process to its parent.
 ///
@@ -62,75 +60,6 @@ pub const EVENT_LINE_PREFIX: &str = "__OMPM_EVENT__ ";
 /// What: Used both for the process-global bus and as the default for the
 ///       test-only constructible bus.
 pub const CHANNEL_CAPACITY: usize = 1024;
-
-/// Domain-tagged inner union carried inside a `HarnessEvent`.
-///
-/// Why: The "adapt, don't fold" decision (ADR-0005): rather than flattening
-///      lifecycle, hook, and keepalive events into one giant enum, we tag by
-///      *domain* so each harness can grow its own payload taxonomy
-///      independently. Hooks in particular are open-ended (arbitrary
-///      tool/event names + JSON data), so they get an untyped `Value` arm
-///      instead of being modelled variant-by-variant.
-/// What: `serde(tag = "domain", content = "event")` produces
-///       `{"domain":"lifecycle","event":{...}}`, `{"domain":"hook","event":
-///       {"kind":...,"data":...}}`, or `{"domain":"ping"}`. `Ping` is the
-///       transport keepalive (promoted out of the lifecycle enum).
-/// Test: `super::tests::payload_*_round_trips` assert the tag shape for each
-///       arm.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "domain", content = "event", rename_all = "snake_case")]
-pub enum HarnessPayload {
-    /// A structured PM-lifecycle event (session/agent/tool/phase/LLM/...).
-    Lifecycle(LifecycleEvent),
-    /// An open-ended hook event: `kind` names the hook, `data` is its payload.
-    Hook { kind: String, data: Value },
-    /// Transport keepalive so long-lived SSE connections don't time out.
-    Ping,
-}
-
-impl HarnessPayload {
-    /// The domain string for this payload (`"lifecycle"`, `"hook"`, `"ping"`).
-    ///
-    /// Why: `Filter` matches on the domain without serialising the whole
-    ///      payload; keeping the mapping here is the single source of truth.
-    /// What: Returns the same string serde uses for the `domain` tag.
-    /// Test: `super::tests::payload_domain_matches_serde_tag`.
-    pub fn domain(&self) -> &'static str {
-        match self {
-            HarnessPayload::Lifecycle(_) => "lifecycle",
-            HarnessPayload::Hook { .. } => "hook",
-            HarnessPayload::Ping => "ping",
-        }
-    }
-}
-
-/// Cross-harness event envelope: metadata + domain-tagged payload.
-///
-/// Why: Subscribers need to order (`seq`), time-stamp (`at`), attribute
-///      (`source`), and correlate (`session`) events uniformly, regardless of
-///      which harness produced them or which domain the payload belongs to.
-///      Carrying that metadata in the envelope keeps the payload taxonomies
-///      free of repeated bookkeeping fields.
-/// What: `source` is the originating harness; `session` is the optional task
-///       correlation key (omitted from JSON when `None`); `seq` is a
-///       process-monotonic counter; `at` is the emit-time UTC timestamp;
-///       `payload` is the domain-tagged union. All fields derive serde.
-/// Test: `super::tests::harness_event_round_trips` and the per-arm payload
-///       tests build full envelopes.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct HarnessEvent {
-    /// Which harness produced this event.
-    pub source: HarnessSource,
-    /// Optional task/session correlation key. Omitted from JSON when absent.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session: Option<String>,
-    /// Process-monotonic sequence number assigned at publish time.
-    pub seq: u64,
-    /// Emit-time UTC timestamp.
-    pub at: DateTime<Utc>,
-    /// Domain-tagged payload.
-    pub payload: HarnessPayload,
-}
 
 /// Notice that a subscriber fell behind and skipped `skipped` events.
 ///

--- a/crates/trusty-agents-common/src/events/mod.rs
+++ b/crates/trusty-agents-common/src/events/mod.rs
@@ -8,24 +8,31 @@
 //!      Phase 0 lands the *foundation only* — the types, the bus, the
 //!      subscription API, and a lightweight filter — with no consumers wired
 //!      yet. The migration of existing emit sites happens in P1–P4.
-//! What: A thin facade that re-exports the public surface from three focused
-//!       submodules (respecting the 500-line cap): `lifecycle` (the
-//!       `HarnessSource` + `LifecycleEvent` taxonomy), `bus` (the
-//!       `HarnessEvent`/`HarnessPayload` envelope, the global bus, and the
-//!       lagged-receiver helper), and `filter` (the subscriber-side `Filter`).
+//! What: A thin facade over two sources. `bus` (local) owns the process-global
+//!       broadcast channel, the stderr relay prefix, and the lagged-receiver
+//!       helper. The types those move — the `HarnessEvent`/`HarnessPayload`
+//!       envelope, the `HarnessSource` + `LifecycleEvent` taxonomy, and the
+//!       subscriber-side `Filter` — now live in `trusty_common::control_bus`
+//!       and are re-exported here, so this module's public surface is
+//!       unchanged for existing consumers.
 //! Test: `tests` (below) is the comprehensive suite for this foundation type;
 //!       submodules document which test exercises each item.
 
 mod bus;
-mod filter;
-mod lifecycle;
 
 pub use bus::{
-    BusClosed, CHANNEL_CAPACITY, EVENT_LINE_PREFIX, HarnessEvent, HarnessPayload, Lag, bus, emit,
-    format_event_line, publish, recv_with_lag, subscribe,
+    BusClosed, CHANNEL_CAPACITY, EVENT_LINE_PREFIX, Lag, bus, emit, format_event_line, publish,
+    recv_with_lag, subscribe,
 };
-pub use filter::Filter;
-pub use lifecycle::{HarnessSource, LifecycleEvent};
+
+// #6846: the types are defined in `trusty_common::control_bus` so trusty-console
+// (the one event bus) can consume them without depending on this producer. They
+// are re-exported rather than moved out of this path, which keeps every existing
+// `trusty_agents_common::events::*` import — and this module's own tests —
+// compiling unchanged.
+pub use trusty_common::control_bus::{
+    Filter, HarnessEvent, HarnessPayload, HarnessSource, LifecycleEvent,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -188,7 +188,7 @@ lru = "0.16"
 #      CTO DB tools became reachable declaratively via the `cto-db` Python
 #      skill. This `install_plugins` mechanism remains available for any
 #      future private launcher.
-trusty-agents-common = { path = "../trusty-agents-common", version = "0.6.0" }
+trusty-agents-common = { path = "../trusty-agents-common", version = "0.7" }
 
 # [patch.crates-io] moved to workspace root Cargo.toml (Cargo requires
 # [patch] tables to live in the workspace root; see #460 for context).

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -69,7 +69,13 @@ name = "trusty-common"
 # what a published crate owes a new public module. Same reasoning as 0.44.0's
 # `uds::server`. Nothing existing was removed or changed; the module's contents
 # are moved verbatim out of trusty-search, which never published them.
-version = "0.48.0"
+# 0.49.0 (#6846): minor — the new public `control_bus` module is additive, and
+# under Cargo's 0.x rule a MINOR bump is what a published crate owes a new public
+# module. Same reasoning as 0.44.0's `uds::server` and 0.48.0's `machine_tier`.
+# Nothing existing was removed or changed, and the module adds no dependency:
+# `serde`, `serde_json` and `chrono` are already unconditional here, so it is
+# ungated rather than sitting behind a feature.
+version = "0.49.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/6846-control-bus-types.md
+++ b/crates/trusty-common/changelog.d/6846-control-bus-types.md
@@ -1,0 +1,11 @@
+Added
+
+- New public `control_bus` module carrying the shared event types every harness
+  and trusty-console agree on: the `HarnessEvent` envelope, its `HarnessPayload`
+  domain union, the `LifecycleEvent` / `HarnessSource` taxonomy, and the
+  subscriber-side `Filter`. Moved verbatim from `trusty_agents_common::events`
+  so consuming the envelope no longer means depending on a producer crate.
+  Types only — no channel and no global state, enforced against the module's own
+  sources by `control_bus::tests::control_bus_declares_no_transport`. Ungated:
+  `serde`, `serde_json` and `chrono` were already unconditional, so the module
+  adds no dependency. (#6846)

--- a/crates/trusty-common/src/control_bus/envelope.rs
+++ b/crates/trusty-common/src/control_bus/envelope.rs
@@ -1,0 +1,98 @@
+//! The `HarnessEvent` envelope and its domain-tagged `HarnessPayload` union.
+//!
+//! Why: Producers stamp events here and trusty-console consumes them there, so
+//!      the envelope has to be a type both sides link against. Carrying
+//!      `source`, `session`, `seq` and `at` on the envelope keeps each domain's
+//!      payload taxonomy free of repeated bookkeeping fields, and lets a
+//!      subscriber order, correlate and route an event without decoding what is
+//!      inside it.
+//! What: Defines `HarnessPayload` (the domain-tagged inner union) and
+//!       `HarnessEvent` (the envelope). Types only — the transport that fills
+//!       `seq` and `at`, and the channel these travel over, belong to whoever
+//!       owns the bus.
+//! Test: `super::tests::harness_event_round_trips`,
+//!       `super::tests::harness_event_omits_none_session`,
+//!       `super::tests::payload_lifecycle_round_trips`,
+//!       `super::tests::payload_hook_round_trips`,
+//!       `super::tests::payload_ping_round_trips`,
+//!       `super::tests::payload_domain_matches_serde_tag`.
+
+// #6846: `HarnessPayload` and `HarnessEvent` moved here from
+// `trusty_agents_common::events::bus`; that module keeps its stderr transport.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::lifecycle::{HarnessSource, LifecycleEvent};
+
+/// Domain-tagged inner union carried inside a `HarnessEvent`.
+///
+/// Why: The "adapt, don't fold" decision (ADR-0005): rather than flattening
+///      lifecycle, hook, and keepalive events into one giant enum, we tag by
+///      *domain* so each harness can grow its own payload taxonomy
+///      independently. Hooks in particular are open-ended (arbitrary
+///      tool/event names + JSON data), so they get an untyped `Value` arm
+///      instead of being modelled variant-by-variant.
+/// What: `serde(tag = "domain", content = "event")` produces
+///       `{"domain":"lifecycle","event":{...}}`, `{"domain":"hook","event":
+///       {"kind":...,"data":...}}`, or `{"domain":"ping"}`. `Ping` is the
+///       transport keepalive, kept out of the lifecycle enum.
+/// Test: `super::tests::payload_lifecycle_round_trips`,
+///       `super::tests::payload_hook_round_trips`,
+///       `super::tests::payload_ping_round_trips`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "domain", content = "event", rename_all = "snake_case")]
+pub enum HarnessPayload {
+    /// A structured PM-lifecycle event (session/agent/tool/phase/LLM/...).
+    Lifecycle(LifecycleEvent),
+    /// An open-ended hook event: `kind` names the hook, `data` is its payload.
+    Hook { kind: String, data: Value },
+    /// Transport keepalive so long-lived SSE connections don't time out.
+    Ping,
+}
+
+impl HarnessPayload {
+    /// The domain string for this payload (`"lifecycle"`, `"hook"`, `"ping"`).
+    ///
+    /// Why: `Filter` matches on the domain without serialising the whole
+    ///      payload; keeping the mapping here is the single source of truth.
+    /// What: Returns the same string serde uses for the `domain` tag.
+    /// Test: `super::tests::payload_domain_matches_serde_tag`.
+    pub fn domain(&self) -> &'static str {
+        match self {
+            HarnessPayload::Lifecycle(_) => "lifecycle",
+            HarnessPayload::Hook { .. } => "hook",
+            HarnessPayload::Ping => "ping",
+        }
+    }
+}
+
+/// Cross-harness event envelope: metadata plus domain-tagged payload.
+///
+/// Why: Subscribers order (`seq`), time-stamp (`at`), attribute (`source`) and
+///      correlate (`session`) events uniformly, whichever harness produced them
+///      and whichever domain the payload belongs to. Holding that metadata on
+///      the envelope keeps the payload taxonomies free of repeated bookkeeping
+///      fields.
+/// What: `source` is the originating harness; `session` is the optional task
+///       correlation key (omitted from JSON when `None`); `seq` is a
+///       process-monotonic counter assigned by the producer; `at` is the
+///       emit-time UTC timestamp; `payload` is the domain-tagged union. All
+///       fields are public so a producer can stamp one by struct literal.
+/// Test: `super::tests::harness_event_round_trips` and
+///       `super::tests::harness_event_omits_none_session`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessEvent {
+    /// Which harness produced this event.
+    pub source: HarnessSource,
+    /// Optional task/session correlation key. Omitted from JSON when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+    /// Process-monotonic sequence number assigned at publish time.
+    pub seq: u64,
+    /// Emit-time UTC timestamp.
+    pub at: DateTime<Utc>,
+    /// Domain-tagged payload.
+    pub payload: HarnessPayload,
+}

--- a/crates/trusty-common/src/control_bus/filter.rs
+++ b/crates/trusty-common/src/control_bus/filter.rs
@@ -1,19 +1,21 @@
-//! Subscriber-side event filter for the unified harness bus (ADR-0005).
+//! Subscriber-side event filter over `HarnessEvent`.
 //!
-//! Why: The global bus broadcasts *everything* to *every* subscriber. A given
-//!      consumer (a task-scoped SSE stream, a single-harness relay, a
-//!      hook-only aggregator) usually wants a slice of that firehose. Rather
-//!      than running N filtered channels, subscribers filter in their own recv
-//!      loop with a small predicate. Phase 0 deliberately avoids adding a
-//!      Stream dependency: `Filter::matches` is the lightweight primitive
-//!      consumers will call inside `recv_with_lag` loops in later phases.
+//! Why: The bus delivers everything to every subscriber. A given consumer (a
+//!      task-scoped SSE stream, a single-harness relay, a hook-only
+//!      aggregator) usually wants a slice of that firehose. Rather than running
+//!      N filtered channels, subscribers filter in their own receive loop with
+//!      a small predicate. Keeping the predicate beside the envelope it matches
+//!      on means the producer and the consumer agree on what a filter means.
 //! What: A `Filter` of optional constraints (source, session, domains) plus a
-//!       `matches` predicate that ANDs the present constraints. An empty /
+//!       `matches` predicate that ANDs the present constraints. An empty or
 //!       default filter matches everything.
-//! Test: `super::tests::filter_*` cover each axis, combinations, and the
-//!       default-matches-all case.
+//! Test: `super::tests::filter_default_matches_all`,
+//!       `super::tests::filter_by_source`, `super::tests::filter_by_session`,
+//!       `super::tests::filter_by_domain`, `super::tests::filter_combination`.
 
-use super::bus::HarnessEvent;
+// #6846: moved verbatim from `trusty_agents_common::events::filter`.
+
+use super::envelope::HarnessEvent;
 use super::lifecycle::HarnessSource;
 
 /// A conjunctive (AND) filter over `HarnessEvent`s.
@@ -50,8 +52,11 @@ impl Filter {
     ///       requires the event to carry that exact session (events with
     ///       `session = None` do not match a session constraint). A `domains`
     ///       constraint matches if the event's domain is in the list.
-    /// Test: `super::tests::filter_by_source`, `filter_by_session`,
-    ///       `filter_by_domain`, `filter_combination`, `filter_default_matches_all`.
+    /// Test: `super::tests::filter_by_source`,
+    ///       `super::tests::filter_by_session`,
+    ///       `super::tests::filter_by_domain`,
+    ///       `super::tests::filter_combination`,
+    ///       `super::tests::filter_default_matches_all`.
     pub fn matches(&self, ev: &HarnessEvent) -> bool {
         if let Some(source) = self.source
             && source != ev.source

--- a/crates/trusty-common/src/control_bus/lifecycle.rs
+++ b/crates/trusty-common/src/control_bus/lifecycle.rs
@@ -1,27 +1,30 @@
-//! Lifecycle event taxonomy + harness source enum for the shared event bus.
+//! Lifecycle event taxonomy and harness source enum for the control bus.
 //!
-//! Why: Wave 3 unifies the three harnesses (trusty-agents, trusty-mpm,
-//!      trusty-code) onto a single event envelope (see ADR-0005). The richest
-//!      existing event taxonomy is `trusty-agents::events::Event` — the full PM
-//!      lifecycle. To avoid a flag-day rewrite, Phase 0 *copies* that taxonomy
-//!      here as `LifecycleEvent` (minus `Ping`, which becomes a transport-level
-//!      `HarnessPayload::Ping` arm). The de-duplication / migration of the
-//!      original `trusty-agents` enum happens in later phases (P1/P2); for now
-//!      this is purely additive and wires up no consumers.
+//! Why: trusty-console hosts the only event bus (owner ruling 2026-09-05,
+//!      superseding DOC-73 §4.1 Option C). Every producer — trusty-agents,
+//!      trusty-mpm, trusty-code — pushes to it, so the taxonomy those producers
+//!      and that consumer agree on cannot live inside any one of them. Hoisting
+//!      it here gives all four crates one definition to compile against instead
+//!      of a producer depending on a sibling producer.
 //! What: Defines `HarnessSource` (which harness produced an event) and
 //!       `LifecycleEvent` (the per-domain lifecycle taxonomy), both
 //!       serde-round-trippable with stable snake_case wire tags.
-//! Test: `super::tests` round-trips representative variants and asserts the
-//!       `{"type": ...}` tag shape; `session_id` is covered there too.
+//! Test: `super::tests::harness_source_round_trips`,
+//!       `super::tests::lifecycle_event_serializes_with_type_tag`,
+//!       `super::tests::lifecycle_session_id_returns_correct_field`,
+//!       `super::tests::lifecycle_recap_round_trips`.
+
+// #6846: moved verbatim from `trusty_agents_common::events::lifecycle`. The
+// serde tags are read by separate processes — renaming one breaks the wire.
 
 use serde::{Deserialize, Serialize};
 
 /// Which harness emitted an event.
 ///
-/// Why: Once all three harnesses share one bus, a subscriber (UI, relay,
-///      aggregator) must be able to tell trusty-agents events from trusty-mpm
-///      or trusty-code events without inspecting the payload. Encoding the
-///      origin in the envelope keeps that routing decision O(1) and explicit.
+/// Why: With all three harnesses pushing to one bus, a subscriber (UI, relay,
+///      aggregator) must tell trusty-agents events from trusty-mpm or
+///      trusty-code events without inspecting the payload. Encoding the origin
+///      in the envelope keeps that routing decision O(1) and explicit.
 /// What: A copy-able enum with three variants serialising as snake_case
 ///       (`"agents"`, `"mpm"`, `"code"`).
 /// Test: `super::tests::harness_source_round_trips`.
@@ -42,16 +45,16 @@ pub enum HarnessSource {
 ///      `serde(tag = "type")` produces `{"type":"agent_message", ...}` so the
 ///      UI can pattern-match on type and the back-end can grow new variants
 ///      without breaking older clients (unknown variants degrade to "ignored
-///      event"). This is a verbatim copy of `trusty-agents::events::Event`
-///      *minus* the `Ping` keepalive, which is promoted to a transport-level
-///      `HarnessPayload::Ping` arm (keepalives are not a lifecycle concern).
+///      event"). Keepalives are not a lifecycle concern, so they sit on the
+///      envelope as `HarnessPayload::Ping` rather than as a variant here.
 /// What: Variants cover the full PM lifecycle — session, PM activity, agent
 ///       activity, tool calls, AST analysis, workflow phases, persona
 ///       detection, LLM call lifecycle, and report/recap generation.
 ///       `session_id` correlates events to a specific task; the UI filters by
 ///       session when scoped to a task view.
 /// Test: `super::tests::lifecycle_event_serializes_with_type_tag` asserts the
-///       wire shape; `super::tests::lifecycle_session_id_*` cover the helper.
+///       wire shape; `super::tests::lifecycle_recap_round_trips` covers a
+///       structured variant.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LifecycleEvent {
@@ -206,8 +209,8 @@ pub enum LifecycleEvent {
 impl LifecycleEvent {
     /// Return the event's `session_id` if it has one.
     ///
-    /// Why: Filtering the broadcast stream to a single task subscription needs
-    ///      a uniform accessor across the ~21 variants without each call site
+    /// Why: Filtering the event stream to a single task subscription needs a
+    ///      uniform accessor across the ~21 variants without each call site
     ///      re-matching. Every current variant carries a session, but the
     ///      `Option` keeps the contract stable if a session-less lifecycle
     ///      variant is ever added.

--- a/crates/trusty-common/src/control_bus/mod.rs
+++ b/crates/trusty-common/src/control_bus/mod.rs
@@ -1,0 +1,33 @@
+//! Shared event types for the control bus — types only, no transport.
+//!
+//! Why: Owner ruling 2026-09-05 (superseding DOC-73 §4.1 Option C) makes
+//!      trusty-console the one and only event bus. Every harness —
+//!      trusty-agents, trusty-mpm, trusty-code — is a producer that pushes to
+//!      it. Producers and that consumer must agree on the envelope, so the
+//!      envelope cannot live inside any one producer: before this module,
+//!      reaching these types meant depending on `trusty-agents-common`, which
+//!      is a sibling producer, not a shared library. Hoisting the types here
+//!      gives all four crates one definition and no producer-to-producer edge.
+//! What: Re-exports `HarnessSource` and `LifecycleEvent` (the taxonomy),
+//!       `HarnessPayload` and `HarnessEvent` (the envelope), and `Filter` (the
+//!       subscriber-side predicate). Nothing here transports an event: no
+//!       channel, no process-global sender, no sequence counter. A producer
+//!       stamps `seq` and `at` itself and hands the envelope to whatever moves
+//!       it; the bus that owns delivery is trusty-console's.
+//! Test: `tests` below covers serde round-trips and the filter matrix, and
+//!       `tests::control_bus_declares_no_transport` reads this module's own
+//!       sources to keep the types-only boundary from eroding.
+
+// #6846: hoisted out of `trusty_agents_common::events`, which keeps its
+// in-process channel and stderr relay until slice 9 (#6854) removes them.
+
+mod envelope;
+mod filter;
+mod lifecycle;
+
+pub use envelope::{HarnessEvent, HarnessPayload};
+pub use filter::Filter;
+pub use lifecycle::{HarnessSource, LifecycleEvent};
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-common/src/control_bus/tests.rs
+++ b/crates/trusty-common/src/control_bus/tests.rs
@@ -1,0 +1,335 @@
+//! Coverage for the `control_bus` event types and the types-only boundary.
+//!
+//! Why: The types moved here from `trusty-agents-common` (#6846) are a wire
+//!      contract between separate processes, so their serde shapes need
+//!      assertions that live beside the definitions rather than in the crate
+//!      they left. The boundary itself also needs a gate: the owner ruling that
+//!      put the bus in trusty-console only holds as long as nothing grows a
+//!      channel back into this module.
+//! What: Serde round-trips for each type and tag shape, the `Filter` matrix,
+//!       and `control_bus_declares_no_transport`, which reads this module's own
+//!       sources at compile time and fails on any transport spelling.
+//! Test: this file.
+
+use super::*;
+use serde_json::json;
+
+fn sample_lifecycle() -> LifecycleEvent {
+    LifecycleEvent::PmThinking {
+        session_id: "s1".into(),
+        text: "considering options".into(),
+    }
+}
+
+fn envelope(payload: HarnessPayload, session: Option<&str>) -> HarnessEvent {
+    HarnessEvent {
+        source: HarnessSource::Agents,
+        session: session.map(str::to_string),
+        seq: 0,
+        at: chrono::Utc::now(),
+        payload,
+    }
+}
+
+// ---- HarnessSource ----
+
+#[test]
+fn harness_source_round_trips() {
+    for (src, tag) in [
+        (HarnessSource::Agents, "\"agents\""),
+        (HarnessSource::Mpm, "\"mpm\""),
+        (HarnessSource::Code, "\"code\""),
+    ] {
+        let s = serde_json::to_string(&src).expect("serialize source");
+        assert_eq!(s, tag);
+        let back: HarnessSource = serde_json::from_str(&s).expect("deserialize source");
+        assert_eq!(back, src);
+    }
+}
+
+// ---- LifecycleEvent ----
+
+#[test]
+fn lifecycle_event_serializes_with_type_tag() {
+    let s = serde_json::to_string(&sample_lifecycle()).expect("serialize");
+    assert!(s.contains("\"type\":\"pm_thinking\""), "{s}");
+    assert!(s.contains("\"session_id\":\"s1\""), "{s}");
+}
+
+#[test]
+fn lifecycle_session_id_returns_correct_field() {
+    let ev = LifecycleEvent::AgentMessage {
+        session_id: "abc".into(),
+        agent: "python".into(),
+        text: "hi".into(),
+    };
+    assert_eq!(ev.session_id(), Some("abc"));
+}
+
+#[test]
+fn lifecycle_recap_round_trips() {
+    let ev = LifecycleEvent::RecapGenerated {
+        session_id: "s9".into(),
+        summary: "did a thing".into(),
+        table_rows: vec![("step".into(), "ok".into())],
+    };
+    let s = serde_json::to_string(&ev).expect("serialize recap");
+    let back: LifecycleEvent = serde_json::from_str(&s).expect("deserialize recap");
+    assert_eq!(back, ev);
+}
+
+// ---- HarnessPayload tag shapes ----
+
+#[test]
+fn payload_lifecycle_round_trips() {
+    let p = HarnessPayload::Lifecycle(sample_lifecycle());
+    let s = serde_json::to_string(&p).expect("serialize");
+    assert!(s.contains("\"domain\":\"lifecycle\""), "{s}");
+    assert!(s.contains("\"event\":{"), "{s}");
+    assert!(s.contains("\"type\":\"pm_thinking\""), "{s}");
+    let back: HarnessPayload = serde_json::from_str(&s).expect("deserialize");
+    assert_eq!(back, p);
+}
+
+#[test]
+fn payload_hook_round_trips() {
+    let p = HarnessPayload::Hook {
+        kind: "pre_tool_use".into(),
+        data: json!({"tool": "bash", "ok": true}),
+    };
+    let s = serde_json::to_string(&p).expect("serialize");
+    assert!(s.contains("\"domain\":\"hook\""), "{s}");
+    assert!(s.contains("\"kind\":\"pre_tool_use\""), "{s}");
+    let back: HarnessPayload = serde_json::from_str(&s).expect("deserialize");
+    assert_eq!(back, p);
+}
+
+#[test]
+fn payload_ping_round_trips() {
+    let p = HarnessPayload::Ping;
+    let s = serde_json::to_string(&p).expect("serialize");
+    assert_eq!(s, "{\"domain\":\"ping\"}");
+    let back: HarnessPayload = serde_json::from_str(&s).expect("deserialize");
+    assert_eq!(back, p);
+}
+
+#[test]
+fn payload_domain_matches_serde_tag() {
+    assert_eq!(
+        HarnessPayload::Lifecycle(sample_lifecycle()).domain(),
+        "lifecycle"
+    );
+    assert_eq!(
+        HarnessPayload::Hook {
+            kind: "x".into(),
+            data: json!(null)
+        }
+        .domain(),
+        "hook"
+    );
+    assert_eq!(HarnessPayload::Ping.domain(), "ping");
+}
+
+// ---- HarnessEvent envelope ----
+
+#[test]
+fn harness_event_round_trips() {
+    let ev = envelope(HarnessPayload::Ping, Some("sess-1"));
+    let s = serde_json::to_string(&ev).expect("serialize");
+    assert!(s.contains("\"source\":\"agents\""), "{s}");
+    assert!(s.contains("\"session\":\"sess-1\""), "{s}");
+    let back: HarnessEvent = serde_json::from_str(&s).expect("deserialize");
+    assert_eq!(back, ev);
+}
+
+#[test]
+fn harness_event_omits_none_session() {
+    let ev = envelope(HarnessPayload::Ping, None);
+    let s = serde_json::to_string(&ev).expect("serialize");
+    assert!(!s.contains("session"), "session should be omitted: {s}");
+}
+
+// ---- Filter matrix ----
+
+#[test]
+fn filter_default_matches_all() {
+    let f = Filter::default();
+    assert!(f.matches(&envelope(HarnessPayload::Ping, None)));
+    assert!(f.matches(&envelope(
+        HarnessPayload::Lifecycle(sample_lifecycle()),
+        Some("x")
+    )));
+}
+
+#[test]
+fn filter_by_source() {
+    let f = Filter {
+        source: Some(HarnessSource::Mpm),
+        ..Default::default()
+    };
+    let mut ev = envelope(HarnessPayload::Ping, None);
+    ev.source = HarnessSource::Mpm;
+    assert!(f.matches(&ev));
+    ev.source = HarnessSource::Agents;
+    assert!(!f.matches(&ev));
+}
+
+#[test]
+fn filter_by_session() {
+    let f = Filter {
+        session: Some("sess-7".into()),
+        ..Default::default()
+    };
+    assert!(f.matches(&envelope(HarnessPayload::Ping, Some("sess-7"))));
+    assert!(!f.matches(&envelope(HarnessPayload::Ping, Some("other"))));
+    // An event with no session never matches a session constraint.
+    assert!(!f.matches(&envelope(HarnessPayload::Ping, None)));
+}
+
+#[test]
+fn filter_by_domain() {
+    let f = Filter {
+        domains: Some(vec!["hook", "ping"]),
+        ..Default::default()
+    };
+    assert!(f.matches(&envelope(HarnessPayload::Ping, None)));
+    assert!(f.matches(&envelope(
+        HarnessPayload::Hook {
+            kind: "k".into(),
+            data: json!({})
+        },
+        None
+    )));
+    assert!(!f.matches(&envelope(
+        HarnessPayload::Lifecycle(sample_lifecycle()),
+        Some("x")
+    )));
+}
+
+#[test]
+fn filter_combination() {
+    let f = Filter {
+        source: Some(HarnessSource::Code),
+        session: Some("s".into()),
+        domains: Some(vec!["lifecycle"]),
+    };
+    let mut ev = envelope(HarnessPayload::Lifecycle(sample_lifecycle()), Some("s"));
+    ev.source = HarnessSource::Code;
+    assert!(f.matches(&ev));
+
+    // Wrong source fails the conjunction even though session+domain match.
+    ev.source = HarnessSource::Mpm;
+    assert!(!f.matches(&ev));
+}
+
+// ---- types-only boundary ----
+
+/// Every source file in this module, paired with its name for the failure
+/// message. `include_str!` resolves relative to this file, so the check reads
+/// the real shipped text rather than a list someone has to remember to update.
+const MODULE_SOURCES: &[(&str, &str)] = &[
+    ("control_bus/mod.rs", include_str!("mod.rs")),
+    ("control_bus/lifecycle.rs", include_str!("lifecycle.rs")),
+    ("control_bus/envelope.rs", include_str!("envelope.rs")),
+    ("control_bus/filter.rs", include_str!("filter.rs")),
+    ("control_bus/tests.rs", include_str!("tests.rs")),
+];
+
+/// Transport spellings that must never appear in this module.
+///
+/// Each needle is assembled by `concat!` so the literal it forms is absent from
+/// this file's own source text — that is what lets the scan include `tests.rs`
+/// itself instead of carving out an unchecked hole.
+const FORBIDDEN_SUBSTRINGS: &[&str] = &[
+    concat!("broadcast", "::"),
+    concat!("Once", "Lock"),
+    concat!("tokio", "::", "sync"),
+    concat!("lazy_", "static!"),
+    concat!("once_", "cell"),
+];
+
+/// The `control_bus` module carries types and nothing that moves them.
+///
+/// Why: The owner ruling for #6846 puts the one event bus in trusty-console and
+///      leaves `trusty-common` holding only the shared types. A grep proves that
+///      on the day it is run and nothing afterwards; this test makes the
+///      boundary fail the build the moment a channel, a process-global sender,
+///      or a mutable global is added back.
+/// What: Scans every source file of this module for a channel or global-state
+///       spelling, and for any item-position `static` declaration. The
+///       substring needles are `concat!`-assembled so scanning this file does
+///       not match the needle list itself; `&'static str` in a type position is
+///       not an item declaration, so the `static` check is line-anchored rather
+///       than a substring search.
+/// Test: this test itself.
+#[test]
+fn control_bus_declares_no_transport() {
+    for (name, src) in MODULE_SOURCES {
+        for needle in FORBIDDEN_SUBSTRINGS {
+            assert!(
+                !src.contains(needle),
+                "{name} contains `{needle}`: control_bus holds event TYPES only \
+                 — the bus lives in trusty-console (#6846)"
+            );
+        }
+
+        for (idx, line) in src.lines().enumerate() {
+            let trimmed = line.trim_start();
+            assert!(
+                !(trimmed.starts_with("static ") || trimmed.starts_with("pub static ")),
+                "{}:{} declares a global `static`: control_bus holds event TYPES \
+                 only — no global state (#6846)\n  {line}",
+                name,
+                idx + 1
+            );
+        }
+    }
+}
+
+/// The scan above covers every file the module actually ships.
+///
+/// Why: `MODULE_SOURCES` is a hand-written list, and a new submodule added
+///      without a row would be silently unscanned — the fail-open mode that
+///      makes a guard worthless. Counting the module's declarations against the
+///      list turns that omission into a failure.
+/// What: Reads `mod.rs` for its `mod <name>;` declarations and asserts each one
+///       has a `MODULE_SOURCES` row, and that the list also covers `mod.rs` and
+///       this file.
+/// Test: this test itself.
+#[test]
+fn module_source_scan_covers_every_submodule() {
+    let mod_rs = include_str!("mod.rs");
+
+    let declared: Vec<&str> = mod_rs
+        .lines()
+        .map(str::trim)
+        .filter_map(|l| {
+            l.strip_prefix("mod ")
+                .or_else(|| l.strip_prefix("pub mod "))
+        })
+        .filter_map(|rest| rest.strip_suffix(';'))
+        .collect();
+
+    assert!(
+        !declared.is_empty(),
+        "found no `mod` declarations in control_bus/mod.rs — the parser above is \
+         out of date, which would make the transport scan vacuous"
+    );
+
+    for name in &declared {
+        let expected = format!("control_bus/{name}.rs");
+        assert!(
+            MODULE_SOURCES.iter().any(|(n, _)| *n == expected),
+            "control_bus/mod.rs declares `mod {name};` but MODULE_SOURCES has no \
+             row for {expected} — add one so the transport scan covers it"
+        );
+    }
+
+    // `mod.rs` and `tests.rs` are not `mod` declarations, so assert them directly.
+    for expected in ["control_bus/mod.rs", "control_bus/tests.rs"] {
+        assert!(
+            MODULE_SOURCES.iter().any(|(n, _)| *n == expected),
+            "MODULE_SOURCES is missing {expected}"
+        );
+    }
+}

--- a/crates/trusty-common/src/control_bus/tests.rs
+++ b/crates/trusty-common/src/control_bus/tests.rs
@@ -248,6 +248,38 @@ const FORBIDDEN_SUBSTRINGS: &[&str] = &[
     concat!("once_", "cell"),
 ];
 
+/// Strips a leading visibility qualifier (`pub`, `pub(crate)`, `pub(super)`,
+/// `pub(in ...)`) and the whitespace after it, so a static-declaration check
+/// can anchor on `static` regardless of which visibility form precedes it.
+///
+/// Why: The transport scan below needs `static` at the true start of an item
+///      declaration; without stripping visibility first, `pub(crate) static`
+///      and `pub(in crate::foo) static` slipped past a scan that only knew
+///      about bare `static ` and `pub static ` (#6846 review note).
+/// What: Removes one `pub` token, and — when followed by a parenthesized
+///       qualifier — the balanced `(...)` after it, then trims the remaining
+///       leading whitespace. A line with no `pub` prefix passes through
+///       unchanged.
+/// Test: `static_scan_catches_every_visibility_form`.
+fn strip_leading_pub(trimmed: &str) -> &str {
+    let Some(rest) = trimmed.strip_prefix("pub") else {
+        return trimmed;
+    };
+    if let Some(after_paren) = rest.strip_prefix('(') {
+        // `pub(crate)`, `pub(super)`, `pub(in path::to::mod)` — the
+        // qualifier never itself contains `)`, so the first one closes it.
+        match after_paren.find(')') {
+            Some(close) => after_paren[close + 1..].trim_start(),
+            None => rest, // malformed `pub(` with no close — leave as-is
+        }
+    } else if rest.starts_with(char::is_whitespace) || rest.is_empty() {
+        rest.trim_start()
+    } else {
+        // e.g. "public" — not actually the `pub` keyword.
+        trimmed
+    }
+}
+
 /// The `control_bus` module carries types and nothing that moves them.
 ///
 /// Why: The owner ruling for #6846 puts the one event bus in trusty-console and
@@ -256,12 +288,15 @@ const FORBIDDEN_SUBSTRINGS: &[&str] = &[
 ///      boundary fail the build the moment a channel, a process-global sender,
 ///      or a mutable global is added back.
 /// What: Scans every source file of this module for a channel or global-state
-///       spelling, and for any item-position `static` declaration. The
-///       substring needles are `concat!`-assembled so scanning this file does
-///       not match the needle list itself; `&'static str` in a type position is
-///       not an item declaration, so the `static` check is line-anchored rather
-///       than a substring search.
-/// Test: this test itself.
+///       spelling, and for any item-position `static` declaration (`static`
+///       and `static mut`, under any visibility — `pub`, `pub(crate)`,
+///       `pub(super)`, `pub(in ...)`, or none). The substring needles are
+///       `concat!`-assembled so scanning this file does not match the needle
+///       list itself; `&'static str` in a type position is not an item
+///       declaration, so the `static` check is line-anchored (after stripping
+///       a leading visibility qualifier) rather than a substring search.
+/// Test: this test itself, plus the visibility-form negative control in
+///       `static_scan_catches_every_visibility_form`.
 #[test]
 fn control_bus_declares_no_transport() {
     for (name, src) in MODULE_SOURCES {
@@ -274,9 +309,9 @@ fn control_bus_declares_no_transport() {
         }
 
         for (idx, line) in src.lines().enumerate() {
-            let trimmed = line.trim_start();
+            let candidate = strip_leading_pub(line.trim_start());
             assert!(
-                !(trimmed.starts_with("static ") || trimmed.starts_with("pub static ")),
+                !(candidate.starts_with("static ") || candidate.starts_with("static mut ")),
                 "{}:{} declares a global `static`: control_bus holds event TYPES \
                  only — no global state (#6846)\n  {line}",
                 name,
@@ -284,6 +319,43 @@ fn control_bus_declares_no_transport() {
             );
         }
     }
+}
+
+/// Negative control for the visibility stripping in
+/// `control_bus_declares_no_transport`.
+///
+/// Why: The scan above is only as good as its line-anchoring. A prior version
+///      caught bare `static ` and `pub static ` but missed `pub(crate) static`
+///      and `static mut` — this test proves the fix against tiny inline
+///      fixtures rather than trusting the real module sources to happen to
+///      cover every visibility form.
+/// What: Runs the same detection the scan above uses — strip a leading `pub`
+///       qualifier, then check for a `static ` or `static mut ` prefix —
+///       against three one-line fixtures: a `pub(crate) static` declaration
+///       (must be caught), a `static mut` declaration with no visibility
+///       (must be caught), and a `&'static` reference in a `let` binding
+///       (must NOT be caught).
+/// Test: this test itself.
+#[test]
+fn static_scan_catches_every_visibility_form() {
+    let is_static_declaration =
+        |line: &str| -> bool {
+            let candidate = strip_leading_pub(line.trim_start());
+            candidate.starts_with("static ") || candidate.starts_with("static mut ")
+        };
+
+    assert!(
+        is_static_declaration("pub(crate) static X: u8 = 0;"),
+        "`pub(crate) static` must be detected as a static declaration"
+    );
+    assert!(
+        is_static_declaration("static mut Y: u8 = 0;"),
+        "`static mut` with no visibility qualifier must be detected"
+    );
+    assert!(
+        !is_static_declaration("let s: &'static str = \"\";"),
+        "`&'static` in a type position must not be flagged as a static declaration"
+    );
 }
 
 /// The scan above covers every file the module actually ships.

--- a/crates/trusty-common/src/control_bus/tests.rs
+++ b/crates/trusty-common/src/control_bus/tests.rs
@@ -338,11 +338,10 @@ fn control_bus_declares_no_transport() {
 /// Test: this test itself.
 #[test]
 fn static_scan_catches_every_visibility_form() {
-    let is_static_declaration =
-        |line: &str| -> bool {
-            let candidate = strip_leading_pub(line.trim_start());
-            candidate.starts_with("static ") || candidate.starts_with("static mut ")
-        };
+    let is_static_declaration = |line: &str| -> bool {
+        let candidate = strip_leading_pub(line.trim_start());
+        candidate.starts_with("static ") || candidate.starts_with("static mut ")
+    };
 
     assert!(
         is_static_declaration("pub(crate) static X: u8 = 0;"),

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -316,6 +316,22 @@ pub mod supervision;
 /// Test: `cargo test -p trusty-common --features unconditional-only spawn_retry`.
 pub mod spawn_retry;
 
+/// Shared event types for the control bus (issue #6846, DOC-73).
+///
+/// Why: trusty-console hosts the one event bus (owner ruling 2026-09-05), and
+/// trusty-agents, trusty-mpm and trusty-code are all producers pushing to it.
+/// Reaching the envelope used to mean depending on `trusty-agents-common` — a
+/// sibling producer, not a shared library. These types live here so all four
+/// crates compile against one definition.
+/// What: [`control_bus::HarnessEvent`] and [`control_bus::HarnessPayload`] (the
+/// envelope), [`control_bus::LifecycleEvent`] and [`control_bus::HarnessSource`]
+/// (the taxonomy), and [`control_bus::Filter`]. Types only — no channel and no
+/// global state, which `control_bus::tests::control_bus_declares_no_transport`
+/// enforces against the module's own sources. Ungated: `serde`, `serde_json`
+/// and `chrono` are already unconditional here, so it adds no dependency.
+/// Test: `cargo test -p trusty-common --features unconditional-only control_bus`.
+pub mod control_bus;
+
 #[cfg(feature = "axum-server")]
 pub mod server;
 

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.48" }
+trusty-common = { path = "../trusty-common", version = "0.49" }
 # JSON-RPC / MCP primitives, extracted from `trusty_common::mcp` by ADR-0040 (#5803).
 trusty-mcp = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -111,7 +111,7 @@ trusty-mcp = { workspace = true, features = ["daemon-bridge-json-rpc"] }
 # supplies the bind, the peer check, the framing and the accept loop, and
 # `uds::stream_client` the reader `memory.chat` needs. It replaces
 # `axum-server`, which was here for the retired HTTP listener.
-trusty-common = { path = "../trusty-common", version = "0.48", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config", "uds", "machine-tier"] }
+trusty-common = { path = "../trusty-common", version = "0.49", default-features = false, features = ["memory-core", "monitor-tui", "bm25", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli", "crate-config", "palace-resolve", "codex-config", "uds", "machine-tier"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-memory (single-owner-per-binary); the
@@ -203,7 +203,7 @@ serial_test = { workspace = true }
 # `memory-rpc` (#6286): `tests/uds_consumer_contract.rs` drives the SHARED
 # client against a real daemon on a temp socket — the one place the two halves
 # of this migration are proven to agree.
-trusty-common = { path = "../trusty-common", version = "0.48", default-features = false, features = ["memory-core", "embedder-test-support", "docgen", "memory-rpc"] }
+trusty-common = { path = "../trusty-common", version = "0.49", default-features = false, features = ["memory-core", "embedder-test-support", "docgen", "memory-rpc"] }
 chrono = { workspace = true }
 # #6555: `tests/uds_consumer_contract.rs` calls `tctl`'s real
 # `probe_daemon_http` against this daemon's real router. Every other arm hands


### PR DESCRIPTION
Slice 1 of the DOC-73 control-bus work. Owner ruling 2026-09-05 makes
trusty-console the only event bus and leaves `trusty-common` holding the shared
event TYPES; this moves them.

## What changed

Reaching the event envelope used to mean depending on `trusty-agents-common` — a
sibling producer, not a shared library. The types now live in
`trusty_common::control_bus` so trusty-console and all three harnesses compile
against one definition.

Moved: `HarnessSource` and `LifecycleEvent` (whole files), `HarnessPayload` and
`HarnessEvent` out of `events/bus.rs`, and `Filter`.

Stayed in trusty-agents-common: `EVENT_BUS`, `SEQ`, `bus()`, `subscribe()`,
`publish()`, `emit()`, `recv_with_lag()`, `Lag`, `BusClosed`,
`CHANNEL_CAPACITY`, `EVENT_LINE_PREFIX`, `format_event_line`. The stderr
transport is not the type. Its `events` module re-exports the moved names, so
every existing `trusty_agents_common::events::*` import resolves unchanged.

Out of scope: the PushClient (slice 2, #6847) and removing the in-process
channel (slice 9, #6854).

## Acceptance

- [x] **trusty-agents-common's test suite passes UNMODIFIED.** No file under its
      tests was edited; `events/mod.rs`'s `#[cfg(test)] mod tests` uses
      `super::*` and resolves through the re-export. All 22 `events::tests::*`
      pass, including `filter_*`, `harness_*`, `lifecycle_*` and `payload_*`.
- [x] **trusty-common's Cargo.toml `[dependencies]` diff is empty.** The only
      non-comment change to that manifest is `version = "0.49.0"`
      (`git diff origin/main -- crates/trusty-common/Cargo.toml | grep '^+' |
      grep -v '^+#'` returns that one line). The module needs only `serde`,
      `serde_json` and `chrono`, already unconditional, so it is ungated.
- [x] **A durable in-repo gate, not a one-time grep.**
      `control_bus::tests::control_bus_declares_no_transport` `include_str!`s
      every source file of the module and fails on `broadcast::`, `OnceLock`,
      `tokio::sync`, `lazy_static!`, `once_cell`, or any item-position `static`.
      The substring needles are `concat!`-assembled so the scan covers
      `tests.rs` itself rather than carving out an unchecked hole; the `static`
      check is line-anchored so `&'static str` in a type position does not trip
      it. `module_source_scan_covers_every_submodule` reads `mod.rs` and fails
      if a declared submodule has no row in the scanned list, so the gate cannot
      go vacuous by omission.

      Both were verified to FAIL, not just pass. Injecting `static PROBE: u64 =
      1;` into `envelope.rs` produced
      `control_bus/envelope.rs:100 declares a global 'static'`; injecting a
      `tokio::sync` mention into `filter.rs` produced
      `control_bus/filter.rs contains 'tokio::sync'`. Both probes reverted.
- [x] Why/What/Test module docs on `control_bus` and each submodule; `// #6846:`
      comments at the new module, each moved file, the `events` re-export site,
      and the new Cargo dependency.
- [x] Fragments: `crates/trusty-common/changelog.d/6846-control-bus-types.md`
      and `crates/trusty-agents-common/changelog.d/6846-events-types-reexported.md`.

## Versions

`trusty-common` 0.48.0 -> **0.49.0** (new public module; precedent 0.44.0
`uds::server`). Three crate-local pins still read `^0.48` and bypass the
workspace table — trusty-gworkspace and two rows in trusty-memory — and moved to
`^0.49`. `check_workspace_dep_versions.sh` scans the root table only and passed
while those were wrong; `check_sld.sh` caught them.

`trusty-agents-common` 0.6.4 -> **0.7.0**, not the 0.6.5 first planned.
`check_semver.sh --crate trusty-agents-common` exited 1 against published 0.6.3
with `enum_missing` / `struct_missing` for all five types: a cross-crate
re-export leaves no item definition in this crate's rustdoc, and the crate now
requires `trusty-common ^0.49` where it required nothing. Source-level a
consumer is unaffected, but the gate is never advisory (#5050), so the bump goes
to the breaking position for a 0.y.z crate. Its two `^0.6.0` rows moved to `^0.7`.

## Test evidence — ladder rung 4

Every count below is from a `--no-fail-fast` run; the flag is named because a
count without it proves only the targets that ran (#5354).

```
cargo fmt --all --check                                                    -> 0
cargo check -p trusty-common                                               -> 0
cargo clippy -p trusty-common --all-targets --features unconditional-only
              -- -D warnings                                               -> 0
cargo test -p trusty-common --features unconditional-only --no-fail-fast   -> 0
   test result: ok. 455 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out
   test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   (17 of the 455 are the new control_bus tests)
cargo clippy -p trusty-agents-common --all-targets -- -D warnings          -> 0
cargo test -p trusty-agents-common --no-fail-fast                          -> 0
   test result: ok. 516 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
cargo check --workspace (minus the four Tauri UI crates, as ci.yml does) -> 0
   Finished `dev` profile in 33m 41s
```

`--features unconditional-only` is required on every `trusty-common` test run —
its default feature set is empty and the bare form is a `compile_error!` (#4901).
The new module is in the unconditional surface, so that lane covers it.

Doc and repo gates:

```
scripts/check_line_cap.sh                 -> 0  (full tree; 7 changed files also checked alone)
scripts/check_changelog_fragment.sh       -> 0  (both crates recorded)
scripts/check_test_pointers.sh            -> 0  (30763 citations, 0 dangling)
scripts/check_sld.sh                      -> 0  (0 errors, 0 warnings)
scripts/check_workspace_dep_versions.sh   -> 0  (all 12 internal rows accept their crate)
scripts/check_semver.sh --crate trusty-common        -> 0
scripts/check_semver.sh --crate trusty-agents-common -> 0 after the 0.7.0 bump
```

## Dependent crates

`git grep -l "trusty_agents_common::events" crates/` names trusty-agents,
trusty-code and trusty-mpm. All three import only `EVENT_LINE_PREFIX`, which did
not move, so none touches a relocated type. `cargo check --workspace` proves all
three compile. Their full `cargo test` runs were not executed here — noted rather
than claimed.

## Risk

Type relocation with a compatibility re-export, no behavior change. The wire
tags are untouched, which matters because the envelope crosses process
boundaries via the `__OMPM_EVENT__` stderr relay.

## Rung-4 dependents (run by QA against d2428b44a)

```
cargo test -p trusty-agents --no-fail-fast   -> 0   13 targets, all ok (3620 lib), ~81 min
cargo test -p trusty-code --no-fail-fast     -> 0   18 targets, all ok (1708 lib), ~27 min
cargo test -p trusty-mpm --no-fail-fast      -> 0   48 targets, all ok (5920 lib), ~49 min
```

Zero failures across all three. The three dependents import only `EVENT_LINE_PREFIX`, which did not move (grep evidence in "Dependent crates" above), which is why the engineer's run narrowed to `cargo check --workspace`; the suites were run afterwards anyway.

Refs #6846
Refs #6611

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

