### PR TITLE
fix(trusty-common,trusty-search): index registration and auto-pin match an existing index by root path before failing on a basename collision

### DIFF
--- a/crates/trusty-common/changelog.d/6864-registration-matches-existing-root.md
+++ b/crates/trusty-common/changelog.d/6864-registration-matches-existing-root.md
@@ -1,0 +1,9 @@
+Fixed
+- `ensure_project_indexed_reporting` no longer fails a session when the derived
+  index id already identifies another tree. On a `409` — or a
+  `200 {created:false}` naming a different root — it reads
+  `GET /indexes?details=true` and pins the index whose `root_path` IS the
+  requested project, and registers under `derive_checkout_index_id` when nothing
+  serves it. Two checkouts of one repository used to leave the second unpinned,
+  so every MCP `search` in that session answered `missing required string field:
+  index_id` (#6864).

--- a/crates/trusty-common/src/search_index.rs
+++ b/crates/trusty-common/src/search_index.rs
@@ -76,6 +76,12 @@
 
 use std::path::Path;
 
+// #6864: basename-collision recovery lives in a sibling file so this one stays
+// under the 500-SLOC production cap. Same child-module rule as `tests` below.
+#[path = "search_index_reconcile.rs"]
+mod reconcile;
+use reconcile::CreateOutcome;
+
 /// Find-or-create the trusty-search index for `project_root`, best-effort
 /// trigger a reindex so it is actually populated, and return its id (issues
 /// #1373, #1908).
@@ -344,7 +350,7 @@ pub fn ensure_project_indexed_reporting(
             registration: IndexRegistration::RefusedUnindexableRoot(refusal),
         };
     }
-    let index_id = crate::derive_index_id(&root);
+    let mut index_id = crate::derive_index_id(&root);
     if index_id.trim().is_empty() {
         tracing::warn!(
             "skipping trusty-search index registration: empty index id for {}",
@@ -372,7 +378,11 @@ pub fn ensure_project_indexed_reporting(
     // why `DaemonUnreachable` is not a pinnable outcome.
     let registration = match crate::resolve_daemon_base_url("trusty-search") {
         Some(base) => {
-            let outcome = best_effort_create_index(&base, &index_id, &root, opts);
+            // #6864: a derived id the daemon holds for ANOTHER tree resolves to
+            // the index already registered at this root instead of failing.
+            let (resolved, outcome) =
+                reconcile::create_and_reconcile(&base, &index_id, &root, opts);
+            index_id = resolved;
             best_effort_trigger_reindex(&base, &index_id);
             outcome
         }
@@ -1031,10 +1041,11 @@ fn registered_root_from_response(body: &str) -> Option<String> {
 /// so the joined thread returns quickly: this call sits on a hot path and
 /// must NOT stall when the daemon is slow or unreachable.
 ///
-/// Returns [`IndexRegistration::Confirmed`] ONLY for a 2xx response (#5065
-/// review): a non-2xx, a transport error, and a panicked worker thread are all
-/// `NotConfirmed`. They are still logged and swallowed — the return value gives
-/// the caller something honest to report, it does not make the call fallible.
+/// Returns [`CreateOutcome::Confirmed`] ONLY for a 2xx response (#5065
+/// review): a non-2xx other than `409`, a transport error, and a panicked worker
+/// thread are all `NotConfirmed`. They are still logged and swallowed — the
+/// return value gives the caller something honest to report, it does not make
+/// the call fallible.
 ///
 /// A 2xx is no longer sufficient on its own. The daemon answers a find-or-create
 /// for an id it already holds with `200 {created: false}`, and reading only the
@@ -1042,16 +1053,25 @@ fn registered_root_from_response(body: &str) -> Option<String> {
 /// tree differed from the registered one was told the registration succeeded and
 /// then had every query answered from the OTHER tree, with no error and no
 /// warning. The response now carries the registered `root_path` and a mismatch
-/// downgrades the verdict to `NotConfirmed`.
+/// downgrades the verdict to [`CreateOutcome::Conflict`].
+///
+/// #6864: a `409` is that same conflict said out loud — the daemon refuses to
+/// re-register an id over a second tree (`root_path_mismatch_response`), and
+/// refuses a second id over one tree (`root_path_collision_response`, which
+/// names the owning `existing_id`). Both are reported as `Conflict` rather than
+/// `NotConfirmed` because an index for the requested tree may well exist under
+/// another id; [`reconcile::create_and_reconcile`] is what goes and finds it.
 /// Test: `ensure_project_indexed_withholds_id_when_nothing_was_registered`
 /// (daemon-down path), `registered_root_from_response_*` (the body contract),
-/// `create_index_response_for_a_different_tree_is_not_confirmed` (the error arm).
+/// `create_index_response_for_a_different_tree_reports_a_conflict` (the 2xx
+/// conflict arm), `registration_matches_an_existing_index_by_root_path` (the
+/// `409` arm, end to end).
 fn best_effort_create_index(
     base: &str,
     index_id: &str,
     root: &Path,
     opts: IndexOptions,
-) -> IndexRegistration {
+) -> CreateOutcome {
     let url = format!("{base}/indexes");
     let body = create_index_request_body(index_id, root, opts);
     let index_id = index_id.to_string();
@@ -1076,40 +1096,18 @@ fn best_effort_create_index(
     .join();
 
     match result {
-        Ok(Ok((status, body))) if status.is_success() => {
-            // The daemon answers a find-or-create for an id it already holds
-            // with `200 {created: false}`. Reading only `status` made that
-            // byte-identical to a real create, so a session whose tree differs
-            // from the registered one was told it had been registered and then
-            // had every query answered from the OTHER tree. Compare the tree the
-            // daemon reports against the one that was asked for.
-            match registered_root_from_response(&body) {
-                Some(registered) if !crate::identifies_same_path(Path::new(&registered), root) => {
-                    tracing::warn!(
-                        "trusty-search index '{index_id}' is registered at {registered}, not at \
-                         the requested {root_display}; withholding confirmation so the caller \
-                         cannot pin an index that searches a different tree"
-                    );
-                    return IndexRegistration::NotConfirmed;
-                }
-                _ => {}
-            }
-            tracing::debug!("registered trusty-search index '{index_id}' (root={root_display})");
-            IndexRegistration::Confirmed
-        }
-        Ok(Ok((status, _))) => {
-            tracing::warn!(
-                "trusty-search index registration for '{index_id}' returned HTTP {status}"
-            );
-            IndexRegistration::NotConfirmed
+        // #6864: every status→outcome rule lives in `reconcile` beside the
+        // recovery it feeds, so the conflict semantics cannot drift apart.
+        Ok(Ok((status, body))) => {
+            reconcile::classify_create_response(status, &body, &index_id, root, &root_display)
         }
         Ok(Err(e)) => {
             tracing::warn!("trusty-search index registration for '{index_id}' failed: {e}");
-            IndexRegistration::NotConfirmed
+            CreateOutcome::NotConfirmed
         }
         Err(_) => {
             tracing::warn!("trusty-search index registration thread for '{index_id}' panicked");
-            IndexRegistration::NotConfirmed
+            CreateOutcome::NotConfirmed
         }
     }
 }

--- a/crates/trusty-common/src/search_index_reconcile.rs
+++ b/crates/trusty-common/src/search_index_reconcile.rs
@@ -1,0 +1,391 @@
+//! What [`super::ensure_project_indexed_reporting`] does when the derived index
+//! id cannot name the tree it was asked to register (#6864).
+//!
+//! Why: [`crate::derive_index_id`] is the directory basename, and
+//! trusty-search's registry is one-`root_path`-per-id. Two checkouts of one
+//! repository therefore derive one id, and the second one to launch collides:
+//! the daemon answers `409` (`root_path_mismatch_response`) because the id
+//! already identifies the FIRST checkout. The client read that as a plain
+//! failure, so the session got `NotConfirmed`, no pin, and every MCP `search`
+//! call in it answered `missing required string field: index_id` — while an
+//! index for the requested tree was sitting in the same daemon under another id.
+//! On 2026-09-05 that other id was `trusty-tools-checkout` and the session ran
+//! its whole length unable to search the tree it was working in.
+//!
+//! What: [`create_and_reconcile`] runs the find-or-create and, on a conflict,
+//! resolves the id that ALREADY serves this root before giving up — first from
+//! the `existing_id` a root-collision `409` names, then from
+//! `GET /indexes?details=true` matched on `root_path` via
+//! [`crate::identifies_same_path`], and finally by registering the tree under
+//! [`crate::derive_checkout_index_id`], the collision-resistant form #6149
+//! already defined. The caller pins whatever id comes back, so a colliding
+//! basename now costs one extra GET rather than the whole session's search.
+//!
+//! This is the trusty-common half of the same rule #6677 gave the trusty-review
+//! report pass (`report::index_registry::resolve_report_index`): address the
+//! index registered at this checkout's `root_path` when the derived id is not
+//! it. That copy matches through the review crate's own `IndexInfo` and
+//! `config::index_resolver::best_matching_index`, so routing it through here
+//! would be a behavioural change to two crates rather than a move; it is left
+//! alone deliberately.
+//!
+//! Every step stays best-effort: an unreachable or refusing daemon leaves the
+//! registration `NotConfirmed` exactly as it did before, and the extra GET
+//! carries the same ~1s / 750 ms caps as the create it follows.
+//!
+//! Test: the `tests` module below, plus
+//! `registration_matches_an_existing_index_by_root_path` and
+//! `registration_falls_back_to_a_collision_resistant_id` in
+//! `search_index_tests.rs`.
+
+use std::path::Path;
+
+use super::{
+    IndexOptions, IndexRegistration, best_effort_create_index, registered_root_from_response,
+};
+
+/// What one `POST /indexes` achieved, with the conflict told apart (#6864).
+///
+/// Why: [`IndexRegistration`] collapses "the daemon refused" and "the daemon
+/// holds this id, or this tree, under different terms" into `NotConfirmed`, and
+/// only the second is recoverable. Separating them here is what lets
+/// [`create_and_reconcile`] retry instead of stranding the session unpinned.
+/// What: `Confirmed` is a 2xx naming this same tree; `Conflict` is a `409` or a
+/// `200 {created: false}` whose `root_path` is another tree, carrying the
+/// `existing_id` when the daemon named one; `NotConfirmed` is every other
+/// non-2xx, a transport error, and a panicked worker.
+/// Test: `a_root_collision_409_carries_the_existing_id`,
+/// plus `create_index_response_for_a_different_tree_reports_a_conflict` and
+/// `create_index_response_for_the_same_tree_is_confirmed` in
+/// `search_index_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum CreateOutcome {
+    /// The daemon acknowledged the index for the requested tree.
+    Confirmed,
+    /// The requested id cannot name this tree. `existing_id` is set when the
+    /// daemon's `409` named the index that already owns this `root_path`.
+    Conflict { existing_id: Option<String> },
+    /// Nothing was registered and nothing here can recover it.
+    NotConfirmed,
+}
+
+/// Read one `POST /indexes` answer as a [`CreateOutcome`].
+///
+/// Why: the status alone never decided this. A `200 {created: false}` naming
+/// another tree is a conflict wearing a success code (#5065 review), and a `409`
+/// is the daemon saying the same thing outright — one index identifies one
+/// directory tree, so a request naming a tree it does not hold under that id has
+/// not been satisfied. Both are recoverable, and the rule that says so lives
+/// here, beside the recovery, so the two cannot drift apart.
+/// What: `409` yields `Conflict` carrying whatever `existing_id` the body names;
+/// a 2xx whose reported `root_path` is another tree yields `Conflict` with none
+/// (no index for this tree has been identified yet); any other 2xx is
+/// `Confirmed`; every other status is `NotConfirmed`. `root_display` is the
+/// requested root as the caller already rendered it, for the log lines.
+/// Test: `search_index_tests.rs::{create_index_response_for_a_different_tree_reports_a_conflict,
+/// create_index_response_for_the_same_tree_is_confirmed,
+/// create_rejected_by_the_daemon_withholds_the_pinnable_id}`.
+pub(super) fn classify_create_response(
+    status: reqwest::StatusCode,
+    body: &str,
+    index_id: &str,
+    root: &Path,
+    root_display: &str,
+) -> CreateOutcome {
+    if status == reqwest::StatusCode::CONFLICT {
+        tracing::warn!(
+            "trusty-search index registration for '{index_id}' at {root_display} \
+             conflicts (HTTP 409); looking for the index already serving that tree"
+        );
+        return CreateOutcome::Conflict {
+            existing_id: colliding_index_id_from_response(body),
+        };
+    }
+    if !status.is_success() {
+        tracing::warn!("trusty-search index registration for '{index_id}' returned HTTP {status}");
+        return CreateOutcome::NotConfirmed;
+    }
+    match registered_root_from_response(body) {
+        Some(registered) if !crate::identifies_same_path(Path::new(&registered), root) => {
+            tracing::warn!(
+                "trusty-search index '{index_id}' is registered at {registered}, not at the \
+                 requested {root_display}; withholding confirmation so the caller cannot pin \
+                 an index that searches a different tree"
+            );
+            CreateOutcome::Conflict { existing_id: None }
+        }
+        _ => {
+            tracing::debug!("registered trusty-search index '{index_id}' (root={root_display})");
+            CreateOutcome::Confirmed
+        }
+    }
+}
+
+/// Find-or-create `index_id` for `root`, resolving a basename collision to the
+/// index that already serves that tree (#6864).
+///
+/// Why: see the module doc. The returned id is what the caller PINS, so it must
+/// name an index the daemon actually holds for this root — not the id that was
+/// asked for.
+/// What: runs [`best_effort_create_index`]; a `Confirmed` or unrecoverable
+/// answer returns the requested id unchanged, and a conflict goes through
+/// [`resolve_colliding_id`]. Returns the id to pin alongside the registration
+/// verdict; `IndexRegistration::Confirmed` is returned only when some index for
+/// this root was acknowledged.
+/// Test: `search_index_tests.rs::{registration_matches_an_existing_index_by_root_path,
+/// registration_falls_back_to_a_collision_resistant_id,
+/// create_rejected_by_the_daemon_withholds_the_pinnable_id}`.
+pub(super) fn create_and_reconcile(
+    base: &str,
+    index_id: &str,
+    root: &Path,
+    opts: IndexOptions,
+) -> (String, IndexRegistration) {
+    match best_effort_create_index(base, index_id, root, opts) {
+        CreateOutcome::Confirmed => (index_id.to_string(), IndexRegistration::Confirmed),
+        CreateOutcome::NotConfirmed => (index_id.to_string(), IndexRegistration::NotConfirmed),
+        // #6864: the id is taken, or this tree is; ask which index serves it.
+        CreateOutcome::Conflict { existing_id } => {
+            match resolve_colliding_id(base, index_id, root, opts, existing_id) {
+                Some(resolved) => (resolved, IndexRegistration::Confirmed),
+                None => (index_id.to_string(), IndexRegistration::NotConfirmed),
+            }
+        }
+    }
+}
+
+/// The id of an index that serves `root`, after the derived id failed (#6864).
+///
+/// Why: three sources answer the same question and they are tried cheapest
+/// first. The `409` body already names the index owning this `root_path` when
+/// the collision was on the tree, so no request is needed at all. A collision on
+/// the ID instead needs the registry read, which is the one extra round trip
+/// this fix costs. Only when neither finds an index for this tree is a second
+/// create justified — and it uses [`crate::derive_checkout_index_id`], the
+/// path-digest form #6149 defined for exactly this, rather than a new scheme.
+/// What: returns the id to pin, or `None` when nothing serves this root and the
+/// fallback create did not land. Registering under the digest id can itself
+/// conflict — a COLD registry entry for this tree is not listed by
+/// `GET /indexes?details=true` but is still checked by the daemon's
+/// root-collision guard — so that answer's `existing_id` is honoured too.
+/// Test: `a_root_collision_409_carries_the_existing_id` covers the body read; the
+/// three-tier resolution is the two live-daemon tests named on
+/// [`create_and_reconcile`].
+fn resolve_colliding_id(
+    base: &str,
+    derived: &str,
+    root: &Path,
+    opts: IndexOptions,
+    existing_id: Option<String>,
+) -> Option<String> {
+    if let Some(id) = existing_id {
+        tracing::info!(
+            "trusty-search already serves {} as index '{id}'; pinning that instead of \
+             the derived '{derived}' (#6864)",
+            root.display()
+        );
+        return Some(id);
+    }
+
+    if let Some(body) = fetch_index_list(base)
+        && let Some(id) = index_id_serving_root(&body, root)
+    {
+        tracing::info!(
+            "trusty-search index '{derived}' identifies another tree; {} is registered \
+             as '{id}' and that is what this session pins (#6864)",
+            root.display()
+        );
+        return Some(id);
+    }
+
+    let fresh = crate::derive_checkout_index_id(root)?;
+    tracing::info!(
+        "no trusty-search index is registered for {}; registering it under the \
+         collision-resistant id '{fresh}' because '{derived}' names another tree (#6864)",
+        root.display()
+    );
+    match best_effort_create_index(base, &fresh, root, opts) {
+        CreateOutcome::Confirmed => Some(fresh),
+        CreateOutcome::Conflict { existing_id } => existing_id,
+        CreateOutcome::NotConfirmed => None,
+    }
+}
+
+/// The `existing_id` a `409` names as the current owner of a `root_path`.
+///
+/// Why: trusty-search answers a create whose `root_path` is already registered
+/// with `root_path_collision_response`, which names the owning index precisely
+/// so the caller does not have to cross-reference the registry by hand. Reading
+/// it turns the most common recoverable conflict into zero extra requests.
+/// What: the string `existing_id`, or `None` for any other body — including
+/// `root_path_mismatch_response`, the same-id-different-tree `409`, which
+/// deliberately carries no such field because no index serves the requested
+/// tree.
+/// Test: `a_root_collision_409_carries_the_existing_id`,
+/// `a_root_mismatch_409_names_no_existing_index`.
+pub(super) fn colliding_index_id_from_response(body: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    value.get("existing_id")?.as_str().map(str::to_string)
+}
+
+/// The id of the registry entry whose `root_path` IS `root`.
+///
+/// Why: matching on the id is what created #6864; matching on the tree is what
+/// resolves it. [`crate::identifies_same_path`] is the shared `(dev, ino)`
+/// comparison the daemon's own collision guard uses, so a case-variant or
+/// symlinked spelling of one tree matches here exactly as it does there.
+/// What: scans `GET /indexes?details=true`'s `indexes` array and returns the
+/// first entry whose `root_path` names the same tree. Entries missing `id` or
+/// `root_path` are skipped rather than failing the scan — the daemon omits
+/// `root_path` for a non-UTF-8 root, and an entry that cannot be compared is
+/// simply not a match.
+/// Test: `index_id_serving_root_matches_on_the_tree_not_the_id`,
+/// `index_id_serving_root_is_none_when_no_entry_matches`,
+/// `index_id_serving_root_tolerates_a_malformed_body`.
+pub(super) fn index_id_serving_root(body: &str, root: &Path) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    for entry in value.get("indexes")?.as_array()? {
+        let Some(registered) = entry.get("root_path").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !crate::identifies_same_path(Path::new(registered), root) {
+            continue;
+        }
+        if let Some(id) = entry.get("id").and_then(|v| v.as_str()) {
+            return Some(id.to_string());
+        }
+    }
+    None
+}
+
+/// Read the daemon's detailed index list, best-effort.
+///
+/// Why: `root_path` rides only on `?details=true`; the flat list is bare ids and
+/// cannot answer which index serves a tree. This runs on the same hot path as
+/// the create it follows, so it carries the create's caps — ~1s overall, 750 ms
+/// connect — and its own dedicated OS thread, because `reqwest::blocking` panics
+/// when its runtime is dropped inside a tokio worker and both callers of
+/// `ensure_project_indexed*` are frequently async.
+/// What: `GET {base}/indexes?details=true`, returning the body on a 2xx and
+/// `None` for a non-2xx, a transport error, or a panicked worker. A `None` here
+/// falls through to the fallback create rather than failing the registration.
+/// Test: covered through `registration_matches_an_existing_index_by_root_path`
+/// in `search_index_tests.rs`, which serves this request from a fake daemon.
+fn fetch_index_list(base: &str) -> Option<String> {
+    let url = format!("{}/indexes?details=true", base.trim_end_matches('/'));
+
+    let result = std::thread::spawn(move || {
+        // #4392: loopback target, so proxies stay off.
+        let client = crate::http_client::blocking_loopback_client_builder()
+            .timeout(std::time::Duration::from_secs(1))
+            .connect_timeout(std::time::Duration::from_millis(750))
+            .build()?;
+        let resp = client.get(&url).send()?;
+        let status = resp.status();
+        let text = resp.text().unwrap_or_default();
+        Ok::<(reqwest::StatusCode, String), reqwest::Error>((status, text))
+    })
+    .join();
+
+    match result {
+        Ok(Ok((status, body))) if status.is_success() => Some(body),
+        Ok(Ok((status, _))) => {
+            tracing::warn!("trusty-search index list returned HTTP {status}");
+            None
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("trusty-search index list failed: {e}");
+            None
+        }
+        Err(_) => {
+            tracing::warn!("trusty-search index list thread panicked");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: this is the zero-request recovery — the daemon already told us which
+    /// index owns the tree, so reading it must not require a registry scan.
+    /// Test: itself.
+    #[test]
+    fn a_root_collision_409_carries_the_existing_id() {
+        let body =
+            r#"{"error":"root_path is already registered","existing_id":"trusty-tools-checkout"}"#;
+        assert_eq!(
+            colliding_index_id_from_response(body),
+            Some("trusty-tools-checkout".to_string())
+        );
+    }
+
+    /// Why: the same-id-different-tree `409` names the OTHER checkout's root, not
+    /// an index serving ours. Reading an id out of it would pin the very index
+    /// #6864 is about not pinning.
+    /// Test: itself.
+    #[test]
+    fn a_root_mismatch_409_names_no_existing_index() {
+        let body = r#"{"error":"index 'trusty-tools' is registered at ...","index_id":"trusty-tools",
+             "registered_root_path":"/Users/masa/Projects/trusty-tools",
+             "requested_root_path":"/Users/masa/checkout/trusty-tools"}"#;
+        assert_eq!(colliding_index_id_from_response(body), None);
+        assert_eq!(colliding_index_id_from_response("not json"), None);
+    }
+
+    /// Why: the whole fix in one assertion — the entry that matches is the one
+    /// whose ROOT is this tree, even though a different entry carries the id the
+    /// basename derives.
+    /// Test: itself.
+    #[test]
+    fn index_id_serving_root_matches_on_the_tree_not_the_id() {
+        let mine = std::env::temp_dir();
+        let body = format!(
+            r#"{{"indexes":[{{"id":"trusty-tools","root_path":"/nonexistent/other/trusty-tools"}},
+               {{"id":"trusty-tools-checkout","root_path":"{}"}}]}}"#,
+            mine.display()
+        );
+        assert_eq!(
+            index_id_serving_root(&body, &mine),
+            Some("trusty-tools-checkout".to_string()),
+            "the entry rooted at this tree is the one to pin, whatever its id"
+        );
+    }
+
+    /// Why: no match must stay `None` so the caller registers rather than pinning
+    /// somebody else's tree.
+    /// Test: itself.
+    #[test]
+    fn index_id_serving_root_is_none_when_no_entry_matches() {
+        let body = r#"{"indexes":[{"id":"api","root_path":"/nonexistent/work/api"}]}"#;
+        assert_eq!(
+            index_id_serving_root(body, Path::new("/nonexistent/work/other")),
+            None
+        );
+    }
+
+    /// Why: this parses a daemon response on a hot path, so every malformed shape
+    /// must degrade to "no match" rather than panic. An entry with a null
+    /// `root_path` (a non-UTF-8 root) is skipped, not treated as a match.
+    /// Test: itself.
+    #[test]
+    fn index_id_serving_root_tolerates_a_malformed_body() {
+        let root = std::env::temp_dir();
+        assert_eq!(index_id_serving_root("not json", &root), None);
+        assert_eq!(index_id_serving_root("{}", &root), None);
+        assert_eq!(index_id_serving_root(r#"{"indexes":"nope"}"#, &root), None);
+        assert_eq!(
+            index_id_serving_root(r#"{"indexes":[{"id":"x","root_path":null}]}"#, &root),
+            None
+        );
+        assert_eq!(
+            index_id_serving_root(
+                &format!(r#"{{"indexes":[{{"root_path":"{}"}}]}}"#, root.display()),
+                &root
+            ),
+            None,
+            "an entry with no id cannot be pinned"
+        );
+    }
+}

--- a/crates/trusty-common/src/search_index_tests.rs
+++ b/crates/trusty-common/src/search_index_tests.rs
@@ -1368,10 +1368,13 @@ fn registered_root_from_response_tolerates_a_daemon_that_omits_it() {
 /// must not read as confirmation.
 /// What: stands up a fake daemon answering `200` with a `root_path` that is a
 /// real, existing directory OTHER than the one requested, so the comparison runs
-/// on `(dev, ino)` rather than falling back to string equality.
+/// on `(dev, ino)` rather than falling back to string equality. #6864 renamed
+/// the verdict from `NotConfirmed` to `CreateOutcome::Conflict` — the answer is
+/// still not a registration, and is now marked as the recoverable kind so the
+/// caller looks for the index that does serve this tree.
 /// Test: itself.
 #[test]
-fn create_index_response_for_a_different_tree_is_not_confirmed() {
+fn create_index_response_for_a_different_tree_reports_a_conflict() {
     let requested = scratch_dir("mismatch-requested");
     let registered = scratch_dir("mismatch-registered");
     fs::create_dir_all(&requested).unwrap();
@@ -1395,7 +1398,7 @@ fn create_index_response_for_a_different_tree_is_not_confirmed() {
 
     assert_eq!(
         outcome,
-        IndexRegistration::NotConfirmed,
+        CreateOutcome::Conflict { existing_id: None },
         "a 200 naming a different tree must not confirm the registration"
     );
 
@@ -1428,7 +1431,230 @@ fn create_index_response_for_the_same_tree_is_confirmed() {
     );
     let _ = server.join();
 
-    assert_eq!(outcome, IndexRegistration::Confirmed);
+    assert_eq!(outcome, CreateOutcome::Confirmed);
 
     let _ = fs::remove_dir_all(&root);
+}
+
+// ── #6864: a colliding basename resolves to the index serving this root ───────
+
+/// Stand up a fake trusty-search daemon answering a SCRIPTED SEQUENCE.
+///
+/// Why: the #6864 recovery is a conversation, not one call — the create is
+/// refused, the registry is read, and (when nothing serves the tree) a second
+/// create is issued. `one_shot_daemon` answers exactly one request, so it can
+/// only ever reach the first step. Dropping the listener once the script is
+/// exhausted keeps the follow-up reindex probes failing fast with
+/// connection-refused instead of idling out their own timeouts, which is the
+/// same trick the one-shot form uses.
+/// What: binds `127.0.0.1:0` and accepts `responses.len()` connections in order,
+/// replying with each `(status_line, body)` pair in turn. Every request in this
+/// module's flows is `connection: close` on a freshly built client, so
+/// connection order IS request order.
+/// Test: used by `registration_matches_an_existing_index_by_root_path` and
+/// `registration_falls_back_to_a_collision_resistant_id`.
+fn scripted_daemon(
+    responses: Vec<(&'static str, String)>,
+) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind fake daemon");
+    let addr = listener.local_addr().expect("fake daemon local_addr");
+    let handle = std::thread::spawn(move || {
+        use std::io::{Read, Write};
+        for (status_line, body) in responses {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            let _ = stream.write_all(
+                format!(
+                    "{status_line}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            );
+            let _ = stream.flush();
+        }
+        drop(listener);
+    });
+    (addr, handle)
+}
+
+/// The `409` trusty-search returns when an id already identifies another tree.
+///
+/// Mirrors `root_path_mismatch_response` — note it names no `existing_id`,
+/// because no index serves the tree that was asked about.
+fn root_mismatch_409(index_id: &str, registered: &Path, requested: &Path) -> String {
+    format!(
+        r#"{{"error":"index '{index_id}' is registered elsewhere","index_id":"{index_id}",
+           "registered_root_path":"{}","requested_root_path":"{}"}}"#,
+        registered.display(),
+        requested.display()
+    )
+}
+
+/// Run `body` against a scripted fake daemon, with a git-rooted project named
+/// `project_name` (#6864).
+///
+/// Why: the two #6864 regressions need the same arrangement as
+/// [`with_refusing_daemon`] — `ENV_LOCK`, an isolated data dir, the #4255
+/// opt-out, a published daemon address — but they also need the project's PATH
+/// before the responses can be written, because the registry body embeds it.
+/// What: creates `<scratch>/<project_name>/.git`, calls `script(&project)` to
+/// build the response sequence, serves it, runs `body(&project)`, then restores
+/// the environment and removes both scratch trees.
+/// Test: used by the two tests below.
+fn with_scripted_daemon<T>(
+    tag: &str,
+    project_name: &str,
+    script: impl FnOnce(&Path) -> Vec<(&'static str, String)>,
+    body: impl FnOnce(&Path) -> T,
+) -> T {
+    let _guard = crate::data_dir::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let data_dir = scratch_dir(&format!("6864-data-{tag}"));
+    fs::create_dir_all(&data_dir).unwrap();
+    // SAFETY: guarded by ENV_LOCK; both vars are removed below before returning.
+    unsafe {
+        std::env::set_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV, &data_dir);
+        std::env::set_var(crate::test_harness::ALLOW_PRODUCTION_ENV, "1");
+    }
+
+    let workspace = scratch_dir(&format!("6864-ws-{tag}"));
+    let project = workspace.join(project_name);
+    fs::create_dir_all(project.join(".git")).unwrap();
+
+    let (addr, server) = scripted_daemon(script(&project));
+    publish_daemon_addr(&data_dir, addr);
+
+    let out = body(&project);
+
+    let _ = server.join();
+    unsafe {
+        std::env::remove_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV);
+        std::env::remove_var(crate::test_harness::ALLOW_PRODUCTION_ENV);
+    }
+    let _ = fs::remove_dir_all(&workspace);
+    let _ = fs::remove_dir_all(&data_dir);
+    out
+}
+
+/// Regression for #6864: a basename already taken by another tree resolves to
+/// the index registered at THIS tree.
+///
+/// Why: this is the reported failure exactly. The daemon held `trusty-tools` for
+/// `/Users/masa/Projects/trusty-tools` and answered the checkout's registration
+/// `409`; nothing then looked for the index that DID serve the checkout, so the
+/// session got `NotConfirmed`, no pin, and every MCP `search` call in it failed
+/// with `missing required string field: index_id` — while
+/// `trusty-tools-checkout` sat in the same daemon serving the very tree the
+/// session was working in.
+/// What: two checkouts named `trusty-tools`; the daemon refuses the create with
+/// the same-id-different-tree `409` and then reports both indexes on
+/// `GET /indexes?details=true`. The report must come back `Confirmed` carrying
+/// `trusty-tools-checkout`, the id whose `root_path` IS this project.
+/// Test: this test.
+#[test]
+fn registration_matches_an_existing_index_by_root_path() {
+    let other = scratch_dir("6864-other-checkout");
+    fs::create_dir_all(&other).unwrap();
+
+    let report = with_scripted_daemon(
+        "match",
+        "trusty-tools",
+        |project| {
+            vec![
+                (
+                    "HTTP/1.1 409 Conflict",
+                    root_mismatch_409("trusty-tools", &other, project),
+                ),
+                (
+                    "HTTP/1.1 200 OK",
+                    format!(
+                        r#"{{"indexes":[{{"id":"trusty-tools","root_path":"{}"}},
+                           {{"id":"trusty-tools-checkout","root_path":"{}"}}]}}"#,
+                        other.display(),
+                        project.display()
+                    ),
+                ),
+            ]
+        },
+        |project| ensure_project_indexed_reporting(project, IndexOptions::default()),
+    );
+
+    assert_eq!(
+        report.registration,
+        IndexRegistration::Confirmed,
+        "an index registered at this root IS a confirmed registration (#6864)"
+    );
+    assert_eq!(
+        report.index_id,
+        Some("trusty-tools-checkout".to_string()),
+        "the report must carry the id that serves this tree, not the colliding \
+         basename the daemon refused (#6864)"
+    );
+
+    let _ = fs::remove_dir_all(&other);
+}
+
+/// Regression for #6864: when nothing serves this tree, the create is retried
+/// once under a collision-resistant id.
+///
+/// Why: the root-path scan answers "which index already serves me"; it cannot
+/// answer "register me". A checkout whose basename is taken and which has no
+/// index of its own would otherwise stay unregistered forever, because the only
+/// id the client ever tried is the one the daemon refuses. Retrying under
+/// `derive_checkout_index_id` — the path-digest form #6149 defined for two
+/// checkouts of one repository — is what gets it indexed at all.
+/// What: same `409`, but the registry names only the OTHER checkout. The client
+/// must POST a second create under the digest id and confirm THAT.
+/// Test: this test.
+#[test]
+fn registration_falls_back_to_a_collision_resistant_id() {
+    let other = scratch_dir("6864-fallback-other");
+    fs::create_dir_all(&other).unwrap();
+
+    let (report, expected) = with_scripted_daemon(
+        "fallback",
+        "trusty-tools",
+        |project| {
+            vec![
+                (
+                    "HTTP/1.1 409 Conflict",
+                    root_mismatch_409("trusty-tools", &other, project),
+                ),
+                (
+                    "HTTP/1.1 200 OK",
+                    format!(
+                        r#"{{"indexes":[{{"id":"trusty-tools","root_path":"{}"}}]}}"#,
+                        other.display()
+                    ),
+                ),
+                (
+                    "HTTP/1.1 200 OK",
+                    r#"{"id":"trusty-tools-abcdef12","created":true}"#.to_string(),
+                ),
+            ]
+        },
+        |project| {
+            (
+                ensure_project_indexed_reporting(project, IndexOptions::default()),
+                crate::derive_checkout_index_id(project),
+            )
+        },
+    );
+
+    assert_eq!(
+        report.registration,
+        IndexRegistration::Confirmed,
+        "the fallback create landed, so the registration is confirmed (#6864)"
+    );
+    assert_eq!(
+        report.index_id, expected,
+        "the id must be the shared checkout derivation, not a scheme invented here \
+         (#6149 / #6864)"
+    );
+
+    let _ = fs::remove_dir_all(&other);
 }

--- a/crates/trusty-search/changelog.d/6864-auto-pin-matches-root-path.md
+++ b/crates/trusty-search/changelog.d/6864-auto-pin-matches-root-path.md
@@ -1,0 +1,6 @@
+Fixed
+- `serve`'s working-directory auto-pin now scans the index listing it already
+  fetched for an entry rooted at the working directory before refusing. A
+  derived id served from another tree — or served by nobody — pins that entry
+  instead of leaving the session UNPINNED, and the startup line names it
+  (#6864).

--- a/crates/trusty-search/src/commands/serve_scope.rs
+++ b/crates/trusty-search/src/commands/serve_scope.rs
@@ -21,6 +21,13 @@
 //! derive the same id, and pinning on the id alone would silently serve one
 //! project's results to the other.
 //!
+//! #6864: that refusal was too broad. Two checkouts of one repository collide on
+//! the derived id by construction, and the daemon holds the second under a
+//! distinct id — `trusty-tools-checkout` beside `trusty-tools`. So before
+//! refusing, the already-fetched entries are scanned for one whose `root_path`
+//! IS this working directory, and that index is pinned instead. No extra request
+//! is made; only the entries the confirmation already read are re-examined.
+//!
 //! The pin is computed once, at startup. `serve` is a long-lived stdio process
 //! whose working directory cannot change after exec, so re-resolving per call
 //! would re-read an input that never varies.
@@ -45,6 +52,11 @@ pub(crate) enum PinSource {
     /// #5264: derived from the working directory and confirmed against the
     /// daemon's index list.
     WorkingDir,
+    /// #6864: the working directory's DERIVED id names another tree (or nothing),
+    /// but the daemon serves this exact tree under a different id. Reported
+    /// apart from [`PinSource::WorkingDir`] so the startup line says the id was
+    /// substituted rather than derived.
+    WorkingDirRootMatch,
 }
 
 impl PinSource {
@@ -54,6 +66,7 @@ impl PinSource {
             PinSource::Flag => "--index / TRUSTY_INDEX",
             PinSource::Project => "--project",
             PinSource::WorkingDir => "working directory",
+            PinSource::WorkingDirRootMatch => "working directory root_path match",
         }
     }
 }
@@ -163,7 +176,11 @@ pub(crate) struct DaemonIndex {
 pub(crate) enum Confirmation {
     /// The daemon serves this id from this exact root — safe to pin.
     Confirmed,
-    /// The daemon serves the id, but from a different project root.
+    /// #6864: the derived id does not name this tree, but another registered
+    /// index is rooted at it. That index is what the session pins.
+    ServedByAnotherId { index_id: String },
+    /// The daemon serves the id from a different project root, and no other
+    /// registered index is rooted at this one.
     RootMismatch { serving_root: PathBuf },
     /// The daemon does not serve the id at all.
     NotServed,
@@ -203,22 +220,58 @@ fn same_root(a: &Path, b: &Path) -> bool {
 /// What: finds the entry with a matching id, then requires its root to be the
 /// same directory. Every other outcome is a distinct refusal reason so the
 /// report can say which one happened.
+///
+/// #6864: refusing is right only when NOTHING serves this tree. The id
+/// collision it guards against is the ordinary consequence of two checkouts of
+/// one repository, and the second one is routinely registered under a distinct
+/// id — `trusty-tools-checkout` beside `trusty-tools` on 2026-09-05 — so the
+/// entries already in hand are scanned for a `root_path` that IS this tree
+/// before the candidate is refused. That scan costs no request: `entries` is the
+/// single `GET /indexes?details=true` the caller already made. The same scan
+/// runs when the derived id is served from another root and when it is not
+/// served at all, because the remedy is identical in both.
 /// Test: `confirm_accepts_matching_root`, `confirm_rejects_colliding_basename`,
-/// `confirm_rejects_unknown_index`, `confirm_rejects_null_root`.
+/// `confirm_rejects_unknown_index`, `confirm_rejects_null_root`,
+/// `confirm_substitutes_the_index_rooted_at_the_cwd`,
+/// `confirm_substitutes_when_the_derived_id_is_unserved`.
 pub(crate) fn confirm_candidate(candidate: &CwdCandidate, entries: &[DaemonIndex]) -> Confirmation {
     let Some(entry) = entries.iter().find(|e| e.id == candidate.index_id) else {
-        return Confirmation::NotServed;
+        return match index_serving_root(entries, &candidate.project_root) {
+            Some(index_id) => Confirmation::ServedByAnotherId { index_id },
+            None => Confirmation::NotServed,
+        };
     };
     let Some(root) = entry.root_path.as_ref() else {
         return Confirmation::RootUnknown;
     };
     if same_root(root, &candidate.project_root) {
-        Confirmation::Confirmed
-    } else {
-        Confirmation::RootMismatch {
-            serving_root: root.clone(),
-        }
+        return Confirmation::Confirmed;
     }
+    match index_serving_root(entries, &candidate.project_root) {
+        Some(index_id) => Confirmation::ServedByAnotherId { index_id },
+        None => Confirmation::RootMismatch {
+            serving_root: root.clone(),
+        },
+    }
+}
+
+/// The id of the registered index whose root IS `root` (#6864).
+///
+/// Why: an index identifies a directory tree, so the tree — not the id derived
+/// from its basename — is what decides which index answers about it. This is the
+/// trusty-search half of the rule `trusty_common::search_index`'s
+/// `index_id_serving_root` applies at registration time.
+/// What: the first entry whose reported `root_path` is the same directory under
+/// [`same_root`], which already tolerates symlinks and macOS's `/private`
+/// aliasing. Entries with no reported root are skipped — an unconfirmable entry
+/// is not a match.
+/// Test: `confirm_substitutes_the_index_rooted_at_the_cwd`,
+/// `confirm_substitutes_when_the_derived_id_is_unserved`.
+fn index_serving_root(entries: &[DaemonIndex], root: &Path) -> Option<String> {
+    entries
+        .iter()
+        .find(|e| e.root_path.as_deref().is_some_and(|r| same_root(r, root)))
+        .map(|e| e.id.clone())
 }
 
 /// The outcome of the working-directory tier: either a pin, or a refusal that
@@ -254,11 +307,14 @@ impl AutoPin {
 /// explicit `index_id` calls. Staying unpinned is exactly the behavior a bare
 /// `serve` had before this tier existed, so a refusal costs nothing that
 /// previously worked — it only declines to guess.
-/// What: `Confirmed` pins with [`PinSource::WorkingDir`]; every other verdict
-/// leaves the session unpinned and names the reason, the derived id, and the
-/// remedy.
+/// What: `Confirmed` pins with [`PinSource::WorkingDir`] and — since #6864 —
+/// `ServedByAnotherId` pins the substituted id with
+/// [`PinSource::WorkingDirRootMatch`], so the startup line names the index that
+/// was actually pinned and says it came from a root match rather than the
+/// basename. Every other verdict leaves the session unpinned and names the
+/// reason, the derived id, and the remedy.
 /// Test: `decide_pins_on_confirmation`, `decide_refuses_on_root_mismatch`,
-/// `decide_refuses_when_not_served`.
+/// `decide_refuses_when_not_served`, `decide_pins_the_substituted_index`.
 pub(crate) fn decide_auto_pin(candidate: &CwdCandidate, verdict: Confirmation) -> AutoPin {
     let root = candidate.project_root.display();
     let id = &candidate.index_id;
@@ -267,6 +323,18 @@ pub(crate) fn decide_auto_pin(candidate: &CwdCandidate, verdict: Confirmation) -
             index_id: candidate.index_id.clone(),
             source: PinSource::WorkingDir,
         }),
+        // #6864: pin the index registered at this tree, not the derived name.
+        Confirmation::ServedByAnotherId { index_id } => {
+            tracing::info!(
+                "working directory {root} derives index {id}, which does not name this \
+                 tree; the daemon serves it as {index_id} and that is what this session \
+                 pins (#6864)"
+            );
+            AutoPin::Pinned(PinChoice {
+                index_id,
+                source: PinSource::WorkingDirRootMatch,
+            })
+        }
         Confirmation::RootMismatch { serving_root } => AutoPin::Unpinned {
             reason: format!(
                 "MCP session UNPINNED — working directory {root} derives index {id}, \

--- a/crates/trusty-search/src/commands/serve_scope_tests.rs
+++ b/crates/trusty-search/src/commands/serve_scope_tests.rs
@@ -175,6 +175,60 @@ fn confirm_rejects_null_root() {
     );
 }
 
+/// Regression for #6864: the derived id names another tree, but a second
+/// registered index is rooted at THIS one — pin that one instead of refusing.
+///
+/// Why: this is the reported session. `trusty-tools` was registered for
+/// `/Users/masa/Projects/trusty-tools` while the working checkout was served as
+/// `trusty-tools-checkout`; the mismatch alone left the session UNPINNED and
+/// every `search` call in it failed. The entries needed to resolve it were
+/// already in hand — `confirm_candidate` simply never looked past the id.
+#[test]
+fn confirm_substitutes_the_index_rooted_at_the_cwd() {
+    let c = CwdCandidate {
+        index_id: "trusty-tools".into(),
+        project_root: PathBuf::from("/work/checkout/trusty-tools"),
+    };
+    let verdict = confirm_candidate(
+        &c,
+        &[
+            entry("trusty-tools", "/work/projects/trusty-tools"),
+            entry("trusty-tools-checkout", "/work/checkout/trusty-tools"),
+        ],
+    );
+    assert_eq!(
+        verdict,
+        Confirmation::ServedByAnotherId {
+            index_id: "trusty-tools-checkout".into()
+        },
+        "an index registered at this exact root answers about this tree, whatever \
+         its id (#6864)"
+    );
+}
+
+/// Why (#6864): the same substitution when the derived id is served by NOBODY.
+/// The remedy is identical — an index is registered at this tree — so refusing
+/// here would leave the session unpinned for the same non-reason.
+#[test]
+fn confirm_substitutes_when_the_derived_id_is_unserved() {
+    let c = CwdCandidate {
+        index_id: "trusty-tools".into(),
+        project_root: PathBuf::from("/work/checkout/trusty-tools"),
+    };
+    assert_eq!(
+        confirm_candidate(
+            &c,
+            &[entry(
+                "trusty-tools-checkout",
+                "/work/checkout/trusty-tools"
+            )],
+        ),
+        Confirmation::ServedByAnotherId {
+            index_id: "trusty-tools-checkout".into()
+        }
+    );
+}
+
 /// Why: a git worktree is routinely reached through a symlink, and on macOS the
 /// same directory is reachable as both `/tmp/x` and `/private/tmp/x`. A byte
 /// comparison would refuse a pin that is in fact correct, so the check
@@ -231,6 +285,32 @@ fn decide_pins_on_confirmation() {
     assert!(
         report.contains("api") && report.contains("working directory"),
         "the report must name both the index and its source; got {report:?}"
+    );
+}
+
+/// Regression for #6864: the substituted index is pinned, and the startup line
+/// names it.
+///
+/// Why: resolving the right index is only half the fix — an operator reading
+/// the startup line has to see WHICH index the session is on and that it was
+/// not the derived one, or the substitution is invisible until results look
+/// wrong.
+#[test]
+fn decide_pins_the_substituted_index() {
+    let pin = decide_auto_pin(
+        &candidate(),
+        Confirmation::ServedByAnotherId {
+            index_id: "api-checkout".into(),
+        },
+    );
+    let choice = pin.choice().expect("a root-path match pins");
+    assert_eq!(choice.index_id, "api-checkout");
+    assert_eq!(choice.source, PinSource::WorkingDirRootMatch);
+    let report = pin.report();
+    assert!(
+        report.contains("api-checkout") && report.contains("root_path match"),
+        "the report must name the substituted index and say it came from a root \
+         match; got {report:?}"
     );
 }
 
@@ -429,6 +509,33 @@ async fn auto_pin_refuses_a_colliding_index_end_to_end() {
     assert!(
         pin.report().contains("/somewhere/else/entirely"),
         "the refusal must name the conflicting root; got {:?}",
+        pin.report()
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Regression for #6864, end to end: the daemon serves the derived id from
+/// another tree AND serves this one under a different id. The session must pin
+/// the second, from the ONE index listing it already fetched.
+#[tokio::test(flavor = "multi_thread")]
+async fn auto_pin_substitutes_the_index_rooted_at_the_cwd_end_to_end() {
+    let root = scratch("e2e-substitute");
+    git_init(&root);
+    let derived = root.file_name().unwrap().to_string_lossy().into_owned();
+    let base = fixture_daemon(json!({"indexes": [
+        {"id": derived, "root_path": "/somewhere/else/entirely"},
+        {"id": "the-checkout-index", "root_path": root.to_string_lossy()}
+    ]}))
+    .await;
+
+    let pin = auto_pin_from_cwd(&base, &root).await.expect("a candidate");
+    let choice = pin
+        .choice()
+        .expect("an index registered at this root must pin the session (#6864)");
+    assert_eq!(choice.index_id, "the-checkout-index");
+    assert!(
+        pin.report().contains("the-checkout-index"),
+        "the startup line must name the substituted index; got {:?}",
         pin.report()
     );
     let _ = fs::remove_dir_all(&root);


### PR DESCRIPTION
## Outcome

Refs #6864: index registration and trusty-search's auto-pin logic reject a
re-registration whose root path already matches an existing index, failing
instead on a basename collision that should never have blocked it.

## What changed
- `trusty-common::search_index`: registration now matches an existing index by
  root path before falling through to the basename-collision path.
- `trusty-common::search_index_reconcile`: the reconcile path gets the same
  root-path match, and falls back to a collision-resistant id only when no
  existing index shares the root.
- `trusty-search::commands::serve_scope`: auto-pin follows the same
  root-path-first rule so `serve` does not spuriously fail to pin an index it
  already owns.
- Out of scope: no change to the basename-collision fallback behavior for two
  genuinely different roots that happen to share a basename.

## Risk / blast radius
Rung 4 (cross-crate change to `trusty-common`, a shared library). Direct
consumers tested: `trusty-search`, `trusty-mpm`, `trusty-code`.

## Test evidence
All runs `--no-fail-fast`.
- `cargo test -p trusty-common --features search-index` — 518 passed, 0 failed, 6 ignored
- `cargo test -p trusty-search` — 2492 passed, 2 failed, 41 ignored across 35 targets
- `cargo check --workspace` — exit 0
- `cargo test -p trusty-mpm` — 10484 passed, 1 failed
- `cargo test -p trusty-code` — 1799 passed, 0 failed
- `cargo clippy -p trusty-common --all-targets -- -D warnings` — exit 0
- `cargo clippy -p trusty-search --all-targets -- -D warnings` — exit 0
- `scripts/check_line_cap.sh` — 0 violations
- `scripts/check_changelog_fragment.sh` — OK (fragments in `trusty-common` and `trusty-search` `changelog.d/`)
- `scripts/check_test_pointers.sh` — 0 dangling pointers

Two regression tests provably failed before the fix and pass after it:
`registration_matches_an_existing_index_by_root_path`,
`registration_falls_back_to_a_collision_resistant_id`.

## Baseline / pre-existing failures
Three failures on this branch are pre-existing, not caused by this PR:

- `trusty-search::service::socket::tests::a_client_budget_below_this_listeners_refuses_a_response_it_serves`
  reproduces failing with this PR's `src` checked out against `origin/main`
  (Timeout 10s at `socket_tests.rs:677`).
- Its sibling `a_request_frame_over_the_shared_default_is_accepted_and_refused_at_the_default`
  fails with a broken pipe when run in parallel with the above, and passes when
  run serially — a pre-existing test-isolation issue, not this PR's change.
- `trusty-mpm::connectors::tm::tests::create_session_full_lifecycle` passes on
  re-run; `git diff --name-only origin/main...HEAD -- crates/trusty-mpm/` is
  empty, so this PR touches nothing in that crate.

A ticket for the socket test's red is being filed by another agent; none filed
here to avoid a duplicate.

## Documentation / changelog
Changelog fragments added: `crates/trusty-common/changelog.d/6864-registration-matches-existing-root.md`,
`crates/trusty-search/changelog.d/6864-auto-pin-matches-root-path.md`.

## Review-finding disposition
N/A — first review pass on this PR.

Refs #6864

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
