### PR TITLE
feat(trusty-code): own project config under .trusty-code and private state under ~/.trusty-code (#5426)

### DIFF
--- a/crates/trusty-code/README.md
+++ b/crates/trusty-code/README.md
@@ -108,7 +108,88 @@ workstream, and TUI flows. `run-workflow` remains the incomplete surface.
 | `tcode session …` | List, inspect, and create sessions |
 | `tcode attach`, `cancel`, `transcript` | Operate on an existing session |
 | `tcode workstream …` | Manage workstreams and their active state |
+| `tcode paths show\|import` | Report which config root wins; import a `.claude/` catalog |
 | `tcode run-workflow <name>` | Reserved workflow runner; not yet implemented |
+
+## Configuration layout (`.trusty-code`)
+
+Trusty Code owns two directories. It READS from three, and WRITES to only one
+of them.
+
+### Project configuration — `<project>/.trusty-code/`
+
+Agents, skills, plugins, `settings.json`, and `CLAUDE.md` are looked up in this
+order, highest precedence first:
+
+| # | Directory | Role |
+|---|---|---|
+| 1 | `<project>/.trusty-code/<entry>` | Trusty Code's own — read AND written |
+| 2 | `<project>/.claude/<entry>` | Claude Code compatibility input — read only |
+| 3 | `<project>/.open-mpm/<entry>` | Pre-Claude-Code legacy input — read only |
+
+The first candidate that exists **and can be opened** wins. When none exists,
+the resolved path is `<project>/.trusty-code/<entry>` anyway, so a clean project
+with no `.claude/` directory installs and runs normally.
+
+**Fallback is never silent.** A candidate that exists but cannot be read
+(permissions, a broken mount) is skipped rather than fatal — a harness that
+refuses to start over an unreadable optional config is worse than one that
+starts with less config — but it logs at `warn` to stderr naming the path tried,
+and `tcode paths show` lists it. A `settings.json` that resolves but then fails
+to read or parse falls through to the next harness-mode tier with the same
+warning.
+
+**Writes go to `.trusty-code/` only.** `.claude/` and `.open-mpm/` are inputs.
+A write aimed outside `<project>/.trusty-code/` — including one that reaches
+outside through a symlink — is refused, not redirected.
+
+Run `tcode paths show [--json]` to see which root won for each entry.
+
+### Private state — `~/.trusty-code/`
+
+Transcripts, logs, compression telemetry, daemon discovery files, and the
+workstream store are per-user runtime state, not project configuration. They
+live in `~/.trusty-code/`, which is created at mode `0700`; an existing
+directory with a permissive mode is tightened on the next run. `tcode paths
+show` reports whether the mode is currently owner-only.
+
+### Importing an existing `.claude/` catalog
+
+```bash
+tcode paths import --dry-run    # print the plan, write nothing
+tcode paths import              # apply exactly that plan
+```
+
+The import copies `.claude/agents/**`, `.claude/skills/**`, and
+`.claude/settings.json` to the same relative paths under `.trusty-code/`. It is
+deterministic (the plan is a function of the tree, sorted by target), so the dry
+run and the real run cannot disagree, and it is reversible — the report lists
+exactly the files it created and nothing else was touched.
+
+Four sources are refused rather than copied, each named in the output:
+
+- the target already exists — an import never overwrites a user-authored file;
+- the source is, or reaches through, a symlink out of `.claude/`;
+- the source carries the executable bit;
+- `settings.json` carries a secret-bearing key, or will not parse. Put
+  credentials in the environment or the secure store, never in a file the
+  project commits.
+
+Plugins are deliberately not copied: their provenance cannot be vouched for, so
+`.claude/plugins/` stays discoverable in place through the compatibility root.
+
+**What counts as a secret-bearing key.** The key is split into words on
+separators and camelCase boundaries, then matched word-exactly against `token`,
+`secret`, `password`, `passphrase`, `credential`, `authorization`, `apikey`,
+`accesskey` and `privatekey`. One entry covers every spelling: `api_key`,
+`API-KEY`, `x-api-key`, `xApiKey` and `APIKEY` all match. Matching on words
+rather than substrings is what keeps ordinary keys like `tokenizer` and
+`max_tokens` from being refused.
+
+**Limitation — keys, not values.** The scan reads key NAMES only. A credential
+stored under an unrelated key (`"endpoint": "https://user:pw@host"`) is not
+detected, and this check is not a substitute for a secret scanner on the
+repository itself.
 
 ## Build
 
@@ -120,8 +201,12 @@ cargo test -p trusty-code --no-fail-fast
 
 ## Design Constraints
 
-- **Claude-Code compatible** — reads `.claude/` config, agents, skills, MCP
-  descriptors, `CLAUDE.md`, and permission grants exactly as Claude Code does.
+- **Owns its own layout** — project configuration under
+  `<project>/.trusty-code/`, private mutable state under `~/.trusty-code/`
+  (mode `0700`). See [Configuration layout](#configuration-layout-trusty-code).
+- **Claude-Code compatible** — still reads `.claude/` config, agents, skills,
+  MCP descriptors, `CLAUDE.md`, and permission grants exactly as Claude Code
+  does, as a fallback behind its own directory. Never writes there.
 - **Per-agent model routing** — each agent may specify its own model
   (AWS Bedrock or OpenRouter).
 - **Single-instance per project** — one `tcode serve` process per `.claude/`

--- a/crates/trusty-code/README.md
+++ b/crates/trusty-code/README.md
@@ -179,12 +179,18 @@ Plugins are deliberately not copied: their provenance cannot be vouched for, so
 `.claude/plugins/` stays discoverable in place through the compatibility root.
 
 **What counts as a secret-bearing key.** The key is split into words on
-separators and camelCase boundaries, then matched word-exactly against `token`,
-`secret`, `password`, `passphrase`, `credential`, `authorization`, `apikey`,
-`accesskey` and `privatekey`. One entry covers every spelling: `api_key`,
-`API-KEY`, `x-api-key`, `xApiKey` and `APIKEY` all match. Matching on words
-rather than substrings is what keeps ordinary keys like `tokenizer` and
-`max_tokens` from being refused.
+separators and camelCase boundaries, each word is de-pluralised, then matched
+word-exactly against `token`, `secret`, `password`, `passphrase`, `credential`,
+`authorization`, `apikey`, `accesskey` and `privatekey`. One entry covers every
+spelling: `api_key`, `API-KEY`, `x-api-key`, `xApiKey`, `APIKEY` and `apiKeys`
+all match. Matching on words rather than substrings keeps `tokenizer` and
+`secretary` from being refused.
+
+A short exemption list covers whole keys that name a COUNT rather than a
+credential — `max_tokens`, `min_tokens`, `token_count`, `token_limit` and
+friends. Without it, de-pluralising `tokens` would refuse the LLM sampling
+parameters this crate's own settings carry. The exemption matches the entire key
+only, so `max_tokens_api_key` is still refused.
 
 **Limitation — keys, not values.** The scan reads key NAMES only. A credential
 stored under an unrelated key (`"endpoint": "https://user:pw@host"`) is not

--- a/crates/trusty-code/changelog.d/5426-tcode-paths-subcommand.md
+++ b/crates/trusty-code/changelog.d/5426-tcode-paths-subcommand.md
@@ -1,0 +1,19 @@
+Added
+
+- **`tcode paths show` and `tcode paths import` (#5426).** `show` reports which
+  configuration root won for each entry, the write root, and whether the private
+  state directory's permissions are owner-only — `--json` for scripts. `import`
+  copies `.claude/agents/**`, `.claude/skills/**`, and `.claude/settings.json`
+  into `.trusty-code/`. The plan is deterministic and printed before anything is
+  written (`--dry-run` stops there), and the applied report lists exactly the
+  files created, so the import is reversible by deleting them. It refuses four
+  classes of source rather than copying them: a target that already exists (an
+  import never overwrites a user-authored file), a source that reaches through a
+  symlink out of `.claude/`, a source carrying the executable bit, and a
+  `settings.json` that holds a secret-bearing key or will not parse. The
+  secret check splits a key into words on separators and camelCase boundaries
+  and matches word-exactly, so `api_key`, `API-KEY`, `x-api-key` and `xApiKey`
+  are all caught while ordinary keys like `tokenizer` and `max_tokens` are not;
+  it reads key names only, never values. Plugins are not copied — their
+  provenance cannot be vouched for, so `.claude/plugins/` stays discoverable in
+  place through the compatibility root.

--- a/crates/trusty-code/changelog.d/5426-tcode-paths-subcommand.md
+++ b/crates/trusty-code/changelog.d/5426-tcode-paths-subcommand.md
@@ -11,9 +11,11 @@ Added
   import never overwrites a user-authored file), a source that reaches through a
   symlink out of `.claude/`, a source carrying the executable bit, and a
   `settings.json` that holds a secret-bearing key or will not parse. The
-  secret check splits a key into words on separators and camelCase boundaries
-  and matches word-exactly, so `api_key`, `API-KEY`, `x-api-key` and `xApiKey`
-  are all caught while ordinary keys like `tokenizer` and `max_tokens` are not;
-  it reads key names only, never values. Plugins are not copied — their
+  secret check splits a key into words on separators and camelCase boundaries,
+  de-pluralises each word, and matches word-exactly, so `api_key`, `API-KEY`,
+  `x-api-key`, `xApiKey` and `apiKeys` are all caught while `tokenizer` and
+  `secretary` are not; a short whole-key exemption list keeps count-shaped
+  parameters like `max_tokens` and `token_count` importable. It reads key names
+  only, never values. Plugins are not copied — their
   provenance cannot be vouched for, so `.claude/plugins/` stays discoverable in
   place through the compatibility root.

--- a/crates/trusty-code/changelog.d/5426-trusty-code-owns-its-layout.md
+++ b/crates/trusty-code/changelog.d/5426-trusty-code-owns-its-layout.md
@@ -1,0 +1,24 @@
+Changed
+
+- **Trusty Code owns `<project>/.trusty-code/` and `~/.trusty-code/` (#5426,
+  epic #2892).** Every discovery site used to join the literal `.claude/`
+  itself — agents, skills, plugins, `settings.json`, `CLAUDE.md` — which made
+  another product's directory the source of truth for this one, left a clean
+  project unable to install or run without a `.claude/` tree, and put nothing
+  between the harness and a write INTO that directory. The new
+  `trusty_code::paths` module is now the single resolver those call sites route
+  through: `.trusty-code/` first, then `.claude/`, then `.open-mpm/`, and when
+  none exists the resolved path names `.trusty-code/` anyway, so a project with
+  no `.claude/` directory works end to end. `agent_loop::cadence` reads the same
+  resolved `settings.json` as `mode` does, so `cadence_turns` and
+  `max_overhead_fraction_pct` survive the move rather than silently reverting to
+  their defaults on a `.trusty-code`-only project. A candidate that exists but
+  cannot be read is skipped rather than fatal, and says so — a `warn` naming the
+  path tried, and a line in `tcode paths show`. Writes are the other half and
+  are deliberately a different function: `check_native_write_target` anchors
+  `<project>/.trusty-code/` to the project before comparing anything against it,
+  so neither a symlinked subdirectory nor a symlinked config ROOT can redirect a
+  write outside the project. Private mutable state (transcripts, logs,
+  telemetry, the workstream store) resolves through one place too and is created
+  at mode `0700`, with an existing permissive `~/.trusty-code` tightened on the
+  next run.

--- a/crates/trusty-code/src/agent_loop/cadence.rs
+++ b/crates/trusty-code/src/agent_loop/cadence.rs
@@ -19,7 +19,7 @@
 //! for a single pathological oversized turn that would otherwise blow the
 //! budget between cadence fires.
 //! What: [`CadenceConfig`] (`cadence_turns` + `max_overhead_fraction_pct`,
-//! resolved from `.claude/settings.json`'s `code_harness.*` keys and two
+//! resolved from the project's `settings.json` `code_harness.*` keys and two
 //! escape-hatch env vars via [`resolve_cadence_config`], mirroring
 //! `crate::mode`'s precedence convention); [`maybe_cadence_compress`] (the
 //! turn-boundary entry point `agent_loop::AgentLoop` calls) which (1) ticks
@@ -125,8 +125,8 @@ impl CadenceConfig {
 }
 
 /// Resolve a project's [`CadenceConfig`] via the `code_harness.*`
-/// `.claude/settings.json` precedence chain `crate::mode::resolve_mode`
-/// establishes, adapted to this config's two knobs.
+/// `settings.json` precedence chain `crate::mode::resolve_mode` establishes,
+/// adapted to this config's two knobs.
 ///
 /// Why: An operator needs to tune cadence per-project (`settings.json`) or
 /// per-process (the escape-hatch env vars) without a code change, matching
@@ -134,7 +134,7 @@ impl CadenceConfig {
 /// there is no `task.run`-request tier — this ticket does not add a
 /// per-call cadence override to the wire protocol, so the chain is simply
 /// env var (highest) > `settings.json` > built-in default.
-/// What: Starts from `.claude/settings.json`'s `code_harness.cadence_turns`/
+/// What: Starts from the resolved `settings.json`'s `code_harness.cadence_turns`/
 /// `code_harness.max_overhead_fraction_pct` (via
 /// [`read_settings_json_cadence`], falling back to [`CadenceConfig::default`]
 /// when the file/keys are absent or malformed — never an error, matching
@@ -169,23 +169,56 @@ pub fn resolve_cadence_config(project_root: &Path) -> CadenceConfig {
     cfg
 }
 
-/// Read `<project_root>/.claude/settings.json`'s `code_harness.cadence_turns`
-/// / `code_harness.max_overhead_fraction_pct` keys.
+/// Read the project's `settings.json` `code_harness.cadence_turns` /
+/// `code_harness.max_overhead_fraction_pct` keys.
 ///
-/// Why: mirrors `crate::mode::read_settings_json_mode`'s graceful-degrade
-/// convention for the same project-scoped config file.
-/// What: `None` when the file is missing, unreadable, not valid JSON, or has
-/// no `code_harness` object at all; otherwise `Some(CadenceConfig)` starting
-/// from [`CadenceConfig::default`] with either field overridden by whichever
-/// of the two keys is present and a valid non-negative integer (a present
-/// but wrong-typed key is silently skipped for that field, not an error for
-/// the whole read).
+/// Why: this reader and `crate::mode::read_settings_json_mode` read the SAME
+/// physical file. #5426 moved that file to `.trusty-code/settings.json` and left
+/// this one joining `.claude/settings.json`, so a `.trusty-code`-only project
+/// kept its mode override and silently lost its cadence override (code-critic
+/// HIGH, PR #6980). Both now resolve through one function.
+/// What: the file comes from [`crate::paths::settings_file`] — `.trusty-code/`
+/// then `.claude/` then `.open-mpm/`. `None` when no file resolves or it has no
+/// `code_harness` object; otherwise `Some(CadenceConfig)` starting from
+/// [`CadenceConfig::default`] with either field overridden by whichever of the
+/// two keys is present and a valid non-negative integer (a present but
+/// wrong-typed key is skipped for that field, not an error for the whole read).
+/// A file that resolved but then fails to read or parse warns with the path
+/// tried before degrading, matching `mode`'s fail-open convention.
 /// Test: `cadence::tests::resolve_cadence_config_settings_json_override`,
-/// `cadence::tests::read_settings_json_cadence_missing_file_is_not_an_error`.
+/// `cadence::tests::read_settings_json_cadence_missing_file_is_not_an_error`,
+/// `cadence::tests::trusty_code_settings_json_sets_cadence_without_a_claude_dir`.
 fn read_settings_json_cadence(project_root: &Path) -> Option<CadenceConfig> {
-    let path = project_root.join(".claude").join("settings.json");
-    let raw = std::fs::read_to_string(path).ok()?;
-    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    // #5426: resolved, not joined — the same resolver `crate::mode` uses.
+    let resolved = crate::paths::settings_file(project_root);
+    if resolved.source == crate::paths::ConfigSource::Default {
+        return None;
+    }
+    let path = resolved.path;
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "project settings.json resolved but could not be read; \
+                 keeping the default cadence configuration"
+            );
+            return None;
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "project settings.json is not valid JSON; \
+                 keeping the default cadence configuration"
+            );
+            return None;
+        }
+    };
     let harness = value.get("code_harness")?;
 
     let mut cfg = CadenceConfig::default();

--- a/crates/trusty-code/src/agent_loop/cadence_tests.rs
+++ b/crates/trusty-code/src/agent_loop/cadence_tests.rs
@@ -61,6 +61,53 @@ fn read_settings_json_cadence_missing_file_is_not_an_error() {
     assert_eq!(read_settings_json_cadence(project.path()), None);
 }
 
+/// A `.trusty-code`-only project's cadence override is honoured (#5426).
+///
+/// Why: code-critic HIGH on PR #6980 — this reader still joined
+/// `.claude/settings.json` while its sibling reader of the SAME file
+/// (`mode::read_settings_json_mode`) had moved to the resolver, so a project
+/// with no `.claude/` kept its mode override and silently lost its cadence
+/// override. On the reviewed head this returns `None` and the assertion below
+/// fails on the default `cadence_turns`.
+/// What: writes only `.trusty-code/settings.json` and asserts both keys apply,
+/// then adds a conflicting `.claude/settings.json` and asserts the native file
+/// still wins.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn trusty_code_settings_json_sets_cadence_without_a_claude_dir() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let native = tmp.path().join(".trusty-code");
+    std::fs::create_dir_all(&native).expect("mkdir");
+    std::fs::write(
+        native.join("settings.json"),
+        r#"{"code_harness": {"cadence_turns": 3, "max_overhead_fraction_pct": 25}}"#,
+    )
+    .expect("write settings.json");
+    assert!(!tmp.path().join(".claude").exists());
+
+    with_cadence_env(None, None, || {
+        let cfg = resolve_cadence_config(tmp.path());
+        assert_eq!(cfg.cadence_turns, 3);
+        assert_eq!(cfg.max_overhead_fraction_pct, 25);
+    })
+    .await;
+
+    let compat = tmp.path().join(".claude");
+    std::fs::create_dir_all(&compat).expect("mkdir");
+    std::fs::write(
+        compat.join("settings.json"),
+        r#"{"code_harness": {"cadence_turns": 9, "max_overhead_fraction_pct": 90}}"#,
+    )
+    .expect("write settings.json");
+
+    with_cadence_env(None, None, || {
+        let cfg = resolve_cadence_config(tmp.path());
+        assert_eq!(cfg.cadence_turns, 3, ".trusty-code/settings.json must win");
+        assert_eq!(cfg.max_overhead_fraction_pct, 25);
+    })
+    .await;
+}
+
 #[tokio::test]
 async fn resolve_cadence_config_settings_json_override() {
     let project = project_with_settings(Some(

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -204,27 +204,21 @@ pub(crate) fn load_embedded_default_agents() -> Vec<AgentConfig> {
 
 /// Locate the agents directory for the given project root.
 ///
-/// Why: projects may use either `.claude/agents` (Claude Code native) or
-/// `.open-mpm/agents` (open-mpm legacy). Checking both preserves
-/// compatibility. Shared between `main.rs`'s `run-task` CLI path and (#2056)
-/// `serve::build_router`'s `task.run` wiring, so a project's agents resolve
-/// identically whether driven from the CLI or the daemon.
-/// What: returns the first of the two conventional directories that exists;
-/// falls back to `.claude/agents` (which may not exist yet — callers that
-/// need it to exist check separately, e.g. via [`md_loader::load_md_agent`]'s
-/// own error).
-/// Test: `agents::tests::locate_agents_dir_prefers_claude_then_open_mpm_then_default`.
+/// Why: this crate's agents live under Trusty Code's OWN `.trusty-code/agents`
+/// (#5426); `.claude/agents` and `.open-mpm/agents` remain readable so no
+/// existing project breaks. Shared between `main.rs`'s `run-task` CLI path and
+/// (#2056) `serve::build_router`'s `task.run` wiring, so a project's agents
+/// resolve identically whether driven from the CLI or the daemon.
+/// What: delegates to [`crate::paths::agents_dir`] — the single precedence rule
+/// (`.trusty-code` → `.claude` → `.open-mpm`) — and keeps only its path. Falls
+/// back to `.trusty-code/agents`, which may not exist yet; callers that need it
+/// to exist check separately, e.g. via [`md_loader::load_md_agent`]'s own error.
+/// Callers wanting to know WHICH root won call `paths::agents_dir` directly.
+/// Test: `agents::tests::locate_agents_dir_prefers_claude_then_open_mpm_then_default`,
+/// `paths::tests::agents_dir_prefers_trusty_code`.
 pub fn locate_agents_dir(project_root: &Path) -> std::path::PathBuf {
-    let claude_agents = project_root.join(".claude").join("agents");
-    if claude_agents.exists() {
-        return claude_agents;
-    }
-    let open_mpm_agents = project_root.join(".open-mpm").join("agents");
-    if open_mpm_agents.exists() {
-        return open_mpm_agents;
-    }
-    // Default to .claude/agents (may not exist yet).
-    claude_agents
+    // #5426: one resolver, not a second copy of the precedence chain.
+    crate::paths::agents_dir(project_root).path
 }
 
 /// Failure modes of [`resolve_agent`].
@@ -709,16 +703,22 @@ mod tests {
         assert_eq!(agents[0].agent.name, "custom");
     }
 
-    /// `locate_agents_dir` prefers `.claude/agents`, falls back to
-    /// `.open-mpm/agents`, and defaults to `.claude/agents` when neither
-    /// exists.
+    /// `locate_agents_dir` prefers `.trusty-code/agents`, then `.claude/agents`,
+    /// then `.open-mpm/agents`, and defaults to `.trusty-code/agents` when none
+    /// exists (#5426).
+    ///
+    /// Why: the default is the half that changed — a clean project must resolve
+    /// its agents to Trusty Code's OWN directory, not to Claude Code's, so a
+    /// project can install and run with no `.claude/` at all.
+    /// What: walks the three roots bottom-up, asserting the winner at each step.
+    /// Test: this function IS the test.
     #[test]
     fn locate_agents_dir_prefers_claude_then_open_mpm_then_default() {
         let tmp = tempfile::tempdir().expect("tempdir");
         assert_eq!(
             locate_agents_dir(tmp.path()),
-            tmp.path().join(".claude").join("agents"),
-            "default (neither exists) must be .claude/agents"
+            tmp.path().join(".trusty-code").join("agents"),
+            "default (none exists) must be .trusty-code/agents"
         );
 
         std::fs::create_dir_all(tmp.path().join(".open-mpm").join("agents")).expect("mkdir");
@@ -732,7 +732,14 @@ mod tests {
         assert_eq!(
             locate_agents_dir(tmp.path()),
             tmp.path().join(".claude").join("agents"),
-            "must prefer .claude/agents when both exist"
+            "must prefer .claude/agents over .open-mpm/agents"
+        );
+
+        std::fs::create_dir_all(tmp.path().join(".trusty-code").join("agents")).expect("mkdir");
+        assert_eq!(
+            locate_agents_dir(tmp.path()),
+            tmp.path().join(".trusty-code").join("agents"),
+            "must prefer .trusty-code/agents over every compatibility root"
         );
     }
 

--- a/crates/trusty-code/src/cli/mod.rs
+++ b/crates/trusty-code/src/cli/mod.rs
@@ -34,6 +34,10 @@
 //! engineer-model resolution, LLM-client construction). It is a subcommand
 //! handler like every other file here, and was moved out of `main.rs` when
 //! that file reached 498 of the 500-SLOC cap; see its module docs.
+//! (#5426) [`paths`] is the fourth: `tcode paths show|import` reports which
+//! configuration root wins for each entry and migrates a `.claude/` catalog into
+//! `.trusty-code/`. It starts no daemon; every rule lives in
+//! `trusty_code::paths`.
 //! (#5441) [`bakeoff`] is the third: `bakeoff-gate` judges a retained
 //! bake-off evidence bundle entirely offline, so it starts no daemon and makes
 //! no JSON-RPC call at all. It is glue like the rest — every rule lives in
@@ -49,6 +53,7 @@ pub mod bakeoff;
 pub mod cancel;
 pub mod daemon_autospawn;
 pub mod legacy_run_task;
+pub mod paths;
 pub mod run_task;
 pub mod session;
 pub mod tcode_exe;

--- a/crates/trusty-code/src/cli/paths.rs
+++ b/crates/trusty-code/src/cli/paths.rs
@@ -1,0 +1,160 @@
+//! `tcode paths show` / `tcode paths import` — configuration-layout diagnostics
+//! and the legacy import (#5426).
+//!
+//! Why: after #5426 a project can be configured under `.trusty-code/`, under
+//! `.claude/`, or under both, and the operator's first question is "which one is
+//! actually winning?". Answering it by reading the source is exactly the drift
+//! the single resolver exists to prevent, so the resolver reports it directly.
+//! `import` is the other half: it moves an existing `.claude/` catalog into
+//! Trusty Code's own directory, showing the plan before it does anything.
+//!
+//! What: [`show`] prints the winning source and path for agents, skills,
+//! plugins, `settings.json`, and `CLAUDE.md`, plus the private state directory
+//! and whether its permissions are restrictive. [`import`] prints the plan and,
+//! unless `--dry-run`, applies it. Every decision lives in
+//! [`trusty_code::paths`]; this file is argument-shaped glue and rendering, like
+//! every other handler here.
+//!
+//! Test: `tests/cli_e2e.rs::paths_show_reports_the_winning_source`,
+//! `tests/cli_e2e.rs::paths_import_dry_run_writes_nothing`.
+
+use std::path::Path;
+
+use anyhow::Result;
+use trusty_code::paths::{self, EntryKind, private_state};
+
+/// The entries `tcode paths show` reports, in display order.
+///
+/// Why: one table so the human rendering and the JSON rendering cannot list
+/// different things.
+/// What: `(label, relative path, kind)` triples.
+/// Test: `tests/cli_e2e.rs::paths_show_reports_the_winning_source`.
+const REPORTED: &[(&str, &str, EntryKind)] = &[
+    ("agents", "agents", EntryKind::Dir),
+    ("skills", "skills", EntryKind::Dir),
+    ("plugins", "plugins", EntryKind::Dir),
+    ("settings", paths::SETTINGS_FILENAME, EntryKind::File),
+    ("context", "CLAUDE.md", EntryKind::File),
+];
+
+/// Print which configuration root wins for each entry.
+///
+/// Why: the diagnostic #5426 asks for — "report the winning source and target".
+/// What: one line per [`REPORTED`] entry as `<label>  <source>  <path>`, then
+/// the write root and the private state directory with its privacy status. With
+/// `json`, the same facts as one object on stdout so a script can assert on
+/// them. Unreadable candidates that were skipped are listed too — they already
+/// warned to stderr, and a diagnostic that hid them would be the wrong tool for
+/// the job it exists to do.
+/// Test: `tests/cli_e2e.rs::paths_show_reports_the_winning_source`.
+pub fn show(project_root: &Path, json: bool) -> Result<()> {
+    let state_dir = private_state::private_state_dir();
+    let private_ok = private_state::is_restrictive(&state_dir).ok();
+
+    if json {
+        let entries: serde_json::Map<String, serde_json::Value> = REPORTED
+            .iter()
+            .map(|(label, relative, kind)| {
+                let r = paths::resolve_project_entry(project_root, relative, *kind);
+                (
+                    (*label).to_string(),
+                    serde_json::json!({
+                        "source": r.source.as_str(),
+                        "path": r.path.display().to_string(),
+                        "skipped_unreadable": r
+                            .unreadable
+                            .iter()
+                            .map(|p| p.display().to_string())
+                            .collect::<Vec<_>>(),
+                    }),
+                )
+            })
+            .collect();
+        let doc = serde_json::json!({
+            "project_root": project_root.display().to_string(),
+            "write_root": paths::native_config_dir(project_root).display().to_string(),
+            "private_state_dir": state_dir.display().to_string(),
+            "private_state_restrictive": private_ok,
+            "entries": entries,
+        });
+        println!("{}", serde_json::to_string_pretty(&doc)?);
+        return Ok(());
+    }
+
+    println!("project root      {}", project_root.display());
+    println!(
+        "write root        {}  (trusty-code writes only here)",
+        paths::native_config_dir(project_root).display()
+    );
+    println!();
+    for (label, relative, kind) in REPORTED {
+        let r = paths::resolve_project_entry(project_root, relative, *kind);
+        println!("{label:<10} {:<12} {}", r.source.as_str(), r.path.display());
+        for skipped in &r.unreadable {
+            println!("{:<10} {:<12} {}", "", "unreadable", skipped.display());
+        }
+    }
+    println!();
+    println!("private state     {}", state_dir.display());
+    println!(
+        "permissions       {}",
+        match private_ok {
+            Some(true) => "owner-only".to_string(),
+            Some(false) => "PERMISSIVE — run `tcode paths import` or chmod 700".to_string(),
+            None => "unknown (directory not created yet)".to_string(),
+        }
+    );
+    Ok(())
+}
+
+/// Plan, print, and (unless `dry_run`) apply the `.claude/` → `.trusty-code/`
+/// import.
+///
+/// Why: the plan is printed in both modes so `--dry-run` output and the real
+/// run's output describe the same work — the property that makes a dry run
+/// worth trusting.
+/// What: [`paths::import::plan_import`], printed one line per entry; with
+/// `dry_run` it stops there, otherwise it applies the plan and prints the
+/// created and refused counts. It also creates and tightens the private state
+/// directory, since that is the other half of the layout an operator running
+/// this command is adopting.
+/// Test: `tests/cli_e2e.rs::paths_import_dry_run_writes_nothing`.
+pub fn import(project_root: &Path, dry_run: bool) -> Result<()> {
+    let plan = paths::import::plan_import(project_root);
+    if plan.entries.is_empty() {
+        println!("nothing to import: no .claude/agents, .claude/skills, or .claude/settings.json");
+    }
+    for entry in &plan.entries {
+        match &entry.action {
+            paths::import::ImportAction::Copy => {
+                println!("copy    {}", entry.to.display());
+            }
+            paths::import::ImportAction::Refuse(reason) => {
+                println!("skip    {} — {reason}", entry.from.display());
+            }
+        }
+    }
+
+    if dry_run {
+        println!("\n--dry-run: nothing was written.");
+        return Ok(());
+    }
+
+    let report = paths::import::apply_import(&plan);
+    match private_state::ensure_private_state_dir() {
+        Ok(dir) => println!("\nprivate state {} (owner-only)", dir.display()),
+        Err(e) => eprintln!("\nwarning: could not create the private state directory: {e}"),
+    }
+    println!(
+        "imported {} file(s); skipped {}.",
+        report.created.len(),
+        report.refused.len()
+    );
+    if !report.created.is_empty() {
+        println!("to undo, delete exactly these files:");
+        for path in &report.created {
+            println!("  {}", path.display());
+        }
+    }
+    Ok(())
+}

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -180,10 +180,28 @@ pub mod llm;
 /// Test: `assets::tests::*`.
 pub mod assets;
 
+/// Trusty Code's own configuration and state layout (#5426, epic #2892).
+///
+/// Why: every discovery site used to join the literal `.claude/` itself, which
+/// made another product's directory the source of truth for this one and left
+/// nothing stopping a write INTO it. #5426 makes `<project>/.trusty-code/` the
+/// read-preferred and write-only location, with `.claude/` (and `.open-mpm/`)
+/// demoted to compatibility inputs.
+/// What: `resolve_project_entry` (the one precedence rule: `.trusty-code` →
+/// `.claude` → `.open-mpm`, then a native default) plus the per-entry
+/// `agents_dir`/`skills_dir`/`plugins_dir`/`settings_file` wrappers;
+/// `native_config_dir`/`check_native_write_target` (the write boundary, symlink
+/// escapes included); `private_state` (`~/.trusty-code/`, mode `0700`); and
+/// `import` (the deterministic, non-overwriting `.claude/` import).
+/// Test: `paths::tests::*`, `paths::private_state::private_state_tests::*`,
+/// `paths::import::import_tests::*`.
+pub mod paths;
+
 /// Agent configuration loading.
 ///
 /// Why: Sub-agents are defined declaratively in Markdown+frontmatter files
-/// under `.claude/agents/` (#2897 Slice D — TOML retired) so model, prompt,
+/// under `.trusty-code/agents/` — or `.claude/agents/` on a project that has not
+/// imported yet (#5426; #2897 Slice D — TOML retired) so model, prompt,
 /// and parameters can evolve without code changes.
 /// What: `AgentConfig`, `AgentInfo`, `LlmParams`, `SystemPrompt`, `ToolsConfig`,
 /// `RunnerConfig`, `RunnerKind`, `discover_agents`, `load_all_agents`.

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -264,6 +264,17 @@ enum Command {
     /// binary (epic #2400 Wave 1, #2405).
     Config(trusty_common::inference::config::ConfigCommand),
 
+    /// Inspect and migrate trusty-code's own configuration layout (#5426).
+    ///
+    /// Trusty Code reads `<project>/.trusty-code/` first and falls back to
+    /// `.claude/` then `.open-mpm/`; it WRITES only beneath `.trusty-code/`.
+    /// Private mutable state (transcripts, logs, telemetry) lives in
+    /// `~/.trusty-code/` at mode 0700.
+    Paths {
+        #[command(subcommand)]
+        action: PathsCommand,
+    },
+
     /// Manage workstreams — durable named groupings of sessions bound to the
     /// daemon's project (#3296, DOC-48 §5.4). `tcode ws` is a short alias
     /// for this whole family (DOC-48 AC-5.3).
@@ -313,6 +324,37 @@ enum Command {
         /// Emit the verdict as one JSON document instead of a human summary.
         #[arg(long)]
         json: bool,
+    },
+}
+
+/// `tcode paths <action>` subcommands (#5426).
+///
+/// Both variants carry their own `--project` (defaulting to `.`), matching the
+/// per-leaf convention every other subcommand family here uses.
+#[derive(Subcommand)]
+enum PathsCommand {
+    /// Report which configuration root wins for each entry, plus the write
+    /// root and the private state directory's permissions.
+    Show {
+        /// Path to the project root.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+
+        /// Emit the report as JSON instead of a human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Import `.claude/agents`, `.claude/skills`, and `.claude/settings.json`
+    /// into `.trusty-code/`, never overwriting an existing file.
+    Import {
+        /// Path to the project root.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+
+        /// Print the plan and exit without writing anything.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -540,6 +582,13 @@ async fn main() -> Result<()> {
         }
 
         Command::Config(cmd) => cmd.run().await,
+
+        // #5426: offline and daemon-free — it reads the project tree and, for
+        // `import`, writes only beneath `<project>/.trusty-code/`.
+        Command::Paths { action } => match action {
+            PathsCommand::Show { project, json } => cli::paths::show(&project, json),
+            PathsCommand::Import { project, dry_run } => cli::paths::import(&project, dry_run),
+        },
 
         Command::Workstream { action } => match action {
             WorkstreamCommand::List {

--- a/crates/trusty-code/src/mode.rs
+++ b/crates/trusty-code/src/mode.rs
@@ -148,22 +148,56 @@ pub fn resolve_mode(task_param: Option<&str>, project_root: Option<&Path>) -> Ha
     HarnessMode::default()
 }
 
-/// Read `<project_root>/.claude/settings.json`'s `code_harness.mode` key.
+/// Read the project's `settings.json` `code_harness.mode` key.
 ///
-/// Why: the Claude-Code-compatible, project-scoped config location §5.9's
-/// example JSON uses.
-/// What: `None` when the file is missing, unreadable, not valid JSON, or
-/// the key is absent/unparseable — absence at any step is "this source
+/// Why: the project-scoped config location §5.9's example JSON uses. #5426
+/// moves it to Trusty Code's own `.trusty-code/settings.json` while keeping
+/// `.claude/settings.json` readable, so a project that has not imported yet
+/// still gets its configured mode.
+/// What: the file comes from [`crate::paths::settings_file`] — same precedence
+/// as agents, skills, and plugins. `None` when the file is missing, not valid
+/// JSON, or the key is absent/unparseable; absence at any step is "this source
 /// does not contribute", never an error (mirrors
-/// `project_context::load_project_context`'s same graceful-degrade
-/// convention for a project-scoped config file).
+/// `project_context::load_project_context`'s same graceful-degrade convention).
+/// A file that resolved but then fails to READ or PARSE is a different case — a
+/// config the operator wrote and expects to take effect — so it falls back to
+/// the next tier with a `warn` naming the path tried, rather than silently.
 /// Test: `mode::tests::settings_json_wins_over_default`,
 /// `mode::tests::missing_settings_json_is_not_an_error`,
-/// `mode::tests::malformed_settings_json_is_not_an_error`.
+/// `mode::tests::malformed_settings_json_is_not_an_error`,
+/// `mode::tests::trusty_code_settings_json_sets_the_mode_without_a_claude_dir`,
+/// `mode::tests::trusty_code_settings_json_outranks_claude`.
 fn read_settings_json_mode(project_root: &Path) -> Option<HarnessMode> {
-    let path = project_root.join(".claude").join("settings.json");
-    let raw = std::fs::read_to_string(path).ok()?;
-    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    // #5426: resolved, not joined — `.trusty-code/settings.json` wins.
+    let resolved = crate::paths::settings_file(project_root);
+    if resolved.source == crate::paths::ConfigSource::Default {
+        return None;
+    }
+    let path = resolved.path;
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "project settings.json resolved but could not be read; \
+                 falling back to the next harness-mode tier"
+            );
+            return None;
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "project settings.json is not valid JSON; \
+                 falling back to the next harness-mode tier"
+            );
+            return None;
+        }
+    };
     let mode_str = value.get("code_harness")?.get("mode")?.as_str()?;
     HarnessMode::parse_lenient(mode_str)
 }
@@ -346,5 +380,59 @@ mod tests {
     fn malformed_settings_json_is_not_an_error() {
         let project = project_with_settings(Some("not valid json"));
         assert_eq!(read_settings_json_mode(project.path()), None);
+    }
+
+    /// `.trusty-code/settings.json` sets the harness mode on a project with no
+    /// `.claude/` at all (#5426).
+    ///
+    /// Why: "a clean project can install and run without a `.claude/`
+    /// directory" is not true if the mode tier still requires one. On
+    /// `origin/main` this fails: `read_settings_json_mode` joined
+    /// `.claude/settings.json` directly, so a `.trusty-code`-only project fell
+    /// through to the default.
+    /// What: writes only `.trusty-code/settings.json` and asserts the mode.
+    /// Test: this function IS the test.
+    #[test]
+    fn trusty_code_settings_json_sets_the_mode_without_a_claude_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join(".trusty-code");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join("settings.json"),
+            r#"{"code_harness": {"mode": "parity"}}"#,
+        )
+        .expect("write settings.json");
+        assert!(!tmp.path().join(".claude").exists());
+
+        assert_eq!(
+            read_settings_json_mode(tmp.path()),
+            Some(HarnessMode::Parity)
+        );
+    }
+
+    /// `.trusty-code/settings.json` outranks `.claude/settings.json`.
+    ///
+    /// Why: the compatibility root is an input of last resort; a project that
+    /// has stated its own configuration must not be overruled by the file it
+    /// migrated away from.
+    /// What: writes conflicting modes to both and asserts the native one wins.
+    /// Test: this function IS the test.
+    #[test]
+    fn trusty_code_settings_json_outranks_claude() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for (dirname, mode) in [(".trusty-code", "parity"), (".claude", "daily-driver")] {
+            let dir = tmp.path().join(dirname);
+            std::fs::create_dir_all(&dir).expect("mkdir");
+            std::fs::write(
+                dir.join("settings.json"),
+                format!(r#"{{"code_harness": {{"mode": "{mode}"}}}}"#),
+            )
+            .expect("write settings.json");
+        }
+
+        assert_eq!(
+            read_settings_json_mode(tmp.path()),
+            Some(HarnessMode::Parity)
+        );
     }
 }

--- a/crates/trusty-code/src/paths/import.rs
+++ b/crates/trusty-code/src/paths/import.rs
@@ -1,0 +1,377 @@
+//! Deterministic, reversible legacy import from `.claude/` into `.trusty-code/`
+//! (#5426, epic #2892).
+//!
+//! Why: switching discovery to `.trusty-code/` would strand every project whose
+//! agents and skills live under `.claude/`. An import has to be observable
+//! before it runs (a plan), it must never overwrite a file the project author
+//! wrote, and it must be undoable — so it reports exactly which files it
+//! created, and nothing else.
+//!
+//! What: [`plan_import`] walks `.claude/agents/`, `.claude/skills/`, and
+//! `.claude/settings.json` and produces a SORTED [`ImportPlan`] naming, for each
+//! source file, the target under `.trusty-code/` and the [`ImportAction`] that
+//! would be taken. [`apply_import`] executes exactly that plan and returns an
+//! [`ImportReport`] listing the files it created. Determinism is what makes the
+//! dry run trustworthy: the same tree always yields the same plan in the same
+//! order, so `--dry-run` output and the real run cannot disagree.
+//!
+//! Four refusals, all producing [`ImportAction::Refuse`] rather than an error
+//! that aborts the whole import:
+//!
+//! - the target already exists (never overwrite a user-authored file);
+//! - the source is, or reaches through, a symlink out of `.claude/`;
+//! - the source carries the executable bit (an imported executable would be
+//!   trusted by every later `.trusty-code/` consumer);
+//! - a `settings.json` whose JSON carries a secret-bearing key
+//!   ([`super::find_secret_key`]).
+//!
+//! Test: `paths::import_tests::*`.
+
+use std::path::{Path, PathBuf};
+
+use super::{CLAUDE_COMPAT_DIRNAME, SETTINGS_FILENAME, check_native_write_target, native_child};
+
+/// The `.claude/` subtrees an import considers, in plan order.
+///
+/// Why: agents and skills are the authored content #5426 must carry across;
+/// plugins are third-party trees whose provenance this import cannot vouch for,
+/// so they are deliberately NOT copied — a plugin stays discoverable in place
+/// through the compatibility search root.
+/// What: `["agents", "skills"]`.
+/// Test: `paths::import_tests::plan_is_sorted_and_deterministic`.
+pub const IMPORTED_SUBTREES: &[&str] = &["agents", "skills"];
+
+/// What an import would do with one source file.
+///
+/// Why: a plan that only listed copies could not explain a file's absence from
+/// the result, which is the question an operator asks first.
+/// What: [`ImportAction::Copy`] or [`ImportAction::Refuse`] with a
+/// human-readable reason.
+/// Test: `paths::import_tests::existing_target_is_never_overwritten`,
+/// `paths::import_tests::executable_source_is_refused`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportAction {
+    /// The file will be copied to its target.
+    Copy,
+    /// The file will be skipped; the string says why.
+    Refuse(String),
+}
+
+/// One source file and the target it maps to.
+///
+/// Why: the unit both the dry-run listing and the applied report are built from,
+/// so the two can never describe different work.
+/// What: absolute `from` under `.claude/`, absolute `to` under `.trusty-code/`,
+/// and the [`ImportAction`].
+/// Test: `paths::import_tests::plan_is_sorted_and_deterministic`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportEntry {
+    /// The source file under `<project>/.claude/`.
+    pub from: PathBuf,
+    /// The target under `<project>/.trusty-code/`.
+    pub to: PathBuf,
+    /// What the import would do with it.
+    pub action: ImportAction,
+}
+
+/// Everything an import would do, in a stable order.
+///
+/// Why: producing the plan and executing it are separate steps precisely so the
+/// operator can read the first before authorising the second.
+/// What: entries sorted by target path.
+/// Test: `paths::import_tests::plan_is_sorted_and_deterministic`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImportPlan {
+    /// The per-file decisions, sorted by [`ImportEntry::to`].
+    pub entries: Vec<ImportEntry>,
+}
+
+impl ImportPlan {
+    /// The entries that would actually be copied.
+    ///
+    /// Why: the count an operator wants before confirming, without re-filtering
+    /// at each call site.
+    /// What: entries whose action is [`ImportAction::Copy`].
+    /// Test: `paths::import_tests::plan_is_sorted_and_deterministic`.
+    pub fn to_copy(&self) -> impl Iterator<Item = &ImportEntry> {
+        self.entries
+            .iter()
+            .filter(|e| e.action == ImportAction::Copy)
+    }
+}
+
+/// What an applied import actually created, and what it declined.
+///
+/// Why: reversibility is a property of the REPORT, not of a flag — deleting
+/// exactly the paths in `created` restores the tree, and nothing else was
+/// touched.
+/// What: `created` holds the files written (sorted); `refused` pairs each
+/// skipped source with its reason.
+/// Test: `paths::import_tests::apply_creates_only_the_planned_files`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImportReport {
+    /// Files this import created, sorted — delete exactly these to undo it.
+    pub created: Vec<PathBuf>,
+    /// Sources not imported, each with the reason.
+    pub refused: Vec<(PathBuf, String)>,
+}
+
+/// Build the import plan for a project root.
+///
+/// Why: the observable half of the import. It touches nothing, so it is safe to
+/// run in a diagnostic.
+/// What: walks each of [`IMPORTED_SUBTREES`] under `<root>/.claude/`, plus
+/// `.claude/settings.json`, mapping every regular file to the same relative path
+/// under `<root>/.trusty-code/` and classifying it per the module docs. Entries
+/// are sorted by target path so the plan is a function of the tree alone. A
+/// missing `.claude/` yields an empty plan, never an error.
+/// Test: `paths::import_tests::plan_is_sorted_and_deterministic`,
+/// `paths::import_tests::missing_claude_dir_yields_empty_plan`,
+/// `paths::import_tests::symlink_escaping_claude_is_refused`.
+pub fn plan_import(project_root: &Path) -> ImportPlan {
+    let claude_root = project_root.join(CLAUDE_COMPAT_DIRNAME);
+    let mut entries = Vec::new();
+
+    for subtree in IMPORTED_SUBTREES {
+        let dir = claude_root.join(subtree);
+        let mut files = Vec::new();
+        collect_files(&dir, &dir, subtree, &mut files);
+        for (relative, from) in files {
+            entries.push(classify(project_root, &claude_root, &relative, &from));
+        }
+    }
+
+    let settings = claude_root.join(SETTINGS_FILENAME);
+    if settings.is_file() {
+        entries.push(classify(
+            project_root,
+            &claude_root,
+            SETTINGS_FILENAME,
+            &settings,
+        ));
+    }
+
+    entries.sort_by(|a, b| a.to.cmp(&b.to));
+    ImportPlan { entries }
+}
+
+/// Recursively collect the regular files under `dir`, relative to `base`.
+///
+/// Why: the plan must cover a skill's whole directory (`SKILL.md` plus its
+/// `references/`), not just its top level.
+/// What: appends `(relative_path_with_prefix, absolute_path)` pairs. A directory
+/// that cannot be read is skipped and logged at `warn` with the path tried —
+/// fail open, since one unreadable subtree must not abort the import of the
+/// rest. Symlinked DIRECTORIES are not descended into; a symlinked file is
+/// collected and refused later by [`classify`], where the reason can be
+/// reported.
+/// Test: `paths::import_tests::plan_is_sorted_and_deterministic`,
+/// `paths::import_tests::unreadable_subtree_is_skipped_with_a_warning`.
+fn collect_files(base: &Path, dir: &Path, prefix: &str, out: &mut Vec<(String, PathBuf)>) {
+    if !dir.is_dir() {
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            // #5426: fail open — an unreadable subtree loses its files, not the
+            // whole import, and says so.
+            tracing::warn!(
+                path = %dir.display(),
+                error = %e,
+                "could not read a .claude subtree while planning the trusty-code \
+                 import; skipping it and continuing with the rest"
+            );
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.is_dir() {
+            collect_files(base, &path, prefix, out);
+        } else if let Ok(rel) = path.strip_prefix(base) {
+            out.push((format!("{prefix}/{}", rel.display()), path.clone()));
+        }
+    }
+}
+
+/// Decide what to do with one source file.
+///
+/// Why: every refusal rule lives here so the plan and the applied run cannot
+/// diverge on a judgement call.
+/// What: applies, in order, the write-target guard (which catches a symlinked
+/// `.trusty-code/` subdirectory pointing out of the project), the
+/// symlink-escape check on the SOURCE, the existing-target check, the
+/// executable-bit check, and — for `settings.json` — the secret-key check.
+/// Test: `paths::import_tests::existing_target_is_never_overwritten`,
+/// `paths::import_tests::executable_source_is_refused`,
+/// `paths::import_tests::symlink_escaping_claude_is_refused`,
+/// `paths::import_tests::secret_bearing_settings_is_refused`.
+fn classify(project_root: &Path, claude_root: &Path, relative: &str, from: &Path) -> ImportEntry {
+    let to = native_child(project_root, relative);
+    let refuse = |reason: String| ImportEntry {
+        from: from.to_path_buf(),
+        to: to.clone(),
+        action: ImportAction::Refuse(reason),
+    };
+
+    if let Err(e) = check_native_write_target(project_root, &to) {
+        return refuse(e.to_string());
+    }
+    if !source_stays_inside(claude_root, from) {
+        return refuse(format!(
+            "source resolves outside {} — refusing to import through a symlink",
+            claude_root.display()
+        ));
+    }
+    if to.exists() {
+        return refuse(format!(
+            "{} already exists — an import never overwrites a user-authored file",
+            to.display()
+        ));
+    }
+    if is_executable(from) {
+        return refuse(
+            "source carries the executable bit — refusing to import an executable \
+             into trusty-code's own configuration tree"
+                .to_string(),
+        );
+    }
+    if relative == SETTINGS_FILENAME
+        && let Some(key) = settings_secret_key(from)
+    {
+        return refuse(format!(
+            "settings carry a secret-bearing key `{key}` — remove it, or set it \
+             in the environment, before importing"
+        ));
+    }
+
+    ImportEntry {
+        from: from.to_path_buf(),
+        to,
+        action: ImportAction::Copy,
+    }
+}
+
+/// Whether a source file really lives inside `.claude/`.
+///
+/// Why: `.claude/agents/leak.md -> ~/.ssh/id_rsa` would otherwise be copied into
+/// a tree the project commits.
+/// What: canonicalises both and tests containment; a source that cannot be
+/// canonicalised (a dangling symlink) is treated as escaping.
+/// Test: `paths::import_tests::symlink_escaping_claude_is_refused`.
+fn source_stays_inside(claude_root: &Path, from: &Path) -> bool {
+    match (claude_root.canonicalize(), from.canonicalize()) {
+        (Ok(root), Ok(file)) => file.starts_with(&root),
+        _ => false,
+    }
+}
+
+/// Whether a file has any executable bit set.
+///
+/// Why: an imported executable would be trusted by every later consumer of
+/// `.trusty-code/`, which is exactly the provenance this import cannot vouch
+/// for.
+/// What: on Unix, any of `0o111`. On other platforms, `false` — there is no
+/// executable bit to inspect, and the extension-based equivalent would be a
+/// different rule wearing the same name.
+/// Test: `paths::import_tests::executable_source_is_refused`.
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+/// See the Unix variant — non-Unix targets expose no executable bit.
+#[cfg(not(unix))]
+fn is_executable(_path: &Path) -> bool {
+    false
+}
+
+/// The first secret-bearing key in a settings file, if any.
+///
+/// Why: a settings file that will not parse is not evidence that it is clean, so
+/// an unparseable file is refused too rather than waved through.
+/// What: parses the file as JSON and delegates to [`super::find_secret_key`]; an
+/// I/O or parse failure yields a synthetic reason naming the problem, logged at
+/// `warn` with the path tried.
+/// Test: `paths::import_tests::secret_bearing_settings_is_refused`,
+/// `paths::import_tests::unparseable_settings_is_refused`.
+fn settings_secret_key(path: &Path) -> Option<String> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "could not read .claude/settings.json while planning the import; \
+                 refusing to import it rather than assuming it holds no secrets"
+            );
+            return Some("<unreadable>".to_string());
+        }
+    };
+    match serde_json::from_str::<serde_json::Value>(&raw) {
+        Ok(value) => super::find_secret_key(&value),
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "could not parse .claude/settings.json while planning the import; \
+                 refusing to import it rather than assuming it holds no secrets"
+            );
+            Some("<unparseable>".to_string())
+        }
+    }
+}
+
+/// Execute a plan, creating only the files it marked [`ImportAction::Copy`].
+///
+/// Why: taking the plan as an ARGUMENT (rather than recomputing it) is what
+/// makes `--dry-run` meaningful — the operator authorises the exact list they
+/// read.
+/// What: creates each target's parent directory and copies the file, in plan
+/// order. Returns the [`ImportReport`]. A copy that fails mid-run is reported as
+/// a refusal with the I/O error and does not abort the remaining entries, so one
+/// bad file cannot leave the import half-done with no record of what landed.
+/// Test: `paths::import_tests::apply_creates_only_the_planned_files`,
+/// `paths::import_tests::apply_is_idempotent`.
+pub fn apply_import(plan: &ImportPlan) -> ImportReport {
+    let mut report = ImportReport::default();
+    for entry in &plan.entries {
+        match &entry.action {
+            ImportAction::Refuse(reason) => {
+                report.refused.push((entry.from.clone(), reason.clone()));
+            }
+            ImportAction::Copy => match copy_one(&entry.from, &entry.to) {
+                Ok(()) => report.created.push(entry.to.clone()),
+                Err(e) => report
+                    .refused
+                    .push((entry.from.clone(), format!("copy failed: {e}"))),
+            },
+        }
+    }
+    report.created.sort();
+    report
+}
+
+/// Copy one file, creating its parent directory.
+///
+/// Why: a one-line helper keeps [`apply_import`]'s error handling readable.
+/// What: `create_dir_all` on the parent, then `std::fs::copy`.
+/// Test: `paths::import_tests::apply_creates_only_the_planned_files`.
+fn copy_one(from: &Path, to: &Path) -> std::io::Result<()> {
+    if let Some(parent) = to.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::copy(from, to)?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "import_tests.rs"]
+mod import_tests;

--- a/crates/trusty-code/src/paths/import_tests.rs
+++ b/crates/trusty-code/src/paths/import_tests.rs
@@ -1,0 +1,311 @@
+//! Unit tests for the `.claude/` → `.trusty-code/` import (#5426).
+//!
+//! Why: the import's guarantees — deterministic, non-overwriting, reversible,
+//! and refusing four classes of unsafe source — are the ones a project owner
+//! bets their repository on.
+//! What: plan determinism, the empty case, the four refusals, and an applied run
+//! that creates exactly the planned files and nothing else.
+//! Test: this file IS the test module.
+
+use super::*;
+
+use crate::paths::TRUSTY_CODE_DIRNAME;
+
+/// Write `<root>/.claude/<relative>`, creating parents.
+fn write_claude(root: &Path, relative: &str, body: &str) -> PathBuf {
+    let path = root.join(CLAUDE_COMPAT_DIRNAME).join(relative);
+    std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&path, body).expect("write");
+    path
+}
+
+/// Every file created under `<root>/.trusty-code`, sorted.
+fn native_tree(root: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else {
+                out.push(p);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(&root.join(TRUSTY_CODE_DIRNAME), &mut out);
+    out.sort();
+    out
+}
+
+/// The plan is sorted by target and stable across runs.
+///
+/// Why: `--dry-run` is only trustworthy if the real run does the same work in
+/// the same order; a plan whose order came from `read_dir` would vary by
+/// filesystem.
+/// What: stages agents, a nested skill, and settings; asserts the plan is
+/// sorted, covers every file, and is byte-identical across two calls.
+/// Test: this function IS the test.
+#[test]
+fn plan_is_sorted_and_deterministic() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_claude(tmp.path(), "agents/pm.md", "# pm");
+    write_claude(tmp.path(), "agents/engineer.md", "# engineer");
+    write_claude(tmp.path(), "skills/demo/SKILL.md", "# demo");
+    write_claude(tmp.path(), "skills/demo/references/deep.md", "# deep");
+    write_claude(
+        tmp.path(),
+        "settings.json",
+        r#"{"code_harness":{"mode":"parity"}}"#,
+    );
+
+    let plan = plan_import(tmp.path());
+    let again = plan_import(tmp.path());
+
+    assert_eq!(plan, again, "the plan must be a function of the tree alone");
+    assert_eq!(plan.entries.len(), 5);
+    assert!(
+        plan.entries.windows(2).all(|w| w[0].to <= w[1].to),
+        "entries must be sorted by target path"
+    );
+    assert_eq!(plan.to_copy().count(), 5);
+    assert!(
+        plan.entries
+            .iter()
+            .all(|e| e.to.starts_with(tmp.path().join(TRUSTY_CODE_DIRNAME))),
+        "every target must land beneath .trusty-code/"
+    );
+}
+
+/// A project with no `.claude/` plans nothing and errors on nothing.
+#[test]
+fn missing_claude_dir_yields_empty_plan() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert_eq!(plan_import(tmp.path()), ImportPlan::default());
+}
+
+/// Applying a plan creates exactly its `Copy` targets and nothing else.
+///
+/// Why: reversibility means the report is a complete inventory — anything
+/// created but unreported could not be undone.
+/// What: applies a staged plan and asserts the on-disk `.trusty-code/` tree
+/// equals the reported `created` list, with identical file contents.
+/// Test: this function IS the test.
+#[test]
+fn apply_creates_only_the_planned_files() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_claude(tmp.path(), "agents/pm.md", "# pm");
+    write_claude(tmp.path(), "skills/demo/SKILL.md", "# demo");
+
+    let plan = plan_import(tmp.path());
+    let report = apply_import(&plan);
+
+    assert!(report.refused.is_empty(), "refused: {:?}", report.refused);
+    assert_eq!(report.created, native_tree(tmp.path()));
+    assert_eq!(report.created.len(), 2);
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join(TRUSTY_CODE_DIRNAME).join("agents/pm.md"))
+            .expect("read"),
+        "# pm"
+    );
+}
+
+/// A second import overwrites nothing and reports every skip.
+///
+/// Why: the non-overwrite rule has to hold for files THIS import created too,
+/// or re-running it would silently discard edits made after the first run.
+/// What: imports twice; the second plan copies nothing and refuses both files.
+/// Test: this function IS the test.
+#[test]
+fn apply_is_idempotent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_claude(tmp.path(), "agents/pm.md", "# pm");
+    apply_import(&plan_import(tmp.path()));
+
+    // Edit the imported copy: a re-import must not clobber it.
+    let target = tmp.path().join(TRUSTY_CODE_DIRNAME).join("agents/pm.md");
+    std::fs::write(&target, "# edited by the project owner").expect("write");
+
+    let second = plan_import(tmp.path());
+    let report = apply_import(&second);
+
+    assert_eq!(second.to_copy().count(), 0);
+    assert!(report.created.is_empty());
+    assert_eq!(report.refused.len(), 1);
+    assert!(report.refused[0].1.contains("already exists"));
+    assert_eq!(
+        std::fs::read_to_string(&target).expect("read"),
+        "# edited by the project owner"
+    );
+}
+
+/// An existing target is never overwritten, even on a first run.
+#[test]
+fn existing_target_is_never_overwritten() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_claude(tmp.path(), "agents/pm.md", "# from claude");
+    let target = tmp.path().join(TRUSTY_CODE_DIRNAME).join("agents/pm.md");
+    std::fs::create_dir_all(target.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&target, "# authored natively").expect("write");
+
+    let plan = plan_import(tmp.path());
+
+    assert_eq!(plan.entries.len(), 1);
+    assert!(matches!(plan.entries[0].action, ImportAction::Refuse(_)));
+    assert_eq!(
+        std::fs::read_to_string(&target).expect("read"),
+        "# authored natively"
+    );
+}
+
+/// A source carrying the executable bit is refused.
+///
+/// Why: an executable imported into `.trusty-code/` inherits the trust every
+/// later consumer of that tree extends to it — provenance this import cannot
+/// vouch for.
+/// What: chmods a staged agent file to `0o755` and asserts the refusal.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn executable_source_is_refused() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src = write_claude(tmp.path(), "agents/hook.md", "#!/bin/sh\nrm -rf /\n");
+    std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+    let plan = plan_import(tmp.path());
+    let report = apply_import(&plan);
+
+    assert_eq!(plan.to_copy().count(), 0);
+    assert!(report.created.is_empty());
+    assert_eq!(report.refused.len(), 1);
+    assert!(
+        report.refused[0].1.contains("executable"),
+        "reason was: {}",
+        report.refused[0].1
+    );
+}
+
+/// A symlink pointing out of `.claude/` is refused.
+///
+/// Why: `.claude/agents/leak.md -> ~/.ssh/id_rsa` would otherwise be copied into
+/// a directory the project commits.
+/// What: symlinks a file outside the project into `.claude/agents/` and asserts
+/// nothing is copied.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn symlink_escaping_claude_is_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("tempdir");
+    let secret = outside.path().join("id_rsa");
+    std::fs::write(&secret, "PRIVATE KEY").expect("write");
+
+    let agents = tmp.path().join(CLAUDE_COMPAT_DIRNAME).join("agents");
+    std::fs::create_dir_all(&agents).expect("mkdir");
+    std::os::unix::fs::symlink(&secret, agents.join("leak.md")).expect("symlink");
+
+    let plan = plan_import(tmp.path());
+    let report = apply_import(&plan);
+
+    assert_eq!(plan.entries.len(), 1);
+    assert_eq!(plan.to_copy().count(), 0);
+    assert!(report.created.is_empty());
+    assert!(
+        report.refused[0].1.contains("symlink"),
+        "reason was: {}",
+        report.refused[0].1
+    );
+    assert!(
+        !tmp.path()
+            .join(TRUSTY_CODE_DIRNAME)
+            .join("agents/leak.md")
+            .exists()
+    );
+}
+
+/// A settings file carrying a credential is refused.
+///
+/// Why: `.trusty-code/` is project-owned and conventionally committed; a
+/// credential copied there is a leak with a long tail.
+/// What: stages `.claude/settings.json` with an `OPENROUTER_API_KEY` and asserts
+/// the refusal names the offending key.
+/// Test: this function IS the test.
+#[test]
+fn secret_bearing_settings_is_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_claude(
+        tmp.path(),
+        "settings.json",
+        r#"{"env":{"OPENROUTER_API_KEY":"sk-live-xyz"}}"#,
+    );
+
+    let plan = plan_import(tmp.path());
+    let report = apply_import(&plan);
+
+    assert!(report.created.is_empty());
+    assert_eq!(report.refused.len(), 1);
+    assert!(
+        report.refused[0].1.contains("OPENROUTER_API_KEY"),
+        "reason was: {}",
+        report.refused[0].1
+    );
+    assert!(
+        !tmp.path()
+            .join(TRUSTY_CODE_DIRNAME)
+            .join("settings.json")
+            .exists()
+    );
+}
+
+/// Settings that will not parse are refused rather than assumed clean.
+///
+/// Why: an unparseable file is not evidence of the absence of a secret.
+/// What: stages malformed JSON and asserts nothing is copied.
+/// Test: this function IS the test.
+#[test]
+fn unparseable_settings_is_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_claude(tmp.path(), "settings.json", "{ not json");
+
+    let plan = plan_import(tmp.path());
+
+    assert_eq!(plan.to_copy().count(), 0);
+    assert!(matches!(plan.entries[0].action, ImportAction::Refuse(_)));
+}
+
+/// An unreadable subtree loses its own files, not the whole import.
+///
+/// Why: the Fail-Open Check applied to the import walk — one bad directory must
+/// not strand the agents that were readable.
+/// What: chmods `.claude/skills` to `0o000` and asserts the agents still import.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn unreadable_subtree_is_skipped_with_a_warning() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // SAFETY: `geteuid` takes no arguments, touches no memory, and cannot fail.
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_claude(tmp.path(), "agents/pm.md", "# pm");
+    let skills = write_claude(tmp.path(), "skills/demo/SKILL.md", "# demo")
+        .parent()
+        .expect("parent")
+        .parent()
+        .expect("skills")
+        .to_path_buf();
+    std::fs::set_permissions(&skills, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+    let plan = plan_import(tmp.path());
+
+    std::fs::set_permissions(&skills, std::fs::Permissions::from_mode(0o755)).expect("restore");
+
+    assert_eq!(plan.to_copy().count(), 1, "the readable agent must survive");
+    assert!(plan.entries[0].to.ends_with("agents/pm.md"));
+}

--- a/crates/trusty-code/src/paths/mod.rs
+++ b/crates/trusty-code/src/paths/mod.rs
@@ -471,25 +471,48 @@ fn canonicalize_existing(path: &Path) -> Option<PathBuf> {
 /// project's repository by convention, so a credential landing there is a leak
 /// with a long tail. The import path checks against this list before copying a
 /// settings file rather than after.
-/// What: lowercase, separator-free WORD forms — not substrings. A key is split
-/// into words first ([`key_segments`]), so one entry covers every spelling of
-/// it: `api_key`, `API-KEY`, `x-api-key`, `xApiKey` and `APIKEY` all reduce to
-/// the `apikey` form. Multi-word entries (`apikey`, `accesskey`, `privatekey`)
-/// are matched against adjacent word PAIRS as well as against a single
-/// unseparated word.
+/// What: lowercase, separator-free, SINGULAR word forms — not substrings. A key
+/// is split into words first ([`key_segments`]) and each word is de-pluralised
+/// before matching, so one entry covers every spelling of it: `api_key`,
+/// `API-KEY`, `x-api-key`, `xApiKey`, `APIKEY` and `apiKeys` all reduce to the
+/// `apikey` form. Multi-word entries (`apikey`, `accesskey`, `privatekey`) are
+/// matched against adjacent word PAIRS as well as against a single unseparated
+/// word.
 /// Test: `paths::tests::secret_keys_match_across_separator_and_case_spellings`,
+/// `paths::tests::secret_keys_match_plural_spellings`,
 /// `paths::tests::benign_keys_containing_a_hint_are_not_flagged`.
 pub const SECRET_KEY_HINTS: &[&str] = &[
     "accesskey",
     "apikey",
     "authorization",
     "credential",
-    "credentials",
     "passphrase",
     "password",
     "privatekey",
     "secret",
     "token",
+];
+
+/// Whole keys that name a COUNT rather than a credential.
+///
+/// Why: de-pluralising makes `tokens` a hit, and `max_tokens` is an LLM sampling
+/// parameter this crate's own `code_harness` settings carry — refusing to import
+/// the very file the feature exists to migrate is a worse outcome than the leak
+/// risk of a key that holds an integer (code-critic round 2, PR #6980). The
+/// exemption is deliberately a short, closed list rather than a heuristic.
+/// What: normalised whole-key forms. The comparison is against the ENTIRE key,
+/// not a window of it, so appending a credential to an exempt name
+/// (`max_tokens_api_key`) does not inherit the exemption.
+/// Test: `paths::tests::max_tokens_stays_benign_as_a_count_not_a_credential`.
+pub const SECRET_KEY_EXEMPTIONS: &[&str] = &[
+    "maxtokens",
+    "mintokens",
+    "numtokens",
+    "tokenbudget",
+    "tokencount",
+    "tokenlimit",
+    "tokenusage",
+    "totaltokens",
 ];
 
 /// Split a key into lowercase word segments.
@@ -532,18 +555,50 @@ fn key_segments(key: &str) -> Vec<String> {
 ///
 /// Why: the single rule both the import refusal and its tests apply, so the
 /// spelling coverage cannot drift between them.
-/// What: `true` when any single word of the key, or any two ADJACENT words
-/// joined, equals an entry in [`SECRET_KEY_HINTS`]. Word-exact, so `tokenizer`
-/// and `secretary` are clean while `token` and `x-api-key` are not.
+/// What: `false` outright when the whole key is a [`SECRET_KEY_EXEMPTIONS`]
+/// entry. Otherwise `true` when any single word of the key, or any two ADJACENT
+/// words joined, matches [`SECRET_KEY_HINTS`] under [`matches_hint`]'s
+/// de-pluralising comparison. Word-exact, so `tokenizer` and `secretary` are
+/// clean while `token`, `tokens` and `x-api-key` are not.
 /// Test: `paths::tests::secret_keys_match_across_separator_and_case_spellings`,
+/// `paths::tests::secret_keys_match_plural_spellings`,
+/// `paths::tests::max_tokens_stays_benign_as_a_count_not_a_credential`,
 /// `paths::tests::benign_keys_containing_a_hint_are_not_flagged`.
 pub fn is_secret_key(key: &str) -> bool {
     let segments = key_segments(key);
+    // #5426: the exemption matches the WHOLE key, never a window of it, so a
+    // credential appended to an exempt name still trips the check below.
+    if SECRET_KEY_EXEMPTIONS.contains(&segments.concat().as_str()) {
+        return false;
+    }
     (1..=2).any(|width| {
         segments
             .windows(width)
-            .any(|window| SECRET_KEY_HINTS.contains(&window.concat().as_str()))
+            .any(|window| matches_hint(&window.concat()))
     })
+}
+
+/// Whether one normalised word (or word pair) is a hint, singular or plural.
+///
+/// Why: the hint list carried `credential` and `credentials` but left `secret`,
+/// `token`, `apikey`, `accesskey` and `privatekey` singular-only, so `tokens`,
+/// `secretsFile`, `apiKeys` and four more plural spellings walked past the
+/// matcher (code-critic round 2 HIGH, PR #6980). De-pluralising at the
+/// comparison keeps the list singular and closes every plural at once, instead
+/// of doubling the list and inviting the same omission again.
+/// What: matches `joined` against [`SECRET_KEY_HINTS`] as given, then again with
+/// one trailing `s` removed. Stripping only a trailing `s` is deliberately
+/// narrow: `passwordless` becomes `passwordles`, not `password`, and
+/// `secretary` has no trailing `s` to strip at all.
+/// Test: `paths::tests::secret_keys_match_plural_spellings`,
+/// `paths::tests::benign_keys_containing_a_hint_are_not_flagged`.
+fn matches_hint(joined: &str) -> bool {
+    if SECRET_KEY_HINTS.contains(&joined) {
+        return true;
+    }
+    joined
+        .strip_suffix('s')
+        .is_some_and(|singular| SECRET_KEY_HINTS.contains(&singular))
 }
 
 /// Find the first secret-bearing key path in a JSON value, if any.

--- a/crates/trusty-code/src/paths/mod.rs
+++ b/crates/trusty-code/src/paths/mod.rs
@@ -1,0 +1,601 @@
+//! Trusty Code's own configuration and state layout (#5426, epic #2892).
+//!
+//! Why: every discovery site in this crate hard-coded `.claude/` — the agents
+//! directory, the skills directory, the plugin tree, `settings.json`, and the
+//! project context file each joined that literal themselves. That made
+//! Claude Code's directory the source of truth for a product that is not Claude
+//! Code: a clean project could not install or run without a `.claude/` tree, and
+//! nothing stopped Trusty Code writing INTO another product's directory. #5426
+//! inverts the relationship. `<project>/.trusty-code/` is where Trusty Code
+//! reads and — critically — the ONLY place it writes; `.claude/` (and the older
+//! `.open-mpm/`) stay readable as compatibility INPUTS, never as write targets.
+//!
+//! What: one resolver, [`resolve_project_entry`], that every discovery site
+//! calls instead of joining a literal. It walks [`SEARCH_ROOTS`] in order and
+//! reports the winning source ([`ConfigSource`]) alongside the path, so
+//! diagnostics can answer "which directory won, and what else was tried?"
+//! without re-deriving the rule. [`native_config_dir`] and
+//! [`check_native_write_target`] are the write half: a path that is not beneath
+//! `<project>/.trusty-code/` — including one that reaches outside it through a
+//! symlink — is refused rather than written. [`private_state`] owns the private
+//! mutable half (`~/.trusty-code/`, mode `0700`), and [`import`] owns the
+//! deterministic, non-overwriting legacy import from `.claude/`.
+//!
+//! **Precedence, and where it is documented.** The order is
+//! `.trusty-code/` → `.claude/` → `.open-mpm/`, then a default that names
+//! `.trusty-code/` even when nothing exists yet. The operator-facing statement
+//! of that rule, including the fallback and warning behaviour, lives in
+//! [the crate README](../../README.md#configuration-layout-trusty-code) — this
+//! module is its implementation, not a second specification.
+//!
+//! Test: `paths::tests::*`, `paths::private_state_tests::*`,
+//! `paths::import_tests::*`.
+//!
+//! [`private_state`]: crate::paths::private_state
+//! [`import`]: crate::paths::import
+
+use std::path::{Path, PathBuf};
+
+pub mod import;
+pub mod private_state;
+
+/// Trusty Code's own project configuration directory name.
+///
+/// Why: named once so the convention cannot drift to `.trusty_code` /
+/// `.trustycode` at a second call site.
+/// What: `".trusty-code"` — both the project-config directory under a project
+/// root and (via [`private_state`]) the private state directory under `$HOME`,
+/// mirroring trusty-mpm's `.trusty-mpm` precedent.
+/// Test: `paths::tests::native_config_dir_is_always_trusty_code`.
+pub const TRUSTY_CODE_DIRNAME: &str = ".trusty-code";
+
+/// Claude Code's project configuration directory name.
+///
+/// Why: a compatibility INPUT — read when Trusty Code's own directory has not
+/// been created yet, never written to. See [`check_native_write_target`].
+/// What: `".claude"`.
+/// Test: `paths::tests::falls_back_to_claude_when_trusty_code_absent`.
+pub const CLAUDE_COMPAT_DIRNAME: &str = ".claude";
+
+/// The pre-Claude-Code open-mpm configuration directory name.
+///
+/// Why: `agents::locate_agents_dir` already honoured it; dropping it here would
+/// silently break a project that still uses it.
+/// What: `".open-mpm"`.
+/// Test: `paths::tests::falls_back_to_open_mpm_when_neither_native_nor_claude`.
+pub const OPEN_MPM_LEGACY_DIRNAME: &str = ".open-mpm";
+
+/// The search order every project-scoped lookup walks, highest precedence first.
+///
+/// Why: one ordered table rather than a chain of `if exists` blocks repeated per
+/// call site — the bug #5426 exists to remove.
+/// What: `.trusty-code` (native) → `.claude` (compatibility) → `.open-mpm`
+/// (legacy), each paired with the [`ConfigSource`] it resolves to.
+/// Test: `paths::tests::precedence_prefers_trusty_code_over_claude`.
+pub const SEARCH_ROOTS: &[(&str, ConfigSource)] = &[
+    (TRUSTY_CODE_DIRNAME, ConfigSource::TrustyCode),
+    (CLAUDE_COMPAT_DIRNAME, ConfigSource::ClaudeCompat),
+    (OPEN_MPM_LEGACY_DIRNAME, ConfigSource::OpenMpmLegacy),
+];
+
+/// Which configuration root a resolved path came from.
+///
+/// Why: "the winning source" is a diagnostic every CLI and log line needs, and
+/// deriving it back out of a `PathBuf` by string-matching would be a second,
+/// drifting implementation of [`SEARCH_ROOTS`].
+/// What: one variant per search root, plus [`ConfigSource::Default`] for the
+/// case where nothing exists yet and the resolver names the native path anyway.
+/// Test: `paths::tests::precedence_prefers_trusty_code_over_claude`,
+/// `paths::tests::default_source_when_nothing_exists`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// `<project>/.trusty-code/…` — Trusty Code's own directory.
+    TrustyCode,
+    /// `<project>/.claude/…` — Claude Code compatibility input.
+    ClaudeCompat,
+    /// `<project>/.open-mpm/…` — pre-Claude-Code legacy input.
+    OpenMpmLegacy,
+    /// Nothing exists yet; the path names the native location regardless.
+    Default,
+}
+
+impl ConfigSource {
+    /// A stable lowercase token for logs, JSON diagnostics, and CLI output.
+    ///
+    /// Why: the CLI and the log field must agree, and a `Debug` rendering is not
+    /// a wire contract.
+    /// What: `"trusty-code"`, `"claude"`, `"open-mpm"`, `"default"`.
+    /// Test: `paths::tests::source_tokens_are_stable`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TrustyCode => "trusty-code",
+            Self::ClaudeCompat => "claude",
+            Self::OpenMpmLegacy => "open-mpm",
+            Self::Default => "default",
+        }
+    }
+
+    /// Whether this source is Trusty Code's own directory.
+    ///
+    /// Why: a caller deciding whether to suggest `tcode config import` needs the
+    /// question answered once, here.
+    /// What: `true` for [`ConfigSource::TrustyCode`] and [`ConfigSource::Default`]
+    /// — both name a path beneath `.trusty-code/`.
+    /// Test: `paths::tests::source_tokens_are_stable`.
+    pub fn is_native(self) -> bool {
+        matches!(self, Self::TrustyCode | Self::Default)
+    }
+}
+
+/// What a project-scoped lookup resolved to, and what it had to skip to get there.
+///
+/// Why: a bare `PathBuf` cannot answer "did the native directory lose, and why?"
+/// — the exact question the fail-open warning and the `tcode config paths`
+/// diagnostic both need. Carrying `unreadable` as data (not only as a log line)
+/// is what makes the fail-open branch assertable in a test.
+/// What: the winning `path`, its [`ConfigSource`], and every candidate that
+/// existed but could not be read (each already logged at `warn`).
+/// Test: `paths::tests::unreadable_native_dir_falls_back_and_is_reported`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedConfig {
+    /// The resolved path. Exists unless `source` is [`ConfigSource::Default`].
+    pub path: PathBuf,
+    /// Which root won.
+    pub source: ConfigSource,
+    /// Candidates that existed but could not be read, in search order.
+    pub unreadable: Vec<PathBuf>,
+}
+
+/// Whether a lookup targets a directory or a single file.
+///
+/// Why: "unreadable" means different syscalls for the two — a directory is
+/// unreadable when `read_dir` fails, a file when `File::open` fails — and the
+/// fail-open warning must not fire merely because a file candidate is a
+/// directory or vice versa.
+/// What: the two shapes [`resolve_project_entry`] accepts.
+/// Test: `paths::tests::unreadable_native_dir_falls_back_and_is_reported`,
+/// `paths::tests::unreadable_settings_file_falls_back_and_is_reported`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    /// A directory, e.g. `agents/`.
+    Dir,
+    /// A regular file, e.g. `settings.json`.
+    File,
+}
+
+/// Resolve one project-scoped configuration entry across [`SEARCH_ROOTS`].
+///
+/// Why: the single entry point #5426 replaces every hard-coded `.claude/` join
+/// with. Centralising it is what makes the precedence testable in one place and
+/// makes "a clean project with only `.trusty-code/` works" true everywhere at
+/// once rather than per call site.
+/// What: walks [`SEARCH_ROOTS`] in order and returns the first candidate that
+/// exists AND can be opened. A candidate that exists but cannot be opened is
+/// SKIPPED, recorded in [`ResolvedConfig::unreadable`], and logged at `warn`
+/// with the path tried — falling through to the next root rather than failing
+/// the run, because a harness that refuses to start over an unreadable optional
+/// config is worse than one that starts with less config and says so. When no
+/// candidate is usable, the returned path is `<project_root>/.trusty-code/<rel>`
+/// with source [`ConfigSource::Default`]: callers that need existence check for
+/// it themselves, and every WRITE goes to the native path regardless.
+/// Test: `paths::tests::precedence_prefers_trusty_code_over_claude`,
+/// `paths::tests::falls_back_to_claude_when_trusty_code_absent`,
+/// `paths::tests::default_source_when_nothing_exists`,
+/// `paths::tests::unreadable_native_dir_falls_back_and_is_reported`.
+pub fn resolve_project_entry(
+    project_root: &Path,
+    relative: &str,
+    kind: EntryKind,
+) -> ResolvedConfig {
+    let mut unreadable = Vec::new();
+    for (dirname, source) in SEARCH_ROOTS {
+        let candidate = project_root.join(dirname).join(relative);
+        match probe(&candidate, kind) {
+            Probe::Missing => continue,
+            Probe::Usable => {
+                return ResolvedConfig {
+                    path: candidate,
+                    source: *source,
+                    unreadable,
+                };
+            }
+            Probe::Unreadable(err) => {
+                // #5426: fail open — an unreadable candidate must never abort the
+                // run, but it must never be silent either.
+                tracing::warn!(
+                    path = %candidate.display(),
+                    source = source.as_str(),
+                    error = %err,
+                    "trusty-code config path exists but could not be read; \
+                     skipping it and falling back to the next configuration root"
+                );
+                unreadable.push(candidate);
+            }
+        }
+    }
+    ResolvedConfig {
+        path: native_child(project_root, relative),
+        source: ConfigSource::Default,
+        unreadable,
+    }
+}
+
+/// The outcome of testing one candidate path.
+enum Probe {
+    /// Nothing of the requested kind is there.
+    Missing,
+    /// Present and openable.
+    Usable,
+    /// Present but the open failed (permissions, a broken mount, a race).
+    Unreadable(std::io::Error),
+}
+
+/// Test one candidate path for existence and readability.
+///
+/// Why: `Path::exists` alone cannot distinguish "absent" from "present but
+/// unreadable", and only the second deserves a warning.
+/// What: for [`EntryKind::Dir`], a non-directory is `Missing` and a `read_dir`
+/// failure is `Unreadable`; for [`EntryKind::File`], a non-file is `Missing` and
+/// a `File::open` failure is `Unreadable`.
+/// Test: `paths::tests::unreadable_native_dir_falls_back_and_is_reported`,
+/// `paths::tests::unreadable_settings_file_falls_back_and_is_reported`.
+fn probe(candidate: &Path, kind: EntryKind) -> Probe {
+    match kind {
+        EntryKind::Dir => {
+            if !candidate.is_dir() {
+                return Probe::Missing;
+            }
+            match std::fs::read_dir(candidate) {
+                Ok(_) => Probe::Usable,
+                Err(e) => Probe::Unreadable(e),
+            }
+        }
+        EntryKind::File => {
+            if !candidate.is_file() {
+                return Probe::Missing;
+            }
+            match std::fs::File::open(candidate) {
+                Ok(_) => Probe::Usable,
+                Err(e) => Probe::Unreadable(e),
+            }
+        }
+    }
+}
+
+/// The agents directory for a project root.
+///
+/// Why: `agents::locate_agents_dir`'s two-way `.claude`/`.open-mpm` check
+/// predates `.trusty-code/` and is now one instance of the general rule.
+/// What: [`resolve_project_entry`] for `agents`, as a directory.
+/// Test: `paths::tests::agents_dir_prefers_trusty_code`.
+pub fn agents_dir(project_root: &Path) -> ResolvedConfig {
+    resolve_project_entry(project_root, "agents", EntryKind::Dir)
+}
+
+/// The skills directory for a project root.
+///
+/// Why: see [`agents_dir`] — `skills::locate_skills_dir` was pinned to
+/// `.claude/skills` exactly, which is precisely what #5426 unpins.
+/// What: [`resolve_project_entry`] for `skills`, as a directory.
+/// Test: `paths::tests::skills_dir_prefers_trusty_code`.
+pub fn skills_dir(project_root: &Path) -> ResolvedConfig {
+    resolve_project_entry(project_root, "skills", EntryKind::Dir)
+}
+
+/// The plugins directory for a project root.
+///
+/// Why: `plugins::discover_plugin_roots` joined `.claude/plugins` directly.
+/// What: [`resolve_project_entry`] for `plugins`, as a directory.
+/// Test: `paths::tests::plugins_dir_prefers_trusty_code`.
+pub fn plugins_dir(project_root: &Path) -> ResolvedConfig {
+    resolve_project_entry(project_root, "plugins", EntryKind::Dir)
+}
+
+/// The `settings.json` file for a project root.
+///
+/// Why: `mode::read_settings_json_mode` read `.claude/settings.json` directly,
+/// so a project with only `.trusty-code/` could not set `code_harness.mode`.
+/// What: [`resolve_project_entry`] for `settings.json`, as a file.
+/// Test: `paths::tests::settings_file_prefers_trusty_code`.
+pub fn settings_file(project_root: &Path) -> ResolvedConfig {
+    resolve_project_entry(project_root, SETTINGS_FILENAME, EntryKind::File)
+}
+
+/// The project-settings filename, shared by both configuration roots.
+///
+/// Why: `.trusty-code/settings.json` deliberately keeps Claude Code's filename
+/// and schema so an imported file needs no rewriting — the directory moves, the
+/// format does not.
+/// What: `"settings.json"`.
+/// Test: `paths::tests::settings_file_prefers_trusty_code`.
+pub const SETTINGS_FILENAME: &str = "settings.json";
+
+/// Trusty Code's own project configuration directory — the ONLY write target.
+///
+/// Why: [`resolve_project_entry`] may legitimately RESOLVE into `.claude/`, but
+/// a write there would make Trusty Code mutate another product's directory. The
+/// read path and the write path are therefore deliberately different functions.
+/// What: `<project_root>/.trusty-code`, unconditionally — never probed, never
+/// falling back.
+/// Test: `paths::tests::native_config_dir_is_always_trusty_code`.
+pub fn native_config_dir(project_root: &Path) -> PathBuf {
+    project_root.join(TRUSTY_CODE_DIRNAME)
+}
+
+/// A path beneath [`native_config_dir`].
+///
+/// Why: the write-side counterpart of [`resolve_project_entry`]'s `relative`.
+/// What: `<project_root>/.trusty-code/<relative>`.
+/// Test: `paths::tests::native_config_dir_is_always_trusty_code`.
+pub fn native_child(project_root: &Path, relative: &str) -> PathBuf {
+    native_config_dir(project_root).join(relative)
+}
+
+/// Why a candidate write target was refused.
+///
+/// Why: the two refusals are different failures with different fixes — one means
+/// "you aimed at the wrong product's directory", the other "something on this
+/// path is a symlink out of the tree" — and collapsing them into one string
+/// would hide which.
+/// What: [`WriteTargetError::CrossProduct`] for a path outside
+/// `<project>/.trusty-code/`; [`WriteTargetError::SymlinkEscape`] for a path
+/// whose nearest existing ancestor resolves outside it.
+/// Test: `paths::tests::write_to_claude_dir_is_refused`,
+/// `paths::tests::symlinked_native_subdir_escape_is_refused`.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum WriteTargetError {
+    /// The path is not beneath the project's own `.trusty-code/` directory.
+    #[error(
+        "refusing to write to {path}: trusty-code writes only beneath {native_root} \
+         (another product's configuration directory is a read-only compatibility input)"
+    )]
+    CrossProduct {
+        /// The refused path.
+        path: PathBuf,
+        /// The only permitted write root.
+        native_root: PathBuf,
+    },
+    /// A symlink on the path resolves outside `.trusty-code/`.
+    #[error("refusing to write to {path}: it resolves to {resolved}, outside {native_root}")]
+    SymlinkEscape {
+        /// The refused path, as supplied.
+        path: PathBuf,
+        /// Where its nearest existing ancestor actually points.
+        resolved: PathBuf,
+        /// The only permitted write root.
+        native_root: PathBuf,
+    },
+}
+
+/// Refuse any write target that is not genuinely beneath `<project>/.trusty-code/`.
+///
+/// Why: "native project writes stay beneath `<project>/.trusty-code/`" is only a
+/// property if something enforces it, and a lexical `starts_with` does not: a
+/// symlink at `.trusty-code/agents -> ../../elsewhere` satisfies it while every
+/// write lands outside the tree.
+///
+/// Resolving the target alone is not enough either. The first version of this
+/// guard resolved the target AND the config root the same way and compared them
+/// to each other, so a `.trusty-code` that was ITSELF a symlink out of the
+/// project moved the goalposts with the target and approved every write
+/// (code-critic BLOCK, PR #6980). The root is therefore anchored to the project
+/// FIRST, and only then does the target get compared against it.
+///
+/// What: three checks, in order.
+/// 1. Lexical — `path` must start with [`native_config_dir`], else
+///    [`WriteTargetError::CrossProduct`].
+/// 2. Root anchoring — when `<project>/.trusty-code` exists, it must
+///    canonicalise to somewhere inside the canonicalised `project_root`, else
+///    [`WriteTargetError::SymlinkEscape`]. A `project_root` that cannot itself be
+///    canonicalised fails CLOSED here: containment cannot be established, so the
+///    write is refused rather than assumed safe.
+/// 3. Target containment — the target's nearest EXISTING ancestor (the target
+///    itself is usually absent, since we are about to create it) must resolve
+///    inside that same anchored root.
+///
+/// With nothing on the path existing yet, no symlink can be redirecting it and
+/// check 1 is the whole answer.
+/// Test: `paths::tests::write_to_native_dir_is_allowed`,
+/// `paths::tests::write_to_claude_dir_is_refused`,
+/// `paths::tests::write_outside_project_is_refused`,
+/// `paths::tests::symlinked_native_subdir_escape_is_refused`,
+/// `paths::tests::symlinked_native_root_escape_is_refused`.
+pub fn check_native_write_target(
+    project_root: &Path,
+    path: &Path,
+) -> Result<PathBuf, WriteTargetError> {
+    let native_root = native_config_dir(project_root);
+    if !path.starts_with(&native_root) {
+        return Err(WriteTargetError::CrossProduct {
+            path: path.to_path_buf(),
+            native_root,
+        });
+    }
+
+    let escape = |resolved: PathBuf| WriteTargetError::SymlinkEscape {
+        path: path.to_path_buf(),
+        resolved,
+        native_root: native_root.clone(),
+    };
+
+    // #5426: anchor the config root to the project before trusting it. Without
+    // this, a symlinked `.trusty-code` makes every later comparison vacuous.
+    if native_root.exists() {
+        let canon_root = native_root
+            .canonicalize()
+            .map_err(|_| escape(native_root.clone()))?;
+        let canon_project = project_root
+            .canonicalize()
+            .map_err(|_| escape(canon_root.clone()))?;
+        if !canon_root.starts_with(&canon_project) {
+            return Err(escape(canon_root));
+        }
+    }
+
+    // The target itself is typically absent, so containment is judged on the
+    // deepest ancestor that DOES exist.
+    let Some(canon_root) = canonicalize_existing(&native_root) else {
+        // Nothing on this path exists yet, so no symlink can be escaping through
+        // it; the lexical check above is the whole answer.
+        return Ok(path.to_path_buf());
+    };
+    match canonicalize_existing(path) {
+        Some(resolved) if !resolved.starts_with(&canon_root) => Err(escape(resolved)),
+        _ => Ok(path.to_path_buf()),
+    }
+}
+
+/// Canonicalise the deepest existing ancestor of `path` (including `path`).
+///
+/// Why: `Path::canonicalize` fails outright on a path that does not exist yet,
+/// which is the normal case for a write target. Resolving the nearest existing
+/// ancestor still catches every symlink ON the path, which is what the guard
+/// needs.
+/// What: walks up from `path` until `canonicalize` succeeds; `None` when even
+/// the root fails (a path with no existing ancestor at all).
+/// Test: `paths::tests::symlinked_native_subdir_escape_is_refused`.
+fn canonicalize_existing(path: &Path) -> Option<PathBuf> {
+    let mut current = Some(path);
+    while let Some(p) = current {
+        if let Ok(canon) = p.canonicalize() {
+            return Some(canon);
+        }
+        current = p.parent();
+    }
+    None
+}
+
+/// Normalised key words whose presence marks a value as secret-bearing.
+///
+/// Why: project configuration under `.trusty-code/` is committed to the
+/// project's repository by convention, so a credential landing there is a leak
+/// with a long tail. The import path checks against this list before copying a
+/// settings file rather than after.
+/// What: lowercase, separator-free WORD forms — not substrings. A key is split
+/// into words first ([`key_segments`]), so one entry covers every spelling of
+/// it: `api_key`, `API-KEY`, `x-api-key`, `xApiKey` and `APIKEY` all reduce to
+/// the `apikey` form. Multi-word entries (`apikey`, `accesskey`, `privatekey`)
+/// are matched against adjacent word PAIRS as well as against a single
+/// unseparated word.
+/// Test: `paths::tests::secret_keys_match_across_separator_and_case_spellings`,
+/// `paths::tests::benign_keys_containing_a_hint_are_not_flagged`.
+pub const SECRET_KEY_HINTS: &[&str] = &[
+    "accesskey",
+    "apikey",
+    "authorization",
+    "credential",
+    "credentials",
+    "passphrase",
+    "password",
+    "privatekey",
+    "secret",
+    "token",
+];
+
+/// Split a key into lowercase word segments.
+///
+/// Why: matching raw substrings both missed spellings and invented matches —
+/// `x-api-key` contained no hint while `tokenizer` contained `token`
+/// (code-critic HIGH, PR #6980). Splitting into words first makes the rule
+/// spelling-insensitive and word-exact at the same time.
+/// What: breaks on any non-alphanumeric character and on a lower-to-upper
+/// transition (so `xApiKey` yields three words), lowercasing each. An
+/// all-uppercase run stays one word, which is why the unseparated forms
+/// (`apikey`) are listed in [`SECRET_KEY_HINTS`] too.
+/// Test: `paths::tests::secret_keys_match_across_separator_and_case_spellings`,
+/// `paths::tests::benign_keys_containing_a_hint_are_not_flagged`.
+fn key_segments(key: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut prev_was_lower = false;
+    for ch in key.chars() {
+        if !ch.is_ascii_alphanumeric() {
+            if !current.is_empty() {
+                segments.push(std::mem::take(&mut current));
+            }
+            prev_was_lower = false;
+            continue;
+        }
+        if ch.is_ascii_uppercase() && prev_was_lower && !current.is_empty() {
+            segments.push(std::mem::take(&mut current));
+        }
+        prev_was_lower = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+        current.push(ch.to_ascii_lowercase());
+    }
+    if !current.is_empty() {
+        segments.push(current);
+    }
+    segments
+}
+
+/// Whether one JSON key names a credential.
+///
+/// Why: the single rule both the import refusal and its tests apply, so the
+/// spelling coverage cannot drift between them.
+/// What: `true` when any single word of the key, or any two ADJACENT words
+/// joined, equals an entry in [`SECRET_KEY_HINTS`]. Word-exact, so `tokenizer`
+/// and `secretary` are clean while `token` and `x-api-key` are not.
+/// Test: `paths::tests::secret_keys_match_across_separator_and_case_spellings`,
+/// `paths::tests::benign_keys_containing_a_hint_are_not_flagged`.
+pub fn is_secret_key(key: &str) -> bool {
+    let segments = key_segments(key);
+    (1..=2).any(|width| {
+        segments
+            .windows(width)
+            .any(|window| SECRET_KEY_HINTS.contains(&window.concat().as_str()))
+    })
+}
+
+/// Find the first secret-bearing key path in a JSON value, if any.
+///
+/// Why: a boolean would tell an operator that their import was refused without
+/// telling them which key to remove.
+/// What: a depth-first walk returning the dotted key path of the first key
+/// [`is_secret_key`] accepts; `None` when clean. Array elements are indexed
+/// (`mcp.0.token`). Keys only — a bare credential under an unrelated key is out
+/// of scope, as the README states.
+/// Test: `paths::tests::secret_bearing_keys_are_detected`,
+/// `paths::tests::nested_kebab_secret_is_reported_by_path`,
+/// `paths::tests::ordinary_settings_carry_no_secret`.
+pub fn find_secret_key(value: &serde_json::Value) -> Option<String> {
+    fn walk(value: &serde_json::Value, prefix: &str, out: &mut Option<String>) {
+        if out.is_some() {
+            return;
+        }
+        match value {
+            serde_json::Value::Object(map) => {
+                for (key, child) in map {
+                    let path = if prefix.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{prefix}.{key}")
+                    };
+                    if is_secret_key(key) {
+                        *out = Some(path);
+                        return;
+                    }
+                    walk(child, &path, out);
+                    if out.is_some() {
+                        return;
+                    }
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for (i, child) in items.iter().enumerate() {
+                    walk(child, &format!("{prefix}.{i}"), out);
+                    if out.is_some() {
+                        return;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut out = None;
+    walk(value, "", &mut out);
+    out
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/paths/private_state.rs
+++ b/crates/trusty-code/src/paths/private_state.rs
@@ -1,0 +1,175 @@
+//! Private mutable state beneath `~/.trusty-code/` (#5426, epic #2892).
+//!
+//! Why: transcripts, logs, compression telemetry, daemon discovery files, and
+//! channel cursors are per-user runtime state, not project configuration. They
+//! were already landing in `~/.trusty-code` via `workstreams::default_data_dir`,
+//! but nothing named that directory as PRIVATE and nothing set its mode, so a
+//! default-umask machine left `0755` — world-readable transcripts of whatever
+//! the harness was asked to work on.
+//!
+//! What: [`private_state_dir_at`] is the hermetic resolver (an explicit `$HOME`,
+//! so tests never touch a real home directory and never mutate the environment);
+//! [`private_state_dir`] is the production wrapper.
+//! [`ensure_private_state_dir_at`] creates the tree and TIGHTENS the mode to
+//! `0700` on Unix — including on a directory that already existed with a
+//! permissive mode, since the common case is an upgrade over an existing
+//! `~/.trusty-code`. [`is_restrictive`] is the predicate the tests and the
+//! `tcode config paths` diagnostic both assert on.
+//!
+//! Test: `paths::private_state_tests::*`.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::TRUSTY_CODE_DIRNAME;
+
+/// The Unix mode private state is held at: owner-only, no group, no other.
+///
+/// Why: `0700` is the same bar `~/.ssh` sets, and the state here (transcripts,
+/// daemon tokens' neighbours, logs) is comparably sensitive.
+/// What: `0o700`.
+/// Test: `paths::private_state_tests::ensure_tightens_a_permissive_existing_dir`.
+#[cfg(unix)]
+pub const PRIVATE_DIR_MODE: u32 = 0o700;
+
+/// The permission bits that must be clear for a directory to count as private.
+///
+/// Why: comparing the full mode would fail on a directory that is `0700` plus a
+/// sticky or setgid bit, which is not a privacy problem.
+/// What: `0o077` — every group and other bit.
+/// Test: `paths::private_state_tests::permissive_mode_is_not_restrictive`.
+#[cfg(unix)]
+pub const NON_OWNER_BITS: u32 = 0o077;
+
+/// Resolve the private state directory beneath an explicit home directory.
+///
+/// Why: the hermetic core. Every test points `home` at a temp dir, so none of
+/// them reads or writes the developer's real `~/.trusty-code` and none needs to
+/// mutate `$HOME` (an env mutation would race every other test in the binary).
+/// What: `<home>/.trusty-code`.
+/// Test: `paths::private_state_tests::private_state_dir_at_is_dot_trusty_code`.
+pub fn private_state_dir_at(home: &Path) -> PathBuf {
+    home.join(TRUSTY_CODE_DIRNAME)
+}
+
+/// Resolve the production private state directory, `~/.trusty-code`.
+///
+/// Why: the one place `dirs::home_dir()` is consulted for this purpose, so the
+/// no-home fallback is decided once instead of per call site.
+/// What: [`private_state_dir_at`] on `dirs::home_dir()`. With no resolvable home
+/// — a stripped container, a daemon launched with no `$HOME` — it falls back to
+/// a process-relative `.trusty-code` and logs at `warn` with the path used,
+/// rather than panicking a harness that is otherwise fine.
+/// Test: `paths::private_state_tests::private_state_dir_matches_home_when_available`.
+pub fn private_state_dir() -> PathBuf {
+    match dirs::home_dir() {
+        Some(home) => private_state_dir_at(&home),
+        None => {
+            let fallback = PathBuf::from(TRUSTY_CODE_DIRNAME);
+            // #5426: fail open, but never silently — a relative state directory
+            // follows the process's working directory, which is rarely intended.
+            tracing::warn!(
+                path = %fallback.display(),
+                "no home directory could be resolved; falling back to a \
+                 working-directory-relative trusty-code state directory"
+            );
+            fallback
+        }
+    }
+}
+
+/// Create the private state directory and tighten it to owner-only.
+///
+/// Why: creating it with `create_dir_all` alone applies the process umask, which
+/// on a default `022` machine yields `0755`. An upgrade path matters as much as
+/// a fresh install: `~/.trusty-code` already exists on every machine that has
+/// run `tcode`, so this tightens an EXISTING permissive directory rather than
+/// only getting new ones right.
+/// What: `create_dir_all`, then on Unix `set_permissions` to
+/// [`PRIVATE_DIR_MODE`] whenever any of [`NON_OWNER_BITS`] is set. A failure to
+/// tighten is logged at `warn` with the path and the mode observed, and the
+/// directory is still returned — the harness must run on a filesystem that
+/// cannot represent Unix modes. Non-Unix targets create the directory and rely
+/// on the platform's own per-user home ACLs.
+/// Test: `paths::private_state_tests::ensure_creates_restrictive_dir`,
+/// `paths::private_state_tests::ensure_tightens_a_permissive_existing_dir`.
+pub fn ensure_private_state_dir_at(home: &Path) -> io::Result<PathBuf> {
+    let dir = private_state_dir_at(home);
+    std::fs::create_dir_all(&dir)?;
+    harden(&dir);
+    Ok(dir)
+}
+
+/// Create and tighten the production `~/.trusty-code`.
+///
+/// Why: the production wrapper over [`ensure_private_state_dir_at`], so callers
+/// never resolve the home directory themselves.
+/// What: [`private_state_dir`] then the same create-and-tighten sequence.
+/// Test: covered hermetically by `ensure_private_state_dir_at`'s tests; the
+/// wrapper adds only home resolution.
+pub fn ensure_private_state_dir() -> io::Result<PathBuf> {
+    let dir = private_state_dir();
+    std::fs::create_dir_all(&dir)?;
+    harden(&dir);
+    Ok(dir)
+}
+
+/// Tighten `dir` to [`PRIVATE_DIR_MODE`] when any non-owner bit is set.
+///
+/// Why: separated from [`ensure_private_state_dir_at`] so the "already private"
+/// case does a single `metadata` call and no write at all.
+/// What: no-op when [`is_restrictive`] already holds; otherwise
+/// `set_permissions`, logging a `warn` if that fails.
+/// Test: `paths::private_state_tests::ensure_tightens_a_permissive_existing_dir`.
+#[cfg(unix)]
+fn harden(dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let Ok(meta) = std::fs::metadata(dir) else {
+        return;
+    };
+    let mode = meta.permissions().mode();
+    if mode & NON_OWNER_BITS == 0 {
+        return;
+    }
+    if let Err(e) = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))
+    {
+        tracing::warn!(
+            path = %dir.display(),
+            mode = format!("{:o}", mode & 0o777),
+            error = %e,
+            "could not tighten the trusty-code private state directory to 0700; \
+             its contents may be readable by other users on this machine"
+        );
+    }
+}
+
+/// Non-Unix targets have no mode bits to tighten.
+#[cfg(not(unix))]
+fn harden(_dir: &Path) {}
+
+/// Whether a directory's permissions keep it private to its owner.
+///
+/// Why: the assertion the permissive-permissions test makes, and the field the
+/// `tcode config paths` diagnostic reports, must come from ONE rule.
+/// What: on Unix, `true` when none of [`NON_OWNER_BITS`] is set; `Err` when the
+/// directory cannot be stat'd. On non-Unix targets, always `true` — the platform
+/// has no comparable bits and the home directory's ACL governs.
+/// Test: `paths::private_state_tests::permissive_mode_is_not_restrictive`,
+/// `paths::private_state_tests::ensure_creates_restrictive_dir`.
+#[cfg(unix)]
+pub fn is_restrictive(dir: &Path) -> io::Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = std::fs::metadata(dir)?.permissions().mode();
+    Ok(mode & NON_OWNER_BITS == 0)
+}
+
+/// See the Unix variant — non-Unix targets have no mode bits to inspect.
+#[cfg(not(unix))]
+pub fn is_restrictive(dir: &Path) -> io::Result<bool> {
+    std::fs::metadata(dir)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+#[path = "private_state_tests.rs"]
+mod private_state_tests;

--- a/crates/trusty-code/src/paths/private_state_tests.rs
+++ b/crates/trusty-code/src/paths/private_state_tests.rs
@@ -1,0 +1,140 @@
+//! Unit tests for the private `~/.trusty-code/` state root (#5426).
+//!
+//! Why: the permissions property is the one an operator cannot see and cannot
+//! easily audit, so it needs a test that actually reads the mode back off disk.
+//! What: layout, creation mode, tightening an existing permissive directory, and
+//! the predicate that rejects a permissive mode.
+//! Test: this file IS the test module.
+
+use super::*;
+
+/// Whether this process runs as root (which ignores permission bits).
+#[cfg(unix)]
+fn running_as_root() -> bool {
+    // SAFETY: `geteuid` takes no arguments, touches no memory, and cannot fail.
+    unsafe { libc::geteuid() == 0 }
+}
+
+/// The private state directory is `<home>/.trusty-code`.
+///
+/// Why: pins the layout so it cannot drift from the project-side constant.
+/// What: an explicit home; no environment mutation.
+/// Test: this function IS the test.
+#[test]
+fn private_state_dir_at_is_dot_trusty_code() {
+    let home = std::path::Path::new("/tmp/some-home");
+    assert_eq!(
+        private_state_dir_at(home),
+        home.join(TRUSTY_CODE_DIRNAME),
+        "private state must live at <home>/.trusty-code"
+    );
+}
+
+/// The production wrapper agrees with the hermetic core.
+///
+/// Why: the wrapper's only job is home resolution; a divergence would put
+/// production state somewhere the tests never look.
+/// What: compares `private_state_dir()` against `private_state_dir_at(home)` on
+/// a machine that has a home directory. Reads nothing and creates nothing.
+/// Test: this function IS the test.
+#[test]
+fn private_state_dir_matches_home_when_available() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    assert_eq!(private_state_dir(), private_state_dir_at(&home));
+}
+
+/// A freshly created private state directory is `0700`.
+///
+/// Why: `create_dir_all` alone applies the process umask, which on a default
+/// `022` machine leaves transcripts world-readable.
+/// What: creates the directory under a temp home and reads the mode back.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn ensure_creates_restrictive_dir() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = ensure_private_state_dir_at(tmp.path()).expect("create private state dir");
+
+    assert!(dir.is_dir());
+    let mode = std::fs::metadata(&dir).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(mode, PRIVATE_DIR_MODE, "expected 0700, got {mode:o}");
+    assert!(is_restrictive(&dir).expect("stat"));
+}
+
+/// An existing permissive directory is tightened, not left as found.
+///
+/// Why: `~/.trusty-code` already exists on every machine that has run `tcode`,
+/// so getting only fresh installs right would leave the actual fleet exposed.
+/// What: pre-creates the directory at `0755`, runs `ensure_private_state_dir_at`,
+/// and asserts the mode became `0700`.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn ensure_tightens_a_permissive_existing_dir() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if running_as_root() {
+        return;
+    }
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = private_state_dir_at(tmp.path());
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+    assert!(
+        !is_restrictive(&dir).expect("stat"),
+        "precondition: 0755 must not count as restrictive"
+    );
+
+    let created = ensure_private_state_dir_at(tmp.path()).expect("ensure");
+
+    assert_eq!(created, dir);
+    let mode = std::fs::metadata(&dir).expect("stat").permissions().mode() & 0o777;
+    assert_eq!(mode, PRIVATE_DIR_MODE, "expected 0700, got {mode:o}");
+}
+
+/// A permissive mode is rejected by the predicate.
+///
+/// Why: this is the assertion an audit — and the `tcode config paths`
+/// diagnostic — relies on; a predicate that returned `true` for `0755` would
+/// make every other permissions test vacuous.
+/// What: stages `0750`, `0705`, and `0700` and asserts only the last is private.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn permissive_mode_is_not_restrictive() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if running_as_root() {
+        return;
+    }
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("state");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+
+    for permissive in [0o750, 0o705, 0o777] {
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(permissive)).expect("chmod");
+        assert!(
+            !is_restrictive(&dir).expect("stat"),
+            "{permissive:o} exposes bits to group or other and must not count as private"
+        );
+    }
+
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+    assert!(is_restrictive(&dir).expect("stat"));
+}
+
+/// A missing directory surfaces the I/O error rather than claiming privacy.
+///
+/// Why: `is_restrictive` returning `Ok(true)` for an absent path would let an
+/// audit pass on a directory that does not exist.
+/// What: asserts `Err` for a path that was never created.
+/// Test: this function IS the test.
+#[test]
+fn is_restrictive_errors_on_a_missing_dir() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(is_restrictive(&tmp.path().join("nope")).is_err());
+}

--- a/crates/trusty-code/src/paths/tests.rs
+++ b/crates/trusty-code/src/paths/tests.rs
@@ -1,0 +1,517 @@
+//! Unit tests for the `.trusty-code/` project-configuration resolver (#5426).
+//!
+//! Why: the precedence rule, the fail-open warning, and the native-write guard
+//! are the three properties every other #5426 change depends on; each is proven
+//! here against a real temp tree rather than a mocked filesystem.
+//! What: precedence across the three search roots, the default when nothing
+//! exists, the unreadable-candidate fallback (directory AND file), the
+//! write-target guard including a symlink escape, and the secret-key scanner.
+//! Test: this file IS the test module.
+
+use super::*;
+
+use std::sync::{Arc, Mutex};
+
+/// A `tracing` writer collecting every formatted event into a shared buffer.
+///
+/// Why: the Fail-Open Check requires the fallback to LOG at warn with the path
+/// tried; asserting on the returned `unreadable` field alone would pass even if
+/// the warning were deleted.
+/// What: a `MakeWriter` over an `Arc<Mutex<Vec<u8>>>`, installed per-test with
+/// `tracing::subscriber::with_default` (thread-local, so parallel tests in this
+/// binary never race a global subscriber).
+/// Test: used by `unreadable_native_dir_falls_back_and_is_reported`.
+#[derive(Clone)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Run `f` with a thread-local tracing subscriber and return its captured output.
+fn capture_logs<T>(f: impl FnOnce() -> T) -> (T, String) {
+    let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(CaptureWriter(Arc::clone(&buffer)))
+        .with_ansi(false)
+        .with_max_level(tracing::Level::WARN)
+        .finish();
+    let out = tracing::subscriber::with_default(subscriber, f);
+    let logs =
+        String::from_utf8_lossy(&buffer.lock().unwrap_or_else(|e| e.into_inner())).to_string();
+    (out, logs)
+}
+
+/// Create `<root>/<dirname>/<relative>` as a directory.
+fn mkdir(root: &std::path::Path, dirname: &str, relative: &str) -> PathBuf {
+    let p = root.join(dirname).join(relative);
+    std::fs::create_dir_all(&p).expect("mkdir");
+    p
+}
+
+/// Whether this process runs as root (which ignores permission bits).
+#[cfg(unix)]
+fn running_as_root() -> bool {
+    // SAFETY: `geteuid` takes no arguments, touches no memory, and cannot fail.
+    unsafe { libc::geteuid() == 0 }
+}
+
+// -- precedence ------------------------------------------------------------
+
+/// `.trusty-code/` wins over `.claude/` when both exist.
+///
+/// Why: this is the whole inversion #5426 asks for — Trusty Code's own
+/// directory is the source of truth, and `.claude/` only fills in behind it.
+/// What: creates both `agents` directories and asserts the resolved path and
+/// source name the native one.
+/// Test: this function IS the test.
+#[test]
+fn precedence_prefers_trusty_code_over_claude() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let native = mkdir(tmp.path(), TRUSTY_CODE_DIRNAME, "agents");
+    mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "agents");
+
+    let resolved = agents_dir(tmp.path());
+
+    assert_eq!(resolved.path, native);
+    assert_eq!(resolved.source, ConfigSource::TrustyCode);
+    assert!(resolved.unreadable.is_empty());
+}
+
+/// `.claude/` still resolves when `.trusty-code/` is absent.
+///
+/// Why: every existing project has only `.claude/`; breaking them was never on
+/// the table.
+/// What: creates only `.claude/agents` and asserts it wins with the
+/// compatibility source.
+/// Test: this function IS the test.
+#[test]
+fn falls_back_to_claude_when_trusty_code_absent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let claude = mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "agents");
+
+    let resolved = agents_dir(tmp.path());
+
+    assert_eq!(resolved.path, claude);
+    assert_eq!(resolved.source, ConfigSource::ClaudeCompat);
+    assert!(!resolved.source.is_native());
+}
+
+/// `.open-mpm/` is still honoured behind both newer roots.
+///
+/// Why: `agents::locate_agents_dir` already supported it; the rewrite must not
+/// quietly drop a supported layout.
+/// What: creates only `.open-mpm/agents` and asserts it wins.
+/// Test: this function IS the test.
+#[test]
+fn falls_back_to_open_mpm_when_neither_native_nor_claude() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let legacy = mkdir(tmp.path(), OPEN_MPM_LEGACY_DIRNAME, "agents");
+
+    let resolved = agents_dir(tmp.path());
+
+    assert_eq!(resolved.path, legacy);
+    assert_eq!(resolved.source, ConfigSource::OpenMpmLegacy);
+}
+
+/// With nothing on disk, the resolver names the NATIVE path.
+///
+/// Why: "a clean project can install and run without a `.claude/` directory"
+/// requires that the not-yet-created default point at `.trusty-code/`, not at
+/// the compatibility root.
+/// What: an empty project root; asserts the default path and source.
+/// Test: this function IS the test.
+#[test]
+fn default_source_when_nothing_exists() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let resolved = agents_dir(tmp.path());
+
+    assert_eq!(
+        resolved.path,
+        tmp.path().join(TRUSTY_CODE_DIRNAME).join("agents")
+    );
+    assert_eq!(resolved.source, ConfigSource::Default);
+    assert!(resolved.source.is_native());
+}
+
+/// Skills, plugins, and settings follow the same precedence as agents.
+///
+/// Why: the point of one resolver is that no entry has its own rule; a per-kind
+/// test is what proves the wiring actually routes through it.
+/// What: creates each native entry alongside a `.claude/` twin and asserts the
+/// native one wins in all three.
+/// Test: this function IS the test.
+#[test]
+fn skills_dir_prefers_trusty_code() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let native = mkdir(tmp.path(), TRUSTY_CODE_DIRNAME, "skills");
+    mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "skills");
+    assert_eq!(skills_dir(tmp.path()).path, native);
+}
+
+/// See `skills_dir_prefers_trusty_code`.
+#[test]
+fn plugins_dir_prefers_trusty_code() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let native = mkdir(tmp.path(), TRUSTY_CODE_DIRNAME, "plugins");
+    mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "plugins");
+    assert_eq!(plugins_dir(tmp.path()).path, native);
+}
+
+/// See `skills_dir_prefers_trusty_code`.
+#[test]
+fn agents_dir_prefers_trusty_code() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let native = mkdir(tmp.path(), TRUSTY_CODE_DIRNAME, "agents");
+    mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "agents");
+    assert_eq!(agents_dir(tmp.path()).path, native);
+}
+
+/// `settings.json` resolves as a FILE, native first.
+///
+/// Why: a directory named `settings.json` must not satisfy the lookup, and a
+/// project with only `.trusty-code/settings.json` must be able to set
+/// `code_harness.mode`.
+/// What: writes both files and asserts the native one wins.
+/// Test: this function IS the test.
+#[test]
+fn settings_file_prefers_trusty_code() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let native_dir = mkdir(tmp.path(), TRUSTY_CODE_DIRNAME, "");
+    let claude_dir = mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "");
+    std::fs::write(native_dir.join(SETTINGS_FILENAME), "{}").expect("write");
+    std::fs::write(claude_dir.join(SETTINGS_FILENAME), "{}").expect("write");
+
+    let resolved = settings_file(tmp.path());
+
+    assert_eq!(resolved.path, native_dir.join(SETTINGS_FILENAME));
+    assert_eq!(resolved.source, ConfigSource::TrustyCode);
+}
+
+/// The source tokens are the wire contract the CLI and logs share.
+#[test]
+fn source_tokens_are_stable() {
+    assert_eq!(ConfigSource::TrustyCode.as_str(), "trusty-code");
+    assert_eq!(ConfigSource::ClaudeCompat.as_str(), "claude");
+    assert_eq!(ConfigSource::OpenMpmLegacy.as_str(), "open-mpm");
+    assert_eq!(ConfigSource::Default.as_str(), "default");
+    assert!(ConfigSource::TrustyCode.is_native());
+    assert!(ConfigSource::Default.is_native());
+    assert!(!ConfigSource::ClaudeCompat.is_native());
+    assert!(!ConfigSource::OpenMpmLegacy.is_native());
+}
+
+// -- fail-open behaviour ---------------------------------------------------
+
+/// An unreadable `.trusty-code/agents` falls back to `.claude/agents`, records
+/// the skipped path, and WARNS with it.
+///
+/// Why: the Fail-Open Check. A harness that aborts because an optional config
+/// directory lost its read bit is worse than one that starts with less config —
+/// but a silent fallback is worse than both, because the operator then debugs
+/// the wrong directory.
+/// What: chmods `.trusty-code/agents` to `0o000`, resolves under a captured
+/// subscriber, and asserts the winner is `.claude`, the skipped path is
+/// reported, and the warning names the unreadable path.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn unreadable_native_dir_falls_back_and_is_reported() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if running_as_root() {
+        // root ignores permission bits, so the unreadable case cannot be staged.
+        return;
+    }
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let native = mkdir(tmp.path(), TRUSTY_CODE_DIRNAME, "agents");
+    let claude = mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "agents");
+    std::fs::set_permissions(&native, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+    let (resolved, logs) = capture_logs(|| agents_dir(tmp.path()));
+
+    // Restore before any assertion can unwind past the tempdir cleanup.
+    std::fs::set_permissions(&native, std::fs::Permissions::from_mode(0o755)).expect("restore");
+
+    assert_eq!(resolved.source, ConfigSource::ClaudeCompat);
+    assert_eq!(resolved.path, claude);
+    assert_eq!(resolved.unreadable, vec![native.clone()]);
+    assert!(
+        logs.contains(&native.display().to_string()),
+        "warning must name the unreadable path tried; logs were:\n{logs}"
+    );
+    assert!(
+        logs.contains("WARN"),
+        "fallback must be logged at warn; logs were:\n{logs}"
+    );
+}
+
+/// An unreadable `settings.json` falls back to the next root and WARNS.
+///
+/// Why: the file-shaped half of the same Fail-Open Check — `probe` uses a
+/// different syscall for files, so the directory test does not cover it.
+/// What: chmods `.trusty-code/settings.json` to `0o000` and asserts the
+/// `.claude/` one wins with a warning naming the unreadable path.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn unreadable_settings_file_falls_back_and_is_reported() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if running_as_root() {
+        return;
+    }
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let native_dir = mkdir(tmp.path(), TRUSTY_CODE_DIRNAME, "");
+    let claude_dir = mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "");
+    let native = native_dir.join(SETTINGS_FILENAME);
+    std::fs::write(&native, "{}").expect("write");
+    std::fs::write(claude_dir.join(SETTINGS_FILENAME), "{}").expect("write");
+    std::fs::set_permissions(&native, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+    let (resolved, logs) = capture_logs(|| settings_file(tmp.path()));
+
+    std::fs::set_permissions(&native, std::fs::Permissions::from_mode(0o644)).expect("restore");
+
+    assert_eq!(resolved.source, ConfigSource::ClaudeCompat);
+    assert_eq!(resolved.unreadable, vec![native.clone()]);
+    assert!(
+        logs.contains(&native.display().to_string()),
+        "warning must name the unreadable path tried; logs were:\n{logs}"
+    );
+}
+
+// -- native write boundary -------------------------------------------------
+
+/// `native_config_dir` never consults the filesystem.
+///
+/// Why: the read path may resolve into `.claude/`; the WRITE path must not, even
+/// on a project where only `.claude/` exists.
+/// What: an empty root and a `.claude`-only root both yield `.trusty-code`.
+/// Test: this function IS the test.
+#[test]
+fn native_config_dir_is_always_trusty_code() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    mkdir(tmp.path(), CLAUDE_COMPAT_DIRNAME, "agents");
+
+    assert_eq!(
+        native_config_dir(tmp.path()),
+        tmp.path().join(TRUSTY_CODE_DIRNAME)
+    );
+    assert_eq!(
+        native_child(tmp.path(), "agents/pm.md"),
+        tmp.path().join(TRUSTY_CODE_DIRNAME).join("agents/pm.md")
+    );
+}
+
+/// A target beneath `.trusty-code/` is permitted.
+#[test]
+fn write_to_native_dir_is_allowed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let target = native_child(tmp.path(), "agents/pm.md");
+    assert_eq!(
+        check_native_write_target(tmp.path(), &target).expect("native target must be allowed"),
+        target
+    );
+}
+
+/// A write aimed at `.claude/` is refused as a cross-product write.
+///
+/// Why: "native project writes stay beneath `<project>/.trusty-code/`" — a
+/// harness that writes into Claude Code's directory is mutating another
+/// product's state.
+/// What: asserts a `.claude/agents/pm.md` target yields `CrossProduct`.
+/// Test: this function IS the test.
+#[test]
+fn write_to_claude_dir_is_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let target = tmp.path().join(CLAUDE_COMPAT_DIRNAME).join("agents/pm.md");
+
+    let err = check_native_write_target(tmp.path(), &target).expect_err("must be refused");
+
+    assert!(matches!(err, WriteTargetError::CrossProduct { .. }));
+    assert!(err.to_string().contains(TRUSTY_CODE_DIRNAME));
+}
+
+/// A write outside the project entirely is refused.
+#[test]
+fn write_outside_project_is_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let err = check_native_write_target(tmp.path(), std::path::Path::new("/etc/passwd"))
+        .expect_err("must be refused");
+    assert!(matches!(err, WriteTargetError::CrossProduct { .. }));
+}
+
+/// A lexically-inside target that resolves outside through a symlink is refused.
+///
+/// Why: `starts_with` alone is satisfied by `.trusty-code/agents ->
+/// /somewhere/else`, and every write would then land outside the project.
+/// What: symlinks `.trusty-code/agents` at a sibling temp directory and asserts
+/// a target inside it is refused as a `SymlinkEscape`.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn symlinked_native_subdir_escape_is_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("tempdir");
+    let native = native_config_dir(tmp.path());
+    std::fs::create_dir_all(&native).expect("mkdir");
+    std::os::unix::fs::symlink(outside.path(), native.join("agents")).expect("symlink");
+
+    let target = native.join("agents").join("pm.md");
+    let err = check_native_write_target(tmp.path(), &target).expect_err("must be refused");
+
+    assert!(
+        matches!(err, WriteTargetError::SymlinkEscape { .. }),
+        "expected SymlinkEscape, got {err:?}"
+    );
+}
+
+// -- secret scanning -------------------------------------------------------
+
+/// Secret-bearing keys are found anywhere in the JSON tree, by dotted path.
+#[test]
+fn secret_bearing_keys_are_detected() {
+    let value = serde_json::json!({
+        "code_harness": { "mode": "parity" },
+        "mcp": [{ "name": "x", "env": { "OPENROUTER_API_KEY": "sk-live" } }],
+    });
+    assert_eq!(
+        find_secret_key(&value).as_deref(),
+        Some("mcp.0.env.OPENROUTER_API_KEY")
+    );
+
+    let top = serde_json::json!({ "authToken": "abc" });
+    assert_eq!(find_secret_key(&top).as_deref(), Some("authToken"));
+}
+
+/// An ordinary settings file carries no secret.
+#[test]
+fn ordinary_settings_carry_no_secret() {
+    let value = serde_json::json!({ "code_harness": { "mode": "daily-driver" } });
+    assert_eq!(find_secret_key(&value), None);
+}
+
+/// Kebab, camel, header and SCREAMING spellings of the same key all match.
+///
+/// Why: code-critic HIGH on PR #6980 — the scanner matched raw lowercase
+/// substrings, so `api_key` was caught and `API-KEY`, `x-api-key`, `access-key`
+/// and `private-key` were not. A credential under any of those spellings
+/// imported straight into a file the project commits.
+/// What: one key per spelling, each asserted secret-bearing.
+/// Test: this function IS the test.
+#[test]
+fn secret_keys_match_across_separator_and_case_spellings() {
+    for key in [
+        "api_key",
+        "API-KEY",
+        "x-api-key",
+        "xApiKey",
+        "apiKey",
+        "APIKEY",
+        "access-key",
+        "accessKey",
+        "private-key",
+        "AWS_SECRET_ACCESS_KEY",
+        "Authorization",
+        "auth-token",
+        "authToken",
+        "user.password",
+        "PassPhrase",
+        "gh-credential",
+    ] {
+        assert!(
+            is_secret_key(key),
+            "{key} must be recognised as secret-bearing"
+        );
+    }
+}
+
+/// A benign key that merely CONTAINS a hint is not flagged.
+///
+/// Why: the fix for the spelling gap must not be a looser substring match —
+/// `tokenizer` and `secretary` contain `token` and `secret` and are ordinary
+/// configuration, so flagging them would refuse imports for no reason.
+/// What: asserts each benign key is clean, including a compound where the hint
+/// is a strict prefix or suffix of a real word.
+/// Test: this function IS the test.
+#[test]
+fn benign_keys_containing_a_hint_are_not_flagged() {
+    for key in [
+        "tokenizer",
+        "tokenizerPath",
+        "secretary",
+        "max_tokens",
+        "keychain",
+        "keyboard",
+        "passwordless_hint_text",
+        "mode",
+        "cadence_turns",
+    ] {
+        assert!(!is_secret_key(key), "{key} must NOT be flagged as secret");
+    }
+}
+
+/// `find_secret_key` reports the dotted path of a kebab-spelled key.
+///
+/// Why: the walk and the per-key rule are separate; proving the rule alone would
+/// not show the walk actually applies it at depth.
+/// What: a header-style key nested under an array element.
+/// Test: this function IS the test.
+#[test]
+fn nested_kebab_secret_is_reported_by_path() {
+    let value = serde_json::json!({
+        "mcp": [{ "name": "x", "headers": { "X-Api-Key": "sk-live" } }],
+    });
+    assert_eq!(
+        find_secret_key(&value).as_deref(),
+        Some("mcp.0.headers.X-Api-Key")
+    );
+}
+
+/// A `.trusty-code` that is ITSELF a symlink out of the project is refused.
+///
+/// Why: code-critic BLOCK on PR #6980. The guard resolved the target and the
+/// config root the same way and compared them to EACH OTHER, so when
+/// `<project>/.trusty-code` pointed at an outside directory, every "protected"
+/// write agreed with a root that was already outside the project and passed.
+/// `symlinked_native_subdir_escape_is_refused` covers a symlinked SUBdirectory
+/// and does not reach this case.
+/// What: symlinks `<project>/.trusty-code` at a sibling temp directory and
+/// asserts a target inside it is refused as a `SymlinkEscape`.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn symlinked_native_root_escape_is_refused() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("tempdir");
+    std::os::unix::fs::symlink(outside.path(), tmp.path().join(TRUSTY_CODE_DIRNAME))
+        .expect("symlink");
+
+    let target = native_child(tmp.path(), "agents/pm.md");
+    let err = check_native_write_target(tmp.path(), &target).expect_err("must be refused");
+
+    assert!(
+        matches!(err, WriteTargetError::SymlinkEscape { .. }),
+        "expected SymlinkEscape, got {err:?}"
+    );
+}

--- a/crates/trusty-code/src/paths/tests.rs
+++ b/crates/trusty-code/src/paths/tests.rs
@@ -446,6 +446,68 @@ fn secret_keys_match_across_separator_and_case_spellings() {
     }
 }
 
+/// Plural spellings match too — `tokens` is as much a credential as `token`.
+///
+/// Why: code-critic round 2 HIGH on PR #6980. The hint list carried
+/// `credential` AND `credentials` but left `secret`, `token`, `accesskey`,
+/// `apikey` and `privatekey` singular-only, so seven ordinary plural spellings
+/// walked past the matcher into a file the project commits.
+/// What: the seven spellings the critic probed, each asserted secret-bearing.
+/// Test: this function IS the test.
+#[test]
+fn secret_keys_match_plural_spellings() {
+    for key in [
+        "tokens",
+        "secretsFile",
+        "refreshTokens",
+        "apiSecrets",
+        "clientSecrets",
+        "accessKeys",
+        "apiKeys",
+        "credentials",
+        "private-keys",
+    ] {
+        assert!(
+            is_secret_key(key),
+            "{key} must be recognised as secret-bearing"
+        );
+    }
+}
+
+/// `max_tokens` names a COUNT, not a credential, and stays benign.
+///
+/// Why: making the match plural-insensitive turns `tokens` into a hit, which
+/// would sweep up `max_tokens` — an LLM sampling parameter this crate's own
+/// `code_harness` settings carry. Refusing to import the very file the feature
+/// exists to migrate is worse than the leak risk of a key that holds an integer,
+/// so a short exemption list of count-shaped compounds ([`SECRET_KEY_EXEMPTIONS`])
+/// is checked first. The exemption matches the WHOLE key only, so appending a
+/// real credential (`max_tokens_api_key`) still trips the scanner.
+/// What: asserts each count-shaped key is clean and that the exemption cannot be
+/// used as a prefix to smuggle a credential past the check.
+/// Test: this function IS the test.
+#[test]
+fn max_tokens_stays_benign_as_a_count_not_a_credential() {
+    for key in [
+        "max_tokens",
+        "maxTokens",
+        "min_tokens",
+        "token_count",
+        "tokenLimit",
+        "total_tokens",
+    ] {
+        assert!(
+            !is_secret_key(key),
+            "{key} names a count and must NOT be flagged"
+        );
+    }
+
+    assert!(
+        is_secret_key("max_tokens_api_key"),
+        "an exemption must not shield a real credential appended to it"
+    );
+}
+
 /// A benign key that merely CONTAINS a hint is not flagged.
 ///
 /// Why: the fix for the spelling gap must not be a looser substring match —

--- a/crates/trusty-code/src/plugins/mod.rs
+++ b/crates/trusty-code/src/plugins/mod.rs
@@ -78,8 +78,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-/// The `.claude/plugins` directory name, relative to a project root.
-const PLUGINS_DIRNAME: &str = "plugins";
+// #5426: the `plugins` directory name moved to `crate::paths::plugins_dir`,
+// which owns the `.trusty-code` → `.claude` → `.open-mpm` precedence for it.
 
 /// `.claude-plugin/plugin.json` keys Phase 1 recognizes as later-phase
 /// surfaces (commands/hooks/MCP) — present but intentionally unimplemented,
@@ -140,22 +140,25 @@ struct PluginManifest {
     other: serde_json::Map<String, serde_json::Value>,
 }
 
-/// Discover every plugin under `<project_root>/.claude/plugins/`.
+/// Discover every plugin under the project's resolved `plugins/` directory.
 ///
 /// Why: the single scan point [`agents::discover_plugin_agents`],
 /// [`skills::discover_plugin_skills`], and the namespaced-name resolvers in
 /// both submodules all build on.
-/// What: each immediate subdirectory of `.claude/plugins/` is one plugin
-/// root, resolved via `load_plugin_root`. A missing/unreadable
-/// `.claude/plugins/` directory yields an empty list (never an error — a
-/// project simply using no plugins is the common case, mirroring
-/// `agents::discover_agents`'s missing-dir handling). Non-directory entries
-/// are skipped. Sorted by resolved name.
+/// What: the directory comes from [`crate::paths::plugins_dir`], so a project
+/// that has moved to `.trusty-code/plugins/` is scanned there and one still on
+/// `.claude/plugins/` keeps working (#5426). Each immediate subdirectory is one
+/// plugin root, resolved via `load_plugin_root`. A missing/unreadable directory
+/// yields an empty list (never an error — a project simply using no plugins is
+/// the common case, mirroring `agents::discover_agents`'s missing-dir handling).
+/// Non-directory entries are skipped. Sorted by resolved name.
 /// Test: `tests::discover_plugin_roots_missing_dir_is_empty`,
 /// `tests::discover_plugin_roots_finds_subdirs`,
-/// `tests::discover_plugin_roots_honors_manifest_name_override`.
+/// `tests::discover_plugin_roots_honors_manifest_name_override`,
+/// `paths::tests::plugins_dir_prefers_trusty_code`.
 pub fn discover_plugin_roots(project_root: &Path) -> Vec<PluginRoot> {
-    let plugins_dir = project_root.join(".claude").join(PLUGINS_DIRNAME);
+    // #5426: resolved, not joined — `.trusty-code/plugins` then `.claude/plugins`.
+    let plugins_dir = crate::paths::plugins_dir(project_root).path;
     let Ok(entries) = std::fs::read_dir(&plugins_dir) else {
         tracing::debug!(
             "plugins dir not found or unreadable: {}",

--- a/crates/trusty-code/src/project_context/mod.rs
+++ b/crates/trusty-code/src/project_context/mod.rs
@@ -56,25 +56,27 @@ pub fn load_project_context(project_root: &Path) -> Option<String> {
     Some(truncate_with_note(&raw, MAX_CONTEXT_BYTES))
 }
 
-/// Locate the project `CLAUDE.md`, preferring the root then the `.claude/` nest.
+/// Locate the project `CLAUDE.md`, preferring the root then a nested copy.
 ///
 /// Why: Claude Code reads a root `CLAUDE.md`; some projects nest it under
-/// `.claude/`. Checking both (root first) matches what a human session sees
-/// without forcing a particular layout.
-/// What: Returns the first existing path of `<root>/CLAUDE.md` or
-/// `<root>/.claude/CLAUDE.md`; `None` when neither exists.
+/// `.claude/`. Checking the root first matches what a human session sees
+/// without forcing a particular layout. #5426 adds the nested
+/// `.trusty-code/CLAUDE.md` ahead of `.claude/CLAUDE.md` so a project can hold
+/// its context entirely inside Trusty Code's own directory.
+/// What: `<root>/CLAUDE.md` if it exists; otherwise
+/// [`crate::paths::resolve_project_entry`] for `CLAUDE.md` as a file, which
+/// walks `.trusty-code/` → `.claude/` → `.open-mpm/`. `None` when none exists.
 /// Test: `loads_root_claude_md`, `loads_nested_claude_md`,
-/// `missing_file_returns_none`.
+/// `loads_trusty_code_claude_md`, `missing_file_returns_none`.
 fn locate_claude_md(project_root: &Path) -> Option<PathBuf> {
     let root = project_root.join(CLAUDE_MD);
     if root.is_file() {
         return Some(root);
     }
-    let nested = project_root.join(".claude").join(CLAUDE_MD);
-    if nested.is_file() {
-        return Some(nested);
-    }
-    None
+    // #5426: one resolver for every nested project-config lookup.
+    let nested =
+        crate::paths::resolve_project_entry(project_root, CLAUDE_MD, crate::paths::EntryKind::File);
+    (nested.source != crate::paths::ConfigSource::Default).then_some(nested.path)
 }
 
 /// Truncate `content` to at most `max_bytes`, appending a provenance note when
@@ -145,6 +147,36 @@ mod tests {
 
         let ctx = load_project_context(tmp.path()).expect("nested context loaded");
         assert_eq!(ctx, "NESTED RULES");
+    }
+
+    /// A nested `.trusty-code/CLAUDE.md` is loaded, and outranks `.claude/`.
+    ///
+    /// Why: #5426 — a project must be able to hold its context entirely inside
+    /// Trusty Code's own directory. On `origin/main` this fails: the loader
+    /// checked only `<root>/CLAUDE.md` and `<root>/.claude/CLAUDE.md`.
+    /// What: writes the `.trusty-code/` copy alone, then adds a `.claude/` one
+    /// and asserts the native copy still wins.
+    /// Test: this function IS the test.
+    #[test]
+    fn loads_trusty_code_claude_md() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let native = tmp.path().join(".trusty-code");
+        std::fs::create_dir_all(&native).expect("mkdir .trusty-code");
+        std::fs::write(native.join("CLAUDE.md"), "NATIVE RULES").expect("write native");
+
+        assert_eq!(
+            load_project_context(tmp.path()).expect("native context loaded"),
+            "NATIVE RULES"
+        );
+
+        let compat = tmp.path().join(".claude");
+        std::fs::create_dir_all(&compat).expect("mkdir .claude");
+        std::fs::write(compat.join("CLAUDE.md"), "COMPAT RULES").expect("write compat");
+
+        assert_eq!(
+            load_project_context(tmp.path()).expect("native context still wins"),
+            "NATIVE RULES"
+        );
     }
 
     /// The root file wins over a nested one when both exist.

--- a/crates/trusty-code/src/skills/mod.rs
+++ b/crates/trusty-code/src/skills/mod.rs
@@ -88,17 +88,22 @@ pub enum SkillError {
     },
 }
 
-/// Locate the Claude-Code-compatible skills directory for a project root.
+/// Locate the skills directory for a project root.
 ///
-/// Why: #2069 pins this to `.claude/skills/` exactly — the Claude-Code-native
-/// convention — and explicitly NOT the legacy `~/.trusty-mpm/skills/` path
-/// trusty-mpm uses, so a project's skill catalog resolves identically whether
-/// browsed by a human in Claude Code or discovered by `tcode`.
-/// What: Returns `<project_root>/.claude/skills` (may not exist yet — callers
-/// handle absence via `discover_skill_metadata`'s empty-Vec fallback).
-/// Test: `locate_skills_dir_is_dot_claude_skills`.
+/// Why: #2069 pinned this to `.claude/skills/` exactly. #5426 unpins it: Trusty
+/// Code owns `<project_root>/.trusty-code/skills/`, and `.claude/skills/` stays
+/// readable behind it so a project's existing catalog keeps resolving whether
+/// browsed by a human in Claude Code or discovered by `tcode`. It is still
+/// explicitly NOT the `~/.trusty-mpm/skills/` path trusty-mpm uses.
+/// What: delegates to [`crate::paths::skills_dir`] and keeps its path — the
+/// single precedence rule, shared with agents, plugins, and settings. May not
+/// exist yet; callers handle absence via `discover_skill_metadata`'s empty-Vec
+/// fallback.
+/// Test: `locate_skills_dir_is_dot_claude_skills`,
+/// `paths::tests::skills_dir_prefers_trusty_code`.
 pub fn locate_skills_dir(project_root: &Path) -> PathBuf {
-    project_root.join(".claude").join("skills")
+    // #5426: one resolver, not a second copy of the precedence chain.
+    crate::paths::skills_dir(project_root).path
 }
 
 /// Discover skill metadata from every `<dir>/<skill-name>/SKILL.md`.
@@ -382,15 +387,38 @@ mod tests {
         std::fs::write(dir.join("SKILL.md"), format!("{frontmatter}{body}")).expect("write");
     }
 
-    /// `locate_skills_dir` returns `<project_root>/.claude/skills` exactly.
+    /// `locate_skills_dir` defaults to `.trusty-code/skills` and still finds an
+    /// existing `.claude/skills` (#5426).
     ///
-    /// Why: Pins the Claude-Code-compatible path (#2069) so a future edit
-    /// cannot silently drift back to `~/.trusty-mpm/skills/`.
-    /// Test: this test.
+    /// Why: pins both halves — the native default (so a clean project needs no
+    /// `.claude/`) and the compatibility fallback (so an existing catalog keeps
+    /// resolving) — and keeps either from drifting to `~/.trusty-mpm/skills/`.
+    /// What: an empty project resolves native; adding `.claude/skills` makes it
+    /// win; adding `.trusty-code/skills` takes precedence back.
+    /// Test: this function IS the test.
     #[test]
     fn locate_skills_dir_is_dot_claude_skills() {
-        let root = Path::new("/fake/project");
-        assert_eq!(locate_skills_dir(root), root.join(".claude").join("skills"));
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        assert_eq!(
+            locate_skills_dir(root),
+            root.join(".trusty-code").join("skills"),
+            "a clean project must resolve skills under trusty-code's own directory"
+        );
+
+        std::fs::create_dir_all(root.join(".claude").join("skills")).expect("mkdir");
+        assert_eq!(
+            locate_skills_dir(root),
+            root.join(".claude").join("skills"),
+            "an existing .claude/skills must still resolve"
+        );
+
+        std::fs::create_dir_all(root.join(".trusty-code").join("skills")).expect("mkdir");
+        assert_eq!(
+            locate_skills_dir(root),
+            root.join(".trusty-code").join("skills"),
+            ".trusty-code/skills must win when both exist"
+        );
     }
 
     /// Discovery reads `name`/`description` from frontmatter for every

--- a/crates/trusty-code/src/skills/protocol.rs
+++ b/crates/trusty-code/src/skills/protocol.rs
@@ -330,10 +330,12 @@ mod tests {
 
     #[test]
     fn locate_skills_dir_matches_project_only_tier() {
-        // Pins the module doc's central claim: no user-level fallback.
+        // Pins the module doc's central claim: no user-level fallback. The
+        // directory itself is trusty-code's own (#5426) — nothing on disk here,
+        // so the resolver returns the native default.
         let root = std::path::Path::new("/fake/project");
         let s = SkillsCatalogState::new(Some(root));
-        assert_eq!(s.dir, Some(root.join(".claude").join("skills")));
+        assert_eq!(s.dir, Some(root.join(".trusty-code").join("skills")));
         let projectless = SkillsCatalogState::new(None);
         assert_eq!(projectless.dir, None);
     }

--- a/crates/trusty-code/src/workstreams/path.rs
+++ b/crates/trusty-code/src/workstreams/path.rs
@@ -30,18 +30,24 @@ const HASH_LEN: usize = 8;
 /// store regardless of which directory `tcode serve` happened to start in.
 const PROJECTLESS_FILENAME: &str = "workstreams-projectless.json";
 
-/// Resolve `~/.trusty-code`, the trusty-code data directory.
+/// Resolve `~/.trusty-code`, the trusty-code private state directory.
 ///
 /// Why: mirrors `trusty-mpm`'s `~/.trusty-mpm` precedent
 /// (`crates/trusty-mpm/src/core/paths.rs`) rather than inventing a new
-/// resolution convention.
-/// What: `dirs::home_dir()/.trusty-code`, falling back to a relative
-/// `.trusty-code` if the home directory cannot be resolved (never panics).
-/// Test: `path_tests::default_data_dir_is_dot_trusty_code`.
+/// resolution convention. #5426 moved the resolution itself into
+/// [`crate::paths::private_state`], which also owns the `0700` mode this
+/// directory must carry — a workstream store sitting beside transcripts and
+/// logs is private state, not an independent location.
+/// What: delegates to [`crate::paths::private_state::private_state_dir`]:
+/// `dirs::home_dir()/.trusty-code`, falling back to a relative `.trusty-code`
+/// (with a `warn`) if the home directory cannot be resolved. Never panics, and
+/// creates nothing — [`crate::paths::private_state::ensure_private_state_dir`]
+/// is the creating variant.
+/// Test: `path_tests::default_data_dir_is_dot_trusty_code`,
+/// `paths::private_state::private_state_tests::private_state_dir_matches_home_when_available`.
 pub fn default_data_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".trusty-code")
+    // #5426: one resolver for the private state root, shared with its mode guard.
+    crate::paths::private_state::private_state_dir()
 }
 
 /// Turn an arbitrary string into a filesystem-safe, lowercase, hyphenated

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -823,3 +823,161 @@ fn tui_refuses_to_spawn_for_an_unreachable_explicit_daemon_url() {
         "must not have spawned a daemon: {stderr}"
     );
 }
+
+// -- #5426: trusty-code's own configuration layout --------------------------
+
+/// A project whose agents live ONLY under `.trusty-code/agents/`, with no
+/// `.claude/` directory at all.
+///
+/// Why: the #5426 acceptance criterion "a clean project can install and run
+/// without a `.claude/` directory" needs a fixture that genuinely has none —
+/// `support::project_with_agents` writes `.claude/agents/` and so cannot prove
+/// it.
+/// What: the same two agent configs, written under `.trusty-code/agents/`. The
+/// PM is named `native-pm`, a name the EMBEDDED roster does not carry, so the
+/// run can only succeed by reading the project's own directory — a `pm.md` here
+/// would be satisfied by the embedded fallback and prove nothing.
+/// Test: used by `run_task_works_on_a_project_with_no_claude_dir`.
+fn project_with_native_agents() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("project tempdir");
+    let agents = tmp.path().join(".trusty-code").join("agents");
+    std::fs::create_dir_all(&agents).expect("mkdir agents");
+    std::fs::write(
+        agents.join("native-pm.md"),
+        "---\nname: native-pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM. Delegate work to python-engineer.\n",
+    )
+    .expect("write native-pm.md");
+    std::fs::write(
+        agents.join("python-engineer.md"),
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\nYou are a Python engineer.\n",
+    )
+    .expect("write python-engineer.md");
+    tmp
+}
+
+/// The whole harness runs against a project that has no `.claude/` directory.
+///
+/// Why: this is #5426's headline acceptance criterion, and it is the one test
+/// that fails on `origin/main` for the WHOLE change rather than for one
+/// resolver — there, `locate_agents_dir` defaulted to `.claude/agents`, so a
+/// `.trusty-code`-only project never reached its own configuration and the run
+/// died with `unknown agent 'native-pm'`.
+/// What: drives the real `tcode` binary with `TCODE_MOCK_LLM=echo` against a
+/// project whose agents live only under `.trusty-code/agents/`, and asserts the
+/// run finishes.
+/// Test: this function IS the test.
+#[test]
+fn run_task_works_on_a_project_with_no_claude_dir() {
+    let project = project_with_native_agents();
+    assert!(!project.path().join(".claude").exists());
+
+    let output = support::tcode_command()
+        .args([
+            "run-task",
+            "native-pm",
+            "say hi",
+            "--project",
+            &project.path().display().to_string(),
+            "--json",
+        ])
+        .env("TCODE_MOCK_LLM", "echo")
+        .output()
+        .expect("spawn tcode run-task");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "a .trusty-code-only project must run: {:?}\nstdout: {stdout}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be valid JSON: {e}: {stdout}"));
+    assert_eq!(parsed["status"], "finished");
+}
+
+/// `tcode paths show --json` names the winning source for each entry.
+///
+/// Why: the diagnostic is the operator's only way to see which configuration
+/// root won without reading the source.
+/// What: stages `.trusty-code/agents` and `.claude/skills` and asserts the
+/// reported sources differ accordingly, and that the write root is always
+/// `.trusty-code`.
+/// Test: this function IS the test.
+#[test]
+fn paths_show_reports_the_winning_source() {
+    let project = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(project.path().join(".trusty-code").join("agents")).expect("mkdir");
+    std::fs::create_dir_all(project.path().join(".claude").join("skills")).expect("mkdir");
+
+    let output = support::tcode_command()
+        .args([
+            "paths",
+            "show",
+            "--project",
+            &project.path().display().to_string(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn tcode paths show");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "tcode paths show must exit 0: {stdout}{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be valid JSON: {e}: {stdout}"));
+    assert_eq!(parsed["entries"]["agents"]["source"], "trusty-code");
+    assert_eq!(parsed["entries"]["skills"]["source"], "claude");
+    assert_eq!(parsed["entries"]["plugins"]["source"], "default");
+    assert!(
+        parsed["write_root"]
+            .as_str()
+            .expect("write_root")
+            .ends_with(".trusty-code"),
+        "the write root must always be .trusty-code: {parsed}"
+    );
+}
+
+/// `tcode paths import --dry-run` prints the plan and writes nothing.
+///
+/// Why: a dry run that touched the tree would defeat its own purpose, and the
+/// plan it prints has to match what the real run would do.
+/// What: stages `.claude/agents/pm.md`, runs the dry run, and asserts the plan
+/// names the target while no `.trusty-code/` directory appears.
+/// Test: this function IS the test.
+#[test]
+fn paths_import_dry_run_writes_nothing() {
+    let project = tempfile::tempdir().expect("tempdir");
+    let agents = project.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents).expect("mkdir");
+    std::fs::write(agents.join("pm.md"), "---\nname: pm\n---\n").expect("write");
+
+    let output = support::tcode_command()
+        .args([
+            "paths",
+            "import",
+            "--project",
+            &project.path().display().to_string(),
+            "--dry-run",
+        ])
+        .output()
+        .expect("spawn tcode paths import --dry-run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "must exit 0: {stdout}");
+    assert!(
+        stdout.contains("copy") && stdout.contains("agents/pm.md"),
+        "the plan must name the target: {stdout}"
+    );
+    assert!(
+        stdout.contains("--dry-run"),
+        "the run must say it wrote nothing: {stdout}"
+    );
+    assert!(
+        !project.path().join(".trusty-code").exists(),
+        "a dry run must not create .trusty-code/"
+    );
+}


### PR DESCRIPTION
## What changed

Every discovery site in `trusty-code` joined the literal `.claude/` itself — agents, skills, plugins, `settings.json`, `CLAUDE.md`. That made another product's directory the source of truth for this one: a clean project could not install or run without a `.claude/` tree, and nothing stood between the harness and a write INTO it.

`trusty_code::paths` is now the single resolver those call sites route through: `.trusty-code/` → `.claude/` → `.open-mpm/`, and when none exists the resolved path names `.trusty-code/` anyway. Writes are deliberately a different function — `check_native_write_target` refuses anything not beneath `<project>/.trusty-code/`, symlink escapes included. Private mutable state resolves through `paths::private_state` and is created at mode `0700`, tightening an existing permissive `~/.trusty-code`.

New CLI: `tcode paths show [--json]` reports which root won per entry, the write root, and whether private-state permissions are owner-only. `tcode paths import [--dry-run]` migrates a `.claude/` catalog from a printed, deterministic plan.

Refs #5426. Parent epic #2892.

## code-critic APPROVE after two rounds

The change adds a secret scanner, symlink and permission guards, and private-state handling; that is High risk under the test ladder regardless of the crate-scoped gates below, so `code-critic` gated the merge.

Round 1 returned BLOCK on `5da65a2b` (one CRITICAL, two HIGH). Round 2 returned WARN on `1f3e945c` after confirming every round-1 fix by independent reproduction, and raised one further HIGH. The confirmation round returned APPROVE at `f712913b` with no residual findings — see **Critic round 1** and **Critic round 2** at the end of this body. Three MEDIUMs are dispositioned Parent and listed as follow-ups.

## Rung and commands

**Rung 3** — localized behavior inside one crate, plus a binary smoke run for the new CLI surface. No `trusty-common` edit, so this is not rung 4: `trusty_common::crate_config` and `data_dir` cover `~/.trusty-tools/<crate>/config.yaml` and the OS data dir, neither of which is the `~/.trusty-code` private-state root this issue names, and `workstreams::path::default_data_dir` already owned that path inside this crate. It was consolidated there rather than adding a fifth path convention to `trusty-common`.

```
cargo fmt --check                                        → 0
cargo clippy -p trusty-code --all-targets -- -D warnings  → 0
cargo test -p trusty-code --no-fail-fast                  → 0
bash scripts/check_line_cap.sh                            → 0
bash scripts/check_test_pointers.sh                       → 0
bash scripts/check_sld.sh                                 → 0
bash scripts/check_changelog_fragment.sh   (post-commit)  → 0
bash scripts/check-pr-version-bump.sh                     → 0
```

All 18 targets ran under `--no-fail-fast`; every line was `test result: ok`, zero `FAILED`.

| Target | Result |
|---|---|
| lib | 1745 passed; 0 failed; 4 ignored |
| tcode (bin) | 21 passed |
| cli_e2e | 21 passed |
| agent_fallback_e2e / agent_id_e2e / agents_e2e | 3 / 1 / 2 |
| bakeoff_gate_e2e / config_mount / connector_e2e | 7 / 2 / 7 |
| inference_shared_adapter_e2e / logging_e2e / m1_cutline_e2e | 4 / 2 / 5 |
| readiness_e2e / recall_content_e2e / search_hits_e2e | 2 / 1 / 1 |
| session_e2e / task_e2e / tui_client_engine | 2 / 6 / 7 |

Version: no bump. `check-pr-version-bump.sh` reports `trusty-code 0.5.2 — src changed, version not yet published` (published tail is 0.5.1).

## Regression evidence

Primary: `cli_e2e.rs::run_task_works_on_a_project_with_no_claude_dir`. Reverting only `crates/trusty-code/src` to `origin/main` and re-running it:

```
test run_task_works_on_a_project_with_no_claude_dir ... FAILED

thread '...' panicked at crates/trusty-code/tests/cli_e2e.rs:888:5:
a .trusty-code-only project must run: Some(3)
stdout: {
  "agent": "native-pm",
  "binding": { "root": ".../T/.tmpO92Z6a", "state": "directory" },
  "mode": "daily-driver",
  "status": "failed",
  "task": "say hi"
}
```

The fixture names its PM `native-pm` on purpose: a `pm.md` would be satisfied by the embedded roster and prove nothing about disk resolution. On `main`, `locate_agents_dir` defaults to `.claude/agents`, so the project's own `.trusty-code/agents/native-pm.md` is never read and the run exits 3. The same revert also failed the two CLI tests with `error: unrecognized subcommand 'paths'`.

Other tests that fail on `main` (each asserts a path or precedence `main` produces differently; they live in files the revert also reverts, so they cannot be run standalone against it):

- `paths::tests::*` (18), `paths::private_state::private_state_tests::*` (6), `paths::import::import_tests::*` (10) — the resolver, guards, and import do not exist on `main`.
- `mode::tests::trusty_code_settings_json_sets_the_mode_without_a_claude_dir` — `main` joins `.claude/settings.json` directly.
- `project_context::tests::loads_trusty_code_claude_md` — `main` checks only root and `.claude/`.
- `agents::tests::locate_agents_dir_prefers_claude_then_open_mpm_then_default`, `skills::tests::locate_skills_dir_is_dot_claude_skills` — both now assert the native default.

## Fail-open behaviour

Four fallback sites, each logging at `warn` with the path tried, each with a test:

| Site | Test |
|---|---|
| Unreadable config directory → next root | `paths::tests::unreadable_native_dir_falls_back_and_is_reported` |
| Unreadable config file → next root | `paths::tests::unreadable_settings_file_falls_back_and_is_reported` |
| `settings.json` unreadable/unparseable → next mode tier | `mode::tests::malformed_settings_json_is_not_an_error` |
| Unreadable `.claude/` subtree during import | `paths::import::import_tests::unreadable_subtree_is_skipped_with_a_warning` |

The first two install a thread-local `tracing` subscriber and assert the captured `WARN` line contains the path, so deleting the warning fails the test — the returned `ResolvedConfig::unreadable` field alone would not.

## ACs met

- Native discovery moved off `.claude/` for agents, skills, plugins, `settings.json`, `CLAUDE.md`.
- Clean project runs with no `.claude/` — the primary e2e above.
- Precedence preserved without overwriting user-authored files — `apply_is_idempotent`, `existing_target_is_never_overwritten`.
- Deterministic, reversible import — `plan_is_sorted_and_deterministic`, `apply_creates_only_the_planned_files`.
- Cross-product writes rejected — `write_to_claude_dir_is_refused`, `write_outside_project_is_refused`.
- Symlink escapes rejected — `symlinked_native_subdir_escape_is_refused`, `symlink_escaping_claude_is_refused`.
- Unsafe imported executables rejected — `executable_source_is_refused`.
- Secret-bearing project state rejected — `secret_bearing_settings_is_refused`, `unparseable_settings_is_refused`.
- Permissive private-state permissions rejected and repaired — `permissive_mode_is_not_restrictive`, `ensure_tightens_a_permissive_existing_dir`.
- CLI help and diagnostics — `tcode paths show [--json]`.
- Docs — README "Configuration layout (`.trusty-code`)"; Why/What/Test on `resolve_project_entry`, `check_native_write_target`, `private_state_dir_at`, `plan_import`.

## ACs NOT met — the scope line for the critic and the owner

1. **Resolved executable MCP lifecycle data in private state, and provenance/trust validation before executing imported MCP definitions.** `trusty-code` has no MCP-server-spawning lifecycle today — `.claude-plugin/plugin.json`'s `mcpServers` key is explicitly a later phase (#3539), logged and ignored. There is nothing yet to relocate or trust-check. What this PR does instead, without inventing that surface: the import refuses any executable-bit file outright, and refuses to copy `.claude/plugins/` at all.

2. **`.trusty-code/` adapter manifests and provenance metadata.** The issue names a manifest/provenance format but does not specify one, and #5427 (canonical instruction package with traceable assembly) is the sibling issue that defines assembly traceability. No schema was invented ahead of it. `ConfigSource` is the provenance that exists now: every resolution reports which root it came from, in logs and in `tcode paths show --json`.

3. **Relocating transcripts and logs into `~/.trusty-code/` under the new guard.** `paths::private_state` now owns the root and its `0700` mode, and `workstreams::path::default_data_dir` routes through it, so every existing consumer of that path inherits the hardening. Call sites that write elsewhere (e.g. `TRUSTY_DATA_DIR_OVERRIDE`-based paths) were not relocated: that changes on-disk locations for running installs and belongs in its own change with a migration.

---

## Critic round 1 — BLOCK addressed at `1f3e945c`

Review `5128081528` on `5da65a2b` returned BLOCK with one CRITICAL and two HIGH. All three were reproduced before being fixed, each with a regression test that fails on the reviewed head.

### CRITICAL — `check_native_write_target` never anchored the config root

Reproduced with a real root symlink before touching the code:

```
test paths::tests::symlinked_native_root_escape_is_refused ... FAILED
panicked at crates/trusty-code/src/paths/tests.rs:434:62:
must be refused: "/var/folders/.../T/.tmp04cSLi/.trusty-code/agents/pm.md"
```

The guard returned `Ok` for a write landing outside the project. `symlinked_native_subdir_escape_is_refused` never reached it — a symlinked subdirectory still leaves the root honest, so only a symlinked ROOT exposes the gap.

**Fix.** The root is anchored to the project before anything is compared against it. When `<project>/.trusty-code` exists, it must canonicalise inside the canonicalised `project_root`; only then is the target compared against it. A `project_root` that cannot itself be canonicalised now fails CLOSED — containment cannot be established, so the write is refused rather than assumed safe. `import.rs`'s `classify` inherits the fix, since it calls the same guard.

**Test.** `paths::tests::symlinked_native_root_escape_is_refused`.

### HIGH — kebab, camel and header spellings evaded the secret scanner

Confirmed by reading: `x-api-key` lowercased contains no entry of the old substring list, so a credential under that spelling imported cleanly. Two false positives sat on the other side of the same rule — `tokenizer` and `secretary` CONTAIN `token` and `secret` and were refused.

A looser substring match would have fixed one and worsened the other, so the rule is now word-based: `key_segments` splits a key on separators and lower-to-upper transitions, then `is_secret_key` matches each single word and each adjacent word PAIR against the hint set. One entry covers every spelling of a key.

**Tests.** `paths::tests::secret_keys_match_across_separator_and_case_spellings` (16 spellings: `API-KEY`, `x-api-key`, `xApiKey`, `APIKEY`, `access-key`, `AWS_SECRET_ACCESS_KEY`, …), `paths::tests::benign_keys_containing_a_hint_are_not_flagged` (`tokenizer`, `tokenizerPath`, `secretary`, `max_tokens`, `keychain`, `keyboard`, `passwordless_hint_text`, `cadence_turns`), and `paths::tests::nested_kebab_secret_is_reported_by_path` proving the walk applies the rule at depth.

The review's value-only note is now documented rather than implicit: the README states the scan reads key NAMES only and is not a substitute for a repository secret scanner.

### HIGH — `agent_loop::cadence` still read `.claude/settings.json`

Reverting only `cadence.rs` to the reviewed head and running the new test:

```
test agent_loop::cadence::tests::trusty_code_settings_json_sets_cadence_without_a_claude_dir ... FAILED
panicked at crates/trusty-code/src/agent_loop/cadence_tests.rs:90:9:
assertion `left == right` failed
  left: 8      (DEFAULT_CADENCE_TURNS)
 right: 3      (the project's .trusty-code/settings.json)
```

**Fix.** `read_settings_json_cadence` routes through `paths::settings_file` with the same warn-on-unreadable/unparseable fail-open as `mode`. Three stale `.claude/settings.json` mentions in that file's own docs were corrected too.

**Test.** `cadence::tests::trusty_code_settings_json_sets_cadence_without_a_claude_dir` — asserts both keys apply on a `.trusty-code`-only project, then adds a conflicting `.claude/settings.json` and asserts the native file still wins.

### Crate-wide `.claude` audit

`cadence.rs:186` was the only remaining production site. Every other `.claude` join in the crate sits inside a `#[cfg(test)]` region — verified per file by comparing each hit's line number against that file's first `#[cfg(test)]`:

| File | first `#[cfg(test)]` | `.claude` hits |
|---|---|---|
| `mode.rs` | 215 | 241, 405 |
| `tools/skill.rs` | 109 | 206–268 |
| `agents/mod.rs` | 420 | 731–901 |
| `project_context/mod.rs` | 115 | 144, 172, 191 |
| `skills/protocol.rs` | 322 | 577, 588 |
| `serve/mod.rs` | 289 | 522–531 |
| `skills/mod.rs` | 380 | 409–734 |

The one production `.claude` literal left is `binding/mod.rs:227`, which the review explicitly declined to flag: the no-home-directory AND no-project-root fallback, whose doc comment already says it degrades to a nonexistent path deliberately. Left as is.

### Gates at `1f3e945c`

```
cargo fmt --check                                        → 0
cargo clippy -p trusty-code --all-targets -- -D warnings  → 0
cargo test -p trusty-code --no-fail-fast                  → 0
bash scripts/check_line_cap.sh                            → 0   4548 files, 0 violations
bash scripts/check_test_pointers.sh                       → 0   31428 citations, 0 dangling
bash scripts/check_sld.sh                                 → 0   0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh   (post-commit)  → 0
bash scripts/check-pr-version-bump.sh                     → 0   0.5.2 not yet published
```

19 of 19 targets ran under `--no-fail-fast`; every line `test result: ok`, zero `FAILED`. Lib is 1750, up from 1745 — the five new tests.

`git diff --stat 5da65a2b 1f3e945c`:

```
 crates/trusty-code/README.md                       |  19 ++-
 .../changelog.d/5426-tcode-paths-subcommand.md     |  10 +-
 .../5426-trusty-code-owns-its-layout.md            |  21 +--
 crates/trusty-code/src/agent_loop/cadence.rs       |  69 ++++++---
 crates/trusty-code/src/agent_loop/cadence_tests.rs |  47 +++++++
 crates/trusty-code/src/paths/mod.rs                | 154 ++++++++++++++++-----
 crates/trusty-code/src/paths/tests.rs              | 105 ++++++++++++++
 7 files changed, 362 insertions(+), 63 deletions(-)
```

A security agent scanned the full three-dot diff at `1f3e945c` (fixtures reviewed) with no findings.

---

## Critic round 2 — WARN addressed at `f712913b`

Review `5128200598` on `1f3e945c` confirmed every round-1 fix by independent reproduction and raised one new HIGH against the secret scanner, plus one MEDIUM dispositioned Parent.

### HIGH — plural spellings evaded the matcher

The hint list carried `credential` AND `credentials` but left `secret`, `token`, `apikey`, `accesskey` and `privatekey` singular-only, so seven ordinary plural spellings passed. Reproduced before touching the code:

```
test paths::tests::secret_keys_match_plural_spellings ... FAILED
panicked at crates/trusty-code/src/paths/tests.rs:470:9:
tokens must be recognised as secret-bearing
```

**Fix.** `matches_hint` de-pluralises at the COMPARISON rather than doubling the list — doubling is what invited the omission in the first place, and would invite it again on the next entry. The strip is deliberately narrow, one trailing `s` only, and that narrowness is what keeps the existing negatives green: `passwordless` becomes `passwordles`, not `password`, and `secretary` has no trailing `s` to strip at all. `credentials` was dropped from the list, since the rule now covers it.

**Test.** `paths::tests::secret_keys_match_plural_spellings` — the critic's seven spellings (`tokens`, `secretsFile`, `refreshTokens`, `apiSecrets`, `clientSecrets`, `accessKeys`, `apiKeys`) plus `credentials` and `private-keys`.

### The `max_tokens` decision — it stays benign

De-pluralising turns `tokens` into a hit, which sweeps up `max_tokens`: an LLM sampling parameter this crate's own `code_harness` settings carry. Refusing to import the very file the feature exists to migrate is a worse outcome than the leak risk of a key that holds an integer, so `max_tokens` stays importable.

That is implemented as `SECRET_KEY_EXEMPTIONS`, a short CLOSED list — `maxtokens`, `mintokens`, `numtokens`, `tokenbudget`, `tokencount`, `tokenlimit`, `tokenusage`, `totaltokens` — not a heuristic. It is compared against the ENTIRE key, never a window of it, so appending a credential to an exempt name does not inherit the exemption:

```rust
assert!(is_secret_key("max_tokens_api_key"),
    "an exemption must not shield a real credential appended to it");
```

**Test.** `paths::tests::max_tokens_stays_benign_as_a_count_not_a_credential` — six count-shaped keys asserted clean, plus that appended-credential case. `paths::tests::benign_keys_containing_a_hint_are_not_flagged` is unchanged and still green.

The README's "What counts as a secret-bearing key" paragraph and the `Added` changelog fragment both state the de-pluralising rule and the exemption.

### Gates at `f712913b`

```
cargo fmt --check                                        → 0
cargo clippy -p trusty-code --all-targets -- -D warnings  → 0
cargo test -p trusty-code --no-fail-fast                  → 0
bash scripts/check_line_cap.sh                            → 0   4548 files, 0 violations
bash scripts/check_test_pointers.sh                       → 0   31434 citations, 0 dangling
bash scripts/check_sld.sh                                 → 0   0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh   (post-commit)  → 0
bash scripts/check-pr-version-bump.sh                     → 0   0.5.2 not yet published
```

19 of 19 targets ran under `--no-fail-fast`; every line `test result: ok`, zero `FAILED`. Lib is 1752, up from 1750 — the two new tests.

`git diff --stat 1f3e945c f712913b`:

```
 crates/trusty-code/README.md                       | 18 +++--
 .../changelog.d/5426-tcode-paths-subcommand.md     | 10 +--
 crates/trusty-code/src/paths/mod.rs                | 77 ++++++++++++++++++----
 crates/trusty-code/src/paths/tests.rs              | 62 +++++++++++++++++
 4 files changed, 146 insertions(+), 21 deletions(-)
```

A security agent scanned `f712913b` with no findings.

## Follow-ups — three, all dispositioned Parent

None are fixed in this PR, by the coordinator's disposition.

- **plan-to-apply TOCTOU in `import.rs`.** `classify` vets a source at plan time; `copy_one` re-reads it fresh with no re-validation. The separation is what makes `--dry-run` reviewable, and it is also the window an attacker with `.claude/` write access has to swap a vetted file for a symlink, an executable, or a secret-bearing one. Fix is to re-run `source_stays_inside` plus the executable-bit check inside `copy_one`, immediately before the copy.
- **`harden()` chmods only the `~/.trusty-code` root.** Pre-existing files and subdirectories beneath it keep their own modes. `0700` on the parent blocks the normal traversal path, but the stated motivation — world-readable transcripts — is a claim about the FILES, and nothing currently checks or fixes their individual modes. Fix is either a recursive tighten during `ensure_private_state_dir_at`, or a test that stages a pre-existing `0644` file and pins the parent-traversal argument instead of assuming it.
- **Reversed compound order evades the secret matcher (`keyApi`).** `is_secret_key` joins adjacent word pairs in SOURCE order only, so a key spelling a compound backwards — `keyApi`, `keyAccess`, `keyPrivate` — matches neither the pair nor either word alone. Fix is to test both orderings of each pair, or to compare sorted word sets rather than ordered joins.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

