### PR TITLE
fix(trusty-console): saver web view tracks the view bounds on every resize; paint harness takes a frame size

### DIFF
--- a/crates/trusty-console/changelog.d/6871-saver-webview-tracks-bounds.md
+++ b/crates/trusty-console/changelog.d/6871-saver-webview-tracks-bounds.md
@@ -1,0 +1,12 @@
+Fixed
+- The screen saver's web view is sized from the view's `bounds` on every
+  host-driven resize and again on the way into `startAnimation()`, so a host that
+  constructs the view at a preview size or 0x0 and supplies the real screen
+  afterwards cannot leave the dashboard mis-sized. `autoresizingMask` stays as a
+  second line of defence. The saver's `init` line now records the frame it was
+  handed and `startAnimation` records the bounds it owned, both at a log level
+  `log show` persists, so a fits-the-screen report carries the geometry rather
+  than needing a live `log stream`. `PaintHarness.swift` gained a `--frame WxH`
+  argument (default 1280x800, unchanged) and a `resize` mode that grows the view
+  from a small start frame and asserts the web view and the page's own viewport
+  both match the new bounds.

--- a/crates/trusty-console/macos/saver/PaintHarness.swift
+++ b/crates/trusty-console/macos/saver/PaintHarness.swift
@@ -7,7 +7,7 @@
 //   "whatever the view paints when there is no live page", and all three were
 //   reported as a black screen. Nothing measured them, because measuring them
 //   means reading pixels, not navigation callbacks.
-// What: three modes, each instantiating the bundle's principal class offscreen
+// What: four modes, each instantiating the bundle's principal class offscreen
 //   and reading its rendered bitmap through
 //   `bitmapImageRepForCachingDisplay` / `cacheDisplay`:
 //     offline — points the view at a closed port; asserts the frame is not black
@@ -18,6 +18,12 @@
 //               retries instead of hanging.
 //     preview — instantiates with `isPreview: true`; asserts the bundled static
 //               asset is what draws, and that no web view is built for a tile.
+//     resize  — #6871: constructs the view SMALL, animates it, then grows it to
+//               the target frame the way a host that learns the screen late
+//               would; asserts the web view tracks `bounds`, that the page's own
+//               viewport matches, and that the frame is not black at its edges.
+//   Every mode takes the frame it runs at — `--frame WxH`, default 1280x800 —
+//   so the ultrawide geometry #6871 was reported on is reachable.
 // Test: it IS the test. README.md, "Paint harness", has the invocations;
 //   `scripts/build-console-saver.sh` builds the bundle it consumes.
 //
@@ -52,6 +58,12 @@ let minNonBlackRatio = 0.98
 /// worst fixed one. The offline number is the tight side because the asset is
 /// drawn at 35% there, which divides every source pixel's distance from the
 /// background back through that blend. Re-measure before moving it.
+///
+/// #6871: `--frame` moves the geometry those numbers came from. The fallback
+/// asset is drawn to FIT, so a frame wider than the asset's 16:9 letterboxes it
+/// and the ink ratio falls — offline 0.0417 → 0.0328 and preview 0.1152 →
+/// 0.0942 going from 1280x800 to 3440x1440.
+/// The bar is unchanged and still cleared; it is not per-frame.
 let minInkRatio = 0.02
 /// How long from the view being READY to its first non-black, non-empty frame.
 /// #6838's acceptance says one second, and measuring before `startAnimation()`
@@ -84,21 +96,79 @@ let minSlowModeAttempts = 3
 /// The Foundry dark background the view fills before drawing anything, from
 /// `docs/design/UI/design-system/tokens.css` (`--trusty-content-bg: #201612`).
 let backgroundRGB = (r: 0x20, g: 0x16, b: 0x12)
+/// Brightest channel value still counted as black. #6838's bar, named once so
+/// the whole-frame ratio and #6871's five edge samples cannot drift apart.
+let nearBlackLevel = 8
+/// How long `resize` mode waits for the console before growing the view. Only
+/// the page-viewport assertion needs a live page; the frame assertions do not,
+/// so a timeout here downgrades that one check rather than failing the run.
+let resizeLiveWait: TimeInterval = 15
 
 // MARK: - Arguments
-
-let args = CommandLine.arguments
-let mode = args.count > 1 ? args[1] : ""
-let bundlePath = args.count > 2
-    ? args[2]
-    : NSHomeDirectory() + "/Library/Screen Savers/TrustyConsole.saver"
 
 func note(_ message: String) {
     FileHandle.standardError.write("PAINT: \(message)\n".data(using: .utf8)!)
 }
 
-guard ["offline", "slow", "preview"].contains(mode) else {
-    note("usage: paintharness <offline|slow|preview> [bundlePath]")
+/// `WxH` → an `NSSize`. 0 is ACCEPTED: a 0x0 start frame is the degenerate case
+/// #6871 exists to exercise, not a typo to reject.
+func parseSize(_ text: String) -> NSSize? {
+    let parts = text.lowercased().split(separator: "x", maxSplits: 1)
+    guard parts.count == 2,
+          let width = Double(parts[0]), let height = Double(parts[1]),
+          width >= 0, height >= 0, width <= 32768, height <= 32768 else { return nil }
+    return NSSize(width: width, height: height)
+}
+
+/// Unchanged from the harness's first cut, so an invocation with no `--frame`
+/// still measures what the #6838/#6839 ink table was measured at.
+let defaultFrameSize = NSSize(width: 1280, height: 800)
+/// What `resize` starts at: the rough size of a System Settings preview, i.e. a
+/// plausible frame for a host that has not yet decided which screen this is.
+let defaultStartSize = NSSize(width: 320, height: 200)
+
+var positional: [String] = []
+var frameSize: NSSize?
+var startSize: NSSize?
+
+var pending = Array(CommandLine.arguments.dropFirst())
+while let arg = pending.first {
+    pending.removeFirst()
+    switch arg {
+    case "--frame", "--start":
+        guard let value = pending.first, let size = parseSize(value) else {
+            note("\(arg) needs a WxH value, e.g. \(arg) 3440x1440")
+            exit(64)
+        }
+        pending.removeFirst()
+        if arg == "--frame" { frameSize = size } else { startSize = size }
+    default:
+        positional.append(arg)
+    }
+}
+
+// Env is the fallback, not an override: an explicit flag wins.
+if frameSize == nil, let env = ProcessInfo.processInfo.environment["SAVER_HARNESS_FRAME"] {
+    guard let size = parseSize(env) else {
+        note("SAVER_HARNESS_FRAME=\(env) is not a WxH size")
+        exit(64)
+    }
+    frameSize = size
+}
+
+let targetFrame = frameSize ?? defaultFrameSize
+let resizeStart = startSize ?? defaultStartSize
+
+let mode = positional.count > 0 ? positional[0] : ""
+let bundlePath = positional.count > 1
+    ? positional[1]
+    : NSHomeDirectory() + "/Library/Screen Savers/TrustyConsole.saver"
+
+guard ["offline", "slow", "preview", "resize"].contains(mode) else {
+    note("usage: paintharness <offline|slow|preview|resize> [bundlePath]"
+        + " [--frame WxH] [--start WxH]")
+    note("  --frame  the frame to run at (default 1280x800; env SAVER_HARNESS_FRAME)")
+    note("  --start  resize mode only: the frame to construct at (default 320x200)")
     exit(64)
 }
 
@@ -107,6 +177,9 @@ guard ["offline", "slow", "preview"].contains(mode) else {
 let defaultsDomain = "com.trusty.console.saver"
 let portKey = "ConsolePort"
 let pathKey = "ConsolePath"
+/// The console's default port, mirrored from `SaverConfig.defaultPort` — the
+/// port `resize` mode looks for a live dashboard on.
+let SaverDefaultPort = 7788
 let saverDefaults = ScreenSaverDefaults(forModuleWithName: defaultsDomain)
 let priorPort = saverDefaults?.object(forKey: portKey)
 let priorPath = saverDefaults?.object(forKey: pathKey)
@@ -244,7 +317,10 @@ func capture(_ view: NSView) -> NSBitmapImageRep? {
     return rep
 }
 
-func stats(of rep: NSBitmapImageRep) -> PaintStats? {
+/// Decodes a captured rep into a tightly-packed sRGB RGBA buffer. Shared by the
+/// whole-frame ratios and #6871's five edge samples so both read the same
+/// pixels through the same colour space.
+func pixels(of rep: NSBitmapImageRep) -> (width: Int, height: Int, buffer: [UInt8])? {
     guard let cgImage = rep.cgImage else { return nil }
 
     let width = cgImage.width
@@ -268,6 +344,11 @@ func stats(of rep: NSBitmapImageRep) -> PaintStats? {
         return true
     }
     guard drew else { return nil }
+    return (width, height, buffer)
+}
+
+func stats(of rep: NSBitmapImageRep) -> PaintStats? {
+    guard let (width, height, buffer) = pixels(of: rep) else { return nil }
 
     var nonBlack = 0
     var ink = 0
@@ -278,7 +359,7 @@ func stats(of rep: NSBitmapImageRep) -> PaintStats? {
         let r = Int(buffer[offset])
         let g = Int(buffer[offset + 1])
         let b = Int(buffer[offset + 2])
-        if max(r, max(g, b)) > 8 { nonBlack += 1 }
+        if max(r, max(g, b)) > nearBlackLevel { nonBlack += 1 }
         let distance = abs(r - backgroundRGB.r) + abs(g - backgroundRGB.g) + abs(b - backgroundRGB.b)
         if distance > 24 { ink += 1 }
         index += 1
@@ -289,6 +370,31 @@ func stats(of rep: NSBitmapImageRep) -> PaintStats? {
         height: height,
         nonBlackRatio: Double(nonBlack) / Double(total),
         inkRatio: Double(ink) / Double(total))
+}
+
+/// #6871: one sample inside each corner plus the centre — the five points a web
+/// view that failed to grow would leave unpainted along an edge.
+///
+/// This is the "never black" bar (#6838) restated at the target frame, and that
+/// is ALL it is. `cacheDisplay` reads the view's own `draw(_:)`, and the live
+/// page's background is the same `#201612` the view fills with, so these samples
+/// cannot tell a correctly sized page from a letterboxed one. The frame equality
+/// and the page-viewport check are what prove the fit.
+func edgeSamples(of rep: NSBitmapImageRep) -> [(name: String, r: Int, g: Int, b: Int)]? {
+    guard let (width, height, buffer) = pixels(of: rep) else { return nil }
+    let inset = 8
+    guard width > inset * 2, height > inset * 2 else { return nil }
+    let points: [(String, Int, Int)] = [
+        ("top-left", inset, inset),
+        ("top-right", width - 1 - inset, inset),
+        ("bottom-left", inset, height - 1 - inset),
+        ("bottom-right", width - 1 - inset, height - 1 - inset),
+        ("centre", width / 2, height / 2),
+    ]
+    return points.map { name, x, y in
+        let offset = (y * width + x) * 4
+        return (name, Int(buffer[offset]), Int(buffer[offset + 1]), Int(buffer[offset + 2]))
+    }
 }
 
 // MARK: - Bundle load
@@ -317,6 +423,13 @@ case "slow":
     }
     silent = listener
     pointView(atPort: listener.port)
+case "resize":
+    // #6871 is a LIVE-page defect, so this mode points at the real console
+    // rather than a stand-in. It still runs without one — only the viewport
+    // assertion needs the page.
+    let port = ProcessInfo.processInfo.environment["SAVER_HARNESS_PORT"].flatMap(Int.init)
+        ?? SaverDefaultPort
+    pointView(atPort: port)
 default:
     break // preview never touches the network
 }
@@ -326,8 +439,14 @@ default:
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
 
-let frame = NSRect(x: 0, y: 0, width: 1280, height: 800)
+// #6871: `resize` deliberately constructs the view SMALL and grows it later, so
+// it is the one mode whose initial frame is not the frame under test.
+let initialSize = mode == "resize" ? resizeStart : targetFrame
+let frame = NSRect(origin: .zero, size: initialSize)
 let isPreview = mode == "preview"
+/// A 0x0 frame has no bitmap to read — `resize --start 0x0` asks for exactly
+/// that, and its assertions all land after the growth.
+let initialFrameIsMeasurable = initialSize.width > 0 && initialSize.height > 0
 
 var failures: [String] = []
 
@@ -342,29 +461,35 @@ window.contentView = view
 window.orderFrontRegardless()
 window.setFrameOrigin(NSPoint(x: -5000, y: -5000)) // offscreen: do not disturb the operator
 
+note("constructed at \(Int(initialSize.width))x\(Int(initialSize.height)); view.bounds=\(NSStringFromRect(view.bounds))")
+
 // No run loop first: `cacheDisplay` drives `draw(_:)` synchronously, so this is
 // the earliest frame the view can possibly produce.
-guard let firstRep = capture(view) else {
-    note("FAIL — could not read the view's bitmap")
-    silent?.stop()
-    finish(8)
-}
-let firstPaintElapsed = Date().timeIntervalSince(readyAt)
-guard let firstFrame = stats(of: firstRep) else {
-    note("FAIL — could not decode the captured bitmap")
-    silent?.stop()
-    finish(8)
-}
-note("first frame at \(String(format: "%.2f", firstPaintElapsed))s after init returned: \(firstFrame.summary)")
+if initialFrameIsMeasurable {
+    guard let firstRep = capture(view) else {
+        note("FAIL — could not read the view's bitmap")
+        silent?.stop()
+        finish(8)
+    }
+    let firstPaintElapsed = Date().timeIntervalSince(readyAt)
+    guard let firstFrame = stats(of: firstRep) else {
+        note("FAIL — could not decode the captured bitmap")
+        silent?.stop()
+        finish(8)
+    }
+    note("first frame at \(String(format: "%.2f", firstPaintElapsed))s after init returned: \(firstFrame.summary)")
 
-if firstPaintElapsed > firstPaintDeadline {
-    failures.append(String(format: "first frame took %.2fs, budget %.2fs", firstPaintElapsed, firstPaintDeadline))
-}
-if firstFrame.nonBlackRatio < minNonBlackRatio {
-    failures.append(String(format: "frame is black: nonBlack=%.4f < %.4f", firstFrame.nonBlackRatio, minNonBlackRatio))
-}
-if firstFrame.inkRatio < minInkRatio {
-    failures.append(String(format: "no static fallback drawn: ink=%.4f < %.4f", firstFrame.inkRatio, minInkRatio))
+    if firstPaintElapsed > firstPaintDeadline {
+        failures.append(String(format: "first frame took %.2fs, budget %.2fs", firstPaintElapsed, firstPaintDeadline))
+    }
+    if firstFrame.nonBlackRatio < minNonBlackRatio {
+        failures.append(String(format: "frame is black: nonBlack=%.4f < %.4f", firstFrame.nonBlackRatio, minNonBlackRatio))
+    }
+    if firstFrame.inkRatio < minInkRatio {
+        failures.append(String(format: "no static fallback drawn: ink=%.4f < %.4f", firstFrame.inkRatio, minInkRatio))
+    }
+} else {
+    note("start frame is 0x0 — no bitmap to read before the resize")
 }
 
 // Now start it, and confirm the frame survives the load attempt. No time budget
@@ -372,7 +497,9 @@ if firstFrame.inkRatio < minInkRatio {
 // latency to answer for.
 view.startAnimation()
 RunLoop.current.run(until: Date().addingTimeInterval(0.5))
-if let animRep = capture(view), let animFrame = stats(of: animRep) {
+if !initialFrameIsMeasurable {
+    note("skipping the post-startAnimation capture: the view is still 0x0")
+} else if let animRep = capture(view), let animFrame = stats(of: animRep) {
     note("frame after startAnimation: \(animFrame.summary)")
     if animFrame.nonBlackRatio < minNonBlackRatio {
         failures.append(String(format: "frame went black once animating: nonBlack=%.4f", animFrame.nonBlackRatio))
@@ -391,6 +518,74 @@ case "preview":
     // A tile must not cost a WebContent XPC child; the asset is the whole point.
     if view.subviews.contains(where: { $0 is WKWebView }) {
         failures.append("preview built a WKWebView")
+    }
+
+case "resize":
+    // #6871: give the page a chance to come up FIRST, so the growth models a
+    // host that hands over the real screen after the saver is already running —
+    // the order the owner's ultrawide report happened in.
+    let liveBy = Date().addingTimeInterval(resizeLiveWait)
+    var live = false
+    while Date() < liveBy && !live {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        live = view.subviews.compactMap { $0 as? WKWebView }.first.map { !$0.isHidden } ?? false
+    }
+    note("console live before the resize: \(live)")
+
+    note("resizing \(Int(initialSize.width))x\(Int(initialSize.height))"
+        + " → \(Int(targetFrame.width))x\(Int(targetFrame.height))")
+    window.setContentSize(targetFrame)
+    RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+
+    guard let web = view.subviews.compactMap({ $0 as? WKWebView }).first else {
+        failures.append("no web view to size — the view built none")
+        break
+    }
+    note("after the resize: view.bounds=\(NSStringFromRect(view.bounds))"
+        + " webView.frame=\(NSStringFromRect(web.frame))")
+    // The issue's own closure condition: the web view owns the whole view.
+    if web.frame != view.bounds {
+        failures.append("web view does not track the bounds:"
+            + " frame=\(NSStringFromRect(web.frame)) bounds=\(NSStringFromRect(view.bounds))")
+    }
+
+    // What the report was actually about — the PAGE's viewport, which the
+    // bitmap cannot see (`edgeSamples` says why). Only a live page can answer.
+    if web.isHidden {
+        note("SKIP viewport check — the console never went live on this run")
+    } else {
+        var viewport: String?
+        let answered = DispatchSemaphore(value: 0)
+        web.evaluateJavaScript("[window.innerWidth, window.innerHeight].join('x')") { value, error in
+            viewport = value as? String ?? "<error: \(error?.localizedDescription ?? "nil")>"
+            answered.signal()
+        }
+        // The completion lands on the main queue, so the run loop has to turn.
+        let answerBy = Date().addingTimeInterval(5)
+        while answered.wait(timeout: .now()) == .timedOut && Date() < answerBy {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        let expected = "\(Int(view.bounds.width))x\(Int(view.bounds.height))"
+        note("page viewport=\(viewport ?? "<timeout>") expected=\(expected)")
+        if viewport != expected {
+            failures.append("page viewport \(viewport ?? "<timeout>") != view bounds \(expected)")
+        }
+    }
+
+    if let grownRep = capture(view), let samples = edgeSamples(of: grownRep) {
+        note("edge samples: " + samples.map { "\($0.name)=(\($0.r),\($0.g),\($0.b))" }.joined(separator: " "))
+        for sample in samples where max(sample.r, max(sample.g, sample.b)) <= nearBlackLevel {
+            failures.append("frame is black at \(sample.name) after the resize:"
+                + " (\(sample.r),\(sample.g),\(sample.b))")
+        }
+        if let grown = stats(of: grownRep) {
+            note("frame after the resize: \(grown.summary)")
+            if grown.nonBlackRatio < minNonBlackRatio {
+                failures.append(String(format: "frame went black across the resize: nonBlack=%.4f", grown.nonBlackRatio))
+            }
+        }
+    } else {
+        failures.append("could not read the view's bitmap after the resize")
     }
 
 case "slow":

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -17,7 +17,7 @@ or runs on Linux, and no CI job covers it (see "Not covered" below).
 | `Info.plist` | Bundle plist template. `__CONSOLE_VERSION__` is replaced at build time. |
 | `Resources/ConsolePreview.png` | Static render of the dashboard's services frame — the gallery tile and the offline fallback (#6839). Generated, committed, copied into `Contents/Resources/` at build time. |
 | `LoadHarness.swift` | Bundle-load smoke test — resolves the principal class and asserts the page loads. |
-| `PaintHarness.swift` | Paint regression harness — reads the rendered bitmap in the offline, slow-daemon and preview states (#6838). |
+| `PaintHarness.swift` | Paint regression harness — reads the rendered bitmap in the offline, slow-daemon and preview states (#6838), and tracks the web view across a late host resize (#6871). Runs at any frame size. |
 
 The bundle is assembled by `scripts/build-console-saver.sh` and copied into place
 by `scripts/install-console-saver.sh`, both at the repo root.
@@ -133,7 +133,7 @@ daemon**: each mode builds its own endpoint.
 swiftc -O -swift-version 5 -o target/console-saver/harness/paintharness \
   crates/trusty-console/macos/saver/PaintHarness.swift
 
-for mode in offline slow preview; do
+for mode in offline slow preview resize; do
   ./target/console-saver/harness/paintharness "$mode" \
     target/console-saver/TrustyConsole.saver || echo "FAILED: $mode"
 done
@@ -147,14 +147,45 @@ unoptimised build spends over a second in it.
 | `offline` | a closed port | ≥98% of pixels non-black and ≥2% carrying drawn content, both before `startAnimation()` and after |
 | `slow` | a listener that accepts and never answers | the same, plus ≥3 connection attempts in 34 s — i.e. the load timed out and retried instead of hanging on `URLRequest`'s 60 s default |
 | `preview` | none (`isPreview: true`) | the bundled asset draws, and no `WKWebView` is built for a tile |
+| `resize` | the real console (7788, or `SAVER_HARNESS_PORT`) | after a late growth: `webView.frame == view.bounds`, the page's own `innerWidth`×`innerHeight` equals those bounds, and none of five edge samples is black (#6871) |
 
-Measured ink ratios at 1280×800, unfixed bundle → fixed:
+### Frame size (#6871)
 
-| Mode | Unfixed | Fixed |
-|---|---|---|
-| `offline` | 0.0034 | 0.0417 |
-| `slow` | 0.0034 | 0.0417 |
-| `preview` | 0.0022 | 0.1152 |
+Every mode runs at the frame you give it, so the ultrawide geometry #6871 was
+reported on is reachable:
+
+```bash
+./target/console-saver/harness/paintharness offline \
+  target/console-saver/TrustyConsole.saver --frame 3440x1440
+SAVER_HARNESS_FRAME=3440x1440 ./target/console-saver/harness/paintharness offline \
+  target/console-saver/TrustyConsole.saver
+```
+
+The default is 1280×800, unchanged, so an invocation with no `--frame` still
+measures what the ink table below was measured at. An explicit `--frame` wins
+over `SAVER_HARNESS_FRAME`.
+
+`resize` takes a second size: `--start WxH` is the frame the view is
+CONSTRUCTED at before the host grows it to `--frame` (default 320×200, the rough
+size of a System Settings preview). `--start 0x0` exercises the fully degenerate
+case — a view built before the host knows which screen it is on. A 0×0 start has
+no bitmap to read, so that run skips the two pre-resize captures and reports it.
+
+`resize` is the one mode that wants a **live console**; the others build their
+own endpoint and need none. Without one it still asserts the frame geometry and
+prints `SKIP viewport check`.
+
+Measured ink ratios, unfixed bundle → fixed:
+
+| Mode | Unfixed @1280×800 | Fixed @1280×800 | Fixed @3440×1440 |
+|---|---|---|---|
+| `offline` | 0.0034 | 0.0417 | 0.0328 |
+| `slow` | 0.0034 | 0.0417 | 0.0328 |
+| `preview` | 0.0022 | 0.1152 | 0.0942 |
+
+The ultrawide column is lower because the fallback asset is 16:9 and is drawn to
+FIT: on a 21:9 frame it letterboxes, and about a quarter of the width is flat
+background. The 2% bar is not per-frame and is still cleared.
 
 Exit 0 passes; 9 is an assertion failure (every failed assertion is printed);
 2–6 and 8 are setup failures (bundle, principal class, endpoint, bitmap). Like
@@ -164,6 +195,21 @@ sandboxed host.
 The `slow` mode is the regression guard for #6838: against an unfixed bundle it
 reports **one** connection attempt in 34 s, because nothing bounded the load.
 The fixed bundle reports four.
+
+**`resize` is not a regression guard for #6871, and cannot be made into one.**
+Measured against a bundle built from the pre-fix `main` (37d6f11), it passes:
+AppKit's autoresizing already keeps the web view at `bounds` through a
+host-driven `setFrameSize`, from a 320×200 start and from 0×0 alike. What the
+mode does guard is the invariant the fix makes explicit — that the web view owns
+the whole view after a late resize — against a future change to the view
+hierarchy that autoresizing would not survive. The ultrawide symptom itself
+remains unreproduced outside the real host; see "Not covered".
+
+The 1 s first-paint budget is a **machine-load** measurement, not a geometry one.
+It fails on a busy host in every mode (2.7 s at 3440×1440 with a load average of
+24 on 16 cores) because the clock spans WebKit's XPC bring-up. Report it; do not
+raise it. `firstPaintDeadline` in `PaintHarness.swift` says why it is the
+harness's weakest assertion.
 
 ### Manual verification (still owed)
 
@@ -180,6 +226,22 @@ log stream --predicate 'subsystem == "com.trusty.console.saver"'
 Expect `init`, `loading`, then `didFinish`. An `offline` line instead means the
 sandboxed `legacyScreenSaver.appex` host could not reach 127.0.0.1 — the one
 thing the spike could not settle from outside the host.
+
+**Reading it after the fact (#6871).** `log stream` only shows what happens while
+you watch. The `init` and `startAnimation` lines are logged at `.default`, which
+`log show` persists, so a report can carry the geometry the host actually handed
+the view:
+
+```bash
+log show --last 30m --predicate 'subsystem == "com.trusty.console.saver"' --info
+```
+
+`init frame=…` is the frame the host passed to `init(frame:isPreview:)`;
+`startAnimation bounds=…` is what the view owned by the time it loaded the page.
+Those two numbers against the display's real resolution say whether a
+fits-the-screen complaint is the host handing over the wrong frame or the page
+laying out wrongly inside a correct one. Every other line stays at `.info` and is
+memory-only — `log stream` sees them, `log show` will not.
 
 ## Port and route override
 
@@ -222,6 +284,12 @@ configuration sheet this phase (`hasConfigureSheet` is `false`).
   its own data, so this is not a freshness mechanism.
 - **Multi-display** — the framework instantiates one view per screen, so each
   display gets its own web view and timers. No coordination is attempted.
+- **Tracks the frame** — the web view is sized from `bounds` in
+  `resizeSubviews(withOldSize:)` and again on the way into `startAnimation()`, so
+  a host that constructs the view at a preview size or 0×0 and supplies the real
+  screen afterwards cannot leave a mis-sized page on screen (#6871).
+  `autoresizingMask` stays as well; it is a hint about size CHANGES, not a
+  contract that the subview matches `bounds`.
 
 Colours are copied from `docs/design/UI/design-system/tokens.css`
 (`[data-theme='dark']`); the fallback is drawn natively and cannot pick up the
@@ -258,3 +326,18 @@ Reference host for the spike: macOS 26.5.2 arm64, `LSMinimumSystemVersion 13.0`.
   zipped bundle. Stapling is a distribution concern and nothing distributes this
   yet — see `docs/reference/release-workflow.md` for the workspace's Developer ID
   setup.
+- **The ultrawide mis-fit is not reproduced outside the real host (#6871).** The
+  `resize` mode grows the view the way a host that learns the screen late would,
+  and the pre-fix bundle passes it — so whatever the owner saw on a 3440×1440
+  display is not a plain `setFrameSize` the harness can drive. Two candidates the
+  harness cannot reach: the sandboxed `WallpaperLegacyExtension` host sizing the
+  view by a route that is not a subview resize at all, and the System Settings
+  preview pane, which draws the 16:9 fallback asset letterboxed on a 21:9 pane
+  and looks exactly like content that does not fit. The persisted `init frame=`
+  and `startAnimation bounds=` lines above are what the next report should carry
+  to tell those apart.
+- **`cacheDisplay` cannot read a live page.** It runs the view's own `draw(_:)`,
+  and a `WKWebView`'s remote layer is not part of that. The console's dark theme
+  uses the same `#201612` the view fills with, so an edge sample of a live frame
+  is background whether the page covers it or not. That is why `resize` asserts
+  the web view's frame and the page's own viewport rather than trusting pixels.

--- a/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
+++ b/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
@@ -10,11 +10,15 @@
 //   at `http://127.0.0.1:<port><path>`, with a bundled static preview of the
 //   dashboard as its fallback, a bounded load timeout, a 5 s→30 s retry backoff
 //   while the console is down, and an hourly reload for long-run memory hygiene.
+//   The web view is sized from `bounds` on every host-driven resize and again on
+//   the way into `startAnimation()`, so a preview-sized or 0x0 init frame never
+//   survives to the first paint (#6871).
 // Test: `LoadHarness.swift` in this directory resolves the principal class,
 //   instantiates the view outside the screen-saver host and asserts `didFinish`
 //   fires; `PaintHarness.swift` reads the rendered bitmap in the offline,
-//   slow-daemon and preview states. The in-host run is manual — see README.md,
-//   "Manual verification".
+//   slow-daemon and preview states and tracks the web view's frame across a
+//   late host resize in the `resize` state. The in-host run is manual — see
+//   README.md, "Manual verification".
 //
 // Two constraints below are load-tested spike findings, not preference:
 //   * the class is `public` and carries NO `@objc(Name)` rename, so the runtime
@@ -154,9 +158,15 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         animationTimeInterval = 1.0
         autoresizingMask = [.width, .height]
 
-        os_log("init isPreview=%{public}@ url=%{public}@",
-               log: saverLog, type: .info,
-               String(describing: isPreview), config.url.absoluteString)
+        // #6871: `frame` here is the initializer's PARAMETER, which shadows the
+        // property — the frame the host actually handed this view, before any
+        // resize. That is the number a mis-sized-on-ultrawide report needs.
+        // `.default` rather than `.info` so `log show` persists it after the
+        // fact; `.info` entries are memory-only and gone by the time an operator
+        // files the bug.
+        os_log("init frame=%{public}@ isPreview=%{public}@ url=%{public}@",
+               log: saverLog, type: .default,
+               NSStringFromRect(frame), String(describing: isPreview), config.url.absoluteString)
 
         // The System Settings thumbnail is a few hundred pixels of a dashboard
         // nobody can read, and spinning up a WebContent XPC child for it is pure
@@ -191,6 +201,14 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
 
     public override func startAnimation() {
         super.startAnimation()
+        // #6871: the host may have constructed this view at a preview size or at
+        // 0x0 and supplied the screen's real bounds only afterwards. Size the web
+        // view from `bounds` before the load, so no init frame reaches the first
+        // paint.
+        webView?.frame = bounds
+        // #6871: `.default` so `log show` persists it — this line and the `init`
+        // one together say whether the host ever handed the view the real screen.
+        os_log("startAnimation bounds=%{public}@", log: saverLog, type: .default, NSStringFromRect(bounds))
         // #6838: ask for the fallback on the way in rather than waiting for the
         // first animation tick, so the very first frame the host composites is
         // already the preview and never an unpainted view.
@@ -198,6 +216,23 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         guard state != .preview else { return }
         loadConsole()
         scheduleReloadTimer()
+    }
+
+    /// Why: `autoresizingMask` is a hint that acts only on a superview-driven
+    ///   size change, not a contract that the subview matches `bounds`. The
+    ///   modern `WallpaperLegacyExtension` host can hand
+    ///   `init(frame:isPreview:)` a preview-sized or 0x0 frame and reach the real
+    ///   screen bounds by another route, and a web view left at the init frame
+    ///   draws the dashboard at the wrong size — reported on a 3440x1440
+    ///   ultrawide (#6871).
+    /// What: lets autoresizing run, then reasserts the web view's frame from
+    ///   `bounds`, which is the only authority on how much screen this view owns.
+    ///   A no-op in preview, which builds no web view.
+    /// Test: `PaintHarness.swift`'s `resize` mode instantiates the view small,
+    ///   grows it to the target frame, and asserts `webView.frame == bounds`.
+    public override func resizeSubviews(withOldSize oldSize: NSSize) {
+        super.resizeSubviews(withOldSize: oldSize)
+        webView?.frame = bounds
     }
 
     /// Why: `ScreenSaverView`'s contract is that the host drives repainting


### PR DESCRIPTION
## Outcome

Refs #6871: the trusty-console macOS screensaver's web view was sized once at
startup and never re-laid-out, so it stopped matching the view bounds on any
resize; the paint harness had no way to exercise a specific frame size to
catch this.

## What changed
- `TrustyConsoleSaver.swift` — the web view now tracks the view bounds on
  every resize, not just at initial load.
- `PaintHarness.swift` — the harness takes a frame size parameter so a resize
  scenario can be driven directly instead of only at the default size.
- `README.md` — updated for the harness's new frame-size parameter.
- Swift-only change under `crates/trusty-console/macos/saver/`; no Rust source
  touched (`crates/trusty-console/src/` is untouched by this diff).
- Out of scope: no change to the saver's animation or content rendering, only
  its bounds-tracking on resize.

## Risk / blast radius
Rung 6 (UI change) scoped to the macOS saver's native Swift/WebKit surface.
No Rust crate source is touched, so the standard Rust test ladder does not
apply here.

## Test evidence
Engineer evidence: none recorded at handoff — no build or test run for the
Swift saver target is captured in the commit message or the worktree.

**Live verification is pending.** `local-ops` rebuilds and installs the saver
from the merge commit, and the owner verifies bounds-tracking fit on the
3440x1440 display before this is considered confirmed working.

## Baseline / pre-existing failures
None applicable — no Rust test suite runs against this diff.

## Documentation / changelog
No changelog fragment owed: `crates/trusty-console/src/**` is untouched by
this PR (Swift files under `macos/saver/` only), so
`scripts/check_changelog_fragment.sh`'s source-changed condition does not
apply. A fragment is present anyway at
`crates/trusty-console/changelog.d/6871-saver-webview-tracks-bounds.md`.
README updated in-tree alongside the code.

## Review-finding disposition
N/A — first review pass on this PR.

Refs #6871

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
