### PR TITLE
fix(trusty-search): keep sidecar PID forwarding alive across restarts

### DIFF
--- a/crates/trusty-search/changelog.d/6967-pid-forwarder-lifecycle.md
+++ b/crates/trusty-search/changelog.d/6967-pid-forwarder-lifecycle.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Keep sidecar health PIDs current across restart gaps, and retire old PID forwarding tasks safely during shutdown and replacement (#6967).

--- a/crates/trusty-search/src/commands/start/tests.rs
+++ b/crates/trusty-search/src/commands/start/tests.rs
@@ -2181,8 +2181,18 @@ async fn swap_back_real_hardware_kills_sidecar_past_max_restarts() {
     let switchable =
         OrchestratorArc::new(SwitchableEmbedder::new(adapter, test_python_ready_active()));
 
-    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    // The HTTP registration gate requires an explicitly allowed safe root;
+    // OS temp roots such as /tmp are denied even in this hardware fixture.
+    let corpus = home_anchored_root("swap-back-e2e-");
+    let allowlist_dir = tempfile::tempdir().expect("create fixture allowlist directory");
+    let allowlist = approving(allowlist_dir.path(), &[corpus.path()]);
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new())
+        .with_allowlist_paths(allowlist);
     state.install_switchable_embedder(OrchestratorArc::clone(&switchable));
+    // Match daemon startup: publish both the concrete switchable handle and
+    // the trait slot that marks the embedder ready for HTTP registration.
+    let embedder: OrchestratorArc<dyn crate::core::Embedder> = switchable.clone();
+    state.install_embedder(embedder).await;
     state
         .install_embedderd_pid_slot(OrchestratorArc::clone(&pid_slot))
         .await;
@@ -2240,11 +2250,19 @@ async fn swap_back_real_hardware_kills_sidecar_past_max_restarts() {
     // search actually keeps working end-to-end.
     let create_resp = client
         .post(format!("http://{addr}/indexes"))
-        .json(&serde_json::json!({ "id": "swap-back-e2e", "root_path": "/tmp" }))
+        .json(&serde_json::json!({ "id": "swap-back-e2e", "root_path": corpus.path() }))
         .send()
         .await
         .expect("POST /indexes failed");
-    assert!(create_resp.status().is_success());
+    let create_status = create_resp.status();
+    assert!(
+        create_status.is_success(),
+        "fixture registration failed: {create_status}: {}",
+        create_resp
+            .text()
+            .await
+            .expect("registration response body")
+    );
 
     let search_resp = client
         .post(format!("http://{addr}/indexes/swap-back-e2e/search"))

--- a/crates/trusty-search/src/service/embedder_supervisor/mod.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/mod.rs
@@ -255,11 +255,8 @@ struct SpawnedState {
     // behaviour (implicit oneshot cancellation), not for any explicit send.
     #[allow(dead_code)]
     shutdown_tx: tokio::sync::oneshot::Sender<()>,
-    /// Kept alive to ensure the supervisor's `child_pid_slot` Arc remains
-    /// valid as long as the state is live. The forwarder task in `do_spawn`
-    /// clones the same Arc; this field prevents it from becoming a dangling
-    /// clone if the caller drops their reference.
-    #[allow(dead_code)]
+    /// Shared supervised PID slot. Its allocation identifies the current
+    /// spawn so a retired forwarder cannot publish into a successor's slot.
     pid_slot: Arc<AtomicU32>,
     /// Definitive "the supervisor for THIS spawn gave up permanently" signal
     /// (epic #3524 slice 6 PR-4 follow-up, code-critic BLOCK on PR #3584).
@@ -568,8 +565,8 @@ impl LazyEmbedderHandle {
         let Some(spawned) = guard.take() else {
             return;
         };
-        drop(guard);
         self.app_pid_slot.store(0, AtomicOrdering::Release);
+        drop(guard);
         if let Some(handle) = spawned.supervisor_handle {
             handle.shutdown().await;
         }
@@ -742,23 +739,44 @@ async fn do_spawn(
     let initial_pid = child_pid_slot.load(AtomicOrdering::Acquire);
     app_pid_slot.store(initial_pid, AtomicOrdering::Release);
 
-    // Issue #829: abort the previous forwarder before spawning a new one.
-    // On idle-shutdown cycles the old child_pid_slot never resets to 0, so
-    // the old forwarder loops forever without this cancellation.
+    // #6967: a zero PID is also a normal restart gap. Forward while this
+    // spawn owns the state, and publish under its lock so teardown or a new
+    // spawn cannot be overwritten by a stale task. A weak capture prevents
+    // forwarding alone from retaining the state. Test:
+    // `lazy_handle_pid_forwarder_survives_restart_gap`.
     {
         let src = Arc::clone(&child_pid_slot);
         let dst = Arc::clone(&app_pid_slot);
+        let state = Arc::downgrade(&state_cell);
         let join = tokio::spawn(async move {
             loop {
-                let pid = src.load(AtomicOrdering::Acquire);
-                dst.store(pid, AtomicOrdering::Release);
-                if pid == 0 {
-                    break;
+                {
+                    let Some(state) = state.upgrade() else {
+                        break;
+                    };
+                    let guard = state.lock().await;
+                    let Some(spawned) = guard.as_ref() else {
+                        break;
+                    };
+                    if !Arc::ptr_eq(&spawned.pid_slot, &src) {
+                        break;
+                    }
+                    // Read the release-published termination flag before
+                    // sampling PID so permanent give-up forwards its final
+                    // zero, never a PID sampled before the child exited.
+                    let terminated = spawned
+                        .terminated
+                        .as_ref()
+                        .is_some_and(|flag| flag.load(AtomicOrdering::Acquire));
+                    dst.store(src.load(AtomicOrdering::Acquire), AtomicOrdering::Release);
+                    if terminated {
+                        break;
+                    }
                 }
                 tokio::time::sleep(Duration::from_millis(500)).await;
             }
         });
-        // Swap in the new handle, abort the old one.
+        // Preserve #829 cancellation when another lazy spawn replaces us.
         let mut handle_guard = pid_forwarder_handle.lock().await;
         if let Some(old) = handle_guard.take() {
             old.abort();
@@ -913,13 +931,8 @@ async fn idle_watchdog(
             // request arriving during the shutdown just triggers a new
             // `do_spawn` concurrently; it has no reason to wait on the
             // just-stopped process.
-            drop(guard);
-            // Note: a concurrent `do_spawn` racing in here could in principle
-            // overwrite this with a new PID before we finish; correctness
-            // relies on `do_spawn`'s own spawn + client-handshake latency
-            // making that reorder practically unreachable, not on any
-            // explicit ordering/lock between the two stores.
             app_pid_slot.store(0, AtomicOrdering::Release);
+            drop(guard);
 
             // Cooperative shutdown (issue #2979): flips the shared shutdown
             // flag the supervision loop selects on. The loop kills and reaps

--- a/crates/trusty-search/src/service/embedder_supervisor/tests.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/tests.rs
@@ -985,6 +985,119 @@ exit 1
         );
     }
 
+    /// Why: a zero PID during restart backoff must not end health forwarding.
+    /// What: kill this fixture's child, observe the gap and real replacement,
+    /// then verify the public PID catches up before cleaning up the supervisor.
+    /// Test: this test; fails when the forwarder exits at the temporary zero.
+    #[tokio::test]
+    async fn lazy_handle_pid_forwarder_survives_restart_gap() {
+        let (_dir, binary) = write_mock_embedderd();
+        let handle = LazyEmbedderHandle::new(
+            binary,
+            SupervisorConfig {
+                startup_timeout_secs: 5,
+                backoff_max_secs: 2,
+                max_restarts: 3,
+                idle_shutdown_secs: 0,
+                ..SupervisorConfig::default()
+            },
+        );
+        handle
+            .embed_via(|client| async move { client.embed_batch(vec!["probe".to_string()]).await })
+            .await
+            .expect("mock embed_batch must succeed");
+        let actual = Arc::clone(&handle.state.lock().await.as_ref().unwrap().pid_slot);
+        let public = handle.app_pid_slot();
+        let original_pid = actual.load(Ordering::Acquire);
+        assert!(original_pid > 0 && original_pid <= i32::MAX as u32);
+        assert_eq!(public.load(Ordering::Acquire), original_pid);
+        // The only signal target comes from this handle's own live spawn.
+        assert_eq!(actual.load(Ordering::Acquire), original_pid);
+        let killed = std::process::Command::new("kill")
+            .args(["-KILL", &original_pid.to_string()])
+            .status()
+            .expect("send SIGKILL to owned fixture child");
+        assert!(killed.success());
+        let observed = tokio::time::timeout(Duration::from_secs(10), async {
+            while actual.load(Ordering::Acquire) != 0 || public.load(Ordering::Acquire) != 0 {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            loop {
+                let replacement = actual.load(Ordering::Acquire);
+                if replacement != 0 && replacement != original_pid {
+                    while public.load(Ordering::Acquire) != replacement {
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                    }
+                    return replacement;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        let final_pid = actual.load(Ordering::Acquire);
+        handle.shutdown().await;
+        assert!(!process_alive(original_pid));
+        assert!(final_pid > 0 && !process_alive(final_pid));
+        assert_eq!(public.load(Ordering::Acquire), 0);
+        assert!(
+            observed.is_ok(),
+            "public PID never followed replacement {final_pid} after the observed restart gap"
+        );
+    }
+
+    /// Why: shutdown and replacement must retire forwarding tasks (#829).
+    /// What: shut down a real child, immediately respawn, and verify only the
+    /// new task remains; final shutdown must stop that task and clear the PID.
+    /// Test: this test.
+    #[tokio::test]
+    async fn lazy_handle_pid_forwarder_retires_on_shutdown_and_respawn() {
+        let (_dir, binary) = write_mock_embedderd();
+        let handle = LazyEmbedderHandle::new(
+            binary,
+            SupervisorConfig {
+                startup_timeout_secs: 5,
+                idle_shutdown_secs: 0,
+                ..SupervisorConfig::default()
+            },
+        );
+        handle
+            .embed_via(|client| async move { client.embed_batch(vec!["probe".to_string()]).await })
+            .await
+            .expect("initial fixture embed");
+        let old_task = handle.pid_forwarder_handle.lock().await.clone().unwrap();
+        let old_pid = handle.app_pid_slot().load(Ordering::Acquire);
+        handle.shutdown().await;
+        assert!(!process_alive(old_pid));
+        handle
+            .embed_via(|client| async move { client.embed_batch(vec!["probe".to_string()]).await })
+            .await
+            .expect("replacement fixture embed");
+        let new_task = handle.pid_forwarder_handle.lock().await.clone().unwrap();
+        let new_pid = handle.app_pid_slot().load(Ordering::Acquire);
+        let old_finished = tokio::time::timeout(Duration::from_secs(5), async {
+            while !old_task.is_finished() {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        let observed_pid = handle.app_pid_slot().load(Ordering::Acquire);
+        let new_running = !new_task.is_finished();
+        handle.shutdown().await;
+        let new_finished = tokio::time::timeout(Duration::from_secs(5), async {
+            while !new_task.is_finished() {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(old_finished.is_ok(), "old forwarder survived replacement");
+        assert!(new_pid > 0 && new_pid != old_pid);
+        assert_eq!(observed_pid, new_pid, "old forwarder overwrote replacement");
+        assert!(new_running, "new forwarder retired before its spawn");
+        assert!(new_finished.is_ok(), "forwarder survived final shutdown");
+        assert!(!process_alive(new_pid));
+        assert_eq!(handle.app_pid_slot().load(Ordering::Acquire), 0);
+    }
+
     /// `is_confirmed_terminated()` must be `false` when the handle has never
     /// spawned anything — there is no reason to believe an unspawned handle
     /// is "unrecoverably dead" (epic #3524 slice 6 PR-4 follow-up,
@@ -1055,10 +1168,24 @@ exit 1
             }
         })
         .await;
+        let forwarder = handle.pid_forwarder_handle.lock().await.clone().unwrap();
+        let forwarding_stopped = tokio::time::timeout(Duration::from_secs(5), async {
+            while !forwarder.is_finished() {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        let final_public_pid = handle.app_pid_slot().load(Ordering::Acquire);
+        handle.shutdown().await;
         assert!(
             gave_up.is_ok(),
             "is_confirmed_terminated() never flipped true within 45s of \
              exhausting max_restarts=1 against an always-crashing mock child"
         );
+        assert!(
+            forwarding_stopped.is_ok(),
+            "forwarder survived permanent give-up"
+        );
+        assert_eq!(final_public_pid, 0, "give-up must publish final zero PID");
     }
 }

--- a/docs/research/6967-pid-forwarder-lifecycle.md
+++ b/docs/research/6967-pid-forwarder-lifecycle.md
@@ -1,0 +1,37 @@
+# PID forwarding through sidecar restarts
+
+## Why
+
+Issue #6967: the PID forwarder in `service/embedder_supervisor/mod.rs` exits
+when the supervised PID becomes zero. The supervisor clears that slot during
+restart backoff and later stores the replacement PID. The public health slot
+therefore stays zero, hiding a healthy replacement and preventing the hardware
+crash-budget integration test from targeting the next child.
+
+## What
+
+Keep forwarding zero and replacement PIDs for the current `SpawnedState`.
+Identify that state by its shared PID-slot allocation under the existing state
+mutex. Publish under the same guard, exiting when the state disappears or is
+replaced, or after its definitive termination signal. Capture the state weakly
+and release temporary strong references before sleeping. Preserve cancellation
+of the previous task when a new lazy spawn starts (#829).
+
+Clear public PIDs during explicit and idle shutdown under that same mutex,
+before releasing the spawn gate. No public API, supervisor retry budget,
+backoff, or hardware-test deadline changes are needed.
+
+## Test
+
+Use the existing shell stdio fixture as a real supervised child. Kill only the
+PID captured from this test's current spawn, observe the actual/public zero
+restart gap, then require the replacement PID to reach the public slot. Run
+this regression before the fix and retain the failing result; always shut down
+the owned supervisor before asserting a timeout result.
+
+Also verify forwarder termination on shutdown and permanent give-up, then a
+fresh lazy spawn without an old forwarder overwriting its PID. Run focused
+lifecycle tests, crate check/clippy/fmt and the full crate suite with
+`--no-fail-fast`; include ignored lifecycle coverage, especially the unchanged
+real-hardware crash-budget test. Rung 5 also requires workspace check and direct
+consumer coverage. Independent code review and security review precede delivery.


### PR DESCRIPTION
## Outcome

Keep the public sidecar PID current across supervised restarts. Previously, the PID forwarder exited when the child PID temporarily became zero during restart backoff, so health reporting never received the replacement PID.

Refs bobmatnyc/trusty-tools#6967

## Change

Continue forwarding zero and replacement PIDs while the current spawned state owns the shared PID slot. Retire forwarding when that state is replaced, shut down, or permanently terminated. Synchronize shutdown PID publication with the existing state mutex so an old task cannot overwrite a successor's PID.

Type: bug fix. Affected crate: `trusty-search`. No API, retry-budget, backoff, or hardware-test deadline changes.

## Risk / blast radius

Rust ladder rung 5: supervised process lifecycle and public health reporting. The change is a prerequisite discovered during snapshot-consistency verification in PR #6966 and remains independently reviewable.

## Test evidence

The restart-gap regression failed against the baseline because the public PID never became the replacement PID. Final head `a069928b755a9553afae4187102e818a27fbaf82` retains hardware assertions and deadlines while fixing the isolated test fixture's path and switchable embedder installation.

- Full default trusty-search suite: 2,571 passed, 0 failed, 41 ignored (`cargo test -p trusty-search --no-fail-fast`).
- All 28 focused lifecycle/module cases including ignored coverage passed; restart regressions passed 20 repeated runs.
- Shared supervisor/crash-budget coverage: 30 passed.
- Unchanged hardware restart/fallback assertions passed in 18.15 seconds.
- Crate check, clippy with all targets, formatting, SLD, and documentation pointer checks passed.

Baseline defect #6967 is fixed here. The hardware fixture corrections retain assertions and timeouts; no failing gate is waived. All 16 live required CI contexts passed on the final head.

## Review findings

Independent critic and full/delta credential scan both approve exact head `a069928b755a9553afae4187102e818a27fbaf82`, with zero leaks.

Required trusty-review passed on earlier production head `65567208` with authoritative public indexed source context (APPROVE / B+, exit 0). Its shutdown-race advisory was refuted: `guard.take()` precedes PID clearing under the same mutex in both shutdown paths. Final-head trusty-review also passed with authoritative public indexed context: APPROVE / A-, exit 0, no blocking findings. Its remaining observations acknowledge correct ordering and brief mutex contention; no corrective action is required. No review comments are posted to GitHub.

## Docs / changelog

Added `docs/research/6967-pid-forwarder-lifecycle.md` and `crates/trusty-search/changelog.d/6967-pid-forwarder-lifecycle.md`. Public interfaces remain unchanged.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
