### PR TITLE
fix(trusty-common): size accepted UDS sockets explicitly — Linux does not inherit the listener's buffers (#6896, red main #6511)

### DIFF
--- a/crates/trusty-common/changelog.d/6896-accepted-socket-sizing-test-linux.md
+++ b/crates/trusty-common/changelog.d/6896-accepted-socket-sizing-test-linux.md
@@ -1,0 +1,3 @@
+Fixed
+
+- size the accepted end of a UDS connection with the new `uds::accept_sized`. Only macOS copies a listener's `SO_SNDBUF`/`SO_RCVBUF` onto the sockets `accept` returns, so #6896's listener-only sizing left every server-side socket on Linux at `net.core.wmem_default`

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -557,7 +557,16 @@ pub async fn accept_sized(
     // #6896: Linux hands back a default-sized socket here whatever the listener
     // carries, so both platforms need this to end up at the intended sizing.
     if let Err(e) = sockbuf::tune_connected_buffers(&accepted.0) {
+        // #6896: name the listener, matching `drain_shutdown`'s precedent
+        // (#6601 review) — under a persistent failure this warn repeats per
+        // connection, and an unnamed socket leaves no way to tell which one.
+        let socket = listener
+            .local_addr()
+            .ok()
+            .and_then(|addr| addr.as_pathname().map(|p| p.display().to_string()))
+            .unwrap_or_else(|| "<unknown>".to_string());
         tracing::warn!(
+            %socket,
             error = %e,
             "accepted connection left at the platform socket buffer size"
         );

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -22,11 +22,12 @@
 //!     not this process's own, which is what turns the permission bits into an
 //!     enforced boundary rather than a documented intention.
 //!
-//! [`sockbuf`] runs inside [`bind_hardened`] and [`connect_hardened`], so both
-//! ends of every socket here are sized to
+//! [`sockbuf`] runs inside [`bind_hardened`], [`connect_hardened`] and
+//! [`accept_sized`], so both ends of every socket here are sized to
 //! [`sockbuf::SOCKET_BUFFER_BYTES`] rather than the 8 KiB macOS default
-//! (#6896). The listener's sizing is what every accepted socket inherits, so a
-//! service driving its own accept loop is covered too. No consumer calls it.
+//! (#6896). Only macOS copies a listener's sizing onto the sockets `accept`
+//! returns, so a service driving its own accept loop needs [`accept_sized`] in
+//! place of `listener.accept()` to be covered on Linux.
 //!
 //! **What this does and does not guarantee.** With the directory held at `0700`
 //! and owned by this uid, no other unprivileged user can traverse to the socket
@@ -49,6 +50,7 @@
 //! functions behind every refusal, and the `sun_path` budget pre-check.
 //!
 //! [`scratch_socket_dir`]: crate::uds::scratch_socket_dir
+//! [`accept_sized`]: crate::uds::accept_sized
 //! [`bind_hardened`]: crate::uds::bind_hardened
 //! [`connect_hardened`]: crate::uds::connect_hardened
 //! [`ensure_peer_is_self`]: crate::uds::ensure_peer_is_self
@@ -508,13 +510,59 @@ pub fn bind_hardened(path: &Path) -> Result<UnixListener, UdsSecurityError> {
         }
     })?;
 
-    // #6896: sized on the LISTENER, which both Linux and macOS copy onto every
-    // socket `accept` returns — so a service driving its own accept loop gets
-    // the sizing without calling anything. The strict form: a listener has no
-    // peer, so it must never reach the hung-up-peer outcome (#6896 review).
+    // #6896: sized on the LISTENER, which macOS copies onto every socket
+    // `accept` returns. Linux does not, so the accepted end is sized by
+    // `accept_sized`. The strict form: a listener has no peer, so it must never
+    // reach the hung-up-peer outcome (#6896 review).
     sockbuf::tune_listener_buffers(&listener)?;
 
     Ok(listener)
+}
+
+/// Accept one connection and size its buffers.
+///
+/// Why: an accepted socket does not carry the listener's `SO_SNDBUF` /
+/// `SO_RCVBUF` on Linux. AF_UNIX builds the server-side socket from scratch in
+/// `unix_stream_connect`, so it comes back at `net.core.wmem_default` /
+/// `rmem_default` however the listener was sized; only macOS copies the
+/// listener's sizing, in `sonewconn`. #6896 sized the listener alone and stated
+/// the copy as universal, which left every server-side socket on Linux at the
+/// platform default — paying, on one end of every connection, exactly the round
+/// trips that issue exists to remove.
+///
+/// What: `accept`, then [`sockbuf::tune_connected_buffers`] on what came back.
+/// The forgiving form, because an accepted socket can already have lost its
+/// peer: [`probe::socket_is_serving`] connects and closes without sending
+/// anything, and that probe has to stay a probe.
+///
+/// A sizing failure is logged and the connection returned anyway — the one
+/// place in this module a failure is not propagated. The connection is already
+/// accepted and cannot be un-accepted, so refusing it would turn a throughput
+/// knob into an availability failure. [`bind_hardened`] and
+/// [`connect_hardened`] propagate because their caller still has somewhere else
+/// to go.
+///
+/// This does NOT check the peer's uid; [`ensure_peer_is_self`] stays a separate
+/// call, made once per connection where the connection is served.
+///
+/// # Errors
+///
+/// Whatever `UnixListener::accept` returns. Sizing never fails the call.
+///
+/// Test: `accept_sized_raises_the_accepted_socket_to_the_listeners_sizing`.
+pub async fn accept_sized(
+    listener: &UnixListener,
+) -> std::io::Result<(UnixStream, tokio::net::unix::SocketAddr)> {
+    let accepted = listener.accept().await?;
+    // #6896: Linux hands back a default-sized socket here whatever the listener
+    // carries, so both platforms need this to end up at the intended sizing.
+    if let Err(e) = sockbuf::tune_connected_buffers(&accepted.0) {
+        tracing::warn!(
+            error = %e,
+            "accepted connection left at the platform socket buffer size"
+        );
+    }
+    Ok(accepted)
 }
 
 /// Verify a socket and its directory, then connect.

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -100,7 +100,9 @@ use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt as _, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
-use crate::uds::{MAX_FRAME_BYTES, UdsSecurityError, bind_hardened, ensure_peer_is_self};
+use crate::uds::{
+    MAX_FRAME_BYTES, UdsSecurityError, accept_sized, bind_hardened, ensure_peer_is_self,
+};
 
 pub use idle::{IdleGuard, IdleTracker};
 pub use router::{RpcFallback, RpcMethod, RpcRouter, typed_method};
@@ -348,9 +350,10 @@ pub async fn handle_connection(
     router: Arc<RpcRouter>,
     options: RpcServeOptions,
 ) -> Result<Served, RpcServerError> {
-    // #6896: this connection's buffers were sized by `bind_hardened` on the
-    // LISTENER and copied here by `accept`. Sizing them again would fail on a
-    // liveness probe, whose peer has already closed — see `uds::sockbuf`.
+    // #6896: this connection's buffers were sized by `accept_sized`, which the
+    // serving accept sites in this module call in place of `listener.accept()`.
+    // Sizing them again here would repeat two syscalls per connection — see
+    // `uds::sockbuf` for why the listener's sizing is not enough on Linux.
     ensure_peer_is_self(&stream).map_err(|source| RpcServerError::Peer { source })?;
 
     let mut frame: Vec<u8> = Vec::new();
@@ -542,7 +545,7 @@ async fn drain_backlog(
     options: RpcServeOptions,
     idle: &Arc<IdleTracker>,
 ) -> Drained {
-    let Ok(accepted) = tokio::time::timeout(IDLE_EXIT_DRAIN, listener.accept()).await else {
+    let Ok(accepted) = tokio::time::timeout(IDLE_EXIT_DRAIN, accept_sized(listener)).await else {
         return Drained::Nothing;
     };
     let stream = match accepted {
@@ -738,7 +741,7 @@ pub async fn serve_until_idle(
                 return ServeExit::Shutdown;
             }
             () = &mut idle_expired => Step::IdleElapsed,
-            accepted = listener.accept() => Step::Accepted(accepted),
+            accepted = accept_sized(listener) => Step::Accepted(accepted),
         };
         // #6350: the drain runs HERE, not inside the arm — the `select!`'s
         // borrow of `idle_expired` has ended, so the re-arm below can run. The

--- a/crates/trusty-common/src/uds/server/mod.rs
+++ b/crates/trusty-common/src/uds/server/mod.rs
@@ -352,7 +352,7 @@ pub async fn handle_connection(
 ) -> Result<Served, RpcServerError> {
     // #6896: this connection's buffers were sized by `accept_sized`, which the
     // serving accept sites in this module call in place of `listener.accept()`.
-    // Sizing them again here would repeat two syscalls per connection — see
+    // Sizing them again here would repeat four syscalls per connection — see
     // `uds::sockbuf` for why the listener's sizing is not enough on Linux.
     ensure_peer_is_self(&stream).map_err(|source| RpcServerError::Peer { source })?;
 
@@ -640,6 +640,7 @@ async fn drain_shutdown(listener: &UnixListener, open: &Arc<IdleTracker>, budget
 
     let refuse = async {
         loop {
+            // #6896: not sized — this stream is dropped without carrying a frame.
             match listener.accept().await {
                 Ok((stream, _)) => {
                     tracing::debug!("refusing a connection dialled during the shutdown drain");

--- a/crates/trusty-common/src/uds/sockbuf.rs
+++ b/crates/trusty-common/src/uds/sockbuf.rs
@@ -16,11 +16,9 @@
 //! refuses.
 //!   - [`tune_listener_buffers`] is for a socket that has no peer and never
 //!     will: any failure is a failure. [`crate::uds::bind_hardened`] calls it.
-//!     Both platforms copy a listener's buffer sizes onto every socket `accept`
-//!     returns, so this is the whole server side — including a service such as
-//!     `trusty-embedderd` that binds through here and drives its own accept loop.
 //!   - [`tune_connected_buffers`] is for a socket that has a peer, which may
-//!     have gone away. [`crate::uds::connect_hardened`] calls it.
+//!     have gone away. [`crate::uds::connect_hardened`] calls it for the
+//!     dialling end and [`crate::uds::accept_sized`] for the accepted end.
 //!
 //! 🔴 **Why the split is not a stylistic one (#6896 review).** The benign
 //! classification rests on `getpeername` failing, and `getpeername` ALWAYS
@@ -31,14 +29,19 @@
 //! default. The strict form has no benign outcome to reach, in the type as well
 //! as in the code.
 //!
-//! 🔴 **The listener is sized, not each accepted socket.** macOS refuses
-//! `setsockopt(SO_SNDBUF)` with `EINVAL` once a socket's peer has hung up —
-//! `getpeername` on the same fd fails the same way, which is what identifies
-//! the condition. An accepted socket can already be in that state before the
-//! server touches it: a liveness probe connects and closes, which is exactly
-//! what [`crate::uds::probe::socket_is_serving`] does. Sizing per accepted
-//! socket therefore turned every probe into a connection failure. Inheriting
-//! from the listener happens inside `accept`, before any peer can go away.
+//! 🔴 **Both the listener AND each accepted socket are sized, because only
+//! macOS inherits (#6896 follow-up).** macOS builds the server-side socket in
+//! `sonewconn`, which copies the listener's `sb_hiwat` onto it, so sizing the
+//! listener there covers everything `accept` returns. Linux does not: AF_UNIX
+//! builds the server-side socket from scratch in `unix_stream_connect`, so it
+//! comes back at `net.core.wmem_default` / `rmem_default` however the listener
+//! was sized. Sizing only the listener therefore left every server-side socket
+//! on Linux at the platform default. [`crate::uds::accept_sized`] closes that,
+//! through the forgiving entry point: an accepted socket can have lost its peer
+//! before the server touches it — a liveness probe connects and closes, which
+//! is exactly what [`crate::uds::probe::socket_is_serving`] does — and that
+//! peer-hangup is what [`SocketBufferOutcome::PeerHungUp`] absorbs rather than
+//! turning every probe into a connection failure.
 //!
 //! **A failure is propagated, never defaulted — with one named exception.** A
 //! socket left at the platform default still works, at the cost this module
@@ -54,11 +57,20 @@
 //! this raises the buffer where the host allows it and changes nothing where it
 //! does not.
 //!
+//! 🟡 **Nothing here compares a read-back against what was requested.** Linux
+//! stores twice the accepted value and `getsockopt` returns that doubled
+//! figure, so a request of 1 MiB reads back as 2 MiB — or as 425984 on a host
+//! whose `wmem_max` is 212992, the clamp applied first and the doubling after.
+//! The read-back is logged and returned for observation, never asserted
+//! against [`SOCKET_BUFFER_BYTES`]. A caller comparing two sockets on the same
+//! host is comparing like with like; a caller comparing either against the
+//! request is not.
+//!
 //! Test: `tune_connected_buffers_raises_both_buffers_on_a_socketpair`,
 //! `tune_connected_buffers_reports_a_peer_that_already_hung_up`,
 //! `a_listener_can_never_classify_a_failure_as_a_hung_up_peer`,
 //! `tune_listener_buffers_refuses_where_the_connected_form_tolerates`,
-//! `an_accepted_socket_inherits_the_listeners_sizing`,
+//! `accept_sized_raises_the_accepted_socket_to_the_listeners_sizing`,
 //! `hardened_sockets_hold_far_more_in_flight_than_the_platform_default`.
 
 use std::io;
@@ -230,15 +242,16 @@ fn read_buffer(fd: i32, option: i32, name: &'static str) -> Result<usize, UdsSec
 
 /// Read a socket's effective buffer sizes without changing them.
 ///
-/// Why: the only way to observe what a socket carries — an accepted socket's
-/// sizing comes from the listener, so asking it is the one check that proves
-/// the inheritance this module relies on (#6896).
+/// Why: the only way to observe what a socket carries. What the kernel granted
+/// is not what was asked for — Linux doubles it and clamps it first — so a
+/// caller checking that a socket really is sized has to read it back rather
+/// than assume (#6896).
 ///
 /// # Errors
 ///
 /// [`UdsSecurityError::SocketBufferRead`] when either option cannot be read.
 ///
-/// Test: `an_accepted_socket_inherits_the_listeners_sizing`.
+/// Test: `accept_sized_raises_the_accepted_socket_to_the_listeners_sizing`.
 pub fn socket_buffer_sizes<S: AsRawFd + ?Sized>(
     socket: &S,
 ) -> Result<SocketBufferSizes, UdsSecurityError> {
@@ -279,13 +292,15 @@ fn tune(fd: i32, connected: bool) -> Result<Option<SocketBufferSizes>, UdsSecuri
 
 /// Size the buffers of a socket that has no peer, failing on any error.
 ///
-/// Why: a listener is where the whole server side is sized, and it is the one
-/// socket for which the hung-up-peer classification cannot be evaluated — see
-/// the module docs. There is no benign outcome in the return type, so a caller
-/// cannot proceed on an unsized listener without seeing an error (#6896 review).
+/// Why: a listener is the one socket for which the hung-up-peer classification
+/// cannot be evaluated — see the module docs. There is no benign outcome in the
+/// return type, so a caller cannot proceed on an unsized listener without
+/// seeing an error (#6896 review).
 ///
 /// What: `setsockopt` for both options, then `getsockopt` for both, at debug
-/// level. Every accepted socket inherits what this sets.
+/// level. macOS copies what this sets onto every socket `accept` returns; Linux
+/// does not, which is why [`crate::uds::accept_sized`] sizes the accepted end
+/// as well.
 ///
 /// # Errors
 ///
@@ -294,7 +309,7 @@ fn tune(fd: i32, connected: bool) -> Result<Option<SocketBufferSizes>, UdsSecuri
 ///
 /// Test: `a_listener_can_never_classify_a_failure_as_a_hung_up_peer`,
 /// `tune_listener_buffers_refuses_where_the_connected_form_tolerates`,
-/// `an_accepted_socket_inherits_the_listeners_sizing`.
+/// `accept_sized_raises_the_accepted_socket_to_the_listeners_sizing`.
 pub fn tune_listener_buffers<S: AsRawFd + ?Sized>(
     socket: &S,
 ) -> Result<SocketBufferSizes, UdsSecurityError> {

--- a/crates/trusty-common/src/uds/tests.rs
+++ b/crates/trusty-common/src/uds/tests.rs
@@ -836,28 +836,36 @@ impl std::os::fd::AsRawFd for BorrowedFdForTest {
     }
 }
 
-/// The server side is sized by inheritance, which is why nothing sizes an
-/// accepted socket directly.
+/// The server side is sized on the accepted socket, not inherited from the
+/// listener: Linux hands back a default-sized socket from `accept` however the
+/// listener was sized (#6896).
 #[tokio::test]
-async fn an_accepted_socket_inherits_the_listeners_sizing() {
+async fn accept_sized_raises_the_accepted_socket_to_the_listeners_sizing() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let sock = tmp.path().join("sockets").join("inherit.sock");
     let listener = bind_hardened(&sock).expect("bind hardened");
     let _client = connect_hardened(&sock).await.expect("connect hardened");
-    let (server, _) = listener.accept().await.expect("accept");
+    let (server, _) = accept_sized(&listener).await.expect("accept sized");
 
-    // Read back without setting anything: whatever the accepted socket carries
-    // it got from the listener at `accept` time.
     let on_listener = socket_buffer_sizes(&listener).expect("read the listener");
-    let inherited = socket_buffer_sizes(&server).expect("read the accepted socket");
+    let accepted = socket_buffer_sizes(&server).expect("read the accepted socket");
 
+    // Two granted figures compared against each other, never against
+    // `SOCKET_BUFFER_BYTES`: both sockets asked the same host for the same
+    // bytes, so the same `wmem_max` clamp and the same Linux doubling landed on
+    // both, whatever those two produce here. Comparing either against the
+    // request is what fails on Linux — it answers 2 MiB to a 1 MiB request, and
+    // 425984 where `wmem_max` is 212992.
     assert_eq!(
-        inherited, on_listener,
-        "an accepted socket must carry the listener's sizing without being set itself"
+        accepted, on_listener,
+        "an accepted socket must carry the same granted sizing as its listener"
     );
+    // The regression this guards: drop the sizing from `accept_sized` and the
+    // accepted socket falls back to `net.core.wmem_default` on Linux, which is
+    // half the listener's granted figure or less.
     assert!(
-        inherited.send >= FILL_CHUNK * 2 && inherited.recv >= FILL_CHUNK * 2,
-        "the inherited sizing must be the raised one, not the platform default: {inherited:?}"
+        accepted.send >= FILL_CHUNK * 2 && accepted.recv >= FILL_CHUNK * 2,
+        "the accepted socket must carry the raised sizing, not the platform default: {accepted:?}"
     );
 }
 

--- a/crates/trusty-common/src/uds/tests.rs
+++ b/crates/trusty-common/src/uds/tests.rs
@@ -836,8 +836,8 @@ impl std::os::fd::AsRawFd for BorrowedFdForTest {
     }
 }
 
-/// The server side is sized on the accepted socket, not inherited from the
-/// listener: Linux hands back a default-sized socket from `accept` however the
+/// On Linux, the server side is sized on the accepted socket, not inherited
+/// from the listener: `accept` hands back a default-sized socket however the
 /// listener was sized (#6896).
 #[tokio::test]
 async fn accept_sized_raises_the_accepted_socket_to_the_listeners_sizing() {


### PR DESCRIPTION
## Summary
Fixes CI red on Linux: accepted AF_UNIX sockets now inherit listener buffer sizing, matching macOS behavior.

Refs #6896
Refs #6511

## Changes
- New `uds::accept_sized` function sizes accepted sockets explicitly via `tune_connected_buffers` after accept
- `serve_until_idle` and `drain_backlog` call `accept_sized`; shutdown drain does not
- `sockbuf.rs` docs clarify per-platform buffer sizing: macOS copies from listener (sb_hiwat), Linux defaults to net.core wmem/rmem unless explicitly sized
- Test renamed to `accept_sized_raises_the_accepted_socket_to_the_listeners_sizing` comparing granted-vs-granted
- Out of scope: updating four daemon accept loops (trusty-agents, trusty-embedderd, trusty-mcp) — separate issue being filed

## Risk / Blast Radius
Rung 5: Cross-crate change to shared library (trusty-common UDS), process lifecycle (server accept loop), and test infrastructure.
Blast radius: affects all servers and consumers of accepted UDS connections under Linux. Changes are defensive (sizing after accept), non-breaking, and failure-path returns without closing the connection.

## Test Evidence
Test environment: Docker rust:1.94-slim on a 6.x kernel (native Linux CI)

**Merging gates (exit 0, --no-fail-fast):**
- `cargo fmt --check`: PASS
- `cargo clippy -p trusty-common --features unconditional-only --all-targets -D warnings`: PASS
- `cargo clippy -p trusty-common --features uds-supervisor --all-targets -D warnings`: PASS
- `cargo test -p trusty-common --features uds-supervisor --no-fail-fast`: **627 passed, 0 failed, 6 ignored**
- `cargo check --workspace --all-targets`: PASS
- `cargo test -p trusty-memory --test uds_consumer_contract --no-fail-fast`: **8 passed**
- `cargo test -p trusty-mcp --no-fail-fast`: **29+7 passed**
- Line-cap check: 0 violations
- Doc-pointer check: 0 dangling
- Changelog fragment: ✓ recorded
- Rustdoc links: 0 broken
- SLD check: 0/0

**Negative control:** same test with sizing disabled fails at tests.rs:859 as expected.

## Baseline Failures
None pre-existing on this crate.

## Documentation and Changelog
- Changelog fragment recorded at `crates/trusty-common/changelog.d/6896-accepted-socket-sizing-test-linux.md`
- Doc comments updated in sockbuf.rs with per-platform behaviour notes

## Review Disposition
Code-critic round IN PROGRESS. No review findings yet to address or defer. Critic MEDIUM on the untestable sizing-failure arm (no seam to inject a setsockopt failure through &UnixListener) is tracked with the other accept loops in #6940.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

