### PR TITLE
chore(release): assemble trusty-audit 0.14.1 changelog

### DIFF
--- a/crates/trusty-audit/CHANGELOG.md
+++ b/crates/trusty-audit/CHANGELOG.md
@@ -10,6 +10,25 @@ edit this file by hand (see
 
 ---
 
+## [0.14.1] — 2026-09-06
+
+### Added
+
+- The run index (`index.md`, and the copy inside the return package) states how
+  much of each repository the investigation pass actually read — files read,
+  tracked files, the share, and whether that repository's static-analysis lane
+  ran at all — plus the estate total, least-covered first. The figure was in
+  every report's JSON twin and nowhere a recipient would look, so answering "how
+  much of this estate was read" meant opening all 59 reports (#6784, #6811).
+
+### Fixed
+
+- The run index's dead-analyze-lane count now keys on the shared
+  `trusty_common::review_gap_contract` headline instead of a literal of its own,
+  so it recognises every gap line `trusty-review` writes for a total collapse.
+  It previously missed the client-build-failure path and undercounted
+  `Rollup::analyze_lanes_dead()` (#6784).
+
 ## [0.14.0] — 2026-09-04
 
 ### Added

--- a/crates/trusty-audit/changelog.d/6784-index-states-investigation-coverage.md
+++ b/crates/trusty-audit/changelog.d/6784-index-states-investigation-coverage.md
@@ -1,8 +1,0 @@
-Added
-
-- The run index (`index.md`, and the copy inside the return package) states how
-  much of each repository the investigation pass actually read — files read,
-  tracked files, the share, and whether that repository's static-analysis lane
-  ran at all — plus the estate total, least-covered first. The figure was in
-  every report's JSON twin and nowhere a recipient would look, so answering "how
-  much of this estate was read" meant opening all 59 reports (#6784, #6811).

--- a/crates/trusty-audit/changelog.d/6784-rollup-keys-on-shared-headline.md
+++ b/crates/trusty-audit/changelog.d/6784-rollup-keys-on-shared-headline.md
@@ -1,7 +1,0 @@
-Fixed
-
-- The run index's dead-analyze-lane count now keys on the shared
-  `trusty_common::review_gap_contract` headline instead of a literal of its own,
-  so it recognises every gap line `trusty-review` writes for a total collapse.
-  It previously missed the client-build-failure path and undercounted
-  `Rollup::analyze_lanes_dead()` (#6784).

--- a/crates/trusty-audit/templates/engagement.template.toml
+++ b/crates/trusty-audit/templates/engagement.template.toml
@@ -47,10 +47,10 @@ engagement = "2026-Q3"
 #
 # Replace these with the versions your auditor pinned for this engagement.
 [tools]
-tga = "7.1.0"
-trusty-search = "0.52.0"
+tga = "7.1.1"
+trusty-search = "0.54.0"
 trusty-analyze = "0.12.6"
-trusty-review = "0.34.0"
+trusty-review = "0.35.0"
 
 # A pin may name the artifact's digest as well as its version, in which case a
 # download whose bytes do not match is refused:


### PR DESCRIPTION
## Summary
- Folds the two #6784 changelog.d fragments into CHANGELOG.md as [0.14.1]
- Refreshes the engagement template's `[tools]` pins to the current workspace versions (tga 7.1.1, trusty-search 0.54.0, trusty-review 0.35.0) per #6772

Refs #6784

## Test plan
- [x] `bash scripts/refresh-engagement-pins.sh --check` (before) reported the three stale pins; refresh applied and re-verified clean
- [x] `bash scripts/check_semver.sh --crate trusty-audit` — no semver update required beyond the already-declared 0.14.1
- Docs/changelog-only change; no Rust gates required beyond the semver check above

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools