### PR TITLE
feat(trusty-mpm): ticketing seeds every policy label through one path; launch stops creating in-progress/blocked (#6914)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/6914-ticketing-ensure-labels.md
+++ b/crates/trusty-agents-common/changelog.d/6914-ticketing-ensure-labels.md
@@ -1,0 +1,3 @@
+Changed
+
+- The ticketing agent now runs `tm issue seed-labels` on first use in a repository, and re-runs it plus one retry when `gh issue edit --add-label` or `gh issue create --label` fails on an unknown label. Both commands fail outright on a label the repo has never seen, and the agent previously had no instruction that would create one (#6914).

--- a/crates/trusty-agents-common/src/assets/agents/ticketing.md
+++ b/crates/trusty-agents-common/src/assets/agents/ticketing.md
@@ -139,9 +139,23 @@ gh issue create --title "…" --body "…" \
   --label bug --label trusty-memory --label P1
 ```
 
-Check `gh label list` before inventing a variant of a label the repo already
-carries; create a genuinely missing one (`gh label create <name>`) rather than
-dropping the family.
+### Seed the labels before the first filing
+
+🔴 **Run `tm issue seed-labels` on first use in a repository.** It creates the
+four `status:*` lifecycle labels, `trusty-mpm`, and `ws/<session>`. It is
+idempotent and leaves every label that already exists untouched — colour and
+description included — so running it unconditionally costs less than checking
+whether it is needed.
+
+🔴 **When `gh issue edit --add-label` or `gh issue create --label` fails on an
+unknown label, run `tm issue seed-labels`, then retry the original command
+once.** Both commands fail outright on a label the repo has never seen, and the
+seed is what makes the retry succeed.
+
+If the retry still fails, the label is not one the harness owns. Check `gh label
+list` before inventing a variant of a label the repo already carries; create a
+genuinely missing one (`gh label create <name>`) rather than dropping the
+family.
 
 ## Milestones Are Release Slots, Not a Field to Fill
 

--- a/crates/trusty-mpm/changelog.d/6914-ticketing-ensure-labels.md
+++ b/crates/trusty-mpm/changelog.d/6914-ticketing-ensure-labels.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `tm issue seed-labels` now seeds every label the harness applies, not just the ones `issue-state.yaml` declares: the lifecycle labels, `trusty-mpm`, and `ws/<session>` when a tmux session name is available. Before this, a fresh repo's first `gh issue create --label trusty-mpm` failed on an unknown label with nothing in the tooling that would have created it. Labels the repo already carries stay untouched, colour and description included; with no session name the `ws/` label is skipped and the output says so (#6914).
+- Session launch no longer creates the retired `in-progress` / `blocked` label pair. That pair predates the `status:*` lifecycle and was seeded into every repo a managed session ever launched against. Launch now ensures the same policy set `seed-labels` does, from one shared table in `core::policy_labels` (#6914).
+- The crate builds its `gh label create` command line in exactly one place. Session launch and `tm issue` each kept their own argv builder and their own label table, which is how launch went on creating retired labels unnoticed (#6914).

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -200,6 +200,13 @@ because the session that filed the issue happened to run under tm. When no
 component label fits, apply none — that decision is final, not a trigger to
 reach for `trusty-mpm`.
 
+🔴 **Seed the harness's own labels on first use in a repository.** `tm issue
+seed-labels` creates the four `status:*` lifecycle labels, `trusty-mpm`, and
+`ws/<session>`. It is idempotent and never rewrites a label that already
+exists, so run it rather than checking first. Re-run it whenever a `gh issue
+edit --add-label` or `gh issue create --label` fails on an unknown label, then
+retry the original command once.
+
 🔴 **Never invent a label the repository does not carry.** Check `gh label list`
 before using one; create a genuinely missing label rather than dropping the
 family or substituting an approximation.

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
@@ -62,7 +62,10 @@ fn dispatch<S: TicketSystem>(backend: &S, cmd: IssueCmd) -> anyhow::Result<()> {
     match cmd {
         IssueCmd::SeedLabels { config, dry_run } => {
             let model = load_model(config.as_deref())?;
-            let report = ops::seed_labels(backend, &model, dry_run)?;
+            // #6914: the `ws/<session>` policy label needs the same session
+            // name session launch labels with — the tmux session name.
+            let session = crate::commands::tmux_attach::current_tmux_session_name();
+            let report = ops::seed_labels(backend, &model, session.as_deref(), dry_run)?;
             print_seed_report(&report);
         }
         IssueCmd::Transition {
@@ -115,6 +118,10 @@ fn print_seed_report(report: &ops::SeedReport) {
         println!("  + {name}");
     }
     println!("already present: {} label(s)", report.already_present.len());
+    // #6914: an omitted ws/ label is stated, never silent.
+    if report.workstream_skipped {
+        println!("skipped ws/<session>: no tmux session name to derive it from");
+    }
 }
 
 /// Print the configured states and transitions.

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/ops.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/ops.rs
@@ -30,6 +30,10 @@ pub(crate) struct SeedReport {
     pub(crate) already_present: Vec<String>,
     /// Whether this was a dry-run (no `create_label` calls made).
     pub(crate) dry_run: bool,
+    /// `true` when no session name was known, so the `ws/<session>` policy
+    /// label was left out of the seed (#6914). The caller says so in its
+    /// output rather than letting the omission pass silently.
+    pub(crate) workstream_skipped: bool,
 }
 
 /// Outcome of a `transition` (for printing + assertion).
@@ -49,44 +53,66 @@ pub(crate) struct TransitionReport {
     pub(crate) assignee_changed: bool,
 }
 
-/// Collect every label the model declares (state labels + extra labels).
+/// Every label the harness applies by policy, in seed order.
 ///
-/// Why: seeding ensures both families exist; gathering them once keeps the diff
-/// simple.
-/// What: maps state labels and extra labels into [`RepoLabel`]s.
-/// Test: exercised via `ops_seed_creates_only_missing`.
-fn declared_labels(model: &StateModel) -> Vec<RepoLabel> {
+/// Why: #6914 — `gh issue edit --add-label` and `gh issue create --label` fail
+/// on a label the repo has never seen, so `seed-labels` has to cover EVERY
+/// label the harness applies, not just the model's. Two families make that up:
+/// the project-configured lifecycle labels from `issue-state.yaml`, and the
+/// framework's own set from `trusty_mpm::core::policy_labels` (`trusty-mpm`,
+/// plus `ws/<session>` when a session name is known). One list, so a family cannot
+/// be seeded by one caller and forgotten by another.
+/// What: the model's state labels and extra labels first (a label-less state
+/// like `open`/`closed` has nothing to seed), then the policy set. A name
+/// already contributed by the model is not repeated.
+/// Test: `ops_seed_creates_only_missing`,
+/// `ops_seed_includes_policy_labels`,
+/// `ops_seed_without_session_skips_workstream_label`.
+fn desired_labels(model: &StateModel, session_name: Option<&str>) -> Vec<RepoLabel> {
     let mut out: Vec<RepoLabel> = model
         .states
         .iter()
         // A label-less state (`open`, `closed`) has nothing to seed.
         .filter_map(|s| s.label.as_ref())
-        .map(|l| RepoLabel {
-            name: l.name.clone(),
-            color: l.color.clone(),
-            description: l.description.clone(),
-        })
+        .map(|l| RepoLabel::new(l.name.clone(), l.color.clone(), l.description.clone()))
         .collect();
-    out.extend(model.extra_labels.iter().map(|l| RepoLabel {
-        name: l.name.clone(),
-        color: l.color.clone(),
-        description: l.description.clone(),
-    }));
+    out.extend(
+        model
+            .extra_labels
+            .iter()
+            .map(|l| RepoLabel::new(l.name.clone(), l.color.clone(), l.description.clone())),
+    );
+    // #6914: the framework's own labels come from the shared policy table that
+    // session launch also uses — never a second list spelled out here.
+    for label in trusty_mpm::core::policy_labels::policy_labels(session_name) {
+        if !out.iter().any(|existing| existing.name == label.name) {
+            out.push(label);
+        }
+    }
     out
 }
 
-/// `tm issue seed-labels` — idempotent create-missing of all model labels.
+/// `tm issue seed-labels` — idempotent create-missing of every label the
+/// harness applies.
 ///
-/// Why: a repo must have the state + family labels before transitions can apply
-/// them; create-missing is non-destructive so re-runs are safe.
-/// What: lists existing repo labels, then for each declared label not present
-/// creates it (unless `dry_run`); leaves existing labels (incl. drifted
-/// color/description) untouched (RFC §5.1). Returns a [`SeedReport`].
+/// Why: a repo must carry the state, family, and policy labels before any
+/// transition or `gh issue create --label` can apply them; create-missing is
+/// non-destructive so re-runs are safe, and re-running is the documented
+/// recovery when a `--add-label` fails on an unknown label.
+/// What: lists existing repo labels, then for each label in
+/// [`desired_labels`] not already present, creates it (unless `dry_run`).
+/// Existing labels are left untouched, drifted colour/description included
+/// (RFC §5.1) — seeding never rewrites what a project already styled. Records
+/// `workstream_skipped` when `session_name` is `None`, so the caller can say
+/// the `ws/<session>` label was left out. Returns a [`SeedReport`].
 /// Test: `ops_seed_creates_only_missing`, `ops_seed_dry_run_creates_nothing`,
-/// `ops_seed_idempotent_when_all_present`.
+/// `ops_seed_idempotent_when_all_present`, `ops_seed_includes_policy_labels`,
+/// `ops_seed_without_session_skips_workstream_label`,
+/// `ops_seed_leaves_present_policy_labels_untouched`.
 pub(crate) fn seed_labels<S: TicketSystem>(
     sys: &S,
     model: &StateModel,
+    session_name: Option<&str>,
     dry_run: bool,
 ) -> anyhow::Result<SeedReport> {
     let existing = sys.list_repo_labels()?;
@@ -95,9 +121,10 @@ pub(crate) fn seed_labels<S: TicketSystem>(
 
     let mut report = SeedReport {
         dry_run,
+        workstream_skipped: session_name.is_none_or(|n| n.trim().is_empty()),
         ..Default::default()
     };
-    for label in declared_labels(model) {
+    for label in desired_labels(model, session_name) {
         if existing_names.contains(label.name.as_str()) {
             report.already_present.push(label.name.clone());
             continue;

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/ops_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/ops_tests.rs
@@ -115,24 +115,30 @@ fn issue_with_labels(number: u64, labels: &[&str]) -> Issue {
 
 // ---- seed-labels ----------------------------------------------------------
 
+/// The tmux session name the `ws/` policy label is derived from in these tests.
+const SESSION: &str = "tm-tcode-01";
+
+/// Every `create_label` name the fake recorded, in call order.
+fn create_names(sys: &FakeSystem) -> Vec<String> {
+    sys.calls()
+        .into_iter()
+        .filter_map(|c| match c {
+            Call::CreateLabel(n) => Some(n),
+            _ => None,
+        })
+        .collect()
+}
+
 #[test]
 fn ops_seed_creates_only_missing() {
     let m = model();
     // Repo already has the base `unicorn` label and `unicorn:queued`.
     let existing = vec![
-        RepoLabel {
-            name: "unicorn".to_string(),
-            color: "7B68EE".to_string(),
-            description: String::new(),
-        },
-        RepoLabel {
-            name: "unicorn:queued".to_string(),
-            color: "BFD4F2".to_string(),
-            description: String::new(),
-        },
+        RepoLabel::new("unicorn", "7B68EE", ""),
+        RepoLabel::new("unicorn:queued", "BFD4F2", ""),
     ];
     let sys = FakeSystem::new(issue_with_labels(1, &[])).with_repo_labels(existing);
-    let report = seed_labels(&sys, &m, false).expect("seed");
+    let report = seed_labels(&sys, &m, Some(SESSION), false).expect("seed");
 
     // Present ones not re-created.
     assert!(report.already_present.contains(&"unicorn".to_string()));
@@ -146,23 +152,89 @@ fn ops_seed_creates_only_missing() {
     assert!(report.created.contains(&"blast:high".to_string()));
     assert!(report.created.contains(&"approval:level-1".to_string()));
     // No create call for the already-present labels.
-    let create_names: Vec<String> = sys
-        .calls()
-        .into_iter()
-        .filter_map(|c| match c {
-            Call::CreateLabel(n) => Some(n),
-            _ => None,
-        })
-        .collect();
-    assert!(!create_names.contains(&"unicorn".to_string()));
-    assert!(!create_names.contains(&"unicorn:queued".to_string()));
+    let created = create_names(&sys);
+    assert!(!created.contains(&"unicorn".to_string()));
+    assert!(!created.contains(&"unicorn:queued".to_string()));
+}
+
+/// #6914: seeding covers the FRAMEWORK's own labels, not just the model's.
+///
+/// Before the fix, `trusty-mpm` and `ws/<session>` were absent from
+/// `seed-labels` entirely — the first `gh issue create --label trusty-mpm` in a
+/// fresh repo failed on an unknown label.
+#[test]
+fn ops_seed_includes_policy_labels() {
+    let m = model();
+    // Zero existing labels: everything the harness applies must be created.
+    let sys = FakeSystem::new(issue_with_labels(1, &[]));
+    let report = seed_labels(&sys, &m, Some(SESSION), false).expect("seed");
+
+    let created = create_names(&sys);
+    assert!(
+        created.contains(&"trusty-mpm".to_string()),
+        "the convention label must be seeded; got {created:?}"
+    );
+    assert!(
+        created.contains(&"ws/tm-tcode-01".to_string()),
+        "the workstream label must be seeded; got {created:?}"
+    );
+    assert_eq!(created, report.created, "report must match the calls made");
+    assert!(!report.workstream_skipped);
+
+    // The retired pair session launch used to seed must never come back.
+    assert!(
+        !created.iter().any(|n| n == "in-progress" || n == "blocked"),
+        "the retired lifecycle pair must not be seeded; got {created:?}"
+    );
+}
+
+/// #6914: with no session name there is no `ws/` label — and the report says so.
+#[test]
+fn ops_seed_without_session_skips_workstream_label() {
+    let m = model();
+    let sys = FakeSystem::new(issue_with_labels(1, &[]));
+    let report = seed_labels(&sys, &m, None, false).expect("seed");
+
+    let created = create_names(&sys);
+    assert!(created.contains(&"trusty-mpm".to_string()));
+    assert!(
+        !created.iter().any(|n| n.starts_with("ws/")),
+        "no session name means no ws/ label; got {created:?}"
+    );
+    assert!(
+        report.workstream_skipped,
+        "the omission must be reported, not silent"
+    );
+}
+
+/// #6914: a policy label the repo already carries is left untouched — no
+/// re-create, and therefore no colour or description rewrite.
+#[test]
+fn ops_seed_leaves_present_policy_labels_untouched() {
+    let m = model();
+    let existing = vec![
+        RepoLabel::new("trusty-mpm", "111111", "a project's own wording"),
+        RepoLabel::new("ws/tm-tcode-01", "222222", "already styled"),
+    ];
+    let sys = FakeSystem::new(issue_with_labels(1, &[])).with_repo_labels(existing);
+    let report = seed_labels(&sys, &m, Some(SESSION), false).expect("seed");
+
+    let created = create_names(&sys);
+    assert!(!created.contains(&"trusty-mpm".to_string()));
+    assert!(!created.contains(&"ws/tm-tcode-01".to_string()));
+    assert!(report.already_present.contains(&"trusty-mpm".to_string()));
+    assert!(
+        report
+            .already_present
+            .contains(&"ws/tm-tcode-01".to_string())
+    );
 }
 
 #[test]
 fn ops_seed_dry_run_creates_nothing() {
     let m = model();
     let sys = FakeSystem::new(issue_with_labels(1, &[]));
-    let report = seed_labels(&sys, &m, true).expect("seed dry");
+    let report = seed_labels(&sys, &m, Some(SESSION), true).expect("seed dry");
     assert!(report.dry_run);
     // Everything reported as created (would-be), but ZERO create calls.
     assert!(!report.created.is_empty());
@@ -182,22 +254,26 @@ fn ops_seed_idempotent_when_all_present() {
             .states
             .iter()
             .filter_map(|s| s.label.as_ref())
-            .map(|l| RepoLabel {
-                name: l.name.clone(),
-                color: l.color.clone(),
-                description: l.description.clone(),
-            })
+            .map(|l| RepoLabel::new(l.name.clone(), l.color.clone(), l.description.clone()))
             .collect();
-        v.extend(m.extra_labels.iter().map(|l| RepoLabel {
-            name: l.name.clone(),
-            color: l.color.clone(),
-            description: l.description.clone(),
-        }));
+        v.extend(
+            m.extra_labels
+                .iter()
+                .map(|l| RepoLabel::new(l.name.clone(), l.color.clone(), l.description.clone())),
+        );
+        // #6914: the policy set is part of what a second run must find present.
+        v.extend(trusty_mpm::core::policy_labels::policy_labels(Some(
+            SESSION,
+        )));
         v
     };
     let sys = FakeSystem::new(issue_with_labels(1, &[])).with_repo_labels(all);
-    let report = seed_labels(&sys, &m, false).expect("seed");
-    assert!(report.created.is_empty(), "second run creates nothing");
+    let report = seed_labels(&sys, &m, Some(SESSION), false).expect("seed");
+    assert!(
+        report.created.is_empty(),
+        "second run creates nothing; got {:?}",
+        report.created
+    );
 }
 
 // ---- transition -----------------------------------------------------------

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/project_model_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/project_model_tests.rs
@@ -347,7 +347,7 @@ fn project_seed_labels_skips_the_labelless_states() {
     let m = project_model();
     let gh = FakeGh::new(vec![ok_out("[]")]);
     let sys = GhTicketSystem::new(gh);
-    let report = ops::seed_labels(&sys, &m, true).expect("seed dry-run");
+    let report = ops::seed_labels(&sys, &m, None, true).expect("seed dry-run");
     assert_eq!(
         report.created,
         vec![
@@ -355,7 +355,36 @@ fn project_seed_labels_skips_the_labelless_states() {
             "status:coded".to_string(),
             "status:merged".to_string(),
             "status:tested".to_string(),
+            // #6914: the framework's own labels seed alongside the model's.
+            "trusty-mpm".to_string(),
         ],
-        "only the four labelled states are seeded"
+        "only the four labelled states, plus the policy set, are seeded"
     );
+    assert!(
+        report.workstream_skipped,
+        "no session name was supplied, so the ws/ label is skipped and said so"
+    );
+}
+
+/// #6914: against THIS repo's real `issue-state.yaml`, one `seed-labels` run
+/// creates every label the harness applies — the four lifecycle labels, the
+/// `trusty-mpm` convention label, and `ws/<session>`.
+#[test]
+fn project_seed_labels_covers_the_whole_harness_label_set() {
+    let m = project_model();
+    let gh = FakeGh::new(vec![ok_out("[]")]);
+    let sys = GhTicketSystem::new(gh);
+    let report = ops::seed_labels(&sys, &m, Some("tm-tcode-01"), true).expect("seed dry-run");
+    assert_eq!(
+        report.created,
+        vec![
+            "status:in-progress".to_string(),
+            "status:coded".to_string(),
+            "status:merged".to_string(),
+            "status:tested".to_string(),
+            "trusty-mpm".to_string(),
+            "ws/tm-tcode-01".to_string(),
+        ]
+    );
+    assert!(!report.workstream_skipped);
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/labels.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/labels.rs
@@ -13,30 +13,19 @@
 //! `gh_set_assignee`) that drive `gh` through the injected [`CommandRunner`].
 //! Test: the `gh_*` unit tests in this file drive a `FakeRunner` (no live `gh`).
 
-use serde::Deserialize;
-
 use super::runner::CommandRunner;
 
 /// A repository label as it exists (or should exist) on GitHub.
 ///
 /// Why: seeding (`tm issue seed-labels`) is create-missing against the repo's
-/// label set, so both the "what the YAML wants" and "what the repo has" sides
-/// need the same name/color/description shape for a diff.
-/// What: the label `name`, its 6-hex `color` (no leading `#`), and an optional
-/// `description`.
+/// label set, so both the "what the model wants" and "what the repo has" sides
+/// need the same name/color/description shape for a diff. #6914 made that shape
+/// the library's [`trusty_mpm::core::policy_labels::PolicyLabel`] rather than a
+/// second, identical struct here — session launch and `tm issue` now diff and
+/// create the same type.
 /// Test: round-tripped through `gh_list_repo_labels` parsing in
 /// `gh_list_repo_labels_parses`.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub(crate) struct RepoLabel {
-    /// Label name (e.g. `unicorn:queued`).
-    pub(crate) name: String,
-    /// 6-hex color, no `#` (e.g. `BFD4F2`). `gh label list` returns it without `#`.
-    #[serde(default)]
-    pub(crate) color: String,
-    /// Optional human description shown in the GitHub label UI.
-    #[serde(default)]
-    pub(crate) description: String,
-}
+pub(crate) use trusty_mpm::core::policy_labels::PolicyLabel as RepoLabel;
 
 /// The effective assignee mutation a transition should apply.
 ///
@@ -79,23 +68,20 @@ pub(crate) fn gh_list_repo_labels<R: CommandRunner>(runner: &R) -> anyhow::Resul
 ///
 /// Why: the create-missing half of seeding; the caller decides *whether* to
 /// create (post-diff), this just performs one creation.
-/// What: invokes `gh label create` with the label's color/description (omitting
-/// the `--description` flag when empty); maps failure to an `anyhow` error.
+/// What: builds the command line with
+/// [`trusty_mpm::core::policy_labels::create_label_argv`] — the crate's single
+/// `gh label create` spelling since #6914 — and runs it through `runner`.
+/// Never forces: seeding must leave a label the repo already carries untouched,
+/// colour and description included.
 /// Test: `gh_create_label_invokes_create`,
 /// `gh_create_label_omits_empty_description`.
 pub(crate) fn gh_create_label<R: CommandRunner>(
     runner: &R,
     label: &RepoLabel,
 ) -> anyhow::Result<()> {
-    let mut args: Vec<&str> = vec!["label", "create", &label.name];
-    if !label.color.is_empty() {
-        args.push("--color");
-        args.push(&label.color);
-    }
-    if !label.description.is_empty() {
-        args.push("--description");
-        args.push(&label.description);
-    }
+    // #6914: one argv builder for both the launch path and `tm issue`.
+    let argv = trusty_mpm::core::policy_labels::create_label_argv(label, None, false);
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
     runner.run("gh", &args)?.ok_or_stderr("gh label create")?;
     Ok(())
 }
@@ -305,11 +291,7 @@ mod tests {
     #[test]
     fn gh_create_label_invokes_create() {
         let r = FakeRunner::new(vec![ok_out("")]);
-        let label = RepoLabel {
-            name: "unicorn:done".to_string(),
-            color: "0075CA".to_string(),
-            description: "Done".to_string(),
-        };
+        let label = RepoLabel::new("unicorn:done", "0075CA", "Done");
         gh_create_label(&r, &label).expect("create");
         assert_eq!(
             r.calls()[0].1,
@@ -328,11 +310,7 @@ mod tests {
     #[test]
     fn gh_create_label_omits_empty_description() {
         let r = FakeRunner::new(vec![ok_out("")]);
-        let label = RepoLabel {
-            name: "T4".to_string(),
-            color: "0075CA".to_string(),
-            description: String::new(),
-        };
+        let label = RepoLabel::new("T4", "0075CA", "");
         gh_create_label(&r, &label).expect("create");
         let args = &r.calls()[0].1;
         assert!(!args.iter().any(|a| a == "--description"));

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -137,6 +137,11 @@ pub mod overseer_config;
 pub mod own_binary_names;
 pub mod paths;
 pub mod pid_registry;
+// The labels trusty-mpm applies by policy, shared by session launch and
+// `tm issue seed-labels` (#6914). Doc lives in the module's own `//!` header —
+// an outer `///` here would resolve its intra-doc links in THIS scope and break
+// them (`check_rustdoc_links.sh`).
+pub mod policy_labels;
 pub mod process;
 pub mod project;
 pub mod project_aliases;

--- a/crates/trusty-mpm/src/core/policy_labels.rs
+++ b/crates/trusty-mpm/src/core/policy_labels.rs
@@ -1,0 +1,452 @@
+//! The GitHub labels trusty-mpm applies BY POLICY, and the one `gh label
+//! create` argv the crate builds for them (#6914).
+//!
+//! Why: `gh issue edit --add-label` and `gh issue create --label` both fail on a
+//! label the repository has never seen, so every label the harness applies by
+//! policy has to exist before the first issue that uses it. Two places need that
+//! answer — session launch (`core::session_launch::workstream_label`) and
+//! `tm issue seed-labels` — and before this module they each carried their own
+//! table, which drifted: launch was still creating a retired `in-progress` /
+//! `blocked` pair the `status:*` lifecycle replaced, and neither knew about the
+//! other's labels.
+//! What: the [`PolicyLabel`] value type, the policy set ([`policy_labels`] =
+//! the [`CONVENTION_LABEL`] plus `ws/<session>` when a session name is known),
+//! the `ws/` name/color derivation, and [`create_label_argv`] — the single place
+//! in the crate that spells a `gh label create` command line.
+//!
+//! This module deliberately holds NO process-spawning code. Its two consumers
+//! reach `gh` through different, already-established seams (the launch path's
+//! `GhLabelRunner`, the `tm issue` path's `CommandRunner`), and both build their
+//! command line here.
+//! Test: `convention_label_is_stable`, `policy_labels_includes_workstream`,
+//! `policy_labels_without_session_skips_workstream`,
+//! `policy_labels_blank_session_skips_workstream`, `owned_namespace_is_ws_only`,
+//! `label_color_is_stable_and_valid_hex`, `label_color_differs_across_names`,
+//! `label_name_short_is_verbatim`, `label_name_stays_within_github_cap`,
+//! `label_name_long_is_truncated_with_hash_suffix`,
+//! `label_name_distinct_long_names_get_distinct_labels`,
+//! `create_label_argv_full`, `create_label_argv_omits_empty_fields`,
+//! `create_label_argv_repo_and_force`.
+
+use serde::Deserialize;
+
+/// GitHub's hard cap on a label name's length (the full `ws/<name>` string).
+pub const GITHUB_LABEL_MAX_LEN: usize = 50;
+
+/// The framework's own crate/component label.
+///
+/// Why: `tm-ticketing` requires an owning-component label on every issue filed
+/// against the harness itself, and that label has to exist for the first such
+/// filing to succeed.
+/// What: name only — the color and description live in [`convention_label`].
+pub const CONVENTION_LABEL: &str = "trusty-mpm";
+
+/// Color and description for [`CONVENTION_LABEL`], matching the value the
+/// trusty-tools repo already carries so seeding a fresh repo reads identically.
+const CONVENTION_LABEL_COLOR: &str = "BFD4F2";
+const CONVENTION_LABEL_DESCRIPTION: &str = "trusty-mpm platform and related work";
+
+/// The `ws/` prefix marking trusty-mpm's OWN label namespace.
+const WORKSTREAM_PREFIX: &str = "ws/";
+
+/// A repository label as it exists (or should exist) on GitHub.
+///
+/// Why: both halves of an idempotent seed — "what policy wants" and "what the
+/// repo has" — need the same name/color/description shape for a diff, and
+/// `gh label list --json name,color,description` returns exactly that, so the
+/// type doubles as the list DTO.
+/// What: the label `name`, its 6-hex `color` (no leading `#`), and a
+/// description (empty means "omit the flag").
+/// Test: `create_label_argv_full`, and `gh_list_repo_labels_parses` in
+/// `bin/tm/commands/ticket/labels.rs`, which deserializes into this type.
+// Deliberately NOT `#[non_exhaustive]`: the `tm` binary is a separate crate and
+// builds these as struct literals in its own tests and `gh label list` fixtures.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct PolicyLabel {
+    /// Label name (e.g. `ws/tm-tcode-01`).
+    pub name: String,
+    /// 6-hex color, no `#` (e.g. `BFD4F2`).
+    #[serde(default)]
+    pub color: String,
+    /// Human description shown in the GitHub label UI; empty means none.
+    #[serde(default)]
+    pub description: String,
+}
+
+impl PolicyLabel {
+    /// Build a label from owned or borrowed parts.
+    pub fn new(
+        name: impl Into<String>,
+        color: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            color: color.into(),
+            description: description.into(),
+        }
+    }
+}
+
+/// The [`CONVENTION_LABEL`], fully specified.
+pub fn convention_label() -> PolicyLabel {
+    PolicyLabel::new(
+        CONVENTION_LABEL,
+        CONVENTION_LABEL_COLOR,
+        CONVENTION_LABEL_DESCRIPTION,
+    )
+}
+
+/// The `ws/<session_name>` workstream label, or `None` when no session name is
+/// known.
+///
+/// Why: the PM brief's `--label ws/<name>` convention needs the label to exist
+/// before a session's first issue or PR. A blank name has nothing to label
+/// with, so it is a clean skip rather than a malformed `ws/` label.
+/// What: `Some` with the truncated-and-hashed name from [`label_name_for`] and
+/// the stable color from [`label_color_for`]; `None` when `session_name` is
+/// empty or whitespace.
+/// Test: `policy_labels_includes_workstream`,
+/// `policy_labels_blank_session_skips_workstream`.
+pub fn workstream_label(session_name: &str) -> Option<PolicyLabel> {
+    let name = session_name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some(PolicyLabel::new(
+        label_name_for(name),
+        label_color_for(name),
+        format!("trusty-mpm workstream {name}"),
+    ))
+}
+
+/// Every label the harness applies by policy.
+///
+/// Why: one table, so session launch and `tm issue seed-labels` cannot drift
+/// apart on which labels the harness owns — the drift #6914 records.
+/// What: the [`CONVENTION_LABEL`], plus the `ws/<session>` label when
+/// `session_name` names one. The issue-lifecycle (`status:*`) labels are NOT
+/// here: those are project-configured, read from `issue-state.yaml`, and
+/// `tm issue seed-labels` merges the two sets.
+/// Test: `policy_labels_includes_workstream`,
+/// `policy_labels_without_session_skips_workstream`.
+pub fn policy_labels(session_name: Option<&str>) -> Vec<PolicyLabel> {
+    let mut out = vec![convention_label()];
+    out.extend(session_name.and_then(workstream_label));
+    out
+}
+
+/// Whether `name` sits in trusty-mpm's OWN label namespace.
+///
+/// Why: the force policy for `gh label create` turns on exactly this. `ws/` is
+/// the framework's namespace, so refreshing its color/description is safe;
+/// every other policy label is an ordinary repo label a project may already own
+/// and have styled, and `--force` would silently rewrite that on every launch.
+/// Test: `owned_namespace_is_ws_only`.
+pub fn is_owned_namespace(name: &str) -> bool {
+    name.starts_with(WORKSTREAM_PREFIX)
+}
+
+/// The `gh label create …` argv — the crate's single spelling of that command.
+///
+/// Why: #6914 — two independent argv builders (one at session launch, one in
+/// `tm issue`) is the duplication that let the launch path keep creating retired
+/// labels. Flag order and the omit-when-empty rules now live in one place.
+/// What: `label create <name>`, then `--color`/`--description` when non-empty,
+/// then `--repo <repo>` when the caller targets a specific repository, then
+/// `--force` when the caller owns the label's namespace. Returned owned so the
+/// caller can borrow it against either of the crate's two spawn seams.
+/// Test: `create_label_argv_full`, `create_label_argv_omits_empty_fields`,
+/// `create_label_argv_repo_and_force`.
+pub fn create_label_argv(label: &PolicyLabel, repo: Option<&str>, force: bool) -> Vec<String> {
+    let mut argv = vec![
+        "label".to_string(),
+        "create".to_string(),
+        label.name.clone(),
+    ];
+    if !label.color.is_empty() {
+        argv.push("--color".to_string());
+        argv.push(label.color.clone());
+    }
+    if !label.description.is_empty() {
+        argv.push("--description".to_string());
+        argv.push(label.description.clone());
+    }
+    if let Some(repo) = repo {
+        argv.push("--repo".to_string());
+        argv.push(repo.to_string());
+    }
+    if force {
+        argv.push("--force".to_string());
+    }
+    argv
+}
+
+/// The `ws/<name>` label name, truncated (with a stable disambiguating suffix)
+/// to stay within GitHub's label-name length cap.
+///
+/// Why: GitHub caps a label name at [`GITHUB_LABEL_MAX_LEN`] characters.
+/// Auto-derived session names are always well within that, but an OPERATOR
+/// rename (`SessionManager::rename`, up to 64 chars) can produce a name whose
+/// `ws/<name>` form overflows the cap — `gh label create`/`--add-label` would
+/// then fail with a 400, exactly the failure this policy exists to prevent.
+/// Simple truncation risks two DIFFERENT long names colliding on the same
+/// truncated label; an 8-hex FNV-1a suffix — hashed from the FULL untruncated
+/// name, not the truncated prefix — keeps them apart.
+/// What: `ws/<name>` verbatim when it already fits. Otherwise
+/// `ws/<truncated-name>-<8-hex-hash>`, where `<truncated-name>` is trimmed to
+/// the nearest earlier `char` boundary so a multi-byte character is never
+/// split.
+/// Test: `label_name_short_is_verbatim`,
+/// `label_name_long_is_truncated_with_hash_suffix`,
+/// `label_name_stays_within_github_cap`,
+/// `label_name_distinct_long_names_get_distinct_labels`.
+fn label_name_for(session_name: &str) -> String {
+    let full = format!("{WORKSTREAM_PREFIX}{session_name}");
+    if full.len() <= GITHUB_LABEL_MAX_LEN {
+        return full;
+    }
+    // 8 lowercase hex chars from the top 32 bits of the FULL name's hash —
+    // stable per name, and keeps two names sharing a truncated prefix apart.
+    let suffix = format!("{:08x}", (fnv1a_hash(session_name) >> 32) as u32);
+    // Budget: "ws/" (3) + truncated name + "-" (1) + suffix (8) <= cap.
+    let prefix_budget = GITHUB_LABEL_MAX_LEN - WORKSTREAM_PREFIX.len() - 1 - suffix.len();
+    let truncated = truncate_at_char_boundary(session_name, prefix_budget);
+    format!("{WORKSTREAM_PREFIX}{truncated}-{suffix}")
+}
+
+/// Truncate `s` to at most `max_bytes` bytes, backing off to the nearest
+/// earlier `char` boundary so a multi-byte UTF-8 character is never split.
+fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Derive a stable, name-specific 6-hex label color.
+///
+/// Scheme: FNV-1a (64-bit, chosen over `std`'s `DefaultHasher` because its
+/// algorithm is explicitly not guaranteed stable across Rust versions — this
+/// color must stay identical for a given name across every future rebuild)
+/// hashes `session_name`; the hash mod 360 becomes an HSL hue, with fixed
+/// saturation (55%) and lightness (45%) chosen to stay readable as GitHub label
+/// text on both light and dark repo themes.
+/// Test: `label_color_is_stable_and_valid_hex`,
+/// `label_color_differs_across_names`.
+fn label_color_for(session_name: &str) -> String {
+    let hue = (fnv1a_hash(session_name) % 360) as f64;
+    hsl_to_hex(hue, 0.55, 0.45)
+}
+
+/// FNV-1a 64-bit hash — deterministic across Rust versions/platforms, unlike
+/// `std::collections::hash_map::DefaultHasher`.
+fn fnv1a_hash(input: &str) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// Convert an HSL color (`h` in `[0, 360)`, `s`/`l` in `[0, 1]`) to an
+/// uppercase 6-hex RGB string with no leading `#` (matching `gh label
+/// create --color`'s expected form).
+fn hsl_to_hex(h: f64, s: f64, l: f64) -> String {
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let h_prime = h / 60.0;
+    let x = c * (1.0 - (h_prime % 2.0 - 1.0).abs());
+    let m = l - c / 2.0;
+    let (r1, g1, b1) = match h_prime as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    let to_byte = |v: f64| ((v + m) * 255.0).round().clamp(0.0, 255.0) as u8;
+    format!("{:02X}{:02X}{:02X}", to_byte(r1), to_byte(g1), to_byte(b1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── the policy set ──────────────────────────────────────────────────
+
+    #[test]
+    fn convention_label_is_stable() {
+        let l = convention_label();
+        assert_eq!(l.name, "trusty-mpm");
+        assert_eq!(l.color.len(), 6);
+        assert!(l.color.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(!l.description.is_empty());
+    }
+
+    #[test]
+    fn policy_labels_includes_workstream() {
+        let names: Vec<String> = policy_labels(Some("tm-tcode-01"))
+            .into_iter()
+            .map(|l| l.name)
+            .collect();
+        assert_eq!(names, ["trusty-mpm", "ws/tm-tcode-01"]);
+    }
+
+    #[test]
+    fn policy_labels_without_session_skips_workstream() {
+        let names: Vec<String> = policy_labels(None).into_iter().map(|l| l.name).collect();
+        assert_eq!(names, ["trusty-mpm"]);
+    }
+
+    #[test]
+    fn policy_labels_blank_session_skips_workstream() {
+        let names: Vec<String> = policy_labels(Some("   "))
+            .into_iter()
+            .map(|l| l.name)
+            .collect();
+        assert_eq!(names, ["trusty-mpm"]);
+    }
+
+    #[test]
+    fn policy_labels_carry_no_retired_lifecycle_pair() {
+        // #6914: `in-progress` / `blocked` predate the `status:*` lifecycle and
+        // must never be seeded again, from either consumer.
+        let names: Vec<String> = policy_labels(Some("tm-tcode-01"))
+            .into_iter()
+            .map(|l| l.name)
+            .collect();
+        assert!(!names.iter().any(|n| n == "in-progress" || n == "blocked"));
+    }
+
+    #[test]
+    fn owned_namespace_is_ws_only() {
+        assert!(is_owned_namespace("ws/tm-tcode-01"));
+        assert!(!is_owned_namespace("trusty-mpm"));
+        assert!(!is_owned_namespace("status:coded"));
+    }
+
+    // ── color derivation ────────────────────────────────────────────────
+
+    #[test]
+    fn label_color_is_stable_and_valid_hex() {
+        let a = label_color_for("tm-tcode-01");
+        let b = label_color_for("tm-tcode-01");
+        assert_eq!(a, b, "same name must always derive the same color");
+        assert_eq!(a.len(), 6);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(a, a.to_ascii_uppercase(), "color must be uppercase hex");
+    }
+
+    #[test]
+    fn label_color_differs_across_names() {
+        let a = label_color_for("tm-tcode-01");
+        let b = label_color_for("tm-dogfood-relaunch-01");
+        assert_ne!(a, b, "distinct names should (overwhelmingly likely) differ");
+    }
+
+    // ── label name length cap ───────────────────────────────────────────
+
+    #[test]
+    fn label_name_short_is_verbatim() {
+        assert_eq!(label_name_for("tm-tcode-01"), "ws/tm-tcode-01");
+    }
+
+    #[test]
+    fn label_name_stays_within_github_cap() {
+        // `SessionManager::rename` allows operator-chosen names up to 64
+        // chars — well past the 47-char budget `ws/<name>` has under the
+        // 50-char GitHub label cap.
+        let long_name = "a".repeat(64);
+        let label = label_name_for(&long_name);
+        assert!(
+            label.len() <= GITHUB_LABEL_MAX_LEN,
+            "label {label:?} ({} chars) exceeds the {GITHUB_LABEL_MAX_LEN}-char GitHub cap",
+            label.len()
+        );
+    }
+
+    #[test]
+    fn label_name_long_is_truncated_with_hash_suffix() {
+        let long_name = "a".repeat(64);
+        let label = label_name_for(&long_name);
+        assert!(label.starts_with("ws/aaaa"), "got {label:?}");
+        // "ws/" + 38-char truncated prefix + "-" + 8-hex suffix == 50.
+        assert_eq!(label.len(), GITHUB_LABEL_MAX_LEN);
+        let suffix = label.rsplit('-').next().expect("has a suffix segment");
+        assert_eq!(suffix.len(), 8, "suffix {suffix:?} must be 8 hex chars");
+        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn label_name_distinct_long_names_get_distinct_labels() {
+        // Share an identical 60-char prefix (well past the ~38-char truncation
+        // budget) and differ only in their last 4 chars — the hash suffix
+        // (derived from the FULL name) must still tell them apart even though
+        // their truncated prefixes are identical.
+        let base = "x".repeat(60);
+        let label_a = label_name_for(&format!("{base}1111"));
+        let label_b = label_name_for(&format!("{base}2222"));
+        assert_ne!(
+            label_a, label_b,
+            "two long names differing only past the truncation point must not collide"
+        );
+        assert!(label_a.len() <= GITHUB_LABEL_MAX_LEN);
+        assert!(label_b.len() <= GITHUB_LABEL_MAX_LEN);
+    }
+
+    // ── the single argv builder ─────────────────────────────────────────
+
+    #[test]
+    fn create_label_argv_full() {
+        let l = PolicyLabel::new("unicorn:done", "0075CA", "Done");
+        assert_eq!(
+            create_label_argv(&l, None, false),
+            [
+                "label",
+                "create",
+                "unicorn:done",
+                "--color",
+                "0075CA",
+                "--description",
+                "Done"
+            ]
+        );
+    }
+
+    #[test]
+    fn create_label_argv_omits_empty_fields() {
+        let l = PolicyLabel::new("T4", "", "");
+        assert_eq!(
+            create_label_argv(&l, None, false),
+            ["label", "create", "T4"]
+        );
+    }
+
+    #[test]
+    fn create_label_argv_repo_and_force() {
+        let l = PolicyLabel::new("ws/x", "0E8A16", "d");
+        assert_eq!(
+            create_label_argv(&l, Some("owner/repo"), true),
+            [
+                "label",
+                "create",
+                "ws/x",
+                "--color",
+                "0E8A16",
+                "--description",
+                "d",
+                "--repo",
+                "owner/repo",
+                "--force"
+            ]
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/session_launch/workstream_label.rs
+++ b/crates/trusty-mpm/src/core/session_launch/workstream_label.rs
@@ -1,5 +1,5 @@
-//! Launch-time `ws/<session-name>` workstream-activity label ensure (issue
-//! #3726, PM-brief decision).
+//! Launch-time policy-label ensure (issue #3726, PM-brief decision; retired
+//! lifecycle pair removed in #6914).
 //!
 //! Why: workstream activity is tracked on GitHub via a `ws/<session-name>`
 //! label — explicitly NOT milestones, which stay reserved for epics/releases
@@ -17,37 +17,30 @@
 //! directory, and its tmux session name, it derives the target
 //! `<owner>/<repo>` (preferring the passed `repo_url`, falling back to the
 //! workspace's own `git remote get-url origin`), and idempotently creates
-//! `ws/<session-name>` via `gh label create --force` with a name-derived
-//! stable color (see [`label_color_for`]). Every non-GitHub-remote case (no
-//! origin, non-GitHub host, `gh` missing/unauthenticated/timed-out) is a
-//! logged, non-fatal skip — [`LabelOutcome`] is returned for callers/tests
+//! `ws/<session-name>` via `gh label create --force`. Every non-GitHub-remote
+//! case (no origin, non-GitHub host, `gh` missing/unauthenticated/timed-out) is
+//! a logged, non-fatal skip — [`LabelOutcome`] is returned for callers/tests
 //! that want to observe the branch taken, but production call sites (session
 //! launch) MUST treat every variant as fire-and-forget: this must NEVER block
 //! or fail a session launch.
-//! The same launch hook also ensures the two issue-lifecycle labels
-//! ([`LIFECYCLE_LABELS`]) `tm-ticketing`'s Lifecycle section applies, for the
-//! same first-use reason — see that constant for why they are created without
-//! `--force`.
+//! The same launch hook ensures every OTHER policy label too, from the shared
+//! [`crate::core::policy_labels`] table. Before #6914 this module carried its
+//! own second table and was still creating a retired `in-progress` / `blocked`
+//! pair the `status:*` lifecycle replaced.
 //! Test: `owner_repo_from_ssh_origin`, `owner_repo_from_https_origin`,
-//! `owner_repo_rejects_non_github_host`, `label_color_is_stable_and_valid_hex`,
-//! `label_color_differs_across_names`, `label_name_short_is_verbatim`,
-//! `label_name_stays_within_github_cap`,
-//! `label_name_long_is_truncated_with_hash_suffix`,
-//! `label_name_distinct_long_names_get_distinct_labels`,
-//! `ensure_skips_when_no_origin`, `ensure_skips_when_non_github`,
-//! `ensure_skips_when_name_blank`, `ensure_creates_label_via_runner`,
-//! `ensure_reports_runner_failure` drive the pure derivation + a scripted
-//! [`GhLabelRunner`] fake — no live `gh`/network. The lifecycle-label half and
-//! the launch-path failure contract are covered by
-//! `lifecycle_label_table_is_valid`,
-//! `lifecycle_labels_are_created_without_force`,
-//! `lifecycle_labels_attempt_every_label_when_gh_fails`,
-//! `launch_labels_ensure_all_three`,
-//! `lifecycle_labels_run_even_when_workstream_label_fails`,
-//! `workstream_label_runs_even_when_lifecycle_labels_fail`,
+//! `owner_repo_rejects_non_github_host`, `ensure_skips_when_no_origin`,
+//! `ensure_skips_when_non_github`, `ensure_skips_when_name_blank`,
+//! `ensure_creates_label_via_runner`, `ensure_reports_runner_failure` drive the
+//! pure derivation + a scripted [`GhLabelRunner`] fake — no live `gh`/network.
+//! The launch-path composition and its failure contract are covered by
+//! `launch_labels_ensure_the_policy_set`,
+//! `launch_labels_never_create_the_retired_lifecycle_pair`,
+//! `convention_label_is_created_without_force`,
+//! `convention_label_runs_even_when_workstream_label_fails`,
+//! `workstream_label_runs_even_when_convention_label_fails`,
 //! `launch_labels_survive_total_gh_failure`,
 //! `launch_labels_skip_cleanly_on_non_github_remote`,
-//! `launch_labels_ensure_lifecycle_labels_when_session_name_is_blank`.
+//! `launch_labels_ensure_convention_label_when_session_name_is_blank`.
 
 use std::path::Path;
 use std::time::Duration;
@@ -55,6 +48,7 @@ use std::time::Duration;
 use trusty_common::github_path::GithubPath;
 
 use crate::core::gh_account::run_bounded;
+use crate::core::policy_labels::{self, PolicyLabel};
 
 /// Bound for the `gh label create` call this module makes at session launch.
 ///
@@ -97,9 +91,8 @@ pub enum LabelOutcome {
 /// issue/PR.
 /// What: derives `<owner>/<repo>` (via [`owner_repo_from_origin`] on
 /// `repo_url` when present, else by reading `workspace_dir`'s
-/// `remote.origin.url`), then runs `gh label create ws/<session_name> --repo
-/// <owner>/<repo> --color <hex> --description "trusty-mpm workstream
-/// <session_name>" --force` through [`RealGhRunner`], bounded by
+/// `remote.origin.url`), then creates the shared
+/// [`policy_labels::workstream_label`] through [`RealGhRunner`], bounded by
 /// [`GH_LABEL_TIMEOUT`]. Every failure path is a logged, non-fatal skip — see
 /// [`LabelOutcome`].
 /// Test: `ensure_creates_label_via_runner`, `ensure_skips_when_no_origin`,
@@ -121,106 +114,67 @@ fn ensure_workstream_label_with<R: GhLabelRunner>(
     workspace_dir: &Path,
     session_name: &str,
 ) -> LabelOutcome {
-    let name = session_name.trim();
-    if name.is_empty() {
+    // #6914: the ws/ label's name, color and description come from the shared
+    // policy table, not from a second copy in this module.
+    let Some(label) = policy_labels::workstream_label(session_name) else {
         tracing::debug!("workstream label: blank session name — skipping");
         return LabelOutcome::SkippedBlankName;
-    }
+    };
 
     let gh_path = match resolve_github_repo(repo_url, workspace_dir) {
         Ok(gh_path) => gh_path,
         Err(skip) => {
-            tracing::debug!(session = %name, ?skip, "workstream label: repo not resolvable — skipping");
+            tracing::debug!(?skip, "workstream label: repo not resolvable — skipping");
             return skip;
         }
     };
-
-    let label = label_name_for(name);
-    let color = label_color_for(name);
-    let description = format!("trusty-mpm workstream {name}");
     let repo = gh_path.rel_path();
 
-    if runner.create_label(&repo, &label, &color, &description, true) {
-        tracing::info!(session = %name, repo = %repo, label = %label, "workstream label ensured");
+    if create_policy_label(runner, &repo, &label) {
+        tracing::info!(repo = %repo, label = %label.name, "workstream label ensured");
         LabelOutcome::Ensured
     } else {
         tracing::debug!(
-            session = %name,
             repo = %repo,
-            label = %label,
+            label = %label.name,
             "workstream label: `gh label create` failed/unavailable — skipping (non-fatal)"
         );
         LabelOutcome::GhFailed
     }
 }
 
-/// The issue-lifecycle labels the PM's ticketing lifecycle applies, as
-/// `(name, color, description)`.
+/// Create one policy label on `repo`, best-effort, applying the shared
+/// force rule.
 ///
-/// Why: a GitHub issue is only ever open or closed, so `tm-ticketing`'s
-/// Lifecycle section expresses progress with an `in-progress` / `blocked`
-/// label plus comments. `gh issue edit --add-label` fails on a label the repo
-/// has never seen, so the rule cannot fire on first use unless launch creates
-/// them — the same reason [`ensure_workstream_label`] exists.
-/// What: colors are ones this workspace's repo already uses (`0E8A16` from
-/// `tga`, `B60205` from `blocked-on-mvp`), so the two labels read as native
-/// rather than framework-branded.
-/// Test: `lifecycle_labels_are_created_without_force`,
-/// `lifecycle_label_table_is_valid`.
-const LIFECYCLE_LABELS: [(&str, &str, &str); 2] = [
-    (
-        "in-progress",
-        "0E8A16",
-        "Work has started; a session or agent is on it",
-    ),
-    (
-        "blocked",
-        "B60205",
-        "Blocked on a prerequisite; not scheduled",
-    ),
-];
-
-/// Ensure both [`LIFECYCLE_LABELS`] exist on `repo`, best-effort.
-///
-/// Why: see [`LIFECYCLE_LABELS`].
-/// What: one plain `gh label create` per label — deliberately WITHOUT
-/// `--force`, unlike the `ws/<session>` label. `ws/` is trusty-mpm's own
-/// namespace, but `in-progress`/`blocked` are ordinary repo labels a project
-/// may already own and have styled; `--force` would silently rewrite that
-/// project's color and description on every session launch. A create that
-/// fails because the label already exists is therefore the expected steady
-/// state, indistinguishable here from a real `gh` failure and equally
-/// harmless — both are debug-logged and neither is returned, because every
-/// caller is fire-and-forget. Both labels are always attempted: a failure on
-/// the first must not suppress the second.
-/// Test: `lifecycle_labels_are_created_without_force`,
-/// `lifecycle_labels_attempt_every_label_when_gh_fails`.
-fn ensure_lifecycle_labels_with<R: GhLabelRunner>(runner: &R, repo: &str) {
-    for (name, color, description) in LIFECYCLE_LABELS {
-        if runner.create_label(repo, name, color, description, false) {
-            tracing::info!(repo = %repo, label = %name, "issue lifecycle label created");
-        } else {
-            tracing::debug!(
-                repo = %repo,
-                label = %name,
-                "issue lifecycle label not created (already exists, or `gh` unavailable) — non-fatal"
-            );
-        }
-    }
+/// Why: `--force` refreshes an existing label's color and description. That is
+/// right for `ws/`, which is trusty-mpm's own namespace, and wrong for every
+/// other policy label — those are ordinary repo labels a project may already
+/// own and have styled, and forcing would silently rewrite that on every
+/// launch. [`policy_labels::is_owned_namespace`] is the single place that rule
+/// lives.
+/// What: builds the argv with [`policy_labels::create_label_argv`] and returns
+/// whether `gh` succeeded. A create that fails because the label already exists
+/// is the expected steady state on the non-forced path, indistinguishable here
+/// from a real `gh` failure and equally harmless.
+/// Test: `ensure_creates_label_via_runner`,
+/// `convention_label_is_created_without_force`.
+fn create_policy_label<R: GhLabelRunner>(runner: &R, repo: &str, label: &PolicyLabel) -> bool {
+    let force = policy_labels::is_owned_namespace(&label.name);
+    runner.create_label(repo, label, force)
 }
 
-/// Every launch-time label ensure, in one call: the session's `ws/<name>`
-/// label plus the two [`LIFECYCLE_LABELS`].
+/// Every launch-time label ensure, in one call: the shared policy set from
+/// [`policy_labels::policy_labels`].
 ///
-/// Why: the daemon's spawn paths need a single fire-and-forget entry point,
-/// and the two ensures must be independent — a `gh` failure on either one must
-/// leave the other attempted and must never propagate to the launch.
-/// What: runs [`ensure_workstream_label_with`], discards its outcome (already
-/// logged), then resolves the repo again for
-/// [`ensure_lifecycle_labels_with`]. Nothing here returns or panics on a
-/// failed `gh` call.
-/// Test: `launch_labels_ensure_all_three`,
-/// `lifecycle_labels_run_even_when_workstream_label_fails`,
+/// Why: the daemon's spawn paths need a single fire-and-forget entry point, and
+/// the ensures must be independent — a `gh` failure on any one must leave the
+/// rest attempted and must never propagate to the launch.
+/// What: runs [`ensure_workstream_label_with`] for the `ws/` label (discarding
+/// its outcome, already logged), then resolves the repo again and creates every
+/// remaining policy label. Nothing here returns or panics on a failed `gh`
+/// call.
+/// Test: `launch_labels_ensure_the_policy_set`,
+/// `convention_label_runs_even_when_workstream_label_fails`,
 /// `launch_labels_survive_total_gh_failure`.
 fn ensure_launch_labels_with<R: GhLabelRunner>(
     runner: &R,
@@ -229,8 +183,25 @@ fn ensure_launch_labels_with<R: GhLabelRunner>(
     session_name: &str,
 ) {
     let _ = ensure_workstream_label_with(runner, repo_url, workspace_dir, session_name);
-    if let Ok(gh_path) = resolve_github_repo(repo_url, workspace_dir) {
-        ensure_lifecycle_labels_with(runner, &gh_path.rel_path());
+    let Ok(gh_path) = resolve_github_repo(repo_url, workspace_dir) else {
+        return;
+    };
+    let repo = gh_path.rel_path();
+    // #6914: the ws/ label above is already ensured; everything else in the
+    // shared policy set follows, each independently best-effort.
+    for label in policy_labels::policy_labels(Some(session_name)) {
+        if policy_labels::is_owned_namespace(&label.name) {
+            continue;
+        }
+        if create_policy_label(runner, &repo, &label) {
+            tracing::info!(repo = %repo, label = %label.name, "policy label created");
+        } else {
+            tracing::debug!(
+                repo = %repo,
+                label = %label.name,
+                "policy label not created (already exists, or `gh` unavailable) — non-fatal"
+            );
+        }
     }
 }
 
@@ -254,8 +225,7 @@ fn resolve_github_repo(
     owner_repo_from_origin(&origin).ok_or(LabelOutcome::SkippedNonGithub)
 }
 
-/// Fire-and-forget [`ensure_launch_labels_with`] on the blocking thread pool —
-/// the session's `ws/<name>` label plus the two [`LIFECYCLE_LABELS`].
+/// Fire-and-forget [`ensure_launch_labels_with`] on the blocking thread pool.
 ///
 /// Why: the ensures shell out to `gh` (bounded by
 /// [`GH_LABEL_TIMEOUT`], but still up to a few seconds on a slow/offline
@@ -296,58 +266,6 @@ pub fn spawn_workstream_label_ensure(
             tracing::debug!("workstream label ensure task failed to join: {e}");
         }
     });
-}
-
-/// GitHub's hard cap on a label name's length (the full `ws/<name>` string).
-const GITHUB_LABEL_MAX_LEN: usize = 50;
-
-/// The `ws/<name>` label name for a session, truncated (with a stable
-/// disambiguating suffix) to stay within GitHub's label-name length cap.
-///
-/// Why: GitHub caps a label name at [`GITHUB_LABEL_MAX_LEN`] characters.
-/// Auto-derived session names are always well within that, but an OPERATOR
-/// rename (`SessionManager::rename`, up to 64 chars) can produce a name
-/// whose `ws/<name>` form overflows the cap — `gh label create`/`--add-label`
-/// would then fail with a 400, exactly the failure this module exists to
-/// prevent. Simple truncation risks two DIFFERENT long names colliding on
-/// the same truncated label; an 8-hex FNV-1a suffix — hashed from the FULL
-/// untruncated name, not the truncated prefix — keeps them apart.
-/// What: `ws/<name>` verbatim when it already fits. Otherwise:
-/// `ws/<truncated-name>-<8-hex-hash>`, where `<truncated-name>` is `name`'s
-/// leading bytes (trimmed to the nearest earlier `char` boundary so a
-/// multi-byte character is never split) shortened just far enough that the
-/// full `ws/<truncated>-<hash>` string is at most [`GITHUB_LABEL_MAX_LEN`]
-/// characters, and `<hash>` is the lowercase 8-hex encoding of the top 32
-/// bits of `name`'s FNV-1a-64 hash.
-/// Test: `label_name_short_is_verbatim`,
-/// `label_name_long_is_truncated_with_hash_suffix`,
-/// `label_name_stays_within_github_cap`,
-/// `label_name_distinct_long_names_get_distinct_labels`.
-fn label_name_for(session_name: &str) -> String {
-    let full = format!("ws/{session_name}");
-    if full.len() <= GITHUB_LABEL_MAX_LEN {
-        return full;
-    }
-    // 8 lowercase hex chars from the top 32 bits of the FULL name's hash —
-    // stable per name, and keeps two names sharing a truncated prefix apart.
-    let suffix = format!("{:08x}", (fnv1a_hash(session_name) >> 32) as u32);
-    // Budget: "ws/" (3) + truncated name + "-" (1) + suffix (8) <= cap.
-    let prefix_budget = GITHUB_LABEL_MAX_LEN - "ws/".len() - 1 - suffix.len();
-    let truncated = truncate_at_char_boundary(session_name, prefix_budget);
-    format!("ws/{truncated}-{suffix}")
-}
-
-/// Truncate `s` to at most `max_bytes` bytes, backing off to the nearest
-/// earlier `char` boundary so a multi-byte UTF-8 character is never split.
-fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
-    if s.len() <= max_bytes {
-        return s;
-    }
-    let mut end = max_bytes;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
 }
 
 /// Read `remote.origin.url` from `dir` via `git config`, best-effort.
@@ -416,78 +334,23 @@ fn owner_repo_from_origin(origin: &str) -> Option<GithubPath> {
     trusty_common::github_path::parse_github_path(trimmed)
 }
 
-/// Derive a stable, name-specific 6-hex label color.
-///
-/// Scheme: FNV-1a (64-bit, chosen over `std`'s `DefaultHasher` because its
-/// algorithm is explicitly not guaranteed stable across Rust versions — this
-/// color must stay identical for a given name across every future rebuild)
-/// hashes `session_name`; the hash mod 360 becomes an HSL hue, with fixed
-/// saturation (55%) and lightness (45%) chosen to stay readable as GitHub
-/// label text on both light and dark repo themes. The hue spread means
-/// distinct workstream names get visually distinct, deterministic colors.
-/// Test: `label_color_is_stable_and_valid_hex`,
-/// `label_color_differs_across_names`.
-fn label_color_for(session_name: &str) -> String {
-    let hue = (fnv1a_hash(session_name) % 360) as f64;
-    hsl_to_hex(hue, 0.55, 0.45)
-}
-
-/// FNV-1a 64-bit hash — deterministic across Rust versions/platforms, unlike
-/// `std::collections::hash_map::DefaultHasher`.
-fn fnv1a_hash(input: &str) -> u64 {
-    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
-    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-    let mut hash = FNV_OFFSET_BASIS;
-    for byte in input.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(FNV_PRIME);
-    }
-    hash
-}
-
-/// Convert an HSL color (`h` in `[0, 360)`, `s`/`l` in `[0, 1]`) to an
-/// uppercase 6-hex RGB string with no leading `#` (matching `gh label
-/// create --color`'s expected form).
-fn hsl_to_hex(h: f64, s: f64, l: f64) -> String {
-    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
-    let h_prime = h / 60.0;
-    let x = c * (1.0 - (h_prime % 2.0 - 1.0).abs());
-    let m = l - c / 2.0;
-    let (r1, g1, b1) = match h_prime as u32 {
-        0 => (c, x, 0.0),
-        1 => (x, c, 0.0),
-        2 => (0.0, c, x),
-        3 => (0.0, x, c),
-        4 => (x, 0.0, c),
-        _ => (c, 0.0, x),
-    };
-    let to_byte = |v: f64| ((v + m) * 255.0).round().clamp(0.0, 255.0) as u8;
-    format!("{:02X}{:02X}{:02X}", to_byte(r1), to_byte(g1), to_byte(b1))
-}
-
 /// A seam for the one `gh` invocation this module makes, so tests can script
 /// the outcome instead of shelling out to a live `gh`.
 ///
 /// Why: mirrors the `CommandRunner` seam `tm ticket`/`watch` use
 /// (`bin/tm/commands/ticket/runner.rs`) — that trait lives in the `tm` binary
 /// crate and is not reachable from this library module, so this is a small,
-/// purpose-built equivalent scoped to the one call this module needs.
+/// purpose-built equivalent scoped to the one call this module needs. The
+/// COMMAND LINE both seams build is shared
+/// ([`policy_labels::create_label_argv`]); only the spawn differs.
 /// What: `create_label` returns whether the `gh` call succeeded; callers never
 /// see the raw stdout/stderr since label-create has nothing worth surfacing on
 /// success and every failure is already a non-fatal skip.
 /// Test: driven by `FakeGhRunner` in this module's tests.
 trait GhLabelRunner {
-    /// Run `gh label create <name> --repo <repo> --color <color> --description
-    /// <description>` (with `--force` when `force`), returning whether it
-    /// succeeded.
-    fn create_label(
-        &self,
-        repo: &str,
-        name: &str,
-        color: &str,
-        description: &str,
-        force: bool,
-    ) -> bool;
+    /// Run `gh label create …` for `label` against `repo` (with `--force` when
+    /// `force`), returning whether it succeeded.
+    fn create_label(&self, repo: &str, label: &PolicyLabel, force: bool) -> bool;
 }
 
 /// Production [`GhLabelRunner`] — spawns real `gh`, bounded by
@@ -495,35 +358,14 @@ trait GhLabelRunner {
 struct RealGhRunner;
 
 impl GhLabelRunner for RealGhRunner {
-    fn create_label(
-        &self,
-        repo: &str,
-        name: &str,
-        color: &str,
-        description: &str,
-        force: bool,
-    ) -> bool {
-        let repo = repo.to_string();
-        let name = name.to_string();
-        let color = color.to_string();
-        let description = description.to_string();
+    fn create_label(&self, repo: &str, label: &PolicyLabel, force: bool) -> bool {
+        // #6914: the argv comes from the crate's single `gh label create`
+        // builder, not from a second copy spelled out here.
+        let argv = policy_labels::create_label_argv(label, Some(repo), force);
         run_bounded(GH_LABEL_TIMEOUT, move || {
             // #5475: single `gh` entry point.
-            let mut argv: Vec<&str> = vec![
-                "label",
-                "create",
-                &name,
-                "--repo",
-                &repo,
-                "--color",
-                &color,
-                "--description",
-                &description,
-            ];
-            if force {
-                argv.push("--force");
-            }
-            trusty_common::gh::GhCommand::new(argv)
+            let borrowed: Vec<&str> = argv.iter().map(String::as_str).collect();
+            trusty_common::gh::GhCommand::new(borrowed)
                 .output_blocking()
                 .ok()
                 .map(|out| out.success)
@@ -575,77 +417,6 @@ mod tests {
         assert!(owner_repo_from_origin("   ").is_none());
     }
 
-    // ── color derivation ────────────────────────────────────────────────
-
-    #[test]
-    fn label_color_is_stable_and_valid_hex() {
-        let a = label_color_for("tm-tcode-01");
-        let b = label_color_for("tm-tcode-01");
-        assert_eq!(a, b, "same name must always derive the same color");
-        assert_eq!(a.len(), 6);
-        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
-        assert_eq!(a, a.to_ascii_uppercase(), "color must be uppercase hex");
-    }
-
-    #[test]
-    fn label_color_differs_across_names() {
-        let a = label_color_for("tm-tcode-01");
-        let b = label_color_for("tm-dogfood-relaunch-01");
-        assert_ne!(a, b, "distinct names should (overwhelmingly likely) differ");
-    }
-
-    // ── label name length cap ───────────────────────────────────────────
-
-    #[test]
-    fn label_name_short_is_verbatim() {
-        assert_eq!(label_name_for("tm-tcode-01"), "ws/tm-tcode-01");
-    }
-
-    #[test]
-    fn label_name_stays_within_github_cap() {
-        // `SessionManager::rename` allows operator-chosen names up to 64
-        // chars — well past the 47-char budget `ws/<name>` has under the
-        // 50-char GitHub label cap.
-        let long_name = "a".repeat(64);
-        let label = label_name_for(&long_name);
-        assert!(
-            label.len() <= GITHUB_LABEL_MAX_LEN,
-            "label {label:?} ({} chars) exceeds the {GITHUB_LABEL_MAX_LEN}-char GitHub cap",
-            label.len()
-        );
-    }
-
-    #[test]
-    fn label_name_long_is_truncated_with_hash_suffix() {
-        let long_name = "a".repeat(64);
-        let label = label_name_for(&long_name);
-        assert!(label.starts_with("ws/aaaa"), "got {label:?}");
-        // "ws/" + 38-char truncated prefix + "-" + 8-hex suffix == 50.
-        assert_eq!(label.len(), GITHUB_LABEL_MAX_LEN);
-        let suffix = label.rsplit('-').next().expect("has a suffix segment");
-        assert_eq!(suffix.len(), 8, "suffix {suffix:?} must be 8 hex chars");
-        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit()));
-    }
-
-    #[test]
-    fn label_name_distinct_long_names_get_distinct_labels() {
-        // Share an identical 60-char prefix (well past the ~38-char
-        // truncation budget) and differ only in their last 4 chars — the
-        // hash suffix (derived from the FULL name) must still tell them
-        // apart even though their truncated prefixes are identical.
-        let base = "x".repeat(60);
-        let name_a = format!("{base}1111");
-        let name_b = format!("{base}2222");
-        let label_a = label_name_for(&name_a);
-        let label_b = label_name_for(&name_b);
-        assert_ne!(
-            label_a, label_b,
-            "two long names differing only past the truncation point must not collide"
-        );
-        assert!(label_a.len() <= GITHUB_LABEL_MAX_LEN);
-        assert!(label_b.len() <= GITHUB_LABEL_MAX_LEN);
-    }
-
     // ── ensure_workstream_label skip-cleanly paths ──────────────────────
 
     /// One recorded `create_label` call: `(repo, name, color, description,
@@ -688,22 +459,15 @@ mod tests {
     }
 
     impl GhLabelRunner for FakeGhRunner {
-        fn create_label(
-            &self,
-            repo: &str,
-            name: &str,
-            color: &str,
-            description: &str,
-            force: bool,
-        ) -> bool {
+        fn create_label(&self, repo: &str, label: &PolicyLabel, force: bool) -> bool {
             self.calls.borrow_mut().push((
                 repo.to_string(),
-                name.to_string(),
-                color.to_string(),
-                description.to_string(),
+                label.name.clone(),
+                label.color.clone(),
+                label.description.clone(),
                 force,
             ));
-            self.succeed && !self.fail_for.contains(&name)
+            self.succeed && !self.fail_for.contains(&label.name.as_str())
         }
     }
 
@@ -778,57 +542,12 @@ mod tests {
         assert_eq!(outcome, LabelOutcome::GhFailed);
     }
 
-    // ── issue-lifecycle labels ──────────────────────────────────────────
+    // ── launch-time composition (the shared policy set) ─────────────────
 
     const REPO_URL: &str = "https://github.com/bobmatnyc/trusty-tools.git";
 
     #[test]
-    fn lifecycle_label_table_is_valid() {
-        for (name, color, description) in LIFECYCLE_LABELS {
-            assert!(!name.is_empty() && name.len() <= GITHUB_LABEL_MAX_LEN);
-            assert_eq!(color.len(), 6, "{name}'s color must be 6 hex chars");
-            assert!(color.chars().all(|c| c.is_ascii_hexdigit()));
-            assert!(!description.is_empty(), "{name} needs a description");
-        }
-        let names: Vec<&str> = LIFECYCLE_LABELS.iter().map(|(n, ..)| *n).collect();
-        assert_eq!(names, ["in-progress", "blocked"]);
-    }
-
-    #[test]
-    fn lifecycle_labels_are_created_without_force() {
-        let runner = FakeGhRunner::new(true);
-        ensure_lifecycle_labels_with(&runner, "bobmatnyc/trusty-tools");
-        let calls = runner.calls.borrow();
-        assert_eq!(calls.len(), LIFECYCLE_LABELS.len());
-        for (repo, name, color, description, force) in calls.iter() {
-            assert_eq!(repo, "bobmatnyc/trusty-tools");
-            assert!(
-                !force,
-                "{name} is an ordinary repo label — --force would rewrite a \
-                 project's own color/description on every launch"
-            );
-            let (_, want_color, want_description) = LIFECYCLE_LABELS
-                .iter()
-                .find(|(n, ..)| n == name)
-                .expect("only table labels are created");
-            assert_eq!(color, want_color);
-            assert_eq!(description, want_description);
-        }
-    }
-
-    #[test]
-    fn lifecycle_labels_attempt_every_label_when_gh_fails() {
-        // Every `gh` call fails (missing binary, unauthenticated, offline).
-        // Both labels must still be attempted, and nothing may panic.
-        let runner = FakeGhRunner::new(false);
-        ensure_lifecycle_labels_with(&runner, "bobmatnyc/trusty-tools");
-        assert_eq!(runner.label_names(), ["in-progress", "blocked"]);
-    }
-
-    // ── launch-time composition (failure paths) ─────────────────────────
-
-    #[test]
-    fn launch_labels_ensure_all_three() {
+    fn launch_labels_ensure_the_policy_set() {
         let runner = FakeGhRunner::new(true);
         ensure_launch_labels_with(
             &runner,
@@ -836,15 +555,59 @@ mod tests {
             Path::new("/nonexistent"),
             "tm-tcode-01",
         );
-        assert_eq!(
-            runner.label_names(),
-            ["ws/tm-tcode-01", "in-progress", "blocked"]
+        assert_eq!(runner.label_names(), ["ws/tm-tcode-01", "trusty-mpm"]);
+    }
+
+    #[test]
+    fn launch_labels_never_create_the_retired_lifecycle_pair() {
+        // #6914: `in-progress` / `blocked` predate the `status:*` lifecycle.
+        // Launch used to seed them on every session; it must not any more.
+        let runner = FakeGhRunner::new(true);
+        ensure_launch_labels_with(
+            &runner,
+            Some(REPO_URL),
+            Path::new("/nonexistent"),
+            "tm-tcode-01",
+        );
+        let names = runner.label_names();
+        assert!(
+            !names.iter().any(|n| n == "in-progress" || n == "blocked"),
+            "launch must not create the retired pair; got {names:?}"
         );
     }
 
     #[test]
-    fn lifecycle_labels_run_even_when_workstream_label_fails() {
-        // The ws/ label's `gh` call fails; the lifecycle labels are an
+    fn convention_label_is_created_without_force() {
+        let runner = FakeGhRunner::new(true);
+        ensure_launch_labels_with(
+            &runner,
+            Some(REPO_URL),
+            Path::new("/nonexistent"),
+            "tm-tcode-01",
+        );
+        let calls = runner.calls.borrow();
+        let (repo, name, color, description, force) = calls
+            .iter()
+            .find(|(_, name, ..)| name == "trusty-mpm")
+            .expect("the convention label is ensured at launch");
+        assert_eq!(repo, "bobmatnyc/trusty-tools");
+        assert_eq!(name, "trusty-mpm");
+        assert_eq!(color, &policy_labels::convention_label().color);
+        assert_eq!(
+            description,
+            &policy_labels::convention_label().description,
+            "description must come from the shared policy table"
+        );
+        assert!(
+            !force,
+            "an ordinary repo label — --force would rewrite a project's own \
+             color/description on every launch"
+        );
+    }
+
+    #[test]
+    fn convention_label_runs_even_when_workstream_label_fails() {
+        // The ws/ label's `gh` call fails; the rest of the policy set is an
         // independent concern and must still be attempted.
         let runner = FakeGhRunner::failing_for(&["ws/tm-tcode-01"]);
         ensure_launch_labels_with(
@@ -853,15 +616,12 @@ mod tests {
             Path::new("/nonexistent"),
             "tm-tcode-01",
         );
-        assert_eq!(
-            runner.label_names(),
-            ["ws/tm-tcode-01", "in-progress", "blocked"]
-        );
+        assert_eq!(runner.label_names(), ["ws/tm-tcode-01", "trusty-mpm"]);
     }
 
     #[test]
-    fn workstream_label_runs_even_when_lifecycle_labels_fail() {
-        let runner = FakeGhRunner::failing_for(&["in-progress", "blocked"]);
+    fn workstream_label_runs_even_when_convention_label_fails() {
+        let runner = FakeGhRunner::failing_for(&["trusty-mpm"]);
         ensure_launch_labels_with(
             &runner,
             Some(REPO_URL),
@@ -870,9 +630,8 @@ mod tests {
         );
         assert_eq!(
             runner.label_names(),
-            ["ws/tm-tcode-01", "in-progress", "blocked"],
-            "a lifecycle-label failure must not suppress the ws/ label or the \
-             label after it"
+            ["ws/tm-tcode-01", "trusty-mpm"],
+            "a policy-label failure must not suppress the ws/ label"
         );
     }
 
@@ -888,10 +647,7 @@ mod tests {
             Path::new("/nonexistent"),
             "tm-tcode-01",
         );
-        assert_eq!(
-            runner.label_names(),
-            ["ws/tm-tcode-01", "in-progress", "blocked"]
-        );
+        assert_eq!(runner.label_names(), ["ws/tm-tcode-01", "trusty-mpm"]);
     }
 
     #[test]
@@ -910,11 +666,11 @@ mod tests {
     }
 
     #[test]
-    fn launch_labels_ensure_lifecycle_labels_when_session_name_is_blank() {
-        // A blank session name skips the ws/ label only — the lifecycle
-        // labels do not depend on it.
+    fn launch_labels_ensure_convention_label_when_session_name_is_blank() {
+        // A blank session name skips the ws/ label only — the rest of the
+        // policy set does not depend on it.
         let runner = FakeGhRunner::new(true);
         ensure_launch_labels_with(&runner, Some(REPO_URL), Path::new("/nonexistent"), "  ");
-        assert_eq!(runner.label_names(), ["in-progress", "blocked"]);
+        assert_eq!(runner.label_names(), ["trusty-mpm"]);
     }
 }


### PR DESCRIPTION
## Summary

Ticketing now seeds every policy label through a single path. Launch stops creating the retired `in-progress` and `blocked` lifecycle pair.

Refs #6914

## What changed

- New module `core/policy_labels.rs` holds the single label table and the crate's only `gh label create` argv builder.
- `seed-labels` now covers workstream and convention labels plus the policy model's defined set.
- Launch no longer creates the retired `in-progress`/`blocked` pair.
- Duplicate `RepoLabel` struct folded into `PolicyLabel`.
- Ticketing agent asset and `tm-ticketing` skill now tell agents to seed on first use.

Out of scope: label automation beyond initial seed; policy label enforcement at comment time.

## Risk and blast radius

**Low.** Affects label initialization and launch configuration only. No runtime policy changes. Pre-existing `status:coded` / `status:merged` / `status:tested` labels unaffected.

## Test evidence

Rung 3 + rung-4 dependent run. All gates pass with `--no-fail-fast`:

```
cargo fmt --check                     : PASS
cargo clippy -p trusty-mpm --all-targets -D warnings : PASS
cargo clippy -p trusty-agents-common --all-targets -D warnings : PASS
cargo test -p trusty-mpm --no-fail-fast   : 54 targets, 10655 passed, 0 failed, 19 ignored
cargo test -p trusty-agents-common --no-fail-fast : 516 passed, 0 failed
bash scripts/check_line_cap.sh         : 0 violations
bash scripts/check_changelog_fragment.sh : PASS (both crates)
bash scripts/check_test_pointers.sh     : 0 dangling
bash scripts/check_sld.sh               : 0/0
```

Five pre-fix failing tests now shipping as regression coverage:
- `launch_labels_never_create_the_retired_lifecycle_pair`
- `ops_seed_includes_policy_labels`
- `ops_seed_without_session_skips_workstream_label`
- `ops_seed_leaves_present_policy_labels_untouched`
- `project_seed_labels_covers_the_whole_harness_label_set`

## Baseline failures

`check_rustdoc_links.sh` fails on pre-existing unresolved link in `crates/trusty-common/src/lib.rs:1144` (`sockbuf`). Branch touches nothing under `trusty-common`.

## Documentation and changelog

Two changelog fragments added:
- `crates/trusty-mpm/changelog.d/6914-ticketing-ensure-labels.md`
- `crates/trusty-agents-common/changelog.d/6914-ticketing-ensure-labels.md`

## Review-finding disposition

None. All gates pass cleanly.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
