### PR TITLE
docs(trusty-common): resolve the two sockbuf intra-doc links left by #6907

### DIFF
--- a/crates/trusty-common/changelog.d/6907-uds-sockbuf-doc-links.md
+++ b/crates/trusty-common/changelog.d/6907-uds-sockbuf-doc-links.md
@@ -1,0 +1,3 @@
+Documentation
+
+- resolve the two `sockbuf` intra-doc links in `uds` left unresolved by #6907

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -53,6 +53,8 @@
 //! [`connect_hardened`]: crate::uds::connect_hardened
 //! [`ensure_peer_is_self`]: crate::uds::ensure_peer_is_self
 //! [`dir::prepare_socket_dir`]: crate::uds::dir::prepare_socket_dir
+//! [`sockbuf`]: crate::uds::sockbuf
+//! [`sockbuf::SOCKET_BUFFER_BYTES`]: crate::uds::sockbuf::SOCKET_BUFFER_BYTES
 
 #[cfg(test)]
 #[path = "tests.rs"]


### PR DESCRIPTION
## Summary

Resolves two broken rustdoc intra-doc links in `trusty-common`'s UDS socket buffer documentation left by PR #6907.

Refs #6896

## What Changed

- Fixed rustdoc link references in doc comments for UDS socket buffer setup

## Risk / Blast Radius

None. Documentation only.

## Test Evidence

Rung 1 (docs-only):
- `bash scripts/check_rustdoc_links.sh`: 26 crate(s) examined by rustdoc, 0 broken link(s)
- `cargo fmt --check`: clean
- `bash scripts/check_line_cap.sh`: 0 violations
- `bash scripts/check_test_pointers.sh`: 0 dangling

## Baseline Failures

None.

## Documentation / Changelog

Doc comment update; no changelog fragment required for docs-only change.

## Review Disposition

N/A — docs-only.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
