### PR TITLE
docs(specs,design): apply 2026-09-06 rulings — per-session dashboard first, TUI scrollback rendering, registry-backed resume picker

### DIFF
--- a/docs/design/trusty-code/tui/requirements.md
+++ b/docs/design/trusty-code/tui/requirements.md
@@ -163,19 +163,45 @@ session (`interaction-model.md` context). — **NEW**, optional.
 (`interaction-model.md` "Quick commands"). — **NEW**, optional, folds into
 R17.
 
-## Conflicts and flags (not resolved here)
+## Resolved by owner ruling, 2026-09-06 (now MUST)
 
-**R23 — CONFLICT with DOC-50 §3.1/§9 Q3.** DOC-50 mandates ratatui's
-alt-screen + raw mode unconditionally in the shared `trusty-code-tui` crate
-(§2.2/§3.1) and defers an SSH/narrow-terminal plain-line fallback to Phase 2
-(§9 Q3, "RESOLVED … Phase 2"). The real Claude Code TUI instead keeps
-**classic (non-alt-screen) rendering as the default in more situations than
-fullscreen**, and reserves fullscreen for terminals/situations it can
-positively detect as compatible (`rendering-and-layout.md` "Transcript
-structure"; fullscreen doc "Fullscreen by default" table). Flagging for Bob:
-should trusty-code-tui's Phase-2 SSH fallback follow DOC-50's original
-plain-line design, or invert to "classic is the default, alt-screen is the
-opt-in enhancement" the way the real product now does? Not resolved here.
+**R23 (owner ruling, 2026-09-06).** The TUI MUST render so the terminal's
+native scrollback survives. Alt-screen MUST NOT be the default rendering
+mode; classic/inline rendering — like Claude Code's own default
+(`rendering-and-layout.md` "Transcript structure") — is the default, and
+fullscreen is at most an opt-in mode. — **Resolves R23**, previously flagged
+as a conflict with DOC-50 §3.1/§9 Q3, which mandated ratatui's alt-screen +
+raw mode unconditionally in the shared `trusty-code-tui` crate and deferred
+an SSH/narrow-terminal plain-line fallback to Phase 2 (§9 Q3, "RESOLVED …
+Phase 2"). Asked what trusty-code-tui uses today (alt-screen + raw mode via
+ratatui/crossterm, DOC-50 `setup_terminal`), the owner ruled:
+
+> "I want rendering that allows scroll back."
+> — Bob, 2026-09-06
+
+DOC-50 is amended accordingly — see its 2026-09-06 Amendment near
+`setup_terminal`, the Phase 2 SSH fallback, and the "requires full-size
+terminal with alt-screen support" known limitation. The SSH/narrow-terminal
+plain-line fallback (#3405) is no longer a separate Phase 2 feature: classic
+rendering is the default everywhere, so the same rendering mode already
+covers SSH and narrow terminals. Cross-reference R16.
+
+**R25 (owner ruling, 2026-09-06).** The `/resume`-equivalent picker MUST read
+the shared trusty-mpm project registry (DOC-48 §8 Rev 9, DOC-39 §5.8.1, issue
+#3435) and MUST filter its roster to the project that owns the current
+working directory — registry and cwd are meant to agree. A cwd outside any
+registered project is a designed-for edge case, not an error: the picker MUST
+either offer to register the cwd as a new project, or show every registry
+project and let the user pick one, and when the user picks, the picker MUST
+mark that pick as the PM's assumption rather than a confirmed match. —
+**Resolves R25**, previously flagged as a conflict between cloning Claude
+Code's cwd-scoped `/resume` picker verbatim and the owner directive to source
+the roster from the shared trusty-mpm registry:
+
+> "Resume picker should use registry which should align to cwd."
+> — Bob, 2026-09-06
+
+## Conflicts and flags (not resolved here)
 
 **R24 — CONFLICT with DOC-50 §2.1 C-4 (thin-client axiom).** The real Claude
 Code TUI sources its PR/MR badge (R18) and spell-check (R17) from **local**
@@ -190,23 +216,12 @@ already states for any such case. Flagging for Bob: is a daemon-side
 descoped for trusty-code-tui because the daemon should never shell out to
 per-user local tooling on the client's behalf?
 
-**R25 — CONFLICT with owner directive (trusty-mpm project registry reuse).**
-The real Claude Code TUI's project/session picker (`/resume`,
-`screen-inventory.md` §16) is scoped to sessions in the current working
-directory tree only. The owner directive in force for trusty-code (DOC-48
-§8 Rev 9, DOC-39 §5.8.1, issue #3435) requires any project/workstream roster
-the TUI shows to come from the **shared trusty-mpm project registry**, which
-is cross-project by design. Any trusty-code-tui `/resume`-equivalent picker
-therefore needs a roster source model that has no direct analogue in the
-real product being cloned — flagging that "clone Claude Code's picker
-verbatim" and "source the roster from the shared trusty-mpm registry" are in
-tension, not identical asks. Not resolved here.
-
 ## Summary counts
 
-- MUST: R1–R12 (12)
+- MUST: R1–R12, R23, R25 (14)
 - SHOULD: R13–R19 (7)
 - MAY: R20–R22 (3)
-- Flagged conflicts: R23, R24, R25 (3) — counted separately, not folded into
-  the MUST/SHOULD/MAY totals above since each is a flag, not an accepted
-  requirement.
+- Flagged conflicts: R24 (1) — counted separately, not folded into the
+  MUST/SHOULD/MAY totals above since it is a flag, not an accepted
+  requirement. R23 and R25 were flagged conflicts too, until the 2026-09-06
+  owner rulings above resolved each into a MUST.

--- a/docs/specs/DOC-50-tcode-tui-claude-code-clone.md
+++ b/docs/specs/DOC-50-tcode-tui-claude-code-clone.md
@@ -419,14 +419,14 @@ belongs to trusty-memory).
 - Tool-call cards: fancy rendering of tool invocations (blocks, colors, indentation).
 - Streaming diffs: code changes render incrementally (Phase 2B+).
 - Model/agent pickers: modal/inline UI (reuse from tagent's pickers).
-- SSH fallback (#3405): detect narrow terminals (< 80 cols?) and fall back to plain-line mode (no alt-screen, no ratatui).
+- SSH fallback (#3405): detect narrow terminals (< 80 cols?) and fall back to plain-line mode (no alt-screen, no ratatui). *(Superseded — see the 2026-09-06 Amendment near Q3: this is no longer a separate Phase 2 feature.)*
 - Workstream switcher UI: header showing active workstream name; Ctrl-w or `/ws activate` with inline picker.
 
 **Acceptance criteria:**
 - Permission prompts are surfaced and responses are relayed to the daemon.
 - Tool calls render with colors and indentation.
 - Users can pick models and agents via TUI modal (not just text commands).
-- SSH mode works (plain-line fallback, no alt-screen).
+- SSH mode works (plain-line fallback, no alt-screen). *(Superseded — see the 2026-09-06 Amendment near Q3.)*
 
 ### 4.3 Phase 3 (future) — Suggested next prompts, advanced workstream features
 
@@ -486,7 +486,7 @@ Each slice is independently shippable and critic-gateable.
 **What:** Implement the panic-safe terminal RAII guards, event channel, key reader thread, 100ms-tick loop, and validate ratatui 0.30 compatibility.
 
 **Deliverable:**
-- `setup_terminal()` → Terminal with alt-screen + raw mode + mouse capture.
+- `setup_terminal()` → Terminal with alt-screen + raw mode + mouse capture. *(Superseded — see the 2026-09-06 Amendment near Q3: alt-screen is no longer the default mode `setup_terminal` enters.)*
 - `restore_terminal()` RAII guard implemented as Drop trait (panic-safe: terminal is restored even if event loop panics).
 - Key reader thread spawned; KeyEvent routed to mpsc channel.
 - 100ms-tick interval with backpressure note (see §10 below).
@@ -672,7 +672,43 @@ Removes vulnerable `lru` transitive (#2886). Spike de-risks incompatibilities be
 
 **RESOLVED (Bob, 2026-07-20):** Phase 2 (not MVP).
 
-Known limitation: "tcode tui requires full-size terminal with alt-screen support; SSH/narrow terminals use `tcode run-task` CLI."
+Known limitation: "tcode tui requires full-size terminal with alt-screen support; SSH/narrow terminals use `tcode run-task` CLI." *(Superseded — see the 2026-09-06 Amendment immediately below.)*
+
+### 2026-09-06 Amendment: rendering mode
+
+**This amendment supersedes Q3's alt-screen mandate and the alt-screen +
+raw mode default stated at `setup_terminal()` (§3.1 Slice 2) and in §4.2's
+Phase 2 feature list. It does not rewrite this spec's body — the superseded
+text stays in place with a pointer to this section.**
+
+Asked what trusty-code-tui uses today for rendering (alt-screen + raw mode
+via ratatui/crossterm, `setup_terminal`), the owner ruled (resolves R23 in
+`docs/design/trusty-code/tui/requirements.md`):
+
+> "I want rendering that allows scroll back."
+> — Bob, 2026-09-06
+
+**What is superseded.** Q3's resolution treated alt-screen + raw mode as the
+unconditional default and treated a plain-line SSH/narrow-terminal fallback
+as a separate Phase 2 feature (#3405) layered on top of that default.
+
+**What replaces it.**
+
+- The TUI renders so the terminal's own native scrollback survives. Classic,
+  scrollback-append rendering — the same shape Claude Code's own CLI defaults
+  to — is the default rendering mode, not alt-screen.
+- Alt-screen is no longer the default `setup_terminal()` enters. A fullscreen,
+  alt-screen mode may still exist, but only as an explicit opt-in, never the
+  mode a plain `tcode tui` invocation starts in.
+- The SSH/narrow-terminal plain-line fallback (#3405) is no longer a separate
+  Phase 2 phase. Classic rendering is now the default in every terminal, so
+  the same rendering mode already covers SSH sessions and narrow terminals —
+  there is no second code path left to build in Phase 2 for that case.
+
+This is a MUST per `docs/design/trusty-code/tui/requirements.md` R23.
+Implementation (the `setup_terminal()` default, the Slice 2/Phase 2 acceptance
+criteria above, and any successor to Q3) is a follow-up engineering change to
+this spec's body, not made in this amendment.
 
 ### Q4 — Engine adapter flexibility (slash command routing)
 

--- a/docs/specs/DOC-73-unified-mpm-code-agents-dashboard.md
+++ b/docs/specs/DOC-73-unified-mpm-code-agents-dashboard.md
@@ -170,11 +170,19 @@ described in §5.3, built on the `/ui/screensaver` route #6519 landed.
 **Acceptance test.** A dashboard design with no per-session route, or with no
 link from the session list, fails this ruling.
 
-Where a machine-wide view survives elsewhere in this spec — the unfiltered,
-cross-session list in §2.1's PM-operator story, and the unfiltered-by-default
-`/ui/stream/list` and `/ui/stream/tree` routes in §5.1 — it is reached through
-the Sessions console and composes per-session dashboards, rather than standing
-as its own top-level destination.
+**Start with per session (owner ruling, 2026-09-06).**
+
+> "Start with per session."
+> — Bob, 2026-09-06
+
+§2.1's PM-operator story and §5.1's list route (and, symmetrically, §5.2's tree
+route) are per session first: both routes require a `session=<id>`, reached
+from a session's row in the Sessions console, and there is no bare unfiltered
+route in this phase. The machine-wide aggregate view this spec's earlier draft
+described as the default — an unfiltered, cross-session list or tree — is kept,
+not deleted, and moved to "Deferred: machine-wide view" (§5.4): a later phase
+reached through the Sessions console, composing per-session dashboards rather
+than standing as its own top-level destination.
 
 **What this spec does not change.**
 
@@ -211,15 +219,16 @@ in the tree, and what they click through to.
 
 ### 2.1 The mpm PM operator
 
-*I am running five sessions across three projects, and I want to know which agent
-is doing what right now.*
+*I have dispatched several agents within one session, and I want to know which
+agent is doing what right now.*
 
-- **List.** One row per event across every live `tm` session, newest at the
-  bottom, filtered to `source=mpm`. A row reads: timestamp, session name, actor,
-  kind, and a one-line object summary — "14:03:12 · tm-trusty-tools-02 ·
-  rust-engineer · workflow.spawn · code-critic". A dispatch, a worktree creation,
-  a hook firing, and a session ending are all rows in the same column.
-- **Tree.** The PM session is the root. Each dispatched agent is a child node
+- **List.** One row per event in one `tm` session — `session=<id>`, opened from
+  that session's row in the Sessions console — newest at the bottom. A row
+  reads: timestamp, actor, kind, and a one-line object summary —
+  "14:03:12 · rust-engineer · workflow.spawn · code-critic". A dispatch, a
+  worktree creation, a hook firing, and a session ending are all rows in the
+  same column.
+- **Tree.** The session is the root. Each dispatched agent is a child node
   that appears when its `Workflow::Spawn` arrives and stays lit until its
   `Workflow::Stop`. Under an agent, its tool calls and file writes are leaves.
   The operator sees at a glance that four agents are live, one has been running
@@ -228,7 +237,12 @@ is doing what right now.*
   links to the diff viewer; a `Workflow::Spawn` node links to the delegation's
   prompt and the worktree path.
 
-*What this replaces:* reading five tmux panes, or `tm session list` on a loop.
+*What this replaces:* reading one tmux pane, or `tm session status` on a loop.
+
+*Running five sessions across three projects?* Each has its own dashboard,
+opened from its own row in the Sessions console — one tab per session. A
+single view showing every session's events unfiltered is not this phase's
+deliverable; see "Deferred: machine-wide view" (§5.4).
 
 ### 2.2 The trusty-code user
 
@@ -277,7 +291,9 @@ from indentation.
 sitting at it.*
 
 - It shows the same two views, unfiltered, rotating between them on a fixed
-  cadence.
+  cadence. Machine-wide, unfiltered rotation is the "Deferred: machine-wide
+  view" case (§5.4) — the wall display's own dashboard is a per-session one
+  until that phase lands.
 - It never prompts, never waits for input, and never shows an error dialog. A
   daemon that goes away is a degraded badge, not a modal.
 - It renders correctly with zero events — an empty stream is a legitimate state,
@@ -671,8 +687,15 @@ pure functions of its inputs, the `.svelte` file is a renderer over them.
 
 ### 5.1 List view — `/ui/stream/list`
 
-Sequential, newest last, scrolling.
+Sequential, newest last, scrolling, per session (owner ruling, 2026-09-06 —
+"Start with per session."; §1).
 
+- **`session=<id>` is required.** The route always scopes to one session and
+  never renders unfiltered by default. It is reached from that session's row in
+  the Sessions console (§1) — `/ui/stream/list?session=<id>` — not as a
+  standalone destination a user navigates to directly. A request with no
+  `session` is the "Deferred: machine-wide view" case (§5.4), not something
+  this phase serves.
 - **Virtualized.** Only the visible rows exist in the DOM. A day-long session
   produces tens of thousands of events and an unvirtualized list stops scrolling
   smoothly in the low thousands.
@@ -681,10 +704,9 @@ Sequential, newest last, scrolling.
   cursor route, not by scrolling forever.
 - **Follow-tail by default.** The view pins to the newest row. A wall display
   never needs to be scrolled to stay current.
-- **Filters live in the URL**, not in a widget:
-  `?source=mpm&session=<id>&kind=file&actor=rust-engineer`. Absent means
-  unfiltered. Combining axes ANDs them, matching `events::Filter`'s existing
-  semantics.
+- **Further filters live in the URL**, additive to the required `session`:
+  `?session=<id>&source=mpm&kind=file&actor=rust-engineer`. Combining axes ANDs
+  them, matching `events::Filter`'s existing semantics.
 - **A row is:** timestamp (mono), source badge, session, actor, kind badge, and
   the first `ObjectRef`'s label as a link. Foundry's typographic split applies —
   IBM Plex Mono for every identifier, path, count, and status, IBM Plex Sans for
@@ -694,7 +716,9 @@ Sequential, newest last, scrolling.
 
 ### 5.2 Tree view — `/ui/stream/tree`
 
-A call graph, keyed on `parent_id`.
+A call graph, keyed on `parent_id`. Like the list view, `session=<id>` is
+required (§5.1) — the tree route is also per session first, reached from the
+same Sessions-console row.
 
 **Node lifecycle.** A node appears when its opening event arrives and stays
 *active* until its closing event does.
@@ -770,6 +794,31 @@ test-covered without a browser.
   `http://127.0.0.1:7788/ui/screensaver` in a WKWebView. Both stream views must
   therefore be correct with no observer for hours, which is what §5.2's collapse
   rule and §8.2's memory ceiling exist to guarantee.
+
+### 5.4 Deferred: machine-wide view
+
+**Not built in this phase.** §5.1 and §5.2 require `session=<id>` on every
+list and tree route (owner ruling, 2026-09-06 — "Start with per session.";
+§1). A machine-wide view — every live session's events in one unfiltered list
+or tree, as the pre-2026-09-06 draft of this spec described as the default —
+is kept, not deleted. It is deferred to a later phase, reached through the
+Sessions console once that phase lands, and composes the per-session
+dashboards rather than replacing them.
+
+- **What it would add.** A route with no required `session` (or an explicit
+  `session=all`) showing every live session's events interleaved. §5.1's and
+  §5.2's per-session mechanics — virtualization, the bounded window,
+  follow-tail, node lifecycle, timed collapse — carry over unchanged; only the
+  query's scope widens.
+- **Who it serves, once built.** The PM operator running several sessions at
+  once (§2.1) and the wall display's unfiltered rotation (§2.4) both describe
+  this view. Until it lands, each gets a per-session dashboard per session
+  instead.
+- **Milestone 72 predates this ruling.** Its title,
+  "trusty-mpm dashboard — machine-wide event visualization (DOC-73)", names
+  what is now the deferred phase this subsection describes, not the
+  per-session phase §9 orders first. Re-titling or splitting milestone 72 is a
+  milestone-tracker follow-up, not a change this spec makes.
 
 ---
 
@@ -1119,7 +1168,9 @@ browser ceilings are initial values rather than derived ones.
 ## {#SPEC-UNIDASH-11~draft} 11. Implementation issues to cut
 
 Milestone 72 cut these as ten slices, re-scoped to the 2026-09-05
-push-to-console ruling (§4.1). Each references #6611.
+push-to-console ruling (§4.1). Each references #6611. Milestone 72's title
+now names the deferred machine-wide phase, not the per-session phase these
+slices build first — see §5.4.
 
 1. [#6846](https://github.com/bobmatnyc/trusty-tools/issues/6846) — Types-only
    move: relocate the `HarnessEvent` envelope and lifecycle/filter types from


### PR DESCRIPTION
## Summary

Applies the 2026-09-06 owner rulings to DOC-73 and DOC-50/requirements: the
unified dashboard ships per-session first (workstream/global views deferred),
the TUI renders scrollback with the terminal's own escape-sequence handling
rather than reimplementing one, and session resume goes through a
registry-backed picker.

Refs milestone 72, DOC-73, DOC-50, PR #6880, PR #6881.

## Changes

- `docs/specs/DOC-73-unified-mpm-code-agents-dashboard.md` — per-session
  dashboard entry point ruling
- `docs/specs/DOC-50-tcode-tui-claude-code-clone.md` — scrollback rendering
  ruling
- `docs/design/trusty-code/tui/requirements.md` — registry-backed resume
  picker ruling

Out of scope: implementation of any of these rulings; that follows in
separate tracked work.

## Risk

Docs-only change (rung 1). No source, no build, no runtime behavior affected.

## Test evidence

- `check_sld.sh` — 0/0
- `check_doc_numbers.sh` — 0 violations
- `check_public_docs.sh` — all resolve

## Baseline

No gates run against source; nothing pre-existing to report.

## Docs

Docs-only PR; no changelog fragment required (source unchanged).

## Review-finding disposition

R24 (thin-client axiom vs local gh/glab and spell-check reads) stays flagged;
not ruled.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
