### PR TITLE
fix(trusty-mpm): tm issue seed-labels probe reads existing labels (idempotent)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6914-seed-labels-idempotent.md
+++ b/crates/trusty-mpm/changelog.d/6914-seed-labels-idempotent.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `tm issue seed-labels` is idempotent again on a repo with more than 30 labels. The existence probe ran `gh label list` with no `--limit`, so gh returned its default first 30 and said nothing about the rest — on bobmatnyc/trusty-tools, which carries 89 labels, all six policy labels fell outside that page, the run judged every one of them missing, and `gh label create` exited 1 on the first that already existed. The probe now goes through `policy_labels::list_labels_argv`, the crate's single `gh label list` spelling, which asks for `LABEL_LIST_LIMIT` (1000) labels; a page that comes back exactly that full is reported as a possibly-truncated read rather than passed on as a complete set (#6914).

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/ops_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/ops_tests.rs
@@ -361,6 +361,104 @@ fn ops_seed_idempotent_when_all_present() {
     );
 }
 
+/// A `CommandRunner` that emulates gh's paging for `gh label list`: it returns
+/// the first `--limit` labels of `repo_labels`, defaulting to gh's own 30 when
+/// the caller passes no `--limit`, and never says that it truncated.
+///
+/// Why: #6914 — the seed probe asked for no limit, so on a repo with more than
+/// 30 labels it read a partial set, judged every policy label missing, and the
+/// run died on the first `gh label create` of a label that already existed.
+/// Only a runner that reproduces gh's silent cap can catch that.
+struct PagedGhRunner {
+    repo_labels: Vec<RepoLabel>,
+}
+
+impl crate::commands::ticket::runner::CommandRunner for PagedGhRunner {
+    fn run(
+        &self,
+        _program: &str,
+        args: &[&str],
+    ) -> anyhow::Result<crate::commands::ticket::runner::CommandOutput> {
+        assert_eq!(args.first(), Some(&"label"), "only `gh label` is scripted");
+        assert_eq!(args.get(1), Some(&"list"), "only `label list` is scripted");
+        let limit: usize = args
+            .iter()
+            .position(|a| *a == "--limit")
+            .and_then(|i| args.get(i + 1))
+            .map_or(30, |v| v.parse().expect("--limit must be a number"));
+        let page: Vec<serde_json::Value> = self
+            .repo_labels
+            .iter()
+            .take(limit)
+            .map(|l| {
+                serde_json::json!({
+                    "name": l.name,
+                    "color": l.color,
+                    "description": l.description,
+                })
+            })
+            .collect();
+        Ok(crate::commands::ticket::runner::CommandOutput {
+            success: true,
+            stdout: serde_json::to_string(&page).expect("serialize"),
+            stderr: String::new(),
+        })
+    }
+}
+
+/// Why: #6914's live failure — every policy label existed on the repo, yet the
+/// run reported all six missing and exited 1 on `gh label create`. This drives
+/// the real gh-backed system over a runner that reproduces gh's silent 30-label
+/// page, with the desired labels deliberately past that page.
+/// What: 40 filler labels ahead of the desired set; a correct probe reads the
+/// whole list and creates nothing.
+#[test]
+fn ops_seed_reads_past_the_default_label_page() {
+    let m = model();
+    let desired = desired_labels(&m, &ResolvedTicketing::default(), Some(SESSION));
+    // Filler ahead of the desired labels, so a 30-label read sees none of them.
+    let mut repo_labels: Vec<RepoLabel> = (0..40)
+        .map(|i| RepoLabel::new(format!("filler-{i:02}"), "CCCCCC", ""))
+        .collect();
+    repo_labels.extend(desired.iter().cloned());
+
+    let sys = crate::commands::ticket::system::GhTicketSystem::new(PagedGhRunner { repo_labels });
+    let report = seed_labels(&sys, &m, &ResolvedTicketing::default(), Some(SESSION), true)
+        .expect("seed reads the whole label set");
+
+    assert!(
+        report.created.is_empty(),
+        "every desired label already exists; got created {:?}",
+        report.created
+    );
+    assert_eq!(
+        report.already_present.len(),
+        desired.len(),
+        "all {} desired labels must be reported present",
+        desired.len()
+    );
+}
+
+/// Why: a read that comes back exactly as long as the requested page may be
+/// truncated, and seeding against a truncated set is the #6914 failure. It is
+/// an error, never a silently-accepted "complete" set.
+#[test]
+fn ops_seed_errors_when_the_label_page_is_full() {
+    let m = model();
+    let limit = trusty_mpm::core::policy_labels::LABEL_LIST_LIMIT;
+    let repo_labels: Vec<RepoLabel> = (0..limit + 5)
+        .map(|i| RepoLabel::new(format!("filler-{i:04}"), "CCCCCC", ""))
+        .collect();
+
+    let sys = crate::commands::ticket::system::GhTicketSystem::new(PagedGhRunner { repo_labels });
+    let err = seed_labels(&sys, &m, &ResolvedTicketing::default(), Some(SESSION), true)
+        .expect_err("a full page must not pass as a complete label set");
+    assert!(
+        err.to_string().contains("truncated"),
+        "error must name the truncation; got {err}"
+    );
+}
+
 // ---- transition -----------------------------------------------------------
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/labels.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/labels.rs
@@ -46,21 +46,43 @@ pub(crate) enum AssigneeTarget {
     None,
 }
 
-/// `gh label list --json name,color,description` → existing repo labels.
+/// `gh label list --limit <n> --json name,color,description` → existing repo
+/// labels.
 ///
 /// Why: idempotent seeding needs the current label set so only missing labels
-/// are created (and present ones are left untouched).
-/// What: runs `gh label list` through `runner`, parses the JSON array into
-/// [`RepoLabel`]s; surfaces an actionable error on `gh` failure or bad JSON.
-/// Test: `gh_list_repo_labels_parses`, `gh_list_repo_labels_errors`.
+/// are created (and present ones are left untouched). #6914: a partial read is
+/// worse than no read — `gh label list` returns 30 labels by default and never
+/// says it truncated, so on any larger repo (trusty-tools carries 89) the seed
+/// judged every policy label missing and died on the first `gh label create`
+/// of a label that already existed.
+/// What: runs the argv from
+/// [`trusty_mpm::core::policy_labels::list_labels_argv`] through `runner` and
+/// parses the JSON array into [`RepoLabel`]s. A page that comes back exactly
+/// `LABEL_LIST_LIMIT` long is reported as an error rather than passed on as a
+/// complete set; `gh` failure and bad JSON surface actionable errors too.
+/// Test: `gh_list_repo_labels_parses`, `gh_list_repo_labels_errors`,
+/// `gh_list_repo_labels_reads_past_the_default_page`,
+/// `gh_list_repo_labels_rejects_a_truncated_page`.
 pub(crate) fn gh_list_repo_labels<R: CommandRunner>(runner: &R) -> anyhow::Result<Vec<RepoLabel>> {
-    let out = runner.run("gh", &["label", "list", "--json", "name,color,description"])?;
+    // #6914: the probe asked for gh's default 30-label page and read a partial
+    // label set as if it were the whole repo.
+    let limit = trusty_mpm::core::policy_labels::LABEL_LIST_LIMIT;
+    let argv = trusty_mpm::core::policy_labels::list_labels_argv(None, limit);
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let out = runner.run("gh", &args)?;
     let json = out.ok_or_stderr("gh label list")?;
     if json.is_empty() {
         return Ok(Vec::new());
     }
     let labels: Vec<RepoLabel> = serde_json::from_str(&json)
         .map_err(|e| anyhow::anyhow!("failed to parse `gh label list` JSON: {e}"))?;
+    if labels.len() >= limit {
+        anyhow::bail!(
+            "`gh label list` returned a full {limit}-label page, so the repo's label set may be \
+             truncated; seeding against a partial set would try to re-create labels that already \
+             exist (see #6914)"
+        );
+    }
     Ok(labels)
 }
 
@@ -272,7 +294,10 @@ mod tests {
         assert_eq!(labels[0].description, "Queued");
         assert_eq!(
             r.calls()[0].1,
-            vec!["label", "list", "--json", "name,color,description"]
+            trusty_mpm::core::policy_labels::list_labels_argv(
+                None,
+                trusty_mpm::core::policy_labels::LABEL_LIST_LIMIT
+            )
         );
     }
 
@@ -280,6 +305,44 @@ mod tests {
     fn gh_list_repo_labels_empty_is_empty() {
         let r = FakeRunner::new(vec![ok_out("")]);
         assert!(gh_list_repo_labels(&r).expect("empty ok").is_empty());
+    }
+
+    /// Why: #6914 — without an explicit `--limit`, `gh label list` returns its
+    /// default 30 labels and never says it truncated, so the seed read a
+    /// partial label set as the whole repo.
+    #[test]
+    fn gh_list_repo_labels_reads_past_the_default_page() {
+        let r = FakeRunner::new(vec![ok_out("[]")]);
+        gh_list_repo_labels(&r).expect("list");
+        let args = &r.calls()[0].1;
+        let limit: usize = args
+            .iter()
+            .position(|a| a == "--limit")
+            .and_then(|i| args.get(i + 1))
+            .expect("`gh label list` must carry an explicit --limit")
+            .parse()
+            .expect("--limit is a number");
+        assert!(limit > 30, "--limit {limit} must exceed gh's 30-label page");
+    }
+
+    /// Why: a page returned exactly as long as the one requested may be
+    /// truncated, and seeding against a truncated set is the #6914 failure.
+    #[test]
+    fn gh_list_repo_labels_rejects_a_truncated_page() {
+        let limit = trusty_mpm::core::policy_labels::LABEL_LIST_LIMIT;
+        let json: String = format!(
+            "[{}]",
+            (0..limit)
+                .map(|i| format!(r#"{{"name":"l{i}","color":"CCCCCC","description":""}}"#))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let r = FakeRunner::new(vec![ok_out(&json)]);
+        let err = gh_list_repo_labels(&r).expect_err("a full page is not a complete set");
+        assert!(
+            err.to_string().contains("truncated"),
+            "error must name the truncation; got {err}"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/policy_labels.rs
+++ b/crates/trusty-mpm/src/core/policy_labels.rs
@@ -11,8 +11,9 @@
 //! other's labels.
 //! What: the [`PolicyLabel`] value type, the policy set ([`policy_labels`] =
 //! the [`CONVENTION_LABEL`] plus `ws/<session>` when a session name is known),
-//! the `ws/` name/color derivation, and [`create_label_argv`] — the single place
-//! in the crate that spells a `gh label create` command line.
+//! the `ws/` name/color derivation, and [`create_label_argv`] /
+//! [`list_labels_argv`] — the single place in the crate that spells a
+//! `gh label` command line.
 //!
 //! This module deliberately holds NO process-spawning code. Its two consumers
 //! reach `gh` through different, already-established seams (the launch path's
@@ -26,7 +27,9 @@
 //! `label_name_long_is_truncated_with_hash_suffix`,
 //! `label_name_distinct_long_names_get_distinct_labels`,
 //! `create_label_argv_full`, `create_label_argv_omits_empty_fields`,
-//! `create_label_argv_repo_and_force`,
+//! `create_label_argv_repo_and_force`, `list_labels_argv_full`,
+//! `list_labels_argv_repo`,
+//! `list_labels_argv_requests_more_than_the_gh_default`,
 //! `configured_labels_match_builtin_when_block_absent`,
 //! `configured_labels_append_extra_labels`,
 //! `configured_labels_restyle_a_builtin_by_name`.
@@ -217,6 +220,45 @@ pub fn create_label_argv(label: &PolicyLabel, repo: Option<&str>, force: bool) -
     }
     if force {
         argv.push("--force".to_string());
+    }
+    argv
+}
+
+/// The page size every `gh label list` in this crate asks for.
+///
+/// Why: `gh label list` returns 30 labels by default and says nothing when it
+/// truncates, so the seed probe read a partial set on any larger repo, judged
+/// every policy label missing, and `gh label create` then failed on the first
+/// one that already existed (#6914 — trusty-tools carries 89 labels, and all
+/// six policy labels fell outside that first page). Large enough that no
+/// realistic repo truncates; the caller treats a read that comes back exactly
+/// this full as an error rather than as a complete set.
+/// Test: `list_labels_argv_requests_more_than_the_gh_default`.
+pub const LABEL_LIST_LIMIT: usize = 1000;
+
+/// The `gh label list …` argv — the crate's single spelling of that command.
+///
+/// Why: #6914 — an omitted `--limit` is exactly the flag that goes missing when
+/// a command line is spelled inline at a call site, so this command joins
+/// [`create_label_argv`] in the one module that owns `gh label` argv.
+/// What: `label list --limit <limit> --json name,color,description` — those
+/// JSON fields are precisely [`PolicyLabel`]'s, so the output deserializes
+/// straight into the diff's "what the repo has" side — plus `--repo <repo>`
+/// when the caller targets a specific repository.
+/// Test: `list_labels_argv_full`, `list_labels_argv_repo`,
+/// `list_labels_argv_requests_more_than_the_gh_default`.
+pub fn list_labels_argv(repo: Option<&str>, limit: usize) -> Vec<String> {
+    let mut argv = vec![
+        "label".to_string(),
+        "list".to_string(),
+        "--limit".to_string(),
+        limit.to_string(),
+        "--json".to_string(),
+        "name,color,description".to_string(),
+    ];
+    if let Some(repo) = repo {
+        argv.push("--repo".to_string());
+        argv.push(repo.to_string());
     }
     argv
 }
@@ -528,6 +570,60 @@ mod tests {
                 "owner/repo",
                 "--force"
             ]
+        );
+    }
+
+    #[test]
+    fn list_labels_argv_full() {
+        assert_eq!(
+            list_labels_argv(None, 1000),
+            [
+                "label",
+                "list",
+                "--limit",
+                "1000",
+                "--json",
+                "name,color,description"
+            ]
+        );
+    }
+
+    #[test]
+    fn list_labels_argv_repo() {
+        assert_eq!(
+            list_labels_argv(Some("owner/repo"), 7),
+            [
+                "label",
+                "list",
+                "--limit",
+                "7",
+                "--json",
+                "name,color,description",
+                "--repo",
+                "owner/repo"
+            ]
+        );
+    }
+
+    /// Why: #6914 — the probe read only `gh label list`'s default first page,
+    /// so a repo with more labels than that reported every policy label
+    /// missing and the run died on the first `gh label create`.
+    #[test]
+    fn list_labels_argv_requests_more_than_the_gh_default() {
+        // gh's own default page size for `gh label list`.
+        const GH_DEFAULT_PAGE: usize = 30;
+        let argv = list_labels_argv(None, LABEL_LIST_LIMIT);
+        let limit: usize = argv
+            .iter()
+            .position(|a| a == "--limit")
+            .and_then(|i| argv.get(i + 1))
+            .expect("`gh label list` argv must carry an explicit --limit")
+            .parse()
+            .expect("--limit is a number");
+        assert_eq!(limit, LABEL_LIST_LIMIT);
+        assert!(
+            limit > GH_DEFAULT_PAGE,
+            "the seed probe must ask for more than gh's default {GH_DEFAULT_PAGE}-label page"
         );
     }
 }


### PR DESCRIPTION
Refs #6914

## What was wrong

`tm issue seed-labels` exited 1 on bobmatnyc/trusty-tools even though every label it seeds already exists:

```
Error: `gh label create` failed: label with name "status:in-progress" already exists; use `--force` to update its color and description
```

and `--dry-run` reported "would create 6 label(s) … already present: 0 label(s)".

The existence probe (`gh_list_repo_labels`) ran `gh label list --json name,color,description` with no `--limit`. gh returns 30 labels by default and says nothing about truncating. This repo carries 89 labels, and all six policy labels sit past that first page, so the probe judged every one missing.

```
$ gh label list --json name | jq length            # 30
$ gh label list --limit 500 --json name | jq length # 89
```

## The fix

- `core::policy_labels::list_labels_argv` — the `gh label list` argv now lives beside `create_label_argv`, in the one module that spells `gh label` command lines. It passes `--limit LABEL_LIST_LIMIT` (1000).
- A page that comes back exactly `LABEL_LIST_LIMIT` long may itself be truncated, so it is an error rather than a set treated as complete. Seeding against a partial read is the defect being fixed; a silent accept would reintroduce it at a higher label count.
- No new `gh` spawn path: the probe still goes through the existing `CommandRunner` seam.

## Regression coverage

`ops_seed_reads_past_the_default_label_page` drives the real `GhTicketSystem` over a `PagedGhRunner` that reproduces gh's silent page cap — it returns the first `--limit` labels and defaults to 30 when no `--limit` is passed — with 40 filler labels ahead of the desired set. Against the unfixed probe:

```
---- ops_seed_reads_past_the_default_label_page stdout ----
every desired label already exists; got created ["unicorn:queued", "unicorn:approved",
"unicorn:active-development", …, "trusty-mpm", "ws/tm-tcode-01"]
test result: FAILED. 2 passed; 5 failed; 0 ignored
```

Four more: `ops_seed_errors_when_the_label_page_is_full`, `gh_list_repo_labels_reads_past_the_default_page`, `gh_list_repo_labels_rejects_a_truncated_page`, `list_labels_argv_requests_more_than_the_gh_default`.

## Gates — rung 3

```
cargo fmt --check                                       # clean
cargo clippy -p trusty-mpm --all-targets -- -D warnings  # EXIT=0
cargo test -p trusty-mpm --no-fail-fast                  # EXIT=0
  test result: ok. 6014 passed; 0 failed; 8 ignored   (lib)
  test result: ok. 2144 passed; 0 failed; 1 ignored   (bin tm)
  … 54 test targets, 0 failed
bash scripts/check_line_cap.sh          # 0 violations
bash scripts/check_changelog_fragment.sh # fragment present and valid
bash scripts/check_test_pointers.sh      # 0 dangling pointers
```

## Same defect elsewhere

`crates/trusty-agents/src/ticketing/gh_cli/client_impl.rs:187` runs the same limitless `gh label list`. Out of scope for this crate-scoped PR; worth its own ticket.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
