### PR TITLE
fix(trusty-review): add the DOC-1 version subcommand tctl's self-check spawns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12012,7 +12012,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -98,7 +98,15 @@ name        = "trusty-review"
 # neither of which is `#[non_exhaustive]` — an out-of-tree struct literal for
 # either stops compiling. `cargo-semver-checks` reports this as
 # `struct_missing_field`-class breakage against the 0.33.1 baseline.
-version     = "0.35.0"
+# 0.35.0 -> 0.35.1 (#6913): PATCH. 0.35.0 is already live on crates.io and this
+# PR edits `src/**`, so the `PR version bump vs crates.io` gate (#4421) requires
+# a bump. PATCH is the right position: the addition is a `version` subcommand on
+# the BINARY (`src/main.rs`, `src/commands/`), and nothing in the `lib` target
+# changes shape — `cargo-semver-checks` compares the library and has nothing to
+# report. A MINOR bump would also have to widen the root
+# `[workspace.dependencies]` row (`trusty-review = { …, version = "0.35" }`),
+# which this change gives no reason to touch.
+version     = "0.35.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6913-version-subcommand.md
+++ b/crates/trusty-review/changelog.d/6913-version-subcommand.md
@@ -1,0 +1,8 @@
+Added
+
+- `trusty-review version [--json]`. `--json` emits the DOC-1 capability-discovery
+  envelope (`contract_version`, `tool`, `tool_version`, `verbs`) that
+  `tctl doctor --self-check trusty-review` spawns and parses. The subcommand did
+  not exist, so clap exited 2 with a usage error and the probe reported
+  `trusty-review version --json exited with exit status: 2` (#6913). It answers
+  from the binary alone — no config file, no tokio runtime, no network.

--- a/crates/trusty-review/src/commands/mod.rs
+++ b/crates/trusty-review/src/commands/mod.rs
@@ -28,3 +28,7 @@ pub(crate) mod diff_source;
 #[cfg(feature = "mcp")]
 pub mod mcp_stdio;
 pub mod run;
+// #6913: `version` answers the DOC-1 capability envelope tctl's self-check
+// spawns. It needs no config, no runtime and no network, so `main` dispatches
+// it before either is built.
+pub mod version;

--- a/crates/trusty-review/src/commands/version.rs
+++ b/crates/trusty-review/src/commands/version.rs
@@ -1,0 +1,101 @@
+//! `trusty-review version` — the DOC-1 capability-discovery envelope tctl reads.
+//!
+//! Why (#6913): `tctl doctor --self-check trusty-review` spawns
+//! `trusty-review version --json` and requires `contract_version` plus a
+//! non-empty `verbs[]` at the TOP LEVEL of that reply
+//! (`trusty-installer::commands::probe::validate_version_envelope`,
+//! ADR-0007/DOC-1). trusty-review had no `version` subcommand, so clap exited
+//! 2 with a usage error and the probe reported
+//! "trusty-review version --json exited with exit status: 2" before it could
+//! parse anything. Same defect trusty-analyze carried until #6631; this is
+//! that fix, ported unchanged.
+//!
+//! What: [`envelope`] builds the JSON object; [`run`] prints it, or a one-line
+//! human summary without `--json`. `verbs` names only `"version"` itself —
+//! `run --json` emits a serialised `ReviewResult` (`trusty_review::run_output`),
+//! not a DOC-1 envelope, and advertising a verb this binary cannot answer
+//! in-contract would be the opposite defect: a controller trusting `verbs[]`
+//! (D3b) and getting a review payload instead.
+//!
+//! Test: `envelope_satisfies_the_doc1_self_check`,
+//! `envelope_carries_the_crate_version`; the subprocess-level
+//! `version_json_parses_and_carries_the_crate_version` in
+//! `tests/version_cli.rs` proves the real binary, not just this function.
+
+use serde_json::{Value, json};
+
+/// DOC-1 `contract_version` baseline
+/// (`docs/trusty-installer/research/02-design/01-tool-contract.md`,
+/// ADR-0007). Bumped only for a non-additive envelope or verb-`data` shape
+/// change — never for adding a verb (D3, restated in that doc's ledger).
+const CONTRACT_VERSION: u32 = 1;
+
+/// Build the `version --json` envelope tctl's self-check parses.
+///
+/// Why/What: see the module doc — `contract_version` and `verbs` sit at the
+/// TOP level, not nested under a `data` key, because that is what
+/// `validate_version_envelope` actually reads off the spawned process's
+/// stdout.
+/// Test: `envelope_satisfies_the_doc1_self_check`,
+/// `envelope_carries_the_crate_version`.
+pub fn envelope() -> Value {
+    json!({
+        "contract_version": CONTRACT_VERSION,
+        "tool": "trusty-review",
+        "tool_version": env!("CARGO_PKG_VERSION"),
+        "verb": "version",
+        "status": "ok",
+        "verbs": ["version"],
+        "messages": [],
+    })
+}
+
+/// Entry point for `trusty-review version [--json]`.
+///
+/// What: `--json` prints [`envelope`]; otherwise a one-line human summary
+/// matching the other trusty-* binaries' plain-text `version` output.
+/// Test: `version_json_parses_and_carries_the_crate_version` and
+/// `version_without_json_prints_the_crate_version` in `tests/version_cli.rs`.
+pub fn run(json: bool) {
+    if json {
+        println!("{}", envelope());
+    } else {
+        println!("trusty-review v{}", env!("CARGO_PKG_VERSION"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why (#6913): this is the literal check `doctor --self-check` runs —
+    /// pinning it here means a future edit that drops either field fails in
+    /// this crate's own test run, not three hops away in trusty-installer's.
+    /// What: `contract_version` is a positive integer and `verbs` is a
+    /// non-empty array, both at the top level.
+    /// Test: itself.
+    #[test]
+    fn envelope_satisfies_the_doc1_self_check() {
+        let v = envelope();
+        assert!(
+            v["contract_version"].as_u64().is_some_and(|n| n >= 1),
+            "contract_version must be a positive integer: {v}"
+        );
+        assert!(
+            v["verbs"].as_array().is_some_and(|a| !a.is_empty()),
+            "verbs must be a non-empty array: {v}"
+        );
+    }
+
+    /// Why: tctl's self-check and any operator reading `version --json` need
+    /// the crate's actual release version, not a placeholder.
+    /// What: `tool_version` equals `CARGO_PKG_VERSION`, and `tool` names this
+    /// binary rather than the crate this pattern was copied from.
+    /// Test: itself.
+    #[test]
+    fn envelope_carries_the_crate_version() {
+        let v = envelope();
+        assert_eq!(v["tool_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(v["tool"], "trusty-review");
+    }
+}

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -125,6 +125,23 @@ enum Commands {
     /// Always dry-run safe: never posts to GitHub.
     Calibrate(CalibrateArgs),
 
+    /// Print the crate version, or (with `--json`) the DOC-1
+    /// capability-discovery envelope `tctl doctor --self-check` reads.
+    ///
+    /// Why (#6913): `tctl doctor --self-check trusty-review` spawns this exact
+    /// form and requires `contract_version` + a non-empty `verbs[]`;
+    /// trusty-review had no `version` subcommand, so the self-check died on a
+    /// clap usage error (exit 2) before it could parse anything.
+    /// What: delegates to `commands::version::run`. Answers from the binary
+    /// alone — no config, no tokio runtime, no network.
+    /// Test: `commands::version::envelope_satisfies_the_doc1_self_check`,
+    /// `tests/version_cli.rs::version_json_parses_and_carries_the_crate_version`.
+    Version {
+        /// Emit the DOC-1 capability-discovery envelope as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Manage inference provider configuration (API keys) — the universal
     /// `config keys set/list/test/unset` surface shared by every trusty-*
     /// binary (epic #2400 Wave 1, #2405).
@@ -174,6 +191,15 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
+    // #6913: `version` is answered from the binary alone, ahead of the tokio
+    // runtime and of `ReviewConfig::from_env_and_file`. tctl's self-check
+    // spawns this on hosts with no trusty-review config at all, so anything it
+    // depends on is a way for capability discovery to fail.
+    if let Commands::Version { json } = &cli.command {
+        commands::version::run(*json);
+        return Ok(());
+    }
+
     // #6290: no synchronous launchd pre-dispatch any more — there is no
     // `service` subcommand, because there is no unit for it to manage.
     let rt = tokio::runtime::Runtime::new().context("build tokio runtime")?;
@@ -210,6 +236,10 @@ async fn async_main(cli: Cli) -> Result<()> {
         Commands::Calibrate(args) => cmd_calibrate(config, args).await,
         Commands::WebhookListen => trusty_review::webhook_listener::run(config).await,
         Commands::Config(cmd) => cmd.run().await,
+        // #6913: dispatched in `main`, before the runtime and the config.
+        Commands::Version { .. } => {
+            unreachable!("version dispatched before the tokio runtime is built")
+        }
     }
 }
 

--- a/crates/trusty-review/tests/version_cli.rs
+++ b/crates/trusty-review/tests/version_cli.rs
@@ -1,0 +1,79 @@
+//! Integration smoke test (#6913): `version --json` answers the way
+//! `tctl doctor --self-check trusty-review` actually invokes it.
+//!
+//! Why: `trusty-installer`'s self-check spawns `<binary> version --json` as a
+//! real subprocess and parses raw stdout (`probe::spawn_member_json`), never
+//! calling into this crate as a library. On `origin/main` there is no `version`
+//! subcommand at all, so clap exits 2 and the probe reports
+//! "trusty-review version --json exited with exit status: 2" — the failure
+//! #6913 records. A unit test on `commands::version::envelope` proves the JSON
+//! shape but not that the CLI is wired up to emit it; this drives the real
+//! built binary the way the self-check does.
+//! What: spawns the binary via the Cargo-provided `CARGO_BIN_EXE_*` path,
+//! parses stdout as JSON, and asserts the fields `validate_version_envelope`
+//! reads plus the crate's own version. Plain `version` gets the same
+//! exit-0-and-prints-the-version check.
+//! Test: this file IS the test.
+
+use std::process::Command;
+
+/// Absolute path to the freshly built binary (Cargo sets this for integration
+/// tests). Using it guarantees we exercise the real mounted CLI, not a stub.
+const BIN: &str = env!("CARGO_BIN_EXE_trusty-review");
+
+#[test]
+fn version_json_parses_and_carries_the_crate_version() {
+    let out = Command::new(BIN)
+        .args(["version", "--json"])
+        .output()
+        .expect("spawn `version --json`");
+    assert!(
+        out.status.success(),
+        "`version --json` should exit 0; status {:?}, stderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("`version --json` must emit valid JSON");
+
+    // The exact fields `validate_version_envelope` reads off this stdout
+    // (trusty-installer::commands::probe) — a positive `contract_version` and
+    // a non-empty `verbs[]`, both at the top level.
+    assert!(
+        v["contract_version"].as_u64().is_some_and(|n| n >= 1),
+        "contract_version must be a positive integer: {v}"
+    );
+    assert!(
+        v["verbs"].as_array().is_some_and(|a| !a.is_empty()),
+        "verbs must be a non-empty array: {v}"
+    );
+    assert_eq!(
+        v["tool"], "trusty-review",
+        "the envelope must name this binary: {v}"
+    );
+    assert_eq!(
+        v["tool_version"],
+        env!("CARGO_PKG_VERSION"),
+        "tool_version must be the crate's real release version: {v}"
+    );
+}
+
+#[test]
+fn version_without_json_prints_the_crate_version() {
+    let out = Command::new(BIN)
+        .arg("version")
+        .output()
+        .expect("spawn `version`");
+    assert!(
+        out.status.success(),
+        "`version` should exit 0; status {:?}, stderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(env!("CARGO_PKG_VERSION")),
+        "plain `version` should print the crate version; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## What

`tctl doctor --self-check trusty-review` spawns `trusty-review version --json`
and reads `contract_version` plus a non-empty `verbs[]` off stdout
(`trusty-installer::commands::probe::validate_version_envelope`, DOC-1 D3b).
`trusty-review` had no `version` subcommand, so clap exited 2 with a usage error
and the probe reported the failure #6913 records:

```
$ trusty-review version --json        # 0.35.0, the released binary
error: unrecognized subcommand 'version'
EXIT=2
```

`crates/trusty-review/src/commands/version.rs` builds the envelope; `main`
dispatches it before the tokio runtime and before
`ReviewConfig::from_env_and_file`, because the self-check runs on hosts with no
trusty-review config and anything it depends on is a way for capability
discovery to fail. `verbs` lists only `"version"`: `run --json` emits a
serialised `ReviewResult`, not an envelope, and advertising a verb the binary
cannot answer in-contract is the opposite defect. Ported unchanged from the same
fix in trusty-analyze (#6631).

After:

```
$ trusty-review version --json
{"contract_version":1,"messages":[],"status":"ok","tool":"trusty-review","tool_version":"0.35.1","verb":"version","verbs":["version"]}
$ tctl doctor --self-check trusty-review
tctl doctor --self-check trusty-review: conformant (1 verbs advertised)
EXIT=0
```

## The launchd half of #6913 is not changed

`tctl install trusty-review --dry-run` still prints
`trusty-review -> trusty-review (would bootstrap launchd service)`, and that is
correct behaviour, not the remaining half of the bug. `plans_service_bootstrap`
(`install_report.rs:305-309`) plans that step for a member with a RETIRED
service precisely so `bootstrap_one`'s eviction branch runs and the stale unit
is removed — the fix #6290 made after a Launchd-only predicate skipped retired
members and left the unit loaded. `manage_strategy_for("trusty-review")` is
already `None` and `BootstrapAction::Skipped("trusty-review has no launchd
service")` is already asserted in `upgrade_tests.rs:394-409`; no unit is
created. The issue's stated expectation ("removes a stale unit when found") is
what that step does. Only the dry-run wording is misleading, and rewording it is
a separate, installer-side change that no acceptance criterion here asks for.

## Version

0.35.0 -> 0.35.1. PATCH: 0.35.0 is live on crates.io and this PR edits `src/**`,
so the #4421 gate requires a bump; the addition is on the binary target and the
`lib` target does not change shape.

## Test ladder — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                        EXIT=0
SKIP_UI_BUILD=1 cargo check   -p trusty-review --all-targets              EXIT=0
SKIP_UI_BUILD=1 cargo clippy  -p trusty-review --all-targets -- -D warnings  EXIT=0
SKIP_UI_BUILD=1 cargo test    -p trusty-review --no-fail-fast            EXIT=0
```

`cargo test -p trusty-review --no-fail-fast` — 14 targets, all green:

```
unittests src/lib.rs      test result: ok. 2198 passed; 0 failed; 5 ignored
unittests src/main.rs     test result: ok. 80 passed; 0 failed; 0 ignored
tests/cast_template_golden.rs             ok. 6 passed
tests/citation_2881_regression.rs         ok. 3 passed
tests/citation_4042_regression.rs         ok. 3 passed
tests/citation_4999_regression.rs         ok. 3 passed
tests/config_mount.rs                     ok. 2 passed
tests/registry_claim_4081_regression.rs   ok. 5 passed
tests/report_analyze_e2e.rs               ok. 4 passed
tests/report_e2e.rs                       ok. 3 passed
tests/report_investigate.rs               ok. 3 passed
tests/report_methodology_6675.rs          ok. 2 passed
tests/version_cli.rs                      ok. 2 passed
```

Regression test: `tests/version_cli.rs::version_json_parses_and_carries_the_crate_version`
spawns the real built binary the way `probe::spawn_member_json` does. It fails
on `origin/main`, where the subcommand does not exist and the spawn exits 2
(reproduced above with the installed 0.35.0 binary).

Doctor side, since the probe is the consumer: `cargo test -p trusty-installer
--no-fail-fast` EXIT=0 — `unittests src/lib.rs ok. 705 passed; 0 failed; 4
ignored`, `tests/config_mount.rs ok. 3 passed`, `tests/path_shadow_e2e.rs ok. 3
passed`.

Doc and repo gates: `check_line_cap.sh` (4539 files, 0 violations),
`check_changelog_fragment.sh` (trusty-review fragment present and valid),
`check_test_pointers.sh` (31323 citations, 0 dangling), `check_sld.sh` (0
errors), `check-pr-version-bump.sh` (0.35.0 -> 0.35.1 OK),
`check_workspace_dep_versions.sh` (12 rows OK) — all EXIT=0.

Refs #6913

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
