### PR TITLE
fix(trusty-audit): declare the trusty-common uds feature; bump 0.14.2 after the burned 0.14.1 tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11493,7 +11493,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/trusty-audit/CHANGELOG.md
+++ b/crates/trusty-audit/CHANGELOG.md
@@ -10,6 +10,17 @@ edit this file by hand (see
 
 ---
 
+## [0.14.2] — 2026-09-06
+
+### Fixed
+
+- Declared `trusty-common`'s `uds` feature, which the `grounding` daemons,
+  hotspots, and search_rpc modules need for their UDS framed-request client.
+  Workspace feature unification hid the missing declaration from every gate
+  except `cargo publish`'s isolated verification build, which failed with
+  11 x E0433 `could not find 'uds' in 'trusty_common'` and burned the
+  trusty-audit-v0.14.1 tag before it could ship.
+
 ## [0.14.1] — 2026-09-06
 
 ### Added

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -17,7 +17,7 @@ name = "trusty-audit"
 # `search_evidence` here, which `cargo-semver-checks` reports as
 # `struct_missing_field` against 0.13.3; for a 0.y.z crate the breaking bump is
 # the MINOR position.
-version = "0.14.1"
+version = "0.14.2"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"
@@ -108,7 +108,13 @@ trusty-installer = { workspace = true }
 # point, used where a board provider's own error text reaches an operator.
 # #5915: `crate-config` for `crate_config_dir_at` — the workspace's one owner of
 # the `~/.trusty-tools/<crate>` layout, which `workdir.rs` now defaults into.
-trusty-common = { workspace = true, features = ["gh-cli", "credentials", "crate-config"] }
+# #6906: `uds` for the UDS framed-request client the `grounding` daemons/
+# hotspots/search_rpc modules use to talk to trusty-analyze/trusty-search over
+# their Unix sockets. Workspace feature unification hid the missing
+# declaration from every gate except `cargo publish`'s isolated verification
+# build, which burned the trusty-audit-v0.14.1 tag (E0433 `could not find
+# 'uds' in 'trusty_common'`).
+trusty-common = { workspace = true, features = ["gh-cli", "credentials", "crate-config", "uds"] }
 # #5822: board validation issues HTTP requests, so it needs `reqwest`'s types —
 # the RequestBuilder, and the error it classifies without quoting the URL. The
 # CLIENT still comes from `trusty_installer::download::http_client`, which stays


### PR DESCRIPTION
## Summary
- Fix trusty-audit v0.14.1 failed to include the trusty-common `uds` feature declaration
- v0.14.1 tag is now spent; v0.14.2 gets tagged immediately before `cargo publish`

Refs #6906

## Changes
- Added `uds` feature to trusty-audit's trusty-common dependency in Cargo.toml
- Bumped trusty-audit to version 0.14.2

## Risk
- Low: isolated feature flag addition for existing cross-crate dependency; v0.14.1 failed at the identical step on this branch
- Pre-existing test flake unrelated to this change

## Test plan
- [x] `SKIP_UI_BUILD=1 cargo publish --dry-run -p trusty-audit` exit 0 (Packaged 112 files; Verifying trusty-audit v0.14.2 compiled clean in 31.65s)
- [x] `cargo fmt --check`, `cargo check -p trusty-audit`, `clippy -p trusty-audit -D warnings` all exit 0
- [x] `cargo test -p trusty-audit --no-fail-fast` 949 passed, 1 failed, 5 ignored
  - Pre-existing flake: `grounding::secrets::secrets_tests::the_raw_report_lives_in_a_private_directory_and_does_not_outlive_the_run`
  - Reproduced identically on origin/main at 34e377351; passes in isolation (pre-existing temp-dir cleanup flake)
- [x] `bash scripts/check_changelog_fragment.sh` OK
- [x] `bash scripts/check-pr-version-bump.sh` OK

## Baseline
- `grounding::secrets::secrets_tests::the_raw_report_lives_in_a_private_directory_and_does_not_outlive_the_run` failed on origin/main at 34e377351 with identical error; passes in isolation; no ticket needed

## Docs
- Changelog fragment added to `crates/trusty-audit/changelog.d/`

## Review
- Tag trusty-audit-v0.14.1 is spent (#6178) after failed publish; v0.14.2 receives the uds feature declaration and gets tagged immediately before `cargo publish`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
