### PR TITLE
feat(trusty-mpm): issue-state allows status:merged -> status:coded for a post-merge fix PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,9 @@ Four mutually exclusive labels between GitHub's native open/closed:
   the closing comment: `tm issue transition N closed --note "<evidence>"`, which
   refuses to run without the note. A merged fix that fails live verification
   stays open.
+- A merged fix that fails live verification and draws a follow-up fix PR goes
+  back to `status:coded` — `tm issue transition N status:coded` (owner ruling
+  2026-09-07). The issue is being coded again, so `status:merged` is stale.
 
 🔴 **`.trusty-mpm/sessions/` is TRACKED** (owner ruling 2026-08-31) — session
 snapshots and the pause log are committed so other sessions and harnesses can

--- a/crates/trusty-agents-common/changelog.d/6914-issue-state-merged-to-coded.md
+++ b/crates/trusty-agents-common/changelog.d/6914-issue-state-merged-to-coded.md
@@ -1,0 +1,3 @@
+Added
+
+- The ticketing agent takes `tm issue transition N status:coded` when live verification of a merged fix fails and a follow-up fix PR opens. The lifecycle model gained the `status:merged -> status:coded` edge that move needs; before it, the agent had no state to move the issue to and left it at `status:merged` (owner ruling 2026-09-07).

--- a/crates/trusty-agents-common/src/assets/agents/ticketing.md
+++ b/crates/trusty-agents-common/src/assets/agents/ticketing.md
@@ -357,6 +357,7 @@ event owes the label pass immediately.** Nothing sweeps for stale labels later.
 | PR opened for the fix | `tm issue transition N status:coded` |
 | Merge CONFIRMED — `gh pr view <n> --json state` reports `MERGED` | `tm issue transition N status:merged` |
 | Live verification evidence in hand | `tm issue transition N status:tested` |
+| Live verification FAILED and a follow-up fix PR is open | `tm issue transition N status:coded` |
 | Closing, with that evidence | `tm issue transition N closed --note "<evidence>"` |
 | Claim released — the session is gone and nothing moved | `tm issue transition N open` |
 
@@ -372,8 +373,9 @@ the advance happens then.
 the live verification evidence** — what was run against the installed artifact
 and what it printed. `tm issue transition N closed --note "<evidence>"` enforces
 both halves: the edge exists only from `status:tested`, and it refuses to run
-without the note. A merged fix that fails live verification stays open at
-`status:merged`.
+without the note. A merged fix that fails live verification stays open — at
+`status:merged` while nobody is working it, and back at `status:coded` once a
+follow-up fix PR is open (owner ruling 2026-09-07).
 
 🔴 **A fix PR references `Refs #N`, never `Closes #N`.** A merge must not
 auto-close an issue that has not been verified live. The PM relays this to

--- a/crates/trusty-mpm/changelog.d/6914-issue-state-merged-to-coded.md
+++ b/crates/trusty-mpm/changelog.d/6914-issue-state-merged-to-coded.md
@@ -1,0 +1,3 @@
+Added
+
+- The repo's issue lifecycle model now declares `status:merged -> status:coded`, so a merged issue whose live verification failed and which drew a follow-up fix PR is tracked as coded again instead of sitting at `status:merged`. Before this, `tm issue transition N status:coded` from `status:merged` was refused with exit 1 — the model offered only `status:tested` and `open`. The `tm-ticketing` skill states when to take the edge (owner ruling 2026-09-07).

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -323,6 +323,7 @@ the label pass then and there:
 | PR opened for the fix | `tm issue transition N status:coded` |
 | Merge CONFIRMED (`gh pr view <n> --json state` reports `MERGED`) | `tm issue transition N status:merged` |
 | Live verification evidence in hand | `tm issue transition N status:tested` |
+| Live verification FAILED and a follow-up fix PR is open | `tm issue transition N status:coded` |
 | Claim released — session gone, nothing moved | `tm issue transition N open` |
 
 A confirmed merge with no label pass is an incomplete step, not a tidy-up for
@@ -336,8 +337,10 @@ verification evidence in the closing comment — what ran against the installed
 artifact and what it printed: `tm issue transition N closed --note "<evidence>"`.
 The model declares that edge only from `status:tested` and marks it
 `requires_note`, so a close without evidence is refused. A merged fix that fails
-live verification stays open at `status:merged`. A fix PR carries `Refs #N`, never `Closes #N`, so a
-merge cannot auto-close something nobody has verified.
+live verification stays open — at `status:merged` while nobody is working it, and
+back at `status:coded` once a follow-up fix PR is open (owner ruling 2026-09-07;
+the model declares `status:merged -> status:coded`). A fix PR carries `Refs #N`,
+never `Closes #N`, so a merge cannot auto-close something nobody has verified.
 
 **Comments along the way.** A progress comment at each meaningful transition —
 diagnosis confirmed, fix pushed, review verdict received, blocked — carrying

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/project_model_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/project_model_tests.rs
@@ -46,6 +46,8 @@ const EXPECTED_EDGES: &[(&str, &str)] = &[
     ("status:coded", "status:merged"),
     ("status:merged", "status:tested"),
     ("status:tested", "closed"),
+    // Backward: live verification failed and a fix PR is open.
+    ("status:merged", "status:coded"),
     // Release a claim, and reopen from anywhere.
     ("status:in-progress", "open"),
     ("status:coded", "open"),
@@ -105,6 +107,31 @@ fn project_model_rejects_skipping_a_rung() {
     assert!(!sm.transition_allowed(Some("status:in-progress"), "status:merged"));
     assert!(!sm.transition_allowed(Some("status:coded"), "status:tested"));
     assert!(!sm.transition_allowed(Some("status:merged"), "closed"));
+}
+
+/// Owner ruling 2026-09-07: a merged issue whose live verification failed and
+/// which drew a follow-up fix PR moves back to `status:coded`.
+///
+/// Before the edge existed, `tm issue transition 6914 status:coded` was refused
+/// because the model declared only `status:merged -> status:tested` and
+/// `status:merged -> open`. The forward and release edges are asserted here too,
+/// so widening the model does not quietly cost `status:merged` its other moves.
+#[test]
+fn project_model_allows_merged_back_to_coded_for_a_followup_fix() {
+    let m = project_model();
+    let sm = StateMachine::new(&m);
+    assert!(
+        sm.transition_allowed(Some("status:merged"), "status:coded"),
+        "a merged issue whose live verification failed must be codeable again"
+    );
+    assert!(sm.transition_allowed(Some("status:merged"), "status:tested"));
+    assert!(sm.transition_allowed(Some("status:merged"), "open"));
+    // The edge is one-directional per rung: nothing else gains a way back.
+    assert!(!sm.transition_allowed(Some("status:tested"), "status:merged"));
+    assert!(!sm.transition_allowed(Some("status:coded"), "status:in-progress"));
+    let mut targets = sm.allowed_targets_from(Some("status:merged"));
+    targets.sort_unstable();
+    assert_eq!(targets, vec!["open", "status:coded", "status:tested"]);
 }
 
 #[test]

--- a/issue-state.yaml
+++ b/issue-state.yaml
@@ -98,6 +98,14 @@ transitions:
     requires_note: true
     description: "Closed with live-verification evidence (--note required)"
 
+  # --- backward: a merged fix that did not hold ----------------------------
+  # Owner ruling 2026-09-07: live verification failed and a follow-up fix PR is
+  # open, so the issue is being coded again rather than sitting at `merged`.
+  - from: "status:merged"
+    to: "status:coded"
+    trigger: human_label
+    description: "Live verification failed; a follow-up fix PR is open"
+
   # --- back to open: release a claim, or reopen ----------------------------
   - from: "status:in-progress"
     to: open


### PR DESCRIPTION
Owner ruling 2026-09-07: the lifecycle model has no edge from `status:merged`
back to `status:coded` — add it.

#6914 sat at `status:merged`, its live verification failed, and fix PR #6952
opened. `tm issue transition 6914 status:coded` was refused with exit 1: the
model declared only `status:merged -> status:tested` and `status:merged -> open`,
so an issue being coded again had nowhere to go.

**The edge:** `issue-state.yaml` declares `status:merged -> status:coded`,
`trigger: human_label`. Every existing edge is unchanged; `open` and
`status:in-progress` behave exactly as before.

**Rung 3** (localized behavior in one crate, plus the shared ticketing agent
asset):

```
cargo fmt                                              EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=0
cargo test -p trusty-mpm --no-fail-fast                 EXIT=0  54 targets, 10694 passed, 0 failed, 19 ignored
cargo test -p trusty-agents-common --no-fail-fast       EXIT=0  517 passed, 0 failed, 0 ignored
scripts/check_line_cap.sh                               EXIT=0  4523 files, 0 violations
scripts/check_changelog_fragment.sh                     EXIT=0  2 crates recorded
scripts/check_test_pointers.sh                          EXIT=0  31192 citations, 0 dangling
scripts/check_sld.sh                                    EXIT=0  0 errors
scripts/check_capabilities.sh                           EXIT=0  up to date (7 generated files)
scripts/check_agent_assets.sh                           EXIT=0
```

Both `project_model_declares_exactly_the_documented_edges` and the new
`project_model_allows_merged_back_to_coded_for_a_followup_fix` FAIL on the
pre-change YAML (verified by reverting `issue-state.yaml` and re-running):
`10 passed; 2 failed`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
