### PR TITLE
chore(sessions): pause snapshots and recompiled instructions for trusty-tools-ec, 2026-09-06/07

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/INSTRUCTIONS-COMPILED.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/INSTRUCTIONS-COMPILED.md
@@ -19,6 +19,9 @@
   memory-index file — this overrides any harness default.
 - Never cite `MEMORY.md`; cite the palace.
 - Durable facts go to the palace (`memory_remember` / `memory_note`).
+- Record your own self-improvement hypotheses in the palace under the tag
+  `self-improvement-hypothesis`, the same one every agent uses; a post-mortem
+  run coalesces by that tag (#6937).
 - `CLAUDE.md` is the only non-dynamic instruction source. Never create another.
 
 ## PM Allowlist (unbudgeted; everything else is budgeted or delegated)
@@ -202,7 +205,9 @@ gate is blocking.
 A **task-completion report** carries four things: what was delegated and to
 whom, the QA evidence (actual output, not claims), the files tracked with their
 commits, and each claim mapped to its evidence source. In-flight responses
-answer the question instead.
+answer the question instead. Route each agent's **Improvement recommendations**
+block to `bobmatnyc/trusty-tools` issues through the `ticketing` agent, whatever
+project the agent ran in (#6935).
 
 ## Prose Style — Write Plainly
 

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -94,3 +94,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260906-164200.md","timestamp":"2026-09-06T16:42:00.516459+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260906-200223.md","timestamp":"2026-09-06T20:02:23.098338+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260906-213223.md","timestamp":"2026-09-06T21:32:23.203795+00:00"}
+{"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260907-002504.md","timestamp":"2026-09-07T00:25:04.149016+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -93,3 +93,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260906-163700.md","timestamp":"2026-09-06T16:37:00.120986+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260906-164200.md","timestamp":"2026-09-06T16:42:00.516459+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260906-200223.md","timestamp":"2026-09-06T20:02:23.098338+00:00"}
+{"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260906-213223.md","timestamp":"2026-09-06T21:32:23.203795+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -92,3 +92,4 @@
 {"session_id":"trusty-tools-38","event":"pause","snapshot":"trusty-tools-38/session-20260906-140035.md","timestamp":"2026-09-06T14:00:35.822826+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260906-163700.md","timestamp":"2026-09-06T16:37:00.120986+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260906-164200.md","timestamp":"2026-09-06T16:42:00.516459+00:00"}
+{"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260906-200223.md","timestamp":"2026-09-06T20:02:23.098338+00:00"}

--- a/.trusty-mpm/sessions/tmux-window-1/session-20260906-200223.md
+++ b/.trusty-mpm/sessions/tmux-window-1/session-20260906-200223.md
@@ -1,0 +1,44 @@
+# Session Pause - 2026-09-06T20:02:23.098338+00:00
+
+## Summary
+Session trusty-tools-ec (harness 01f773fb, tmux tm-dogfood:0:@1) paused 2026-09-06 ~20:5xZ by owner /tm-session-pause; supersedes the 16:42Z snapshot. Bug drive plus console work. Owner authorizations in force this leg: "keep going, merge them when green"; "close them once they pass"; "restart" (tm daemon, DONE); "publish trusty-audit" (train live); "reinstall trusty-search and restart it" (live); console self-dashboard requirement (#6908) and top-nav removal ruling (#6909); "show me the console once the nav is gone" (pre-authorized install+restart+screenshot chain on #6909's merge). CLOSED at status:tested this leg: #6811 #6869 #6888 #6885 #6876. MERGED: #6901 (#6892), #6904 snapshots, #6906 rustdoc links + tm 1.5.18 bump, #6907 (#6896, trusty-common 0.49.1), #6902 (#6581, squash ac95e123d — label still status:coded, advance to status:merged). ARMED: #6905 (#6895, head 58fef57b3). 1.5.17 train published+installed (common 0.49.0, agents-common 0.7.0, review 0.35.0, mpm 1.5.17). FOUR AGENTS LIVE AT PAUSE — ListAgents FIRST on resume; after a process restart verify by artifact before any re-dispatch.
+
+## Completed
+- 1.5.17 publish train: trusty-common 0.49.0, trusty-agents-common 0.7.0, trusty-review 0.35.0, trusty-mpm 1.5.17 published, installed, signed; daemon restart 2 done (pid 82338)
+- Closed at status:tested: #6811 (trusty-review 0.35.0 installed), #6869 #6888 #6885 #6876 (live on tm 1.5.17)
+- #6841 closed; #6838 reopened status:merged; #6900 filed P1; saver research posted on both (no defect in logs; owner-present verification needed)
+- #6892 builder cap merged via #6901, status:merged (ships next tm release, not in 1.5.17)
+- #6895 fixed: PR #6905 armed (Refs template, version-control grep step, tm pr open guard), status:coded
+- #6896 fixed: PR #6907 merged 30e339a5f, status:merged, trusty-common 0.49.1 unpublished
+- #6581 v5: PR #6902 merged ac95e123d (critic 3 rounds, round-4 fixes, teardown manifest rows); label needs status:merged
+- Labels advanced: #6846 #6826 #6821 status:merged; #6876 status:merged then closed
+- PR #6906 rustdoc links + tm 1.5.18 bump merged 43dfab387; PR #6904 session snapshots merged; local main realigned to origin/main
+- Issues filed: #6908 console self-dashboard, #6909 remove top tab bar (both status:in-progress, children of #6516)
+- Worktrees removed: #6581 v1-v4, publish-trusty-audit
+
+## In Progress
+- LIVE AGENT local-ops trusty-audit 0.14.1 train (ab1778c): waits #6906 merge (done), then pre-publish gate on main tip, tag trusty-audit-v0.14.1, publish, install+sign, live-verify #6784. Changelog PR #6903 merged ffd8c732e. Verify by artifact on resume: git tag --list 'trusty-audit-v0.14.1', crates.io max_version, taudit --version. Never re-tag (#6178).
+- LIVE AGENT local-ops trusty-search reinstall+restart (afcb1d8): build 0.54.0 from clean origin/main worktree, sign, connection-safe restart, before/after index inventory in scratchpad ts-before/after.txt, live-verify #6870 #6864 #6826 #6821 #6846. On PASS ticketing closes each at status:tested. Verify by artifact: trusty-search --version, daemon pid/start time.
+- LIVE AGENT svelte-engineer #6909 (a8725c1): branch feat/6909-remove-console-tab-bar, remove tab bar keep config entry, Vitest, cargo build -p trusty-console with UI. Then: security scan -> version-control PR (Refs #6909) -> arm -> on merge: install console from clean worktree (no SKIP_UI_BUILD), restart console service, web-qa screenshot, tell owner to preview (drawer 48c71c23).
+- LIVE AGENT rust-engineer #6908 (a08cd93): branch feat/6908-console-self-roster, ConsoleConnector in detect/console.rs, resolve_pid self arm, MachineHistory sse_client_count on snapshot (schema bump). Then scan -> PR -> arm -> status:coded; Svelte Console details pane is a follow-on slice after this lands. Bus status/service connections deferred to #6460 transport.
+- PR #6905 (#6895) armed at 58fef57b3, checks pending; on merge -> #6895 status:merged.
+- #6581: PR #6902 merged ac95e123d; ticketing must advance to status:merged; live verification needs a trusty-search install that includes it (M005 re-chunks every index on restart; the current reinstall predates it).
+
+## Next Steps
+- ListAgents; then gh-verify: #6905 merged?, trusty-audit-v0.14.1 tag/crates.io, trusty-search installed version + daemon pid, #6909/#6908 branch state
+- Ticketing: #6581 -> status:merged (PR #6902 ac95e123d); #6895 -> status:merged when #6905 lands
+- #6909 chain: scan -> PR -> arm -> install+restart console -> screenshot -> owner preview (pre-authorized)
+- #6908: after Rust PR lands, dispatch svelte-engineer for the Console details pane (version, uptime, CPU/RSS, sse_client_count; 'not yet available' for bus/service-connection panels)
+- trusty-audit: on publish PASS close #6784 at status:tested with the evidence note
+- trusty-search: on verification PASS close #6870 #6864 #6826 #6821 #6846 at status:tested
+- Owner decisions open: saver live verification with owner present (#6838 #6900); Heroku INFERENCE_* creds for #6887 arm E
+- Remaining queue: #6889 pause-all (unblocked by #6888), #6784, #6839, #5220; open count ~238
+- Lesson not filed: check_rustdoc_links.sh under-reports binary targets vs cargo doc
+
+## Git Context
+Branch: HEAD
+Last commit: ac95e123d fix(trusty-search): chunk ids carry the end line; M005 re-chunks the corpus under the index permit (#6902)
+Uncommitted changes: 5 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/tmux-window-1/session-20260906-213223.md
+++ b/.trusty-mpm/sessions/tmux-window-1/session-20260906-213223.md
@@ -1,0 +1,42 @@
+# Session Pause - 2026-09-06T21:32:23.203795+00:00
+
+## Summary
+Session trusty-tools-ec (harness 01f773fb, tmux tm-dogfood:0:@1) paused 2026-09-07 ~00:2xZ by owner /tm-session-pause; supersedes the 2026-09-06 20:02Z snapshot. Leg covered: AWS 1M Consulting account (141377423791) profiles installed, trusty-review Bedrock switched to profile 1m-consulting (Sonnet 4.6 still gated on the Anthropic use-case form; Opus 4.6 works); trusty-search 0.54.0 reinstall verified five issues, exposed the M005 office-doc drop (#6910, fixed in PR #6919 merged 8479e9ac8), recovery sweep complete except matsuoka-com (cap raise chain running); console tab bar removed (#6909 closed at status:tested, live at http://127.0.0.1:7788/) and self-roster shipped (#6908 status:merged, details pane PR #6921 armed); ticketing label-ensure (#6914 in progress) and config-block slice 2 (#6918) under owner rulings (config.yaml, Refs hard, trusty-mpm label component-only); console/dashboard unification epic #6922 filed with 10 children incl. Disk dashboard sunburst and agent-info-in-Sessions #6931, mpm dashboard ports into console (#6924 decided); DOC-73 amendment in progress; recurring self-improvement post-mortem standing instruction (tracker being filed; first run #6932). MAIN IS RED (#6511: uds test from #6907 fails on Linux) — fix in progress; trusty-audit 0.14.2 publish train stopped before tagging (PR #6917 merged b0ecccbb0, nothing burned). Owner authorizations in force: merge when green; close once they pass; publish trusty-audit; run forced re-indexes; raise the cap on matsuoka-com once #6910 lands. SEVEN AGENTS LIVE AT PAUSE — ListAgents FIRST on resume; after a process restart verify by artifact before re-dispatch.
+
+## Completed
+- #6870 #6864 #6826 #6821 #6846 #6909 closed at status:tested (trusty-search 0.54.0 live-verify; console 0.11.0 web-qa)
+- PRs merged, ancestor-verified: #6911 (7c50a4ff5), #6915 (34e377351), #6916 (552556c3b), #6917 (b0ecccbb0), #6919 (8479e9ac8)
+- AWS profiles [1m-consulting] + [profile 1m-consulting-sso] written with backups; .mcp.json / ~/.claude.json / com.trusty.review plist switched to 1m-consulting us-east-1; dead com.trusty.review launchd unit unloaded and parked under ~/Library/LaunchAgents/retired/
+- M005 recovery: cto, trusty-tools-checkout, trusty-tools forced-reindexed via direct API with office text recovered; flyr-duetto-monolith re-registered after the #6920 CLI trap, vectors reconciled; 43 indexes had no office files
+- Console installed from main 552556c3b (pid 81319, port 7788), screenshots delivered to owner
+- Filed: #6910 #6912 #6913 #6914 #6918 #6920 #6922 (+children #6923 #6928 #6924 #6925 #6926 #6927 #6929 #6930 #6931, #6155 reused) #6932
+- Owner rulings recorded in palace: ticketing config.yaml / Refs hard / trusty-mpm component-only; console displays, dashboard manages; row-click to management view; read/write/index pulses; Disk dashboard; agent info in Sessions view; #6924 port into console; recurring post-mortem standing task
+
+## In Progress
+- LIVE rust-engineer red-main fix (branch fix/6896-uds-accepted-socket-sizing-ci): uds::tests::an_accepted_socket_inherits_the_listeners_sizing fails on Linux CI (#6511, from #6907). Then: scan -> PR -> arm -> on green main, resume the trusty-audit 0.14.2 train from worktree .claude/worktrees/publish-trusty-audit-0.14.2 rebased to the green SHA (pre-publish gate, preflight, tag v0.14.2 immediately before publish, publish, install+sign, verify #6784, close at status:tested)
+- LIVE local-ops search install + cap chain: cargo install trusty-search from origin/main (has #6910), tctl sign, TRUSTY_MAX_INDEX_BYTES=4294967296 in com.trusty.search plist, bootout/bootstrap, M005 boot table for 38 cold indexes, index --force matsuoka-com via direct API (expect ~64,517 chunks), /health ok. Then ticketing closes #6910 at status:tested. Verify by artifact: trusty-search binary mtime, daemon pid != 42499, ps eww shows the cap, /health indexes_stage_failed_ids empty
+- LIVE rust-engineer #6914 slice 1 (feat/6914-ticketing-ensure-labels): seed-labels covers all policy labels via one path, workstream_label.rs stops creating in-progress/blocked, agent+skill run seed-labels at first use. Then scan -> PR -> arm -> status:coded; #6918 (config block) dispatches after it merges
+- LIVE documentation DOC-73 amendment (branch docs/doc73-console-unification-and-disk): five rulings + Disk section + #6924 port + #6931 agent info + Sequence with real numbers. Then scan -> PR (Refs #6922) -> arm
+- LIVE ticketing: self-improvement label + standing post-mortem tracker issue + scheduled-trigger child; links #6932
+- ARMED PR #6921 (#6908 details pane, 18a3784f4): on merge -> #6908 status:merged already set; reinstall console from clean main, web-qa verify the Console row opens the pane, close #6908 at status:tested; then dispatch the QUEUED UI SLICE: Trusty Agents row open-dashboard control, Search tab 'Warm Boot Degraded' card renamed to what it measures (any_stage_failed) + text-align center on .stat-label/.stat-value (SearchTab.svelte:240-245), and #6923 (strip DeleteAction/StaleIndexCleanup from SearchTab, row-click to /tools/search/indexes)
+- Bedrock 1M account: Sonnet 4.6 / Sonnet 4.5 / Haiku 4.5 return use-case-form-not-submitted; Sonnet 5 / Opus 5 / Fable 5.1 not available; Opus 4.6-v1 works. The serve --stdio review server in this session keeps the old profile until relaunch
+
+## Next Steps
+- ListAgents; gh-verify #6921 merged?, red-main fix branch state, #6914 branch state, DOC-73 branch state, trusty-search daemon pid/cap/health, trusty-audit tag list (must be NO v0.14.2 unless the train ran)
+- Red main: land the uds test fix, then resume the trusty-audit 0.14.2 train (authorization stands)
+- matsuoka-com: confirm ~64k chunks and /health ok; close #6910 at status:tested with evidence
+- #6921 merge chain: console reinstall, web-qa, close #6908, then the queued UI slice (agents row control, warm-boot label rename + centering, #6923)
+- #6914: scan -> PR -> arm; on merge dispatch #6918 (agents.ticketing block in config.yaml)
+- DOC-73 amendment: scan -> PR Refs #6922 -> arm
+- Post-mortem tracker: confirm filed; dispatch #6932 research when <=2 engineers are live
+- Owner decisions open: Bedrock use-case form for 141377423791 (or move reviewer model to opus-4-6-v1); trusty-search.yaml naming drift in the Duetto repo (#6920)
+- Worktrees to prune after merges: agent-a08cd9324875e35a6 (#6911), agent-a8725c144415592ff (#6915), agent-a78b9e39f119e091c (#6916), agent-a912b8a9ed088d4cd (#6919), publish-trusty-audit-0.14.1, install-console-20260906, fix-trusty-audit-0.14.2
+- Lesson to file into the rust-engineer/workflow post-mortem (#6932): no CI gate builds each crate in isolation; a SendMessage follow-up to a running subagent gets treated as an injection — dispatch fresh instead
+
+## Git Context
+Branch: HEAD
+Last commit: 5dc94598e chore(sessions): pause snapshot for trusty-tools-ec 2026-09-06 20:02Z (five closed, five merged, four agents live: audit train, search reinstall, console #6908/#6909)
+Uncommitted changes: 6 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/tmux-window-1/session-20260907-002504.md
+++ b/.trusty-mpm/sessions/tmux-window-1/session-20260907-002504.md
@@ -1,0 +1,32 @@
+# Session Pause - 2026-09-07T00:25:04.149016+00:00
+
+## Summary
+Session trusty-tools-ec (harness 01f773fb, tmux tm-dogfood:0:@1) paused 2026-09-07 ~06:1xZ by owner /tm-session-pause; supersedes the 2026-09-06 21:32Z snapshot. Leg covered: self-improvement model shipped as owner ruled — BASE-AGENT self-analysis core property (#6935, PR #6944) and the continuous hypothesis loop with tag self-improvement-hypothesis, metrics and significance rules (#6937, PR #6949), post-mortem coalesces (tm-postmortem skill); tracker #6933 rewritten to file to trusty-tools; six hypotheses recorded from this session's own misses, one already promoted to improved. Also merged: DOC-73 amendment (#6936), ticketing labels slice 1 (#6939) and config.yaml block slice 2 (#6948), console search tab display-only (#6943), red-main uds fix (#6942, a real Linux defect: accepted sockets never inherit buffers), capabilities drift fix (#6950). Closed status:tested: #6511, #6784, #6908, #6910, #6923. Published trusty-audit 0.14.2 (tag at 12a249c44). Installed trusty-search 0.54.0 with 4 GiB cap (matsuoka-com 62,122 chunks), trusty-console from c15a0d62f, trusty-audit 0.14.2. origin/main = 0055f2fa2, green. Worktrees 30. ONE AGENT LIVE AT PAUSE: local-ops reinstalling tm from 0055f2fa2 and restarting com.trusty.mpm (owner-authorized "go ahead and reinstall tm and restart the daemon"), then live-verifying #6914/#6918/#6935/#6937 — verify by artifact on resume (tm --version, binary mtime, daemon pid, tm doctor) before re-dispatching. Merge-on-green authorization stands for this session's PRs; none are open.
+
+## Completed
+- Merged: #6921, #6936, #6939, #6942, #6943, #6944, #6948, #6949, #6950 (main 0055f2fa2)
+- Closed status:tested: #6511 (main green run 34063759261), #6784, #6908, #6910, #6923
+- Published trusty-audit 0.14.2 at 12a249c44; installed + live-verified; not Developer-ID signed (no tctl sign target)
+- Installed trusty-search 0.54.0 (pid 55418, cap 4 GiB, matsuoka-com rebuilt) and trusty-console from c15a0d62f (pid 44052)
+- Filed: #6935, #6937 (children of #6933), #6938 pptx extractor, #6940 four daemon accept loops, #6941 prune panel port, #6945 is_local_upstream prefix test, #6946 pm-guard heredoc, #6947 changelog gate pre-commit
+- Six hypotheses under self-improvement-hypothesis; #1 (isolation on every dispatch) promoted improved at n=41/0 denials
+- Worktrees reclaimed to 30; all merged trees and stale release branches gone
+
+## In Progress
+- LIVE local-ops (opus): tm reinstall from clean checkout of 0055f2fa2, cargo install --locked, tctl sign trusty-mpm, connection-safe restart of com.trusty.mpm, three-way pid agreement, tm doctor, tm session ls; then live checks: tm issue standard, tm issue seed-labels, Closes refused via throwaway config, deployed BASE-AGENT carries both new sections. On its report: ticketing closes #6914, #6918, #6935, #6937 at status:tested (memory_list tag self-improvement-hypothesis = 6 already confirmed)
+
+## Next Steps
+- ListAgents first; if the reinstall agent died, verify by artifact (tm --version, ~/.cargo/bin/tm mtime, launchctl print gui/$(id -u)/com.trusty.mpm pid, lsof :7880, tm doctor) before re-dispatching
+- Close #6914/#6918/#6935/#6937 at status:tested with the reinstall agent's evidence
+- Owner decisions open: tctl sign target for trusty-audit or leave ad-hoc; Bedrock use-case form for 141377423791 or move reviewer model to Opus 4.6; trusty-search.yaml naming drift in the Duetto repo (#6920)
+- Follow-ups queued, none dispatched: #6940 (accept_sized in trusty-agents/embedderd/mcp), #6941 (search dashboard prune panel), #6945 (Rust loopback guard), #6946, #6947, #6938
+- Post-mortem lesson to coalesce: a PR adding a tm subcommand must regenerate tm-capabilities references in the same PR (#6948 landed without it; cause not established)
+- Commit this snapshot: .trusty-mpm/sessions/ is tracked (owner ruling 2026-08-31)
+
+## Git Context
+Branch: HEAD
+Last commit: b8c785744 chore(sessions): pause snapshot for trusty-tools-ec 2026-09-07 00:3xZ (six closed, five merged, epic #6922 filed, main red #6511, seven agents live)
+Uncommitted changes: 6 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1


### PR DESCRIPTION
Session snapshots and one recompiled instructions file under `.trusty-mpm/sessions/` (tracked per the 2026-08-31 owner ruling). Docs-only; rung 1, no Cargo gate. Four commits, +127/-1.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools