### PR TITLE
chore(sessions): pause snapshot 2026-09-07

### DIFF
--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -95,3 +95,4 @@
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260906-200223.md","timestamp":"2026-09-06T20:02:23.098338+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260906-213223.md","timestamp":"2026-09-06T21:32:23.203795+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260907-002504.md","timestamp":"2026-09-07T00:25:04.149016+00:00"}
+{"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260907-020817.md","timestamp":"2026-09-07T02:08:17.059305+00:00"}

--- a/.trusty-mpm/sessions/tmux-window-1/session-20260907-020817.md
+++ b/.trusty-mpm/sessions/tmux-window-1/session-20260907-020817.md
@@ -1,0 +1,35 @@
+# Session Pause - 2026-09-07T02:08:17.059305+00:00
+
+## Summary
+Session trusty-tools-ec (harness 01f773fb, tmux tm-dogfood:0:@1) paused 2026-09-07 ~03:4xZ by owner /tm-session-pause; supersedes the 00:25Z snapshot. Leg covered: tm reinstalled TWICE (1.5.18 from 0055f2fa2, then from 3a6d4487c; daemon now pid 96807, signed, sessions intact); `tm install` refreshed the stale BASE-AGENT tier. CLOSED status:tested: #6918, #6935, #6937, #6914 (PR #6952), #6920 (PR #6954). MERGED: #6955 (issue-state merged→coded edge), #6956 (four pause snapshots). FILED: #6951 doctor agent_staleness, #6953 trusty-agents gh label --limit, #6957 search registry eviction, #6958 savings ledger + 💸 statusline segment + docs, #6959 divert savings row, #6960 website flagship pages from markdown. Released stale claims #6754, #94 to open; 11 prune candidates all KEEP; #6892 stays status:merged (8 of 10 ACs unverified — needs a qa synthetic run). OWNER RULINGS: shunt worker = headless Claude Code Haiku under the existing login (no Bedrock/Heroku); Bedrock/Mantle parity PARKED (gap analysis + epic design in scratchpad, unfiled); trusty-audit stays ad-hoc signed; #6920 fixed in CLI; savings stat must be prominent in docs AND website; website prose from markdown via a standard md→Svelte path; PRIORITY = shunt support ASAP, then the under-200 backlog drive. Main checkout detached at origin/main 3a6d4487c, tracked tree clean. THREE ENGINEERS WERE LIVE AT PAUSE (subagents survive a pause — ListAgents FIRST, never re-dispatch a running one; if dead, verify by `gh pr list` + branch names before anything).
+
+## Completed
+- tm 1.5.18 reinstalled from 3a6d4487c, signed, daemon pid 96807, tm doctor daemon checks green; `tm issue seed-labels` exit 0 and merged→coded edge live on the installed binary
+- #6918 #6935 #6937 #6914 #6920 closed at status:tested with live evidence
+- PRs #6952 #6954 #6955 #6956 merged; their worktrees and local branches pruned; four install worktrees pruned (install-mpm-20260907 KEPT for binary_provenance)
+- Issues filed: #6951 #6953 #6957 #6958 #6959 #6960; #6892 reviewed (left at merged); stale claims #6754 #94 released; 11 prune candidates all KEEP
+- #6887 WIP preserved as commit b46e4b5a1 on feat/6887-divert-bulk-read (worktree agent-a24791dadc8515432); #6887 criterion 3 rewritten on the issue; #6882 recommendation line closed out
+- Bedrock parity: gap analysis (scratchpad/bedrock-parity-gap-analysis.md) and epic design (scratchpad/bedrock-parity-epic-design.md) written; PARKED by owner, not filed
+- Statusline savings design written (scratchpad/statusline-savings-design.md)
+
+## In Progress
+- LIVE rust-engineer (opus) #6887: branch feat/6887-divert-haiku from b46e4b5a1, rebasing onto origin/main and replacing the provider worker with `claude -p --model claude-haiku-4-5` over stdin under the session CLAUDE_CONFIG_DIR; risk under test: nested-session env refusal (CLAUDECODE=1); ends with PR + auto-merge armed, Refs #6887 #6882
+- LIVE rust-engineer (opus) #6958: branch feat/statusline-savings-ledger — ~/.trusty-mpm/usage/savings.jsonl, 💸~$X.XX ninth statusline segment (absent when zero, never $0.00), instruction-compression producer at session launch, docs/trusty-mpm/statusline-savings.md (H2 'Cost savings' first, embed-ready) + public-manifest row + README subsection; told NOT to hand-edit +page.svelte
+- LIVE svelte-engineer (opus) #6960: branch feat/website-flagship-pages-from-markdown — flagship tool pages render prose from markdown (mdsvex or the existing /docs manifest loader), trusty-mpm first embedding the Cost savings section; must rewrite CLAUDE.md 'Public Website' + website/README.md; proof commit touching only .md
+
+## Next Steps
+- ListAgents first. For each of the three engineers: if running, wait; if dead, `gh pr list --state open` for feat/6887-divert-haiku, feat/statusline-savings-ledger, feat/website-flagship-pages-from-markdown and inspect its worktree under .claude/worktrees/agent-* for uncommitted work before re-dispatching
+- SHUNT CHAIN (owner priority): #6887 PR → merge on green (session authorization stands) → local-ops reinstall tm from the squash (connection-safe restart) → enable divert in this project's manifest → live bulk-read verification → close #6887 at status:tested → dispatch #6959 (divert savings row; blocked by #6887 + #6958)
+- Merge order: #6958 and #6960 both add the docs/public-manifest.tsv row for statusline-savings.md — whichever lands second rebases
+- After the shunt chain: resume the under-200 backlog drive — bugs first (7 unlabelled bugs from 2026-09-06: #6900 #6912 #6913 #6940 #6945 #6946 + #6957), then status:merged verifications (#6896 #6839 #6838 #5220; #6892 needs a qa synthetic run of its 10 ACs), then P1s (#2063 #2074 #2075 #2892 #6637 #6900). Machine builder cap is 4; three builders were this session's at pause
+- tm doctor housekeeping not yet run (owner not asked): 21 legacy tm-* skill copies in ~/.claude/skills, legacy ~/.trusty-mpm/claude-config dir, 45 project settings files with tm hook entries (`tm hooks clean`)
+- Bedrock/Mantle parity stays PARKED; 1m-consulting STS creds are expired; do not re-raise unless the owner does
+- Commit this snapshot: .trusty-mpm/sessions/ is tracked (owner ruling 2026-08-31) — via a branch + docs-only PR, as #6956 did
+
+## Git Context
+Branch: HEAD
+Last commit: 3a6d4487c chore(sessions): pause snapshots and recompiled instructions for trusty-tools-ec, 2026-09-06/07 (#6956)
+Uncommitted changes: 6 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1


### PR DESCRIPTION
## Outcome

Session snapshot captured for `trusty-tools-ec` orchestration.

## Changes

- Added: `.trusty-mpm/sessions/tmux-window-1/session-20260907-020817.md`
- Modified: `.trusty-mpm/sessions/sessions-log.jsonl`

## Risk

None — docs-only snapshot, rung 1.

## Tests

N/A

## Baseline

N/A

## Docs

No documentation change.

## Review

No review required, docs-only.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
