### PR TITLE
docs(trusty-mpm): resolve heredoc shell-list Rustdoc link

### DIFF
--- a/crates/trusty-mpm/changelog.d/6979-heredoc-rustdoc-link.md
+++ b/crates/trusty-mpm/changelog.d/6979-heredoc-rustdoc-link.md
@@ -1,0 +1,3 @@
+Documentation
+
+- Fix the Rustdoc link to the shell list used by the PM guard's here-document scanner (#6979).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/heredoc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/heredoc.rs
@@ -143,7 +143,7 @@ impl HeredocBodies {
 /// destructive-delete rule that catches it today. `cat`, `python3`, `jq` and
 /// the rest consume the body as data instead.
 /// What: `true` when any whitespace-delimited token of the line, basename
-/// stripped, is one of [`QuoteScan`]'s sibling [`shell_lex::DASH_C_SHELLS`].
+/// stripped, is one of [`QuoteScan`]'s sibling [`super::shell_lex::DASH_C_SHELLS`].
 /// Scanning every token rather than the leading one keeps `sudo bash`,
 /// `env - bash` and `foo && bash <<EOF` on the conservative side; a false
 /// positive only restores the pre-#6946 splitting.


### PR DESCRIPTION
## Outcome

Restore strict Rustdoc validation by qualifying the heredoc documentation link to the sibling `shell_lex::DASH_C_SHELLS` constant. The unresolved link on main blocked CI for other PRs, including #6966.

Refs bobmatnyc/trusty-tools#6946

## Change and risk

One documentation line changes to `super::shell_lex::DASH_C_SHELLS`. Runtime behavior is unchanged. Rust ladder rung 1; no code or test logic changes.

## Validation

Strict broken-link Rustdoc validation passed in 39.01 seconds; the generated link target exists. Formatting, whitespace, and line-cap checks passed. The failure before this correction was an unresolved link at `heredoc.rs:146`. No baseline allowance or lint suppression was added.

## Review and documentation

The one-line documentation correction and `crates/trusty-mpm/changelog.d/6979-heredoc-rustdoc-link.md` are the entire scope. The source-path changelog gate requires the fragment even for this comment-only correction; its committed-head validation now passes.

Independent critic: APPROVE for the exact link correction at `59652421c567df3ab7ef2ce8d945ee4306606adb`, supported by strict Rustdoc validation and the generated target. Trusty-review filtered all comment-only hunks and returned degraded/UNKNOWN with no substantive code to review; that tool limitation is not counted as approval. The explicit documentation review supplies the review evidence.

Gitleaks scans cleared both the link correction and final fragment head `46f23fb760ab08b39f8fd44320ca320d2e558d12` with zero leaks. Required CI must pass before merge.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
