### PR TITLE
fix: route the three remaining daemon accept loops through accept_sized (#6940)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6606,7 +6606,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11749,7 +11749,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/trusty-agents/changelog.d/6940-accept-sized-consumers.md
+++ b/crates/trusty-agents/changelog.d/6940-accept-sized-consumers.md
@@ -1,0 +1,14 @@
+Fixed
+
+- The controller's per-project socket loop (`ctrl::socket_listener`) and the
+  message bus's `accept_loop` now accept through
+  `trusty_common::uds::accept_sized` instead of `UnixListener::accept`
+  ([#6940](https://github.com/bobmatnyc/trusty-tools/issues/6940)). Linux builds
+  the server-side AF_UNIX socket from scratch and does not copy the listener's
+  `SO_SNDBUF`/`SO_RCVBUF` onto it, so both loops were serving sockets at
+  `net.core.wmem_default` however `bind_hardened` had sized the listener —
+  paying, on one end of every connection, the write-then-drain round trips
+  [#6896](https://github.com/bobmatnyc/trusty-tools/issues/6896) exists to
+  remove. `accept_sized` shipped in
+  [#6942](https://github.com/bobmatnyc/trusty-tools/pull/6942) but converted
+  only trusty-common's own call sites. Throughput only; no wire or API change.

--- a/crates/trusty-agents/src/bus/mod.rs
+++ b/crates/trusty-agents/src/bus/mod.rs
@@ -268,7 +268,9 @@ pub async fn subscribe_and_drain(
     };
     let drained = tokio::time::timeout(timeout, async move {
         let mut out: Vec<BusEnvelope> = Vec::new();
-        if let Ok((stream, _)) = listener.accept().await {
+        // #6940: accept the way `accept_loop` does, so the stub's socket carries
+        // the same sizing the real bus gives its own end (#6942).
+        if let Ok((stream, _)) = trusty_common::uds::accept_sized(&listener).await {
             let reader = BufReader::new(stream);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
@@ -296,10 +298,14 @@ pub async fn subscribe_and_drain(
 /// handled in its own spawned task that reads lines until EOF, deserializes
 /// each as `BusEnvelope`, and sends it on the broadcast channel. Lagged
 /// receivers are silently ignored.
-/// Test: Implicit via `start` integration test.
+/// Test: `ctrl_and_bus_accept_loops_size_the_accepted_socket`; the connection
+/// path itself is implicit via the `start` integration test.
 async fn accept_loop(listener: UnixListener, tx: broadcast::Sender<BusEnvelope>) {
     loop {
-        match listener.accept().await {
+        // #6940: Linux builds the accepted socket from scratch and does not copy
+        // the listener's SO_SNDBUF/SO_RCVBUF onto it, so this loop has to size
+        // its own end (#6942).
+        match trusty_common::uds::accept_sized(&listener).await {
             Ok((stream, _addr)) => {
                 // #5099: a foreign-uid peer is dropped without being served.
                 if let Err(e) = trusty_common::uds::ensure_peer_is_self(&stream) {

--- a/crates/trusty-agents/src/ctrl/socket_listener.rs
+++ b/crates/trusty-agents/src/ctrl/socket_listener.rs
@@ -52,12 +52,16 @@ use super::state::ConversationTurn;
 /// to actually stop the controller — Phase A leaves graceful shutdown for
 /// later). Each connection gets its own tokio task so a slow PM call does
 /// not block the listener.
-/// Test: Manual — `trusty-agents` from terminal A, then `trusty-agents "hello"` from
+/// Test: `ctrl_and_bus_accept_loops_size_the_accepted_socket`; end-to-end is
+/// manual — `trusty-agents` from terminal A, then `trusty-agents "hello"` from
 /// terminal B prints the PM's output in B and exits while A keeps running.
 pub async fn spawn_socket_listener(listener: tokio::net::UnixListener) {
     tracing::info!("ctrl: socket listener accepting connections");
     loop {
-        match listener.accept().await {
+        // #6940: Linux builds the accepted socket from scratch and does not copy
+        // the listener's SO_SNDBUF/SO_RCVBUF onto it, so this loop has to size
+        // its own end (#6942).
+        match trusty_common::uds::accept_sized(&listener).await {
             Ok((stream, _addr)) => {
                 // #5099: a foreign-uid peer is dropped without being served.
                 if let Err(e) = trusty_common::uds::ensure_peer_is_self(&stream) {
@@ -397,6 +401,63 @@ pub async fn forward_to_controller(
 mod tests {
     use super::*;
     use tokio::io::AsyncReadExt as _;
+
+    /// Why (#6940): Linux builds the server-side AF_UNIX socket from scratch in
+    /// `unix_stream_connect` and does not copy the listener's
+    /// `SO_SNDBUF`/`SO_RCVBUF` onto it, so an accept loop that calls
+    /// `UnixListener::accept` directly serves a socket at
+    /// `net.core.wmem_default` however the listener was sized.
+    /// `trusty_common::uds::accept_sized` (#6942) closes that, and this crate
+    /// drives two accept loops of its own.
+    ///
+    /// What: slices both accept-loop bodies out of the sources at compile time
+    /// and asserts each awaits `accept_sized` and holds no bare
+    /// `listener.accept()`.
+    ///
+    /// What this proves, and what it does not: the sizing itself belongs to
+    /// `accept_sized_raises_the_accepted_socket_to_the_listeners_sizing` in
+    /// trusty-common. What that test cannot say is whether THESE call sites
+    /// reach it, and no behavioural test here can either — neither loop hands
+    /// the accepted socket back to a caller, and macOS copies the listener's
+    /// sizing in `sonewconn` regardless, so an assertion on granted buffer
+    /// sizes passes on `origin/main` on the platform this suite runs on
+    /// locally. The call graph is what regressed and the call graph is what
+    /// this asserts.
+    /// Test: this test itself.
+    #[test]
+    fn ctrl_and_bus_accept_loops_size_the_accepted_socket() {
+        const CTRL: &str = include_str!("socket_listener.rs");
+        const BUS: &str = include_str!("../bus/mod.rs");
+
+        let loops = [
+            (
+                "ctrl::socket_listener::spawn_socket_listener",
+                CTRL,
+                "pub async fn spawn_socket_listener(",
+            ),
+            ("bus::accept_loop", BUS, "async fn accept_loop("),
+        ];
+
+        for (label, source, signature) in loops {
+            let start = source
+                .find(signature)
+                .unwrap_or_else(|| panic!("{label}: signature `{signature}` not found"));
+            let rest = &source[start..];
+            let end = rest.find("\n}\n").unwrap_or_else(|| {
+                panic!("{label}: no top-level closing brace after `{signature}`")
+            });
+            let body = &rest[..end];
+
+            assert!(
+                body.contains("trusty_common::uds::accept_sized(&listener).await"),
+                "{label} must accept through `accept_sized` (#6940), body was:\n{body}"
+            );
+            assert!(
+                !body.contains("listener.accept()"),
+                "{label} must not call `UnixListener::accept` directly (#6940), body was:\n{body}"
+            );
+        }
+    }
 
     /// Why (#5180): this connection is multi-message, so a send that emitted
     /// zero or two terminators would desynchronise the client's `read_line`

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd"
-version = "0.3.11"
+version = "0.3.12"
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-embedderd/changelog.d/6940-accept-sized-consumers.md
+++ b/crates/trusty-embedderd/changelog.d/6940-accept-sized-consumers.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `run_uds_accept_loop` now accepts through `trusty_common::uds::accept_sized`
+  instead of `UnixListener::accept`
+  ([#6940](https://github.com/bobmatnyc/trusty-tools/issues/6940)). Linux builds
+  the server-side AF_UNIX socket from scratch and does not copy the listener's
+  `SO_SNDBUF`/`SO_RCVBUF` onto it, so the daemon was serving its multi-KiB
+  embedding frames over a socket at `net.core.wmem_default` however
+  `bind_uds_listener` had sized the listener. `accept_sized` shipped in
+  [#6942](https://github.com/bobmatnyc/trusty-tools/pull/6942) but converted
+  only trusty-common's own call sites. Throughput only; no wire or API change.

--- a/crates/trusty-embedderd/src/uds_server.rs
+++ b/crates/trusty-embedderd/src/uds_server.rs
@@ -55,15 +55,19 @@ pub fn bind_uds_listener(path: &Path) -> Result<UnixListener> {
 /// Why: a single-threaded accept loop with detached per-connection tasks
 /// scales well for the daemon's expected load (dozens of concurrent in-host
 /// clients, short-lived requests).
-/// What: loops `listener.accept().await`; on each accepted stream, verifies the
+/// What: loops `trusty_common::uds::accept_sized`; on each accepted stream, verifies the
 /// peer's uid matches this process's own (#5099) and then clones the
 /// `BatchQueue` handle and spawns [`handle_connection`]. A foreign-uid peer is
 /// dropped without being served — the filesystem mode should already have made
 /// that unreachable, and this is what turns the mode into an enforced boundary.
-/// Test: covered by `concurrent_embed.rs` integration test.
+/// Test: `uds_accept_loop_sizes_the_accepted_socket`, plus the
+/// `concurrent_embed.rs` integration test for the connection path.
 pub async fn run_uds_accept_loop(listener: UnixListener, queue: Arc<BatchQueue>) {
     loop {
-        match listener.accept().await {
+        // #6940: Linux builds the accepted socket from scratch and does not copy
+        // the listener's SO_SNDBUF/SO_RCVBUF onto it, so this loop has to size
+        // its own end (#6942).
+        match trusty_common::uds::accept_sized(&listener).await {
             Ok((stream, _addr)) => {
                 if let Err(e) = trusty_common::uds::ensure_peer_is_self(&stream) {
                     tracing::warn!("rejected UDS connection: {e}");
@@ -194,6 +198,47 @@ mod tests {
     fn test_queue() -> BatchQueue {
         let embedder: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(EMBED_DIM));
         BatchQueue::new(embedder, BatchConfig::default())
+    }
+
+    /// Why (#6940): Linux builds the server-side AF_UNIX socket from scratch in
+    /// `unix_stream_connect` and does not copy the listener's
+    /// `SO_SNDBUF`/`SO_RCVBUF` onto it, so an accept loop that calls
+    /// `UnixListener::accept` directly serves a socket at
+    /// `net.core.wmem_default` however the listener was sized. This daemon's
+    /// frames are the multi-KiB embedding payloads that sizing exists for.
+    ///
+    /// What: slices `run_uds_accept_loop`'s body out of the source at compile
+    /// time and asserts it awaits `trusty_common::uds::accept_sized` (#6942)
+    /// and holds no bare `listener.accept()`.
+    ///
+    /// What this proves, and what it does not: the sizing itself belongs to
+    /// `accept_sized_raises_the_accepted_socket_to_the_listeners_sizing` in
+    /// trusty-common. What that test cannot say is whether THIS call site
+    /// reaches it, and no behavioural test here can either — the loop never
+    /// hands the accepted socket back to a caller, and macOS copies the
+    /// listener's sizing in `sonewconn` regardless, so an assertion on granted
+    /// buffer sizes passes on `origin/main` on the platform this suite runs on
+    /// locally. The call graph is what regressed and the call graph is what
+    /// this asserts.
+    /// Test: this test itself.
+    #[test]
+    fn uds_accept_loop_sizes_the_accepted_socket() {
+        const SOURCE: &str = include_str!("uds_server.rs");
+        const SIGNATURE: &str = "pub async fn run_uds_accept_loop(";
+
+        let start = SOURCE.find(SIGNATURE).expect("accept-loop signature");
+        let rest = &SOURCE[start..];
+        let end = rest.find("\n}\n").expect("top-level closing brace");
+        let body = &rest[..end];
+
+        assert!(
+            body.contains("trusty_common::uds::accept_sized(&listener).await"),
+            "run_uds_accept_loop must accept through `accept_sized` (#6940), body was:\n{body}"
+        );
+        assert!(
+            !body.contains("listener.accept()"),
+            "run_uds_accept_loop must not call `UnixListener::accept` directly (#6940), body was:\n{body}"
+        );
     }
 
     /// #5099 regression: the daemon's own bind path must produce a 0600


### PR DESCRIPTION
Consumer half of #6942. Linux builds the server-side AF_UNIX socket from scratch in `unix_stream_connect` and does not copy the listener's `SO_SNDBUF`/`SO_RCVBUF` onto it, so an accept loop calling `UnixListener::accept` directly serves a socket at `net.core.wmem_default` however `bind_hardened` sized the listener. #6942 added `trusty_common::uds::accept_sized` to close that but converted only trusty-common's own call sites.

## Sites converted

| File | Function |
|---|---|
| `crates/trusty-agents/src/ctrl/socket_listener.rs:64` | `spawn_socket_listener` |
| `crates/trusty-agents/src/bus/mod.rs:308` | `accept_loop` |
| `crates/trusty-agents/src/bus/mod.rs:273` | `subscribe_and_drain` (`#[cfg(test)]` stub, converted so it accepts the way the real bus does) |
| `crates/trusty-embedderd/src/uds_server.rs:70` | `run_uds_accept_loop` |

## The fourth site is not one

`crates/trusty-mcp/src/daemon_bridge.rs:372` is a `TcpListener` inside a `#[cfg(test)]` module. `accept_sized` takes a `&UnixListener`, and `git grep UnixListener crates/trusty-mcp/src/` finds only two doc-comment mentions, so that crate binds no Unix listener and has nothing to convert. trusty-mcp is untouched by this PR.

A workspace sweep for `.accept()` outside trusty-common finds 81 further hits across trusty-analyze, trusty-audit, trusty-code, trusty-console, trusty-git-analytics, trusty-installer, trusty-memory, trusty-mpm and trusty-review. Every one sits after that file's `#[cfg(test)]` boundary, so the three production loops above were the whole remainder.

## What the tests prove

Each crate gains one regression test — `ctrl_and_bus_accept_loops_size_the_accepted_socket` and `uds_accept_loop_sizes_the_accepted_socket` — that slices the accept-loop body out of the source at compile time (`include_str!`, the same shape as `trusty-analyze`'s `mcp::tests` and `trusty-common`'s `control_bus::tests`) and asserts it awaits `accept_sized` and holds no bare `listener.accept()`.

They assert the call graph, not the sizing. The sizing belongs to trusty-common's `accept_sized_raises_the_accepted_socket_to_the_listeners_sizing`. A behavioural assertion cannot serve here for two reasons: neither loop hands the accepted socket back to a caller, and macOS copies the listener's sizing in `sonewconn` regardless, so a granted-buffer-size assertion passes on `origin/main` on the development platform. The call graph is what regressed, so the call graph is what these assert.

Both were confirmed red against the pre-fix call sites:

```
test ctrl::socket_listener::tests::ctrl_and_bus_accept_loops_size_the_accepted_socket ... FAILED
ctrl::socket_listener::spawn_socket_listener must accept through `accept_sized` (#6940), body was:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3633 filtered out

test uds_server::tests::uds_accept_loop_sizes_the_accepted_socket ... FAILED
run_uds_accept_loop must accept through `accept_sized` (#6940), body was:
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 27 filtered out
```

## Version bump

`trusty-embedderd 0.3.11` is live on crates.io, so the #4421 gate needs a PATCH bump to `0.3.12` (`scripts/bump-version.sh trusty-embedderd patch --no-changelog`; `Cargo.lock` synced, the `^0.3.11` workspace-dependency row still accepts it). `trusty-agents 0.39.0` is not published and stays put.

```
[ OK ] trusty-agents 0.39.0 — src changed, version not yet published
[ OK ] trusty-embedderd — version bumped 0.3.11 -> 0.3.12
check-pr-version-bump: clear (0 warning(s)).
```

## Gates — rung 3 per crate

`cargo fmt --check` → exit 0.

`SKIP_UI_BUILD=1 cargo clippy -p trusty-agents --all-targets -- -D warnings` → exit 0.
`SKIP_UI_BUILD=1 cargo clippy -p trusty-embedderd --all-targets -- -D warnings` → exit 0.

`SKIP_UI_BUILD=1 cargo test -p trusty-agents --no-fail-fast` → exit 0, 14 targets:

```
running 3634 tests
test result: ok. 3621 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out; finished in 70.36s
test result: ok. 0 passed; 0 failed; 0 ignored (src/main.rs)
test result: ok. 6 passed; 0 failed; 3 ignored (api_e2e)
test result: ok. 4 passed; 0 failed; 0 ignored (cli_project)
test result: ok. 3 passed; 0 failed; 0 ignored (config_mount)
test result: ok. 1 passed; 0 failed; 0 ignored (home_lock_discipline)
test result: ok. 2 passed; 0 failed; 0 ignored (inference_shared_adapter_e2e)
test result: ok. 1 passed; 0 failed; 0 ignored (persona_python_plugin_wiring)
test result: ok. 9 passed; 0 failed; 0 ignored (plain_cli_repl)
test result: ok. 7 passed; 0 failed; 0 ignored (process_tracker_fail_open)
test result: ok. 2 passed; 0 failed; 0 ignored (slack_wss_crypto_provider)
test result: ok. 2 passed; 0 failed; 0 ignored (system_status_cli)
test result: ok. 4 passed; 0 failed; 0 ignored (version_provenance)
test result: ok. 0 passed; 0 failed; 0 ignored (Doc-tests)
```

`SKIP_UI_BUILD=1 cargo test -p trusty-embedderd --no-fail-fast` → exit 0, 4 targets:

```
running 28 tests
test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
test result: ok. 0 passed; 0 failed; 1 ignored (bit_identical)
test result: ok. 4 passed; 0 failed; 0 ignored (concurrent_embed)
test result: ok. 0 passed; 0 failed; 0 ignored (Doc-tests)
```

Doc gates:

```
line-cap: measured 4537 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
changelog-fragment gate: scanned 7 changed path(s); attributed 3 crate-source path(s); all 2 crate(s) with source changes are recorded.
test-pointers: resolved 31318 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.
sld-lint: scanned 63 spec doc(s) + 3681 code file(s); 0 error(s), 0 warning(s)
All 12 internal row(s) accept their member crate version.
```

Refs #6940

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
