### PR TITLE
fix(trusty-console): parse the upstream host in the SSRF guard (#6945)

### DIFF
--- a/crates/trusty-common/changelog.d/6945-origin-authority-userinfo.md
+++ b/crates/trusty-common/changelog.d/6945-origin-authority-userinfo.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `origin_is_loopback` and `origin_matches_self` reject two authority shapes
+  that reached a loopback verdict for a URL connecting somewhere else (#6945).
+  The bracketed-IPv6 branch of the shared parser split on `]` and dropped
+  whatever followed, so `http://[::1].evil.com` read as host `::1`; and neither
+  branch handled userinfo, so `http://127.0.0.1:80@evil.com` and
+  `http://[::1]:80@evil.com` read the part before the `@` as the host. The
+  parser now returns `None` for any authority containing `@`, and for a
+  bracketed literal trailed by anything that is not a `:port`. No well-formed
+  `Origin` header or `http_addr` discovery file carries either shape.

--- a/crates/trusty-common/src/server/origin_guard.rs
+++ b/crates/trusty-common/src/server/origin_guard.rs
@@ -114,7 +114,14 @@ impl SelfOrigins {
 /// check accepts the attacker-controlled DNS name `127.0.0.1.evil.com` (and
 /// `127.attacker.com`) as "loopback", defeating the CSRF guard. `IpAddr::from_str`
 /// rejects any string that is not a bare IP literal.
-/// Test: `origin_is_loopback_*` below, incl. `_rejects_ip_prefixed_dns_names`.
+///
+/// Two shapes that reach a loopback-looking host through the BRACKET branch are
+/// rejected by the parser rather than here (#6945): an authority carrying
+/// userinfo (`http://[::1]:80@evil.com` dials evil.com) and a bracketed literal
+/// trailed by anything but a port (`http://[::1].evil.com`). See
+/// [`parse_origin_authority`].
+/// Test: `origin_is_loopback_*` below, incl. `_rejects_ip_prefixed_dns_names`,
+/// `_rejects_userinfo`, and `_rejects_bracketed_ipv6_lookalikes`.
 pub fn origin_is_loopback(origin: &str) -> bool {
     match parse_origin_authority(origin) {
         Some((host, _port)) => {
@@ -186,17 +193,36 @@ pub fn origin_matches_self(origin: &str, self_origins: &SelfOrigins) -> bool {
 /// parsing in exactly one place.
 /// What: strips the `scheme://` prefix, takes everything up to the first `/`
 /// as the authority, and splits it into host and optional port, unwrapping
-/// `[…]` IPv6 literals. Returns `None` for a value with no `://`.
+/// `[…]` IPv6 literals. Returns `None` for a value with no `://`, for an
+/// authority carrying userinfo (`user@host`), and for a bracketed literal
+/// followed by anything that is not a `:port`.
 /// Test: exercised indirectly via `origin_is_loopback_*` and
-/// `origin_matches_self_*`.
+/// `origin_matches_self_*`, plus `origin_is_loopback_rejects_userinfo` and
+/// `origin_is_loopback_rejects_bracketed_ipv6_lookalikes`.
 fn parse_origin_authority(origin: &str) -> Option<(&str, Option<&str>)> {
     let after_scheme = origin.split_once("://").map(|(_, rest)| rest)?;
     let authority = after_scheme.split('/').next().unwrap_or("");
 
+    // #6945: userinfo is refused outright rather than parsed. What a client
+    // dials in `user@host` is `host`, but the bracket branch below reads
+    // `[::1]@evil.com` as host `::1` — a loopback verdict for a URL that
+    // connects to evil.com. Neither a well-formed `Origin` nor a daemon's
+    // `http_addr` discovery file ever carries userinfo, so rejecting the whole
+    // shape loses nothing and closes every direction of the trick at once.
+    if authority.contains('@') {
+        return None;
+    }
+
     if let Some(rest) = authority.strip_prefix('[') {
         // Bracketed IPv6 literal: `[::1]:7070` → host `::1`, port `7070`.
         let (host, remainder) = rest.split_once(']')?;
-        let port = remainder.strip_prefix(':');
+        // #6945: what follows `]` is a `:port` or nothing. Dropping anything
+        // else read `[::1].evil.com` as host `::1` — a loopback verdict for a
+        // hostname that resolves wherever its owner points it.
+        let port = match remainder {
+            "" => None,
+            _ => Some(remainder.strip_prefix(':')?),
+        };
         Some((host, port))
     } else {
         // host[:port] — split at the FIRST `:` (`split_once`). For a
@@ -327,6 +353,43 @@ mod tests {
         assert!(!origin_is_loopback("http://localhost.evil.com"));
         // A bracketed IPv6 loopback still parses and is trusted.
         assert!(origin_is_loopback("http://[::1]"));
+    }
+
+    /// Why: #6945 — an authority carrying userinfo names one host to a reader
+    /// and dials another. `127.0.0.1:80@evil.com` and `[::1]:80@evil.com` were
+    /// the false accepts: both branches read the part before the `@` as the
+    /// host and returned loopback for a URL that connects to evil.com.
+    /// What: asserts every userinfo shape — loopback as the userinfo (with and
+    /// without a port), loopback as the host, bracketed and not — is rejected.
+    /// Test: this test.
+    #[test]
+    fn origin_is_loopback_rejects_userinfo() {
+        assert!(!origin_is_loopback("http://127.0.0.1:80@evil.com"));
+        assert!(!origin_is_loopback("http://[::1]:80@evil.com"));
+        assert!(!origin_is_loopback("http://[::1]@evil.com"));
+        assert!(!origin_is_loopback("http://127.0.0.1@evil.com"));
+        assert!(!origin_is_loopback("http://localhost@evil.com"));
+        assert!(!origin_is_loopback("http://localhost:80@evil.com"));
+        // The mirror direction — a real loopback host behind userinfo — is
+        // refused too: fail closed, and nothing legitimate emits this shape.
+        assert!(!origin_is_loopback("http://evil.com@127.0.0.1"));
+    }
+
+    /// Why: #6945 — the bracket branch split on `]` and dropped whatever
+    /// followed, so `[::1].evil.com` read as host `::1` and passed as loopback
+    /// while resolving wherever its owner pointed it.
+    /// What: asserts a bracketed literal trailed by anything that is not a
+    /// `:port` is rejected, and that the legitimate forms still pass.
+    /// Test: this test.
+    #[test]
+    fn origin_is_loopback_rejects_bracketed_ipv6_lookalikes() {
+        assert!(!origin_is_loopback("http://[::1].evil.com"));
+        assert!(!origin_is_loopback("http://[::1].evil.com:7070"));
+        assert!(!origin_is_loopback("http://[::1]x.evil.com"));
+        assert!(!origin_is_loopback("http://[::1]-evil.com"));
+        // The two well-formed shapes must still pass.
+        assert!(origin_is_loopback("http://[::1]"));
+        assert!(origin_is_loopback("http://[::1]:7070"));
     }
 
     /// Why: a value with no scheme is not a well-formed Origin; treat as

--- a/crates/trusty-console/changelog.d/6945-upstream-host-parse.md
+++ b/crates/trusty-console/changelog.d/6945-upstream-host-parse.md
@@ -1,0 +1,12 @@
+Fixed
+
+- The reverse proxy's SSRF guard parses the upstream URL's host instead of
+  prefix-matching the string (#6945). `is_local_upstream` tested
+  `http://127.`, `http://[::1]`, and `http://localhost`, so
+  `http://127.0.0.1.evil.com`, `http://localhost.evil.com`, and
+  `http://[::1].evil.com` all read as loopback and the proxy would dial them.
+  It now requires the `http://` scheme and hands the host to the shared
+  `origin_is_loopback` classifier, which accepts only `localhost` or a host
+  that parses as a loopback `IpAddr` (`127.0.0.0/8`, `::1`), and which refuses
+  userinfo (`http://127.0.0.1:80@evil.com`) outright. Same class as #3319 on
+  the inbound CSRF guard, on the outbound sibling that never got the fix.

--- a/crates/trusty-console/src/proxy/routes.rs
+++ b/crates/trusty-console/src/proxy/routes.rs
@@ -669,7 +669,9 @@ mod tests {
     /// What: asserts each loopback-lookalike host is rejected — an IP- or
     /// `localhost`-prefixed DNS name, a bracketed-IPv6 lookalike, and userinfo
     /// in both directions.
-    /// Test: this test itself. Every assertion here FAILS on `origin/main`.
+    /// Test: this test itself. 13 of the 14 assertions FAIL on `origin/main`;
+    /// the last one, `http://evil.com@127.0.0.1`, already passed there because
+    /// it matched none of the three prefixes. It stays as a no-loosening check.
     #[test]
     fn test_is_local_upstream_rejects_loopback_lookalike_hosts() {
         // IP-prefixed DNS names — the case named in the issue.
@@ -691,6 +693,8 @@ mod tests {
         assert!(!is_local_upstream("http://127.0.0.1@evil.com"));
         assert!(!is_local_upstream("http://[::1]@evil.com"));
         assert!(!is_local_upstream("http://localhost@evil.com"));
+        // Not a regression row — the prefix test rejected this one too. Kept so
+        // the parse-based guard cannot loosen it.
         assert!(!is_local_upstream("http://evil.com@127.0.0.1"));
     }
 

--- a/crates/trusty-console/src/proxy/routes.rs
+++ b/crates/trusty-console/src/proxy/routes.rs
@@ -108,16 +108,26 @@ fn full_id(service_key: &str) -> Option<&'static str> {
 /// non-loopback URL to enter the poller cache, forwarding to it would turn the
 /// console into an SSRF vector.  This guard prevents that by enforcing that the
 /// resolved base URL is always a local address before any bytes are sent.
-/// What: Returns `true` if `url` starts with `http://127.`, `http://[::1]`, or
-/// `http://localhost`; `false` for anything else.
-/// Test: `test_is_local_upstream_*` below.
+/// What: Requires the literal `http://` scheme (every upstream connection here
+/// is loopback HTTP), then hands the URL to
+/// [`origin_is_loopback`](crate::routes::origin_guard::origin_is_loopback) —
+/// the shared classifier that parses the authority and accepts only the host
+/// `localhost` or a host that parses as a loopback `IpAddr` (all of
+/// `127.0.0.0/8` and `::1`). Every other URL is `false`.
+///
+/// The host MUST be parsed, never prefix-matched: `url.starts_with("http://127.")`
+/// accepts the attacker-controlled DNS name `http://127.0.0.1.evil.com`, which
+/// resolves wherever its owner points it (#6945, the outbound-SSRF sibling of
+/// the inbound-CSRF #3319).
+/// Test: `test_is_local_upstream_*` below, incl.
+/// `test_is_local_upstream_rejects_loopback_lookalike_hosts`.
 // #6360: `pub(crate)` so the console's delete routes apply the same
 // loopback predicate before dialling a daemon, rather than minting a second
 // answer to "is this upstream local".
 pub(crate) fn is_local_upstream(url: &str) -> bool {
-    url.starts_with("http://127.")
-        || url.starts_with("http://[::1]")
-        || url.starts_with("http://localhost")
+    // #6945: scheme check stays a literal prefix — it is the only part of the
+    // URL a prefix test can decide — and the host goes to the shared parser.
+    url.starts_with("http://") && crate::routes::origin_guard::origin_is_loopback(url)
 }
 
 /// Normalize a service base URL to strip any accidental double-scheme prefix.
@@ -645,6 +655,43 @@ mod tests {
         assert!(!is_local_upstream("http://evil.example.com/steal"));
         assert!(!is_local_upstream("https://127.0.0.1:7878")); // https, not http
         assert!(!is_local_upstream("http://0.0.0.0:7878"));
+        // #6945: a URL with no scheme at all is not a loopback upstream.
+        assert!(!is_local_upstream("127.0.0.1:7878"));
+        assert!(!is_local_upstream(""));
+    }
+
+    /// Why: #6945 — the guard prefix-matched `http://127.`, `http://[::1]`, and
+    /// `http://localhost`, so every host below read as loopback while resolving
+    /// wherever its owner pointed it. The reverse proxy dials whatever passes
+    /// this predicate, which made the console an outbound-SSRF vector. Same
+    /// class as #3319 on the inbound CSRF guard, on the sibling that never got
+    /// the fix.
+    /// What: asserts each loopback-lookalike host is rejected — an IP- or
+    /// `localhost`-prefixed DNS name, a bracketed-IPv6 lookalike, and userinfo
+    /// in both directions.
+    /// Test: this test itself. Every assertion here FAILS on `origin/main`.
+    #[test]
+    fn test_is_local_upstream_rejects_loopback_lookalike_hosts() {
+        // IP-prefixed DNS names — the case named in the issue.
+        assert!(!is_local_upstream("http://127.0.0.1.evil.com"));
+        assert!(!is_local_upstream("http://127.0.0.1.evil.com:7878"));
+        assert!(!is_local_upstream("http://127.0.0.1.evil.com/steal"));
+        assert!(!is_local_upstream("http://127.attacker.com"));
+        // `localhost`-prefixed DNS names.
+        assert!(!is_local_upstream("http://localhost.evil.com"));
+        assert!(!is_local_upstream("http://localhostevil.com:7878"));
+        // Bracketed-IPv6 lookalikes.
+        assert!(!is_local_upstream("http://[::1].evil.com"));
+        assert!(!is_local_upstream("http://[::1]x.evil.com"));
+        // Userinfo, both directions: the host a client dials is what counts,
+        // and the parser refuses the shape rather than guessing which half wins.
+        // The `:80@` rows are the ones a naive host/port split gets wrong.
+        assert!(!is_local_upstream("http://127.0.0.1:80@evil.com"));
+        assert!(!is_local_upstream("http://[::1]:80@evil.com"));
+        assert!(!is_local_upstream("http://127.0.0.1@evil.com"));
+        assert!(!is_local_upstream("http://[::1]@evil.com"));
+        assert!(!is_local_upstream("http://localhost@evil.com"));
+        assert!(!is_local_upstream("http://evil.com@127.0.0.1"));
     }
 
     /// Why: full_id must map all known short service keys to their trusty-* IDs.


### PR DESCRIPTION
Refs #6945

## What changed

`is_local_upstream` (`crates/trusty-console/src/proxy/routes.rs`) prefix-matched
`http://127.`, `http://[::1]`, and `http://localhost`, so `http://127.0.0.1.evil.com`,
`http://localhost.evil.com`, and `http://[::1].evil.com` all read as loopback and
the reverse proxy would dial them. It now requires the `http://` scheme and hands
the host to the shared `origin_is_loopback` classifier, which accepts only
`localhost` or a host that parses as a loopback `IpAddr` (`127.0.0.0/8`, `::1`).

Reusing the shared classifier rather than writing a second parser exposed two
shapes that reached a loopback verdict through it, so the fix goes into
`parse_origin_authority` in `crates/trusty-common/src/server/origin_guard.rs`:

- The bracket branch split on `]` and dropped whatever followed, so
  `http://[::1].evil.com` read as host `::1`.
- Neither branch handled userinfo, so `http://127.0.0.1:80@evil.com` and
  `http://[::1]:80@evil.com` read the part before the `@` as the host.

The parser now returns `None` for any authority containing `@`, and for a
bracketed literal trailed by anything that is not a `:port`. That narrows the
inbound CSRF guard by the same amount; no well-formed `Origin` header or
`http_addr` discovery file carries either shape.

Same class as #3319 on the inbound guard, on the outbound sibling that never got
the fix. The delete-routes call site the issue names is gone — #6285 moved those
to a Unix socket — leaving the reverse proxy as the one live consumer.

Changelog fragments for both crates.

Two doc comments in `ui/src/servicesList.js` and `ui/src/servicesList.test.js`
still describe the Rust predicate as prefix-matching and are now stale. They are
NOT corrected here: any edit under `crates/trusty-console/ui/src/` fails the
required `Committed UI bundles match their source` gate until `ui/dist` is
rebuilt, and landing a regenerated minified bundle inside a security fix is the
wrong trade. Worth a follow-up docs PR that carries the rebuild.

## Rung

**Rung 5** (cross-crate security contract), which subsumes rung 4 for
`trusty-common`. A `code-critic` round is still owed — this PR is a draft and
auto-merge is not armed.

## Gates

Every command below exited 0.

| Command | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy -p trusty-console --all-targets -- -D warnings` | clean |
| `cargo clippy -p trusty-common --features axum-server --all-targets -- -D warnings` | clean |
| `cargo check --workspace --all-targets` | clean |
| `cargo test -p trusty-console --no-fail-fast` | 412 + 0 + 2 + 18 + 5 passed, 0 failed, 4 ignored across 5 targets + doc-tests |
| `bash scripts/test_trusty_common_lanes.sh core` | 2337 + 6 + 4 + 2 + 11 + 4 + 3 + 4 passed, 0 failed |
| `bash scripts/check_line_cap.sh` | 4537 files, 0 violations |
| `bash scripts/check_changelog_fragment.sh` | both crates recorded |
| `bash scripts/check_test_pointers.sh` | 31315 citations, 0 dangling |
| `bash scripts/check-ui-bundle-freshness.sh` | 5 crates, 174 source files, 0 findings |

## Regression tests, and that they fail without the fix

- `proxy::routes::tests::test_is_local_upstream_rejects_loopback_lookalike_hosts`
- `server::origin_guard::tests::origin_is_loopback_rejects_userinfo`
- `server::origin_guard::tests::origin_is_loopback_rejects_bracketed_ipv6_lookalikes`

With both function bodies reverted to their `origin/main` shape and the tests
kept, the raw failures were:

```
thread 'proxy::routes::tests::test_is_local_upstream_rejects_loopback_lookalike_hosts' panicked at
crates/trusty-console/src/proxy/routes.rs:676:9:
assertion failed: !is_local_upstream("http://127.0.0.1.evil.com")
test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 412 filtered out
```

```
thread 'server::origin_guard::tests::origin_is_loopback_rejects_userinfo' panicked at
crates/trusty-common/src/server/origin_guard.rs:352:9:
assertion failed: !origin_is_loopback("http://[::1]@evil.com")
test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 479 filtered out
```

The `[::1].evil.com` row was found by the first green run of the fix itself: the
shared parser accepted it, which is what sent the fix into `trusty-common`.

## Two unrelated flakes observed, neither caused by this branch

1. `cargo test -p trusty-console --no-fail-fast -- --include-ignored` failed once
   on `search_uds::routes::tests::a_slow_open_and_a_silent_first_frame_share_one_budget`
   ("did not open search.status.stream within 1s"). It is a 1s budget under a
   416-test concurrent load. `git diff --name-only origin/main...HEAD -- crates/trusty-console/src/search_uds/`
   is empty, and the test passes in isolation (`1 passed; 0 failed`).
2. The `core` trusty-common lane failed once on
   `migrations::file_stamp::tests::{read_returns_unversioned_on_corrupt_payload,overwrite_replaces_existing_stamp}`.
   Its `tempdir()` fixture names a directory `trusty-common-stamp-test-{pid}-{nanos}`,
   so two concurrent tests that read the same nanosecond share one directory —
   one reads the other's stamp, and one's cleanup removes the dir under the
   other's rename. The lane passes on `origin/main` and passed on re-run here.
   Not fixed in this PR: unrelated file, and widening a security fix to carry it
   is the wrong trade. Worth a separate issue.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
