### PR TITLE
docs(design): trusty-code TUI design analysis and requirements from the Claude Code TUI

### DIFF
--- a/docs/design/trusty-code/tui/README.md
+++ b/docs/design/trusty-code/tui/README.md
@@ -1,0 +1,90 @@
+# trusty-code TUI Design Analysis — Index
+
+**Status:** Informative (design analysis, not a behavior-contract spec)
+**Subsystem:** trusty-code-tui / trusty-code TUI client
+**Owner:** Engineering (trusty-code)
+**Last-updated:** 2026-09-06
+**Scope:** A full design analysis of the real Claude Code interactive terminal
+UI (the `claude` CLI's TUI), producing a traceable requirements set for
+trusty-code's own TUI (`trusty-code-tui` + `crates/trusty-code/src/tui_client`).
+
+## What this set is
+
+This is a **design-analysis document set**, not a spec. It does not carry
+`spec_refs:` frontmatter and creates no new `SPEC-*` IDs, because no governing
+spec cites it yet — per DOC-38's rule against fabricating spec links. Where a
+requirement in [requirements.md](requirements.md) should become binding, it is
+a candidate for folding into [DOC-50](../../../specs/DOC-50-tcode-tui-claude-code-clone.md)
+(or a successor spec) in a follow-up change; this set does not itself edit
+DOC-50.
+
+## Files in this set
+
+1. [screen-inventory.md](screen-inventory.md) — every screen/overlay the real
+   Claude Code TUI presents: trigger, layout, editable surface, exit path.
+2. [interaction-model.md](interaction-model.md) — the full keyboard map, vim
+   mode, multi-line input, paste/@-mention/slash autocomplete, history,
+   interrupt semantics, message queueing, rewind/checkpoints.
+3. [rendering-and-layout.md](rendering-and-layout.md) — transcript structure,
+   markdown/diff rendering, truncation/expansion, theme handling, resize,
+   scrollback, notifications, title-bar.
+4. [state-and-session.md](state-and-session.md) — session ids, resume/continue,
+   checkpoints, compaction/context indicators, settings precedence, memory
+   files, output styles, permission modes, hooks visibility.
+5. [extensibility.md](extensibility.md) — slash commands/skills, subagents
+   display, MCP status, plugins, status line scripts, IDE bridge behavior.
+6. [requirements.md](requirements.md) — the numbered MUST/SHOULD/MAY
+   requirement list derived from files 2–5, each traced to a source section,
+   each marked as DOC-50-covered / new / conflicting.
+7. [gaps-and-open-questions.md](gaps-and-open-questions.md) — what could not
+   be observed or verified, and what would settle it.
+
+## Sources
+
+- **Installed binary:** `claude` v2.1.263 (Claude Code), run non-interactively
+  only (`--help`, `--version`, and every listed subcommand's `--help`). No
+  interactive session was started inside this analysis.
+- **Official docs** (`code.claude.com/docs/en/*`, redirected from
+  `docs.claude.com`): interactive-mode, commands, slash-commands, statusline,
+  hooks-guide, ide-integrations, memory, iam/authentication, permission-modes,
+  permissions, output-styles, mcp, checkpointing, fullscreen, settings,
+  sub-agents, context-window. Each fact below is cited to its source page or
+  to the binary's own `--help` output; where the two disagree, both are
+  recorded (see [gaps-and-open-questions.md](gaps-and-open-questions.md)).
+- **trusty-tools prior art (read, not modified):**
+  [DOC-50](../../../specs/DOC-50-tcode-tui-claude-code-clone.md) (the existing
+  tcode TUI spec — MVP Slices 1–7 and 10 are already implemented per
+  `crates/trusty-code-tui/CHANGELOG.md`), [DOC-48](../../../specs/DOC-48-tcode-workstreams.md)
+  (workstream domain object and SSE events the TUI surfaces),
+  [DOC-51](../../../specs/DOC-51-tcode-plugin-support-phase1.md) (plugin
+  agents/skills discovery), `crates/trusty-code/README.md`,
+  `crates/trusty-code-tui/src/**` (survey level), `docs/design/trust-code/`
+  (checked — empty at the time of this analysis; nothing to reconcile against),
+  `docs/design/UI/README.md` (Foundry design system).
+- **Date of analysis:** 2026-09-06.
+
+## Relation to DOC-50
+
+DOC-50 is the existing functional spec for trusty-code's TUI: a Claude-Code
+*clone* built as a thin client (`TuiEngine` trait) over `trusty-code-tui`
+(shared crate) with `CodeEngine` as the tcode-specific adapter. Its MVP scope
+(Slices 1–7, 10) is implemented; Phase 2 (permission prompts, tool cards,
+pickers, SSH fallback) is open. This design-analysis set:
+
+- **Does not replace DOC-50.** DOC-50 states trusty-code's own architecture
+  (thin-client axiom, engine-adapter seam, extraction plan) — none of that is
+  in scope here.
+- **Adds** a requirements baseline derived from what the *real* Claude Code
+  TUI does today (2026-09), which DOC-50 (drafted 2026-07-20, before several
+  of the described features shipped in the real product) could not have
+  anticipated — session recap, `/btw` side questions, the diff panel,
+  fullscreen rendering, auto mode, agent-view/background-session panels,
+  emoji shortcodes, spell-check, PR-status badges, and more.
+- **Flags** (in [requirements.md](requirements.md)) every place a requirement
+  here conflicts with a DOC-50 decision or an owner directive, without
+  resolving the conflict — resolution is Bob's, as DOC-50 §6 establishes for
+  its own open questions.
+- **Reuses owner directives already in force:** trusty-code reuses trusty-mpm
+  agents and skills; the Projects roster in any workstream/project picker
+  comes from the shared trusty-mpm project registry (DOC-48 §8 Rev 9,
+  DOC-39 §5.8.1, issue #3435) — carried forward here, not re-litigated.

--- a/docs/design/trusty-code/tui/extensibility.md
+++ b/docs/design/trusty-code/tui/extensibility.md
@@ -1,0 +1,113 @@
+# Extensibility — Claude Code TUI
+
+**Status:** Informative (design analysis)
+**Last-updated:** 2026-09-06
+**Sources:** `code.claude.com/docs/en/{slash-commands,commands,mcp,sub-agents,
+output-styles,statusline,ide-integrations}`; `claude plugin --help`,
+`claude mcp --help`.
+
+## Slash commands and skills
+
+- The `/` menu lists built-in commands, bundled and user-authored **skills**,
+  and commands contributed by plugins and MCP servers, filtered live as you
+  type. A few built-ins are deliberately hidden from the menu and only run
+  when typed in full.
+- Custom commands live as `.claude/commands/<name>.md` (legacy) or
+  `.claude/skills/<name>/SKILL.md` (current, recommended — supports
+  supporting files in the skill directory and takes precedence on a name
+  collision). Both use YAML frontmatter; `argument-hint` drives the
+  autocomplete hint; arguments bind via `$ARGUMENTS`, `$N`, or named
+  placeholders; skills can stack (`/write-tests /fix-issue 123`).
+- `[Skill]`-tagged built-ins observed in the commands table (`/batch`,
+  `/claude-api`, `/code-review`, `/dataviz`, `/debug`, `/design`,
+  `/design-sync`, `/doctor`, `/fewer-permission-prompts`) confirm skills are
+  a first-class mechanism the same table lists alongside true built-ins, not
+  a second-tier feature.
+- A `[Workflow]`-tagged command (`/deep-research`) shows a third command
+  provenance: a Workflow tool script, distinct from a Skill.
+
+## MCP-provided slash commands and resources
+
+- MCP servers can expose `prompts/list` capabilities that surface as `/`
+  commands (mcp doc, "MCP-Provided Slash Commands" — e.g. `/database-query`,
+  `/slack-send`). These commands look identical to built-ins/skills in the
+  menu.
+- MCP **resources** (data containers, referenced by URI scheme) are readable
+  by Claude without an explicit tool call, distinct from tools and prompts.
+
+## Subagents display
+
+- Subagent files live at `.claude/agents/` (project, VCS-tracked) and
+  `~/.claude/agents/` (user, cross-project); both are file-watched with
+  seconds-level pickup of edits.
+- `/agents` (v2.1.198+) no longer opens a management wizard — it prints a
+  reminder to ask Claude or edit those directories directly. `/doctor`
+  flags duplicate subagent names.
+- Live display: a panel below the prompt shows running subagents as
+  `name(task)` rows; nested subagents render as a tree with `(+N)` descendant
+  counts; forks (`/fork`, `/subtask`, `/btw`'s `f` key) get one row per fork
+  plus one for the main session. `/tasks` is the authoritative full listing
+  (running + recently completed + failed, with model/effort per subagent).
+- Background subagents needing a permission decision surface the prompt in
+  the *main* session, explicitly naming which subagent is asking.
+
+## MCP server status and tool loading
+
+- `/mcp` is the live management panel: connection status glyphs (see
+  `screen-inventory.md` §22), auth flows, tool counts, per-server
+  enable/disable, per-project persistence in `~/.claude.json`.
+- Tool discovery defaults to lazy **tool search** (schemas fetched on demand)
+  with a legacy `WaitForMcpServers`-blocking mode as fallback; a remote
+  HTTP/SSE server reconnects with exponential backoff (5 attempts, 1s
+  initial delay, doubling); interactive sessions show a pending state in
+  `/mcp` while reconnecting, `-p`/SDK sessions reconnect silently.
+- Per-tool permission surfacing: an MCP tool marked
+  `anthropic/requiresUserInteraction` always prompts, in every permission
+  mode including `bypassPermissions`, with no "don't ask again" option; an
+  org-level connector-tool policy can force an `ask` (prompts even under
+  auto modes) or `blocked` (filtered out before Claude ever sees it) status.
+- The CLI's own `claude mcp` subcommand surface (add/add-json/
+  add-from-claude-desktop/get/list/login/logout/remove/
+  reset-project-choices/serve) is the non-interactive management path that
+  parallels `/mcp`.
+
+## Plugins
+
+- `claude plugin` (alias `claude plugins`) subcommands: `details`, `disable`,
+  `enable`, `eval`, `init|new`, `install|i`, `list`, `marketplace`, `prune|
+  autoremove`, `tag`, `uninstall|remove`, `update`, `validate`.
+- Session-scoped, non-persistent loading is available via CLI flags:
+  `--plugin-dir <path>` (repeatable, directory or `.zip`) and `--plugin-url
+  <url>` (repeatable) — loaded for that session only, not installed.
+- Plugins can ship output styles in an `output-styles/` directory
+  (output-styles doc) — one more artifact type a plugin can contribute
+  alongside agents, skills, hooks, MCP servers, and commands (cross-ref
+  DOC-51 §1, which specifies trusty-code's own Phase-1 plugin
+  agents+skills-only subset of this surface).
+- `--restricted` mode strips code-running tools/WebFetch (unless named) and
+  ignores user/project/local settings files, a distinct hardening posture
+  from a normal plugin-enabled session.
+
+## Status line scripts
+
+- Configured via `/statusline` or a `statusLine` settings key; runs any user
+  shell script, receiving session JSON on stdin (model, cost, context %, git
+  branch/status, etc. — statusline doc, "Available data"). Multi-line output
+  supported. A configured status line suppresses most footer keyboard hints.
+- Subagent status lines are a distinct, separately documented mechanism
+  (statusline doc, "Subagent status lines") — not itemized further here; see
+  `gaps-and-open-questions.md`.
+
+## IDE bridge behavior
+
+- The VS Code extension is "the recommended way to use Claude Code in VS
+  Code" and is a **separate GUI surface**, not the terminal TUI running
+  inside VS Code's integrated terminal — though the terminal CLI also runs
+  there and both can attach to the same IDE session via `--ide` / `/ide`.
+- With an IDE attached: plan review/edit before acceptance, auto-accept
+  toggle, `@`-mention with specific line ranges from the editor selection,
+  conversation history, multiple conversations in separate tabs/windows —
+  capabilities layered on top of, not replacing, the terminal interaction
+  model.
+- `claude --ide` auto-connects to a single available IDE at startup; `/ide`
+  manages IDE integrations and shows status from within a running session.

--- a/docs/design/trusty-code/tui/gaps-and-open-questions.md
+++ b/docs/design/trusty-code/tui/gaps-and-open-questions.md
@@ -1,0 +1,103 @@
+# Gaps and Open Questions — Claude Code TUI Analysis
+
+**Status:** Informative (design analysis)
+**Last-updated:** 2026-09-06
+
+This analysis relied on `claude --help`/subcommand `--help` output (binary
+v2.1.263, run non-interactively) and the official docs at
+`code.claude.com/docs/en/*`. No interactive Claude Code session was started
+during this analysis, per the task constraint — every visual/layout claim
+above is inferred from documentation prose, not direct observation. That is
+the single largest source of uncertainty below.
+
+## 1. Exact resize/repaint contract
+
+`rendering-and-layout.md` names column thresholds for the diff panel (≥110
+opens on demand, ≥144 auto-opens) but the fetched pages did not state a
+general terminal-resize behavior (does the transcript reflow live? does a
+resize below a width threshold degrade fullscreen to classic mid-session?).
+**Settles with:** an interactive session against a real terminal, resized
+live, observing reflow — explicitly out of scope for this analysis per its
+own constraints.
+
+## 2. Color/theme palette specifics (light/dark/ANSI-16 fallback)
+
+`/theme` and `Ctrl+T` (inside the theme picker) were found, but no page
+fetched enumerated the actual palette values, a light-vs-dark toggle
+mechanism, or an ANSI-16-degraded-terminal fallback path. **Settles with:**
+fetching `code.claude.com/docs/en/theme` or `terminal-config` directly (not
+fetched in this pass), or direct observation.
+
+## 3. Notification bell (audible)
+
+No fetched page described an audible terminal bell or OS-level notification
+on turn completion/permission-prompt-waiting, though the hooks-guide doc's
+example hook ("alerted whenever Claude is waiting for your input instead of
+watching the terminal") implies the *feature* exists as a user-configured
+hook, not a built-in default. **Settles with:** reading the hooks reference
+page for the exact `Notification` hook event, or direct observation of
+default behavior with no hook configured.
+
+## 4. Exact PR-badge and spell-check daemon-proxy feasibility
+
+R18/R24 (`requirements.md`) flag that the real product's PR-badge and
+spell-check features use local credentials/binaries the thin-client axiom
+forbids trusty-code-tui from touching directly. Whether a **daemon-side**
+proxy for either is in scope, or whether these two requirements are simply
+descoped, is Bob's call, not something this analysis can settle from
+documentation alone.
+
+## 5. Subagent status-line mechanism
+
+`extensibility.md` "Status line scripts" notes a documented but unexplored
+"Subagent status lines" section in the statusline doc — not read in depth
+during this pass (large-page truncation; the fetch tool's preview did not
+surface this section's body). **Settles with:** a targeted re-fetch of
+`code.claude.com/docs/en/statusline#subagent-status-lines`.
+
+## 6. Full built-in slash-command list
+
+`extensibility.md` and `screen-inventory.md` cite the command table from
+`code.claude.com/docs/en/commands`, but that page's fetch was truncated
+mid-table (marked `[Content truncated due to length...]` by the fetch tool)
+— the alphabetic list stopped partway through the R's. Commands after that
+point (anything alphabetically after `/radio`) were not captured.
+**Settles with:** paginated re-fetch of the same page, or `claude --help`
+combined with in-session `/help` output (not obtainable non-interactively).
+
+## 7. Exact permission-prompt visual layout
+
+`screen-inventory.md` §3's dialog layout (`Accept [a]` / `Don't ask again for
+this tool [d]` / `Deny [n]`) is synthesized from the MCP doc's description of
+*an* MCP tool-call prompt, not a verified screenshot or ASCII rendering of
+the general file/Bash/MCP permission-prompt family. The general
+`permissions` doc confirms Tab-for-comment and Left/Right-tab-cycling
+behavior but does not itself show the dialog's literal on-screen text.
+**Settles with:** direct observation, or the `permissions` doc's own
+un-fetched example blocks (the fetch tool summarized rather than quoting
+verbatim in places).
+
+## 8. Exact "auto memory" and "recap" visual cues in-session
+
+`state-and-session.md` cites "Saved 2 memories" / "Recalled 2 memories" as
+messages the memory doc says appear "in the Claude Code interface" but does
+not specify whether these render as transient toasts, inline transcript
+lines, or status-line segments. **Settles with:** direct observation.
+
+## 9. trusty-code-tui's current widget-level fidelity vs. this analysis
+
+This analysis did not do a line-by-line diff between
+`crates/trusty-code-tui/src/widgets/*` and the requirements in
+`requirements.md` beyond what `crates/trusty-code-tui/CHANGELOG.md` states in
+prose. A follow-up engineering pass (not a research task) should map each
+`requirements.md` MUST/SHOULD item against the actual widget/reducer code to
+confirm the DOC-50-status column in `requirements.md` is accurate at the
+code level, not just at the spec-prose level.
+
+## 10. `docs/design/trust-code/` (misspelled sibling directory)
+
+Per the task's own note, this directory exists as a sibling with a different
+spelling from `docs/design/trusty-code/`. It was confirmed empty
+(`find docs/design/trust-code -type f` returned nothing) at analysis time —
+there is nothing in it to reconcile against. Flagging only so a future reader
+does not assume this analysis silently skipped real prior art there.

--- a/docs/design/trusty-code/tui/interaction-model.md
+++ b/docs/design/trusty-code/tui/interaction-model.md
@@ -1,0 +1,174 @@
+# Interaction Model — Claude Code TUI
+
+**Status:** Informative (design analysis)
+**Last-updated:** 2026-09-06
+**Sources:** `code.claude.com/docs/en/interactive-mode` (primary — full
+shortcut tables quoted verbatim below), `permission-modes`, `permissions`,
+`checkpointing`, `fullscreen`.
+
+## Keyboard map — general controls
+
+| Shortcut | Description | Context |
+|---|---|---|
+| `Ctrl+C` | Interrupt, or clear input | First press (idle) clears prompt; second exits Claude Code |
+| `Ctrl+X Ctrl+K` | Stop all background subagents, disable artifact auto-replies for the rest of the session | press twice within 3s to confirm |
+| `Ctrl+D` | Exit session | First press shows confirmation hint, second within 800ms exits; with text in prompt, deletes char after cursor instead |
+| `Ctrl+G` / `Ctrl+X Ctrl+E` | Open prompt in `$EDITOR` | |
+| `Ctrl+L` | Redraw/clear screen | Recovers a garbled display; in fullscreen also clears and lets you scroll up |
+| `Ctrl+O` | Toggle transcript viewer | Shows tool usage, timestamp, model per message |
+| `Ctrl+R` | Reverse search history | |
+| `Ctrl+V` / `Cmd+V` (iTerm2) / `Alt+V` (Win/WSL) | Paste image from clipboard | inserts `[Image #N]` chip |
+| `Ctrl+B` | Background running Bash/agent task | tmux users press twice |
+| `Ctrl+T` | Toggle task checklist | not the same as `/tasks` |
+| `Ctrl+S` | Stash/restore prompt text | |
+| `Ctrl+Z` | Suspend (Unix only) | |
+| `Left/Right` | Cycle dialog tabs | permission dialogs, menus |
+| `Tab` | Accept autocomplete, or add a comment to a permission answer | |
+| `Up/Down`, `Ctrl+P`/`Ctrl+N` | Move cursor within multi-line input, else navigate history | queued messages: `Up` from first row takes them back |
+| `Esc` | Interrupt turn, or close dialog / decline permission (= No, no comment) | keeps queued messages, sends them next |
+| `Esc Esc` | Clear input draft (saved to history), or open rewind menu when input is empty | |
+| `Shift+Tab` (or `Alt+M` on some Windows terminals) | Cycle permission modes: default → acceptEdits → plan → [bypassPermissions] → [auto] → default | |
+| `Option+P`/`Alt+P` | Switch model | |
+| `Option+T`/`Alt+T` | Toggle extended thinking | |
+| `Option+O`/`Alt+O` | Toggle fast mode | |
+
+## Text editing
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl+A` / `Ctrl+E` | Start / end of current logical line |
+| `Ctrl+K` | Delete to end of line (stores for paste) |
+| `Ctrl+U` | Delete cursor-to-line-start (stores for paste); repeat clears multiline |
+| `Ctrl+W` | Delete back to previous whitespace (whole path/`--flag=value` in one press) |
+| `Ctrl+Y` | Paste last deleted text; `Alt+Y` after that cycles paste history |
+| `Alt+B`/`Alt+F` | Word back/forward (letters+digits only; punctuation is a boundary) |
+| `Alt+D` | Delete to end of word |
+| `Ctrl+_` / `Ctrl+Shift+-` | Undo last input edit |
+
+`Ctrl+W` treats punctuation as part of the deletion (removes a whole path in
+one press); the `Alt+B/F/D` family treats punctuation as a word boundary. This
+distinction is a real usability asymmetry worth preserving deliberately.
+
+## Multi-line input
+
+| Method | Shortcut |
+|---|---|
+| Quick escape | `\` + `Enter` |
+| Option key | `Option+Enter` (macOS, after enabling Option-as-Meta) |
+| Shift+Enter | native in iTerm2/WezTerm/Ghostty/Kitty/Warp/Terminal.app/Windows Terminal |
+| Control sequence | `Ctrl+J` (works everywhere, no config) |
+| Paste mode | paste code blocks/logs directly |
+
+## Quick commands
+
+| Prefix | Meaning |
+|---|---|
+| `/` at start | command or skill — autocomplete filters as you type |
+| `!` at start | shell mode: run directly, add output+response to context, `Ctrl+B` backgrounds, `Tab` completes from `!`-history, live path autocomplete on tokens containing `/` |
+| `@` | file-path mention autocomplete; also suggests other live sessions on this machine (cross-session messaging) |
+| `:` | emoji shortcode — `:name:` inserts, 2+ chars opens suggestions |
+| `?` on empty input | toggles shortcut help panel |
+
+## Vim mode
+
+Enabled via `/config` → Editor mode. Mode persists across `Ctrl+O` toggles and
+panel open/close.
+
+**Mode switching:** `Esc`/`Ctrl+[` → NORMAL; `i`/`I`/`a`/`A`/`o`/`O` → INSERT
+variants; `v`/`V` → VISUAL (char/line-wise). `vimInsertModeRemaps` (e.g. `jj`
+→ Escape) is settable in user/managed settings only — project settings cannot
+remap keystrokes.
+
+**NORMAL navigation:** `h j k l`, `Space`, `w e b`, `0 $ ^`, `gg G`,
+`f{c} F{c} t{c} T{c}`, `; ,`, `/` (reverse history search).
+**NORMAL editing:** `x`, `dd D dw de db`, `df{c} dt{c}`, `cc C cw ce cb`,
+`s S` (v2.1.211+), `yy Y yw ye yb`, `p P`, `>> <<`, `J`, `u`, `.`.
+**Text objects:** `iw/aw`, `iW/aW`, `i"/a"`, `i'/a'`, `i(/a(`, `i[/a[`,
+`i{/a{` — operate with `d`/`c`/`y`.
+**VISUAL:** `d/x` delete, `y` yank, `c/s` change, `p` replace, `r{c}`
+replace-each, `~/u/U` case, `>/<` indent, `J` join, `o` swap ends. Block-wise
+`Ctrl+V` visual is **not supported**.
+
+At cursor extremes in NORMAL mode, `j/k` and arrows fall through to command
+history navigation instead of failing silently.
+
+## Command history
+
+Stored per working directory. `/clear` starts a new session for recall
+purposes (new session's prompts list first). Duplicate consecutive submits
+collapse to one history entry. `Ctrl+R` reverse-search: classic renderer
+searches inline across all projects; fullscreen opens a dialog with `Ctrl+S`
+cycling scope (session / project / all projects).
+
+## Interrupt semantics
+
+- **`Esc`** stops the current response/tool call mid-turn; work done so far
+  is kept; queued messages (see below) are sent next.
+- **`Ctrl+C`** on an idle prompt clears input (first press) then exits
+  (second press); on a running turn it interrupts, same as `Esc`, per the
+  general-controls table.
+- **`Ctrl+X Ctrl+K`** is the heavier interrupt: stops every background
+  subagent and disables artifact auto-replies (double-press-to-confirm).
+
+## Queueing a message while a turn runs
+
+Typing a message and pressing `Enter` mid-turn **queues** it rather than
+interrupting — queued entries list above the input box. Delivery depends on
+kind:
+
+- **Plain messages:** delivered to Claude as soon as in-flight tool calls
+  finish (same turn) if still mid-turn, or as the very next turn (oldest
+  first) once the turn ends; the rest keep queueing behind the same rule.
+- **Commands / shell commands:** held until the turn ends, then run one at a
+  time — except a short list Claude Code runs immediately on submit
+  (`/status`, `/model`, `/effort`, `/fast`).
+- **Take-back:** `Up` from the first input row (empty prompt) pulls every
+  queued item back into the input box, one per line, ahead of anything typed;
+  editing and re-pressing `Enter` re-queues as one entry.
+
+`Esc` interrupts the turn and sends what's queued immediately instead of
+waiting for the turn to end naturally.
+
+## Rewind and checkpoints
+
+`/rewind` or `Esc Esc` on empty input opens the rewind menu (full layout in
+`screen-inventory.md` §20). Checkpoints:
+
+- Captured automatically before every user prompt; the 100 most recent are
+  kept per session, with each file's *first* snapshot retained even after its
+  checkpoint ages out (VS Code diff baseline).
+- Checkpoints persist with the conversation — `/rewind` works after
+  `--resume`.
+- **Not tracked:** bash-command file modifications (`rm`, `mv`, `cp` via
+  shell), most subagent edits (exception: a foreground-forked skill),
+  external/concurrent-session edits, symlinked/hard-linked paths (skipped
+  with a warning, current contents kept).
+- Rewind is explicitly **not a substitute for version control**.
+
+## Paste handling
+
+- Plain paste inserts as multi-line text (see Multi-line input above).
+- Image paste (`Ctrl+V`/`Cmd+V`/`Alt+V`) inserts a positional `[Image #N]`
+  chip.
+- A recalled history entry that had pasted content resends the full pasted
+  content on resubmit (unless it has since been retention-cleaned, in which
+  case the literal `[Pasted text #N]` marker is not resent — interactive-mode
+  doc, "Command history").
+
+## File @-mention and slash-command autocomplete
+
+- `@` triggers file-path autocomplete; in fullscreen the suggestion list also
+  responds to the mouse (hover-highlight, click-to-accept).
+- `/` triggers command/skill autocomplete; the menu lists built-ins, bundled
+  and user skills, and plugin/MCP-contributed commands; a few built-ins are
+  intentionally hidden from the menu and only run when typed in full.
+- Skill `argument-hint` frontmatter drives the hinted-argument display during
+  `/`-autocomplete.
+
+## Terminal setup and platform notes
+
+- macOS Option/Alt-key shortcuts (`Alt+B/F/D/Y/P`) require configuring Option
+  as Meta in the terminal profile.
+- Fullscreen rendering requires the alt-screen buffer (like `vim`/`htop`);
+  incompatible with iTerm2's `tmux -CC` integration mode; needs `set -g mouse
+  on` in `~/.tmux.conf` for wheel scrolling under plain tmux.

--- a/docs/design/trusty-code/tui/rendering-and-layout.md
+++ b/docs/design/trusty-code/tui/rendering-and-layout.md
@@ -1,0 +1,120 @@
+# Rendering and Layout — Claude Code TUI
+
+**Status:** Informative (design analysis)
+**Last-updated:** 2026-09-06
+**Sources:** `code.claude.com/docs/en/fullscreen` (primary), `interactive-mode`,
+`statusline`.
+
+## Transcript structure
+
+Two renderers hold the transcript differently:
+
+- **Classic:** the conversation lives in the terminal's own native scrollback.
+  `Cmd+F` / tmux copy-mode search it directly. Memory grows with conversation
+  length because rendered content accumulates in the native buffer.
+- **Fullscreen:** the conversation lives in the alt-screen buffer, off the
+  terminal's native scrollback. Only currently-visible messages are kept in
+  the render tree, so memory stays flat regardless of conversation length.
+  Native search tools see nothing there by default — `Ctrl+O` (transcript
+  mode) then `[` writes the full expanded conversation into native scrollback
+  on demand, or `v` opens it in `$VISUAL`/`$EDITOR`.
+
+## Markdown rendering
+
+Not itemized exhaustively in the fetched docs; observed conventions: code
+fences render with syntax highlighting (toggle inside the `/theme` picker via
+`Ctrl+T`, "Theme and display" table); assistant text otherwise renders as
+formatted markdown inline in the transcript.
+
+## Code block and diff styling
+
+- Diff content has two dedicated presentations, not just syntax-highlighted
+  fences — see `screen-inventory.md` §7 (diff panel / diff viewer). The
+  fullscreen diff panel shows added/removed line counts per file and can
+  render a mouse-selectable diff region that attaches selected lines to the
+  next prompt.
+- The diff panel explicitly **collapses** test files and generated files, and
+  folds pre-session changes into one expandable summary line — a deliberate
+  truncation policy, not a limitation.
+
+## Tool-result truncation and expansion
+
+- Grouped/repeated MCP calls collapse to one line by default (`Called slack 3
+  times`); `Ctrl+O` (transcript viewer) expands these and any other
+  by-default-collapsed line, e.g. cross-session message previews
+  (`Message from @<sender>`).
+- In fullscreen, a collapsed tool result is individually click-to-expand /
+  click-to-collapse (mouse), independent of the global transcript-viewer
+  toggle.
+
+## Colour and theme handling
+
+- `/theme` picker exists; `Ctrl+T` inside it toggles syntax highlighting for
+  code blocks specifically (light vs dark/ANSI-16 palette selection itself
+  was not itemized in the fetched pages — see
+  `gaps-and-open-questions.md`).
+- Spell-check underline color is themeable (`spellcheck.color`), defaulting
+  to the active theme's error color.
+- Status-line output is arbitrary ANSI from the user's script — the host
+  imposes no palette on it beyond terminal capability.
+
+## Terminal resize
+
+Not directly documented in the fetched pages beyond the general expectation
+that fullscreen rendering "works at any window size" (the fullscreen doc's
+own clarification that "fullscreen" describes alt-screen takeover, not window
+maximization). Diff-panel and prompt-suggestion behaviors are column-gated
+(≥110 cols for the diff panel to open via `/diff`, ≥144 to auto-open,
+≥80 assumed elsewhere per DOC-50's own SSH/narrow-terminal note) — see
+`gaps-and-open-questions.md` for the exact resize-repaint contract.
+
+## Scrollback
+
+- **Classic:** native terminal scrollback; no in-app paging model beyond what
+  the terminal itself provides.
+- **Fullscreen:** `PgUp`/`PgDn` (half-screen), `Ctrl+Home`/`Ctrl+End`
+  (jump to start / jump to latest + re-enable auto-follow), mouse wheel.
+  Auto-follow pauses on manual scroll-up; a floating "Jump to bottom" button
+  shows a new-message count; disable auto-follow entirely via `/config` →
+  Auto-scroll.
+- Scrolling back past a `/compact` boundary still shows every earlier message
+  in fullscreen scrollback (Claude itself only sees the compaction summary
+  going forward).
+
+## Width thresholds
+
+- Diff panel: needs a git repo, fullscreen rendering, and ≥110 columns to
+  open via `/diff`; auto-opens on its own once Claude edits a file only in a
+  ≥144-column terminal.
+- No other exact width threshold was found in the fetched pages for general
+  transcript layout; DOC-50 §4.2/§9 Q3 names an SSH/narrow-terminal fallback
+  (<80 cols) as a real product concern for trusty-code-tui, unconfirmed
+  against the real product's own exact cutoff — flagged in
+  `gaps-and-open-questions.md`.
+
+## Notification bell / title-bar updates
+
+- A PR-review-state badge appears in the footer once a branch has an open PR
+  (`PR #446`), color-coded by review state (green=approved, yellow=pending,
+  red=changes-requested, gray=draft) and disappears on merge/close; same
+  mechanism for GitLab (`MR !N`). `Cmd/Ctrl+click` opens it in the browser.
+  This refreshes on `git push` / `gh pr`·`glab mr` state-changing commands
+  succeeding in-session.
+- Terminal title updates: the CLI accepts `-n/--name` to set "a display name
+  … shown in the prompt box, /resume picker, and terminal title" (`claude
+  --help`), confirming the title bar is actively managed, though the exact
+  update triggers beyond session start were not directly documented in the
+  fetched pages.
+- No explicit terminal-bell (audible) notification behavior was found in the
+  fetched pages; see `gaps-and-open-questions.md`.
+
+## Foundry design-system relevance
+
+trusty-code-tui is a terminal (ratatui) UI, so Foundry's CSS/token system
+(`docs/design/UI/README.md`) does not apply literally. Where it transfers:
+the **palette relationship** (status/semantic colors — ok/warn/error/accent)
+and the **robot-mark idle/working/receiving states** are conceptually
+reusable as ANSI-256/truecolor equivalents and as spinner/status-glyph
+states, respectively, but no CSS token maps directly onto a ratatui `Style`.
+This is a design note, not a requirement — no requirement below claims a
+literal Foundry-to-ratatui mapping exists today.

--- a/docs/design/trusty-code/tui/requirements.md
+++ b/docs/design/trusty-code/tui/requirements.md
@@ -1,0 +1,212 @@
+# Requirements — trusty-code TUI (derived from the Claude Code TUI analysis)
+
+**Status:** Informative (candidate requirements — not yet accepted into
+DOC-50 or any binding spec)
+**Last-updated:** 2026-09-06
+
+Each requirement traces to a section in `screen-inventory.md`,
+`interaction-model.md`, `rendering-and-layout.md`, `state-and-session.md`, or
+`extensibility.md` (cited as `file §n`). Each is written so a wrong
+implementation observably fails it. **DOC-50 status** is one of: `COVERED`
+(DOC-50 already requires this, cite the AC/slice), `NEW` (not in DOC-50),
+`CONFLICT` (contradicts a DOC-50 decision or owner directive — flagged, not
+resolved). Numbering is sequential across the whole set; MUST/SHOULD/MAY
+sections are separated for scanability.
+
+All requirements are subject to DOC-50 §2.1's thin-client axiom (C-1..C-4):
+any requirement below that needs a fact only the daemon can supply is a
+**daemon API requirement**, not a UI-only one — implementing it client-side
+without a corresponding daemon RPC/event is itself a spec violation, not an
+acceptable shortcut.
+
+## MUST
+
+**R1.** The input composer MUST accept multi-line input via at least one
+escape mechanism that works with no terminal configuration (`Ctrl+J`, per
+`interaction-model.md` "Multi-line input"). — **NEW**. Rationale: DOC-50's
+MVP composer is single-line-oriented per its slice descriptions; no
+multi-line escape mechanism is named in DOC-50 §4.1.
+
+**R2.** `Esc` MUST interrupt an in-flight turn while preserving work done so
+far and MUST send any queued input immediately afterward
+(`interaction-model.md` "Interrupt semantics", "Queueing"). — **COVERED**:
+DOC-50 §5 Slice 5 wires `Ctrl-c` to `engine.cancel_session()`; extend the
+same acceptance criterion to `Esc` with queue-drain semantics.
+
+**R3.** A message typed and submitted while a turn is running MUST be
+queued, not interrupt the turn, and MUST be delivered per the turn-boundary
+rule in `interaction-model.md` "Queueing a message while Claude works". —
+**NEW**. trusty-code-tui's current `busy` gate (CHANGELOG 0.1.1) *blocks*
+submission outright while busy rather than queueing it — a behavioral gap
+against the real product, not equivalent design.
+
+**R4.** Every user-facing permission gate MUST render tool name, a
+human description, and an explicit Allow/Deny choice, and MUST offer a
+"don't ask again" affordance where the underlying rule can be persisted
+(`screen-inventory.md` §3; `state-and-session.md` "Permission modes"). —
+**COVERED (Phase 2)**: DOC-50 §4.2 Slice 9 scopes permission/diff prompts to
+Phase 2; this requirement is the acceptance detail for that slice.
+
+**R5.** The active permission mode MUST be visibly indicated at all times
+(status line or equivalent persistent indicator), and switching modes MUST
+be a single explicit user action (`state-and-session.md` "Permission modes
+and their TUI reflection"). — **NEW** relative to DOC-50 §4.1's MVP status
+line (session/workstream/model/project only, no permission-mode field named).
+
+**R6.** Tool invocations MUST render at minimum as a one-line summary with
+an expand affordance; expansion MUST NOT be the only rendering mode
+(`screen-inventory.md` §6; `rendering-and-layout.md` "Tool-result truncation
+and expansion"). — **COVERED**: DOC-50 §4.1 MVP already specifies
+`[TOOL] name: args` / `[RESULT] …` text rendering; fancy cards are §4.2
+Slice 8. This requirement adds the collapse/expand toggle DOC-50 doesn't
+name explicitly.
+
+**R7.** `/help` MUST list every available command, including
+skill/plugin/MCP-contributed ones with a provenance marker
+(`extensibility.md` "Slash commands and skills"). — **COVERED**: DOC-50 §4.1
+lists `/help`; this requirement adds the provenance-marker detail (missing
+from DOC-50's text).
+
+**R8.** Command history MUST be scoped per working directory and MUST
+survive `/clear` (new conversation) without losing prior-session recall
+(`interaction-model.md` "Command history"). — **COVERED**: DOC-50 §4.1 MVP
+lists "Input composer history works"; this requirement adds the
+per-directory-scope and post-`/clear` recall details.
+
+**R9.** A running subagent/background task MUST be visible in a dedicated
+panel distinct from the main transcript, MUST show its task description,
+and MUST offer a stop action (`screen-inventory.md` §9; `extensibility.md`
+"Subagents display"). — **NEW**. Nothing in DOC-50 §1–§5 names a subagent
+panel; DOC-50's scope is a single-turn daemon RPC loop with no visible
+concept of concurrent background work.
+
+**R10.** MCP server connection status MUST be visible via a dedicated
+command/panel (`/mcp`-equivalent) with at minimum connected/failed/pending
+states (`extensibility.md` "MCP server status and tool loading"). — **NEW**.
+DOC-50 does not mention MCP at all — trusty-code's daemon-owned MCP surface
+(per CLAUDE.md's model-context-builder conventions) has no client-visible
+status requirement stated anywhere in DOC-50.
+
+**R11.** Settings precedence (managed → CLI → project-local → project-shared
+→ user) MUST be documented and MUST be discoverable from within the TUI
+(equivalent of `/config`) (`state-and-session.md` "Settings precedence"). —
+**NEW** relative to DOC-50, which defines no settings-precedence model for
+tcode-tui itself (it inherits `.claude/` config per `crates/trusty-code/
+README.md` "Design Constraints", but no TUI-visible settings surface is
+specified).
+
+**R12.** The TUI MUST NOT read the filesystem, spawn a process, or shell out
+to git directly to satisfy any requirement in this document — every fact
+(git branch/status for a status line, PR badge state, file diff content,
+etc.) MUST arrive from a daemon call (DOC-50 §2.1 AC-19.1..19.3). — **COVERED
+(binding, restated)**. This requirement exists here only to flag that several
+real-product behaviors (PR-status badge via local `gh`/`glab` credential
+lookup, spell-check via a local `aspell`/`hunspell` binary) are, in the real
+Claude Code CLI, done by direct local process/credential access — a design
+that DOC-50's thin-client axiom explicitly forbids trusty-code-tui from
+copying verbatim. See **CONFLICT** entries below.
+
+## SHOULD
+
+**R13.** The TUI SHOULD support vim-style editing as an opt-in mode with at
+minimum NORMAL/INSERT mode switching and basic motions
+(`interaction-model.md` "Vim mode"). — **NEW**.
+
+**R14.** The TUI SHOULD render a rewind/checkpoint affordance that lists
+prior prompts and supports at least "restore conversation to here"
+(`screen-inventory.md` §20; `interaction-model.md` "Rewind and checkpoints").
+— **NEW**. No checkpoint/rewind concept appears anywhere in DOC-50.
+
+**R15.** The TUI SHOULD show a colored context-usage indicator (percentage
+or grid) so the user can anticipate compaction (`state-and-session.md`
+"Checkpoints and compaction/context indicators"). — **NEW**. DOC-50 §6 Q9
+explicitly defers even *cost* display as a missing daemon API; context-usage
+display is a distinct, likewise-undeclared daemon API gap.
+
+**R16.** The TUI SHOULD offer a fullscreen/alt-screen rendering mode with
+flicker-free redraws and mouse support as an alternative to a
+scrollback-append classic mode (`rendering-and-layout.md` "Transcript
+structure"). — **NEW**. Ratatui's alt-screen mode (DOC-50 §2.2/§3.1 already
+mandates alt-screen + raw mode unconditionally) makes this **partially
+COVERED** by construction — trusty-code-tui has no non-alt-screen "classic"
+fallback at all, which is the inverse gap from the real product (real
+product defaults toward fullscreen only recently and keeps classic as an
+explicit fallback for narrow/incompatible terminals). Cross-reference R23.
+
+**R17.** The TUI SHOULD support an emoji-shortcode and/or spell-check input
+aid, each independently toggleable (`interaction-model.md` "Quick commands";
+`rendering-and-layout.md` "Colour and theme handling"). — **NEW**, low
+priority.
+
+**R18.** The TUI SHOULD show a PR/MR review-state badge in the footer when
+the current branch has an open pull/merge request, sourced from a daemon
+call, not a local `gh`/`glab` invocation (`rendering-and-layout.md`
+"Notification bell / title-bar updates"). — **NEW**, and see **R12/CONFLICT**
+below for the sourcing constraint.
+
+**R19.** The TUI SHOULD surface hook configuration read-only (a `/hooks`-
+equivalent) without implying hooks execute client-side (`state-and-session.md`
+"Hooks surfaced in the UI"). — **NEW**.
+
+## MAY
+
+**R20.** The TUI MAY offer a `/btw`-style side-question overlay that answers
+from existing context without adding to the transcript or requiring tool
+access (`interaction-model.md`, referenced via `screen-inventory.md`
+context). — **NEW**, explicitly optional; no daemon-side equivalent is known
+to exist.
+
+**R21.** The TUI MAY offer a session-recap line when reattaching to an idle
+session (`interaction-model.md` context). — **NEW**, optional.
+
+**R22.** The TUI MAY support `:emoji:` shortcode completion
+(`interaction-model.md` "Quick commands"). — **NEW**, optional, folds into
+R17.
+
+## Conflicts and flags (not resolved here)
+
+**R23 — CONFLICT with DOC-50 §3.1/§9 Q3.** DOC-50 mandates ratatui's
+alt-screen + raw mode unconditionally in the shared `trusty-code-tui` crate
+(§2.2/§3.1) and defers an SSH/narrow-terminal plain-line fallback to Phase 2
+(§9 Q3, "RESOLVED … Phase 2"). The real Claude Code TUI instead keeps
+**classic (non-alt-screen) rendering as the default in more situations than
+fullscreen**, and reserves fullscreen for terminals/situations it can
+positively detect as compatible (`rendering-and-layout.md` "Transcript
+structure"; fullscreen doc "Fullscreen by default" table). Flagging for Bob:
+should trusty-code-tui's Phase-2 SSH fallback follow DOC-50's original
+plain-line design, or invert to "classic is the default, alt-screen is the
+opt-in enhancement" the way the real product now does? Not resolved here.
+
+**R24 — CONFLICT with DOC-50 §2.1 C-4 (thin-client axiom).** The real Claude
+Code TUI sources its PR/MR badge (R18) and spell-check (R17) from **local**
+`gh`/`glab` credentials and a **local** `aspell`/`hunspell`/`ispell` binary
+respectively — direct local process/credential access that DOC-50's
+thin-client axiom (C-1..C-4, AC-19.1..19.3) forbids trusty-code-tui from
+doing. Any trusty-code-tui implementation of R17/R18 MUST route through a
+daemon RPC instead (per R12) — meaning these are **daemon API gaps to
+specify**, not UI features to build directly, exactly as DOC-50 §2.1 C-2
+already states for any such case. Flagging for Bob: is a daemon-side
+`gh`/`glab`/spell-check proxy in scope at all, or are R17/R18 explicitly
+descoped for trusty-code-tui because the daemon should never shell out to
+per-user local tooling on the client's behalf?
+
+**R25 — CONFLICT with owner directive (trusty-mpm project registry reuse).**
+The real Claude Code TUI's project/session picker (`/resume`,
+`screen-inventory.md` §16) is scoped to sessions in the current working
+directory tree only. The owner directive in force for trusty-code (DOC-48
+§8 Rev 9, DOC-39 §5.8.1, issue #3435) requires any project/workstream roster
+the TUI shows to come from the **shared trusty-mpm project registry**, which
+is cross-project by design. Any trusty-code-tui `/resume`-equivalent picker
+therefore needs a roster source model that has no direct analogue in the
+real product being cloned — flagging that "clone Claude Code's picker
+verbatim" and "source the roster from the shared trusty-mpm registry" are in
+tension, not identical asks. Not resolved here.
+
+## Summary counts
+
+- MUST: R1–R12 (12)
+- SHOULD: R13–R19 (7)
+- MAY: R20–R22 (3)
+- Flagged conflicts: R23, R24, R25 (3) — counted separately, not folded into
+  the MUST/SHOULD/MAY totals above since each is a flag, not an accepted
+  requirement.

--- a/docs/design/trusty-code/tui/screen-inventory.md
+++ b/docs/design/trusty-code/tui/screen-inventory.md
@@ -1,0 +1,254 @@
+# Screen Inventory — Claude Code TUI
+
+**Status:** Informative (design analysis)
+**Subsystem:** trusty-code-tui / trusty-code TUI client
+**Last-updated:** 2026-09-06
+**Sources:** `claude --help` and subcommand `--help` output (binary v2.1.263);
+`code.claude.com/docs/en/{interactive-mode,commands,fullscreen,permission-modes,
+permissions,mcp,sub-agents,checkpointing,context-window,statusline}`.
+
+Two renderers exist side by side: **classic** (default on older/incompatible
+setups, scrollback lives in the terminal's native buffer) and **fullscreen**
+(alt-screen, mouse support, `/tui fullscreen` — interactive-mode doc, fullscreen
+doc). Most screens below exist in both; where behavior differs it is called out.
+
+## 1. Main transcript
+
+- **Trigger:** default view on session start.
+- **Layout — classic:** messages append to the terminal's native scrollback;
+  input box floats near the bottom and moves as output streams (fullscreen
+  doc, "What changes").
+- **Layout — fullscreen:** input box is pinned at the bottom of the alt-screen;
+  only visible messages are kept in the render tree (constant memory).
+- **Editable:** the input line only; transcript content is read-only (but see
+  `/diff` line-selection, §11).
+- **Exit path:** `Ctrl+D` twice, `/exit`, or process exit.
+
+## 2. Input composer
+
+- **Trigger:** always present at the bottom.
+- **Layout:** multi-line box; grows as text wraps. Right-aligned busy
+  indicator while a turn streams (trusty-code-tui's generalized analogue:
+  `busy: bool`, no elapsed timer — CHANGELOG "Deliberately NOT ported").
+  Shows a grayed-out example prompt on first open, and after a turn a
+  next-prompt suggestion (Tab/Right-arrow to accept) — interactive-mode doc,
+  "Prompt suggestions".
+- **Editable:** full readline-style multi-line text with vim mode option
+  (§ interaction-model.md).
+- **Exit path:** `Enter` submits; `Esc` interrupts a running turn or closes an
+  open dialog; `Ctrl+D` on empty input exits the session.
+
+## 3. Permission prompt
+
+- **Trigger:** a tool call needs approval under the active permission mode
+  (permission-modes doc; permissions doc "Permission system").
+- **Layout:** modal-like inline dialog — tool name, description, and (per the
+  claude-code-guide synthesis of the MCP doc) an options list such as
+  `Accept [a]` / `Don't ask again for this tool [d]` / `Deny [n]`. Left/Right
+  arrows cycle dialog tabs; `Tab` on Yes/No opens a one-line comment field
+  (permissions doc, "Add a comment when you answer a permission prompt");
+  `Shift+Tab` with no field open selects the "allow for rest of session"
+  option when offered.
+- **Editable:** the optional comment field; otherwise choice-only.
+- **Exit path:** `Esc` = decline (same as No, no comment); `Enter`/selection
+  confirms.
+
+## 4. Plan-mode view
+
+- **Trigger:** `Shift+Tab` cycle, `/plan`, or `--permission-mode plan`
+  (permission-modes doc, "Analyze before you edit with plan mode").
+- **Layout:** no distinct screen — Claude researches read-only, then presents
+  a plan as transcript text followed by a decision prompt: **Yes, and use auto
+  mode** / **Yes, and switch to BYPASS PERMISSIONS…** / **Yes, manually
+  approve edits** / **No, keep planning**.
+- **Editable:** `Ctrl+G` opens the plan text in `$EDITOR` before proceeding.
+- **Exit path:** selecting an option exits plan mode into the mode that option
+  names; `Shift+Tab` again leaves plan mode without approving.
+
+## 5. AskUserQuestion dialogs
+
+- **Trigger:** the built-in `AskUserQuestion` tool, which always prompts
+  regardless of permission mode (permission-modes doc, "Actions no mode
+  auto-approves").
+- **Layout:** multi-select or single-select menu; a free-text "Other" row
+  focuses an input field on click (fullscreen doc, "Use the mouse").
+- **Editable:** free-text row when present.
+- **Exit path:** submit button / Enter; `Esc` semantics as in §3 for the
+  underlying permission gate.
+
+## 6. Tool-call rendering (collapsed / expanded)
+
+- **Trigger:** every tool invocation.
+- **Layout — collapsed (default):** a one-line summary, e.g. `Called slack 3
+  times` for grouped MCP calls (interactive-mode doc, `Ctrl+O`). Fullscreen:
+  click a collapsed result to expand; click again to collapse (fullscreen
+  doc, "Use the mouse").
+- **Layout — expanded:** `Ctrl+O` toggles the transcript viewer, which shows
+  full tool usage, a timestamp, and the model used per assistant message.
+- **Editable:** none.
+- **Exit path:** `Ctrl+O` again, `q`, or `Esc` (transcript viewer only).
+
+## 7. Diff rendering
+
+- **Trigger:** `/diff`, or automatically once Claude edits a file in a wide
+  enough terminal (fullscreen doc, "Watch your changes in the diff panel").
+- **Layout — fullscreen "diff panel":** persistent side panel beside the
+  conversation; lists changed files with +/- counts, per-file diff below;
+  refreshes on every edit/shell command; needs a git repo and ≥110 columns.
+  `Ctrl+X B` cycles compare-against scope (this session / uncommitted /
+  since branch split).
+- **Layout — classic "diff viewer":** replaces the prompt until closed;
+  **Current** view (uncommitted changes) plus one turn view per prompt that
+  edited files; Left/Right switch views, Up/Down select a file, Enter opens
+  it.
+- **Editable:** mouse-drag line selection in the panel attaches selected
+  lines to the next prompt (fullscreen doc).
+- **Exit path:** `/diff` again or the panel's `✕` (fullscreen); `Esc` from the
+  file view back to the list, then `Esc` again to close (classic).
+
+## 8. Status line
+
+- **Trigger:** always present when configured (`/statusline`, statusline doc).
+- **Layout:** one row above the built-in footer badges; a custom status line
+  suppresses most footer keyboard hints (`esc to interrupt`, `? for
+  shortcuts`, voice-dictation hint). Renders arbitrary shell-script stdout —
+  context %, cost, git branch, model name are common fields (statusline doc,
+  "Available data"). Multi-line status lines are supported.
+- **Editable:** none directly; configured via `/statusline` or settings.
+- **Exit path:** n/a (persistent).
+
+## 9. Spinner / progress and background-task notices
+
+- **Trigger:** a turn in flight; a background Bash command or subagent.
+- **Layout:** busy indicator in the input composer (no elapsed timer exposed
+  per-doc beyond what the status line script computes itself); background
+  subagents appear as rows in a panel below the prompt with a
+  `name(task description)` label and a `(+N)` descendant count for nested
+  subagents (sub-agents doc synthesis). A completed/failed subagent's row
+  persists 30s (`x` clears sooner) with a footer hint `/tasks to see
+  subagents`.
+- **Editable:** `Enter` opens a subagent's transcript and allows typing to
+  resume it; `x` stops the selected one.
+- **Exit path:** row disappears on its own after completion + 30s, or `x`.
+
+## 10. `/tasks`
+
+- **Trigger:** `/tasks` command.
+- **Layout:** list of running/completed/failed subagents and background
+  shells, plus the model (and effort level, v2.1.242+) each subagent runs on.
+- **Editable:** selection to view/stop, per sub-agents doc.
+- **Exit path:** `Esc`/close command.
+
+## 11. `/agents`
+
+- **Trigger:** `/agents` command.
+- **Layout:** as of v2.1.198 this **no longer opens a wizard** — it prints a
+  reminder to ask Claude to create/manage subagents or edit
+  `.claude/agents/`/`~/.claude/agents/` directly (sub-agents doc). Pre-v2.1.198
+  it opened a Running/Library tabbed wizard.
+- **Exit path:** immediate (it is a one-shot print in the current version).
+
+## 12. `/artifacts`
+
+- **Trigger:** `/artifacts` command (`commands` doc table).
+- **Layout:** list of artifacts owned by or shared with the user; select one
+  to attach to the session, open in browser, or copy its link.
+- **Exit path:** selection or dismiss.
+
+## 13. `/config`
+
+- **Trigger:** `/config` command, or `/config key=value` for a direct set.
+- **Layout:** settings menu — theme, model, output style, editor mode (vim
+  on/off), auto-scroll, copy-on-select, prompt suggestions, session recap,
+  auto-continue-at-usage-limit, and more (assembled across output-styles,
+  fullscreen, and interactive-mode docs' cross-references to `/config`).
+- **Editable:** every listed preference.
+- **Exit path:** `Esc` / selection.
+
+## 14. `/help`
+
+- **Trigger:** `/help` command.
+- **Layout:** list of available commands (interactive-mode doc, "Commands").
+- **Exit path:** dismiss.
+
+## 15. `/model`
+
+- **Trigger:** `/model [model]` command, or `Option+P`/`Alt+P` chord.
+- **Layout:** model picker if invoked with no argument; direct switch if an
+  argument is given. A cache-warning confirmation may appear first
+  (interactive-mode doc, "Queue messages while Claude works").
+- **Exit path:** selection or Esc.
+
+## 16. `/resume` picker
+
+- **Trigger:** `claude --resume` / `claude -r` with no argument, or `/resume`.
+- **Layout:** interactive list of prior sessions, filterable by an optional
+  search term (`claude --help`: `-r, --resume [value]`).
+- **Exit path:** selection opens that session; Esc cancels.
+
+## 17. Compaction notice
+
+- **Trigger:** `/compact`, or automatic compaction at the auto-compact
+  threshold (`--autocompact`, `/autocompact`).
+- **Layout:** a **Summarized conversation** marker appears in the transcript
+  at the compaction point (checkpointing doc, "Guide a summary"). Root
+  CLAUDE.md is re-read from disk and re-injected after compaction
+  (memory doc, "Instructions seem lost after /compact").
+- **Exit path:** n/a — transcript marker, not a dismissible dialog.
+
+## 18. Cost / usage displays
+
+- **Trigger:** `/cost` (alias for `/usage`), or fields in a custom status
+  line script (statusline doc, "Cost and duration tracking").
+- **Layout:** text summary of the session's spend; status-line scripts can
+  render it persistently.
+- **Exit path:** command output, no persistent dialog unless in the status
+  line.
+
+## 19. Errors and rate-limit banners
+
+- **Trigger:** a hit usage limit, an auth failure, an `apiKeyHelper` failure,
+  etc.
+- **Layout:** an inline line, e.g. `Usage limit reached · continuing
+  automatically at 3:45pm · esc to cancel` (interactive-mode doc, "Wait for a
+  usage limit to reset"); a `Login expires in 3 days` startup warning
+  (authentication doc); an `apiKeyHelper` slow-helper warning in the prompt
+  bar.
+- **Editable:** none; some carry an action hint (`/rate-limit-options`,
+  `/login`).
+- **Exit path:** self-clears on the triggering condition changing, or `Esc`/
+  `Ctrl+C` to cancel an auto-continue wait.
+
+## 20. Rewind menu
+
+- **Trigger:** `/rewind`, or `Esc Esc` on an empty prompt.
+- **Layout:** list of every prompt sent this session; per-selection actions
+  **Restore code and conversation** / **Restore conversation** / **Restore
+  code** / **Summarize from here** / **Summarize up to here** / **Never
+  mind** (checkpointing doc). A `Summarize` row can take optional freeform
+  guidance text.
+- **Exit path:** **Never mind**, or completing an action.
+
+## 21. Transcript viewer (fullscreen-only extras)
+
+- **Trigger:** `Ctrl+O` in fullscreen rendering.
+- **Layout:** `less`-style paged view with `/` search, `n`/`N` next/prev
+  match, `{`/`}` jump between prompts (fullscreen doc, "Search and review the
+  conversation").
+- **Exit path:** `Ctrl+O`, `Esc`, or `q`.
+
+## 22. `/mcp` panel
+
+- **Trigger:** `/mcp` command.
+- **Layout:** server list with status glyphs (`✔ Connected`, `! Needs
+  authentication`, `✘ Failed to connect`, `⏸ Pending approval`, `✘ Rejected`,
+  `⊘ Disabled for this project`, cached-with-tool-count), tool counts,
+  reconnect/toggle/auth actions (mcp doc synthesis).
+- **Exit path:** dismiss / Esc.
+
+## 23. `/focus`
+
+- **Trigger:** `/focus` toggle.
+- **Layout:** quieter view — last prompt, one-line tool-call summary with
+  diffstats, final response only (fullscreen doc).
+- **Exit path:** `/focus` again.

--- a/docs/design/trusty-code/tui/state-and-session.md
+++ b/docs/design/trusty-code/tui/state-and-session.md
@@ -1,0 +1,125 @@
+# State and Session — Claude Code TUI
+
+**Status:** Informative (design analysis)
+**Last-updated:** 2026-09-06
+**Sources:** `code.claude.com/docs/en/{memory,permission-modes,permissions,
+settings,checkpointing,context-window,authentication}`; `claude --help`.
+
+## Session identity, `--resume` and `--continue`
+
+- `-c/--continue`: continue the most recent conversation in the current
+  directory (`claude --help`).
+- `-r/--resume [value]`: resume by session ID, or open an interactive picker
+  filtered by an optional search term (`claude --help`; `screen-inventory.md`
+  §16).
+- `--fork-session`: on resume, mint a new session ID instead of reusing the
+  original.
+- `--session-id <uuid>`: pin a specific session id.
+- `-n/--name <name>`: display name shown in prompt box, `/resume` picker, and
+  terminal title.
+- `/branch [name]`: fork the conversation at the current point into a new
+  session without disturbing the current one (distinct from `/fork`, which
+  detaches to a background session).
+
+## Checkpoints and compaction/context indicators
+
+- Checkpointing mechanics are in `interaction-model.md` ("Rewind and
+  checkpoints").
+- `/compact [instructions]` frees context by summarizing; `/autocompact
+  [auto|<tokens>]` sets the auto-compact threshold (100k–1M tokens or `auto`).
+  `/context [all]` visualizes current context usage as a colored grid
+  (context-window doc).
+- **What survives compaction:** project-root `CLAUDE.md` is re-read from disk
+  and re-injected after `/compact`; nested subdirectory `CLAUDE.md`/rules
+  reload only when Claude next reads a matching file; a conversation-only
+  instruction (never written to `CLAUDE.md`) does not survive.
+- A `Summarized conversation` marker appears in the transcript at the
+  compaction point (see `screen-inventory.md` §17); fullscreen scrollback
+  still holds every pre-compaction message even after repeated compactions.
+
+## Settings precedence
+
+Five layers, highest first: **managed settings** (`managed-settings.json`,
+MDM, claude.ai console) → **command line** (`claude --settings`) →
+**project local** (`.claude/settings.local.json`) → **shared project**
+(`.claude/settings.json`) → **user** (`~/.claude/settings.json`) (settings
+doc, "Settings precedence"). Notable per-key exceptions this analysis
+surfaced:
+
+- `permissions.defaultMode: "auto"` and `"bypassPermissions"` take effect
+  only from `~/.claude/settings.json` or managed settings — the same values
+  set in `.claude/settings.json` or `.claude/settings.local.json` are
+  silently ignored and the built-in default applies instead
+  (permission-modes doc, "Which mode a session starts in").
+- `vimInsertModeRemaps` is honored only from user settings, `--settings`, or
+  managed settings — a project's `.claude/settings.json`/
+  `.claude/settings.local.json` cannot remap keystrokes (interactive-mode
+  doc, vim mode section).
+- `spellcheck` is read from user settings, `--settings`, or managed
+  settings only, and never combined across sources — the first one found
+  wins wholesale, fields are not merged.
+
+## Memory files (CLAUDE.md, auto memory)
+
+- **CLAUDE.md load order**, broadest to narrowest scope: managed policy
+  (`/Library/Application Support/ClaudeCode/CLAUDE.md` on macOS, etc.) → user
+  (`~/.claude/CLAUDE.md`) → project (`./CLAUDE.md` or `./.claude/CLAUDE.md`)
+  → local (`./CLAUDE.local.md`). All discovered files are **concatenated**,
+  not override-replaced; within a directory, `CLAUDE.local.md` is appended
+  after `CLAUDE.md`.
+- Nested-directory `CLAUDE.md`/`CLAUDE.local.md` load on demand when Claude
+  reads files in that subdirectory, not at launch.
+- `@path/to/import` syntax expands recursively (max depth 4); an import that
+  resolves outside the working directory in a *project*-level file triggers
+  a one-time approval dialog; user-scope imports (e.g. `~/.claude/CLAUDE.md`)
+  are trusted without the dialog except in Cowork desktop sessions.
+- `.claude/rules/` supports path-scoped rules (`paths:` frontmatter glob) that
+  load only when Claude touches a matching file, plus unconditional rules
+  loaded at launch alongside `CLAUDE.md`.
+- Auto memory is a separate, Claude-authored mechanism: `~/.claude/projects/
+  <project>/memory/MEMORY.md` (index, first 200 lines or 25KB loaded at
+  session start) plus per-topic files loaded on demand. `/memory` browses and
+  toggles it; `/context` confirms what actually loaded.
+
+## Permission modes and their TUI reflection
+
+Six modes, cycled with `Shift+Tab`: `default` (labeled **Manual**),
+`acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`. Full behavior
+table:
+
+| Mode | Runs without asking | TUI cue |
+|---|---|---|
+| `default` (Manual) | Reads only | mode indicator shows "Manual"; every write/exec prompts |
+| `acceptEdits` | Reads, file edits, common FS commands | prompts only for shell/network beyond that |
+| `plan` | Reads, plus classifier-approved commands when auto mode is available | edits blocked until a plan is approved; approval prompt names the mode it will switch to |
+| `auto` | Everything, background classifier review | on Pro/Max/Team this is the **default starting mode**; a one-time startup notice explains it |
+| `dontAsk` | Only pre-approved tools | unapproved calls are silently denied, not prompted |
+| `bypassPermissions` | Everything | reserved for containers/VMs; still prompts for a narrow "actions no mode auto-approves" list (AskUserQuestion, MCP `requiresUserInteraction` tools, critical-path `rm`, cross-session-messaging safeguards) |
+
+`Shift+Tab` cycles `default → acceptEdits → plan → [bypassPermissions] →
+[auto] → default`; `auto`'s first press returns to `default`, not around the
+loop. Plan-mode approval offers **Yes, and use auto mode** / **Yes, manually
+approve edits** / **No, keep planning**, each switching the session's active
+mode. A managed-settings `disableAutoMode: "disable"` removes `auto` from the
+cycle entirely and demotes a running auto-mode session to Manual with a
+`auto mode disabled by settings` notice.
+
+## Hooks surfaced in the UI
+
+Hooks (`hooks-guide` doc) are shell commands bound to lifecycle events
+(`PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `InstructionsLoaded`, etc.).
+The TUI's direct visibility into hook execution is thin by design — hooks are
+meant to run silently and deterministically:
+
+- `/hooks` shows the configured hook table (per-event bindings), a
+  configuration view, not a live-execution log.
+- A hook that blocks an action (e.g. a `PreToolUse` "allow"/"deny" hook
+  result) surfaces as the corresponding permission outcome, not as a
+  separate "hook ran" notice.
+- A blocking `UserPromptSubmit` hook that stops an automatic usage-limit
+  continuation is reported to the user as "the continuation didn't run"
+  (interactive-mode doc) — an indirect surfacing via the affected feature,
+  not a hook-specific banner.
+- `/debug` + the `InstructionsLoaded` hook are the documented path to
+  *actually* observe which instruction files loaded and why — i.e. hook
+  visibility is opt-in and debug-log-mediated, not a first-class panel.


### PR DESCRIPTION
## Outcome

Analysis and requirements for a trusty-code TUI, derived from studying the
real Claude Code TUI's interaction model, rendering, session state, and
screen inventory. No issue number — owner-requested 2026-09-06, exploratory
design work ahead of any implementation ticket.

## What changed
- `docs/design/trusty-code/tui/README.md` — index and reading order for the
  set.
- `docs/design/trusty-code/tui/interaction-model.md` — input modes, keybinds,
  shell-mode `!` prefix, autocomplete.
- `docs/design/trusty-code/tui/rendering-and-layout.md` — ratatui rendering,
  classic vs alt-screen, and where Foundry's CSS/token system does and does
  not map onto a ratatui `Style`.
- `docs/design/trusty-code/tui/state-and-session.md` — session state,
  `/resume`, compaction thresholds.
- `docs/design/trusty-code/tui/screen-inventory.md` — every screen and its
  triggers.
- `docs/design/trusty-code/tui/extensibility.md` — plugin/extension surface.
- `docs/design/trusty-code/tui/requirements.md` — requirements for a
  trusty-code TUI drawn from the above.
- `docs/design/trusty-code/tui/gaps-and-open-questions.md` — open questions,
  including the three flagged conflicts below.
- Out of scope: no trusty-code source changes; this is docs-only design
  analysis.

## Risk / blast radius
Rung 1 — docs only, no crate `src/**` touched. Eight new files under
`docs/design/trusty-code/tui/`, no edits to existing files.

## Test evidence
Rung 1, docs-only gates:
- `bash scripts/check_sld.sh` — "scanned 63 spec doc(s) + 4629 code file(s);
  resolved 41 frontmatter + 77 inline reference(s), rejected 0 + 0 on path
  shape; 0 error(s), 0 warning(s)"
- `bash scripts/check_public_docs.sh` — "public-docs gate: 27 page(s) across
  5 section(s) — all resolve inside the public boundary."
- No Cargo gate applies (no crate source changed).

## Baseline / pre-existing failures
None — docs-only change, no gate went red.

## Documentation / changelog
No changelog fragment — docs-only PR, no crate `src/**` changed
(`scripts/check_changelog_fragment.sh` scope).

## Review-finding disposition
Three conflicts between DOC-50 (the trusty-code TUI spec) and the real
Claude Code TUI this analysis studied, flagged open, not resolved:

- **R23** — DOC-50 mandates alt-screen rendering unconditionally. The real
  Claude Code TUI defaults to classic (non-alt-screen) rendering, with
  fullscreen as an opt-in.
- **R24** — The real product reads local `gh`/`glab` credentials and a local
  spell-check binary. DOC-50's thin-client axiom forbids a trusty-code TUI
  from reading local credentials or shelling out to a local spell-check
  binary.
- **R25** — The real `/resume` picker is scoped to the current working
  directory. The owner directive for trusty-code requires the roster to come
  from the shared trusty-mpm project registry instead.

No issue tracks these; they are the deliverable of this analysis for a future
design decision.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
