### PR TITLE
docs(trusty-mpm): regenerate tm-capabilities references for tm issue standard (#6918)

### DIFF
--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -46,6 +46,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `repair` — Resolve a mid-transition issue carrying multiple state labels
   - `seed-config` — Write the embedded default model to the user config path
   - `seed-labels` — Create any missing labels (states + extra families) in the repo
+  - `standard` — Print the ticketing standard in effect (#6918; reads config, no `gh`)
   - `states` — List the configured states and transitions (reads YAML only)
   - `transition` — Move an issue to `<to-state>`, validating the edge against the model
 - `launch` — Launch a session with full setup: deploys instructions, agents, and skills, then starts Claude


### PR DESCRIPTION
## Summary

Main tip 12a249c44 is red on Capabilities drift workflow (run 34064902791). PR #6948 added `tm issue standard` without regenerating cli.md. Fix: `cargo run -p trusty-mpm --bin tm -- generate capabilities`, one line added.

## What Changed

- Regenerated cli.md to include `tm issue standard` command reference
- No source changes; generated reference file only

## Risk

Low — docs-only generated reference file. No code changes.

## Test Evidence

Rung 1 (docs-only):
- `bash scripts/check_capabilities.sh` exit 1 before ("drift detected in 1 file(s)"), exit 0 after ("up to date (7 generated files)")

## Baseline Failures

None.

## Documentation

No changelog fragment required (docs-only).

## Review

No changes to review. Generated reference update only.

Refs #6918

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
