### PR TITLE
fix(tga): jira sync posts to /rest/api/3/search/jql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10450,7 +10450,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "7.1.1"
+version = "7.1.2"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -59,7 +59,7 @@ name = "tga"
 # new config table; nothing existing is removed or changed. `src/**` changed
 # while 6.0.0 was already live on crates.io, so the `PR version bump vs
 # crates.io` gate (#4421) requires the bump.
-version = "7.1.1"
+version = "7.1.2"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/6812-jira-search-jql.md
+++ b/crates/trusty-git-analytics/changelog.d/6812-jira-search-jql.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `tga jira sync` posts to `/rest/api/3/search/jql`. Atlassian removed
+  `/rest/api/3/search` and answers it with HTTP 410 (CHANGE-2046), so every
+  sync against a Jira Cloud site left `fact_ticket_transitions` and
+  `fact_jira_comment_detail` empty and wrote no cursor. The replacement
+  endpoint paginates by an opaque `nextPageToken` instead of `startAt`,
+  reports no `total`, takes `expand` as a comma-delimited string rather than
+  an array, and may return a page shorter than the requested `maxResults`
+  while more pages remain — so both search walks now end on the absent token
+  and never on page length (#6812).

--- a/crates/trusty-git-analytics/src/collect/errors.rs
+++ b/crates/trusty-git-analytics/src/collect/errors.rs
@@ -171,7 +171,9 @@ pub enum CollectError {
     /// A paged JIRA walk did not terminate within its page budget.
     ///
     /// Why: every termination condition on a paged walk trusts the server to
-    /// honour `startAt` or to eventually return an empty page. One that
+    /// honour its own pagination — `startAt` on the comment endpoint, the
+    /// `nextPageToken` cursor on `/search/jql` (#6812) — or to eventually
+    /// stop offering another page. One that
     /// replays the same page forever satisfies neither, and these walks run
     /// once per ticket across a window of up to 10,000 tickets. Surfacing a
     /// runaway as an error keeps it a bounded, named failure instead of a
@@ -179,12 +181,13 @@ pub enum CollectError {
     /// produced — it can never be mistaken for a complete result.
     #[error(
         "JIRA {endpoint} paging for {key} did not terminate within {pages} pages; \
-         the server is not honouring `startAt`"
+         the server is not advancing its pagination"
     )]
     PagingBudgetExceeded {
         /// Short name of the endpoint being walked, e.g. `changelog`.
         endpoint: &'static str,
-        /// JIRA issue key whose walk ran away, e.g. `PROJ-123`.
+        /// What the runaway walk was reading: a JIRA issue key for the
+        /// per-ticket endpoints (`PROJ-123`), or the JQL for `search/jql`.
         key: String,
         /// Page budget that was exhausted.
         pages: usize,

--- a/crates/trusty-git-analytics/src/collect/jira/client.rs
+++ b/crates/trusty-git-analytics/src/collect/jira/client.rs
@@ -41,6 +41,15 @@ const USER_AGENT_VALUE: &str = "trusty-git-analytics/0.1";
 /// Page size for JQL search pagination.
 const SEARCH_PAGE_SIZE: usize = 50;
 
+/// Extra pages [`JiraClient::search_issues`] will follow beyond the ideal
+/// page count before declaring the server's cursor runaway.
+///
+/// `/rest/api/3/search/jql` reports no total and may return a short page with
+/// more to come (#6812), so the only thing left to bound the loop is a page
+/// budget: a server that hands out a continuation token with every empty page
+/// would otherwise never terminate it.
+const SEARCH_PAGE_BUDGET_SLACK: usize = 8;
+
 /// Async JIRA Cloud / Server client.
 pub struct JiraClient {
     client: reqwest::Client,
@@ -120,18 +129,24 @@ struct MyselfResponse {
     time_zone: Option<String>,
 }
 
-/// Wire shape of a JQL search response.
+/// Wire shape of a `POST /rest/api/3/search/jql` response.
 ///
-/// `startAt` is deliberately NOT modelled: the client tracks its own offset.
-/// Deriving the next offset from the server's echo is unsafe under
-/// `#[serde(default)]`, which silently yields `0` when the field is absent —
-/// pinning the loop on page 2 forever. The `/search/jql` successor endpoint
-/// omits `startAt` entirely, so this is a live hazard, not a hypothetical.
+/// Neither `startAt` nor `total` exists on this endpoint. Atlassian removed
+/// `/rest/api/3/search` — it answers HTTP 410 (CHANGE-2046, issue #6812) —
+/// and its successor paginates by an opaque `nextPageToken` and reports no
+/// result count. A caller that needs a count asks
+/// `POST /rest/api/3/search/approximate-count` instead; this client needs
+/// none, because [`JiraClient::search_issues`] is bounded by the caller's own
+/// `max_results` and was only ever reading `total` to decide when to stop.
+///
+/// `nextPageToken` is absent (or `null`) on the last page, and that is the
+/// only end-of-results signal the endpoint gives: it may return fewer items
+/// than the requested `maxResults` while more pages remain.
 #[derive(Debug, Deserialize)]
 struct SearchResponse {
     issues: Vec<ApiIssue>,
-    #[serde(default)]
-    total: u64,
+    #[serde(rename = "nextPageToken", default)]
+    next_page_token: Option<String>,
 }
 
 impl JiraClient {
@@ -308,17 +323,24 @@ impl JiraClient {
     /// Why: many JIRA workflows (sprint rollups, ticket-id enrichment for
     /// commit messages) need bulk reads; single-issue fetches would be O(N)
     /// HTTP round-trips.
-    /// What: `POST /rest/api/3/search` with `{ jql, startAt, maxResults }`,
-    /// loops until either `max_results` issues are collected or the server
-    /// reports no more pages.
-    /// Test: covered by `jira_search_response_deserializes` (wire shape).
+    /// What: `POST /rest/api/3/search/jql` with
+    /// `{ jql, maxResults, nextPageToken, fields }`, following the server's
+    /// `nextPageToken` until it is absent or `max_results` issues are held.
+    /// The retired `/rest/api/3/search` took a `startAt` offset and reported
+    /// a `total`; its replacement has neither (#6812), so the loop terminates
+    /// on the token alone.
+    /// Test: `jira_search_response_deserializes` (wire shape),
+    /// `search_issues_posts_to_the_jql_endpoint`,
+    /// `search_issues_follows_the_next_page_token`.
     ///
     /// # Errors
     ///
     /// - [`CollectError::Http`] on transport / non-success HTTP responses.
     /// - [`CollectError::Json`] on payload parse failures.
+    /// - [`CollectError::PagingBudgetExceeded`] when the server keeps issuing
+    ///   continuation tokens past the page budget.
     pub async fn search_issues(&self, jql: &str, max_results: usize) -> Result<Vec<JiraIssue>> {
-        let url = format!("{}/rest/api/3/search", self.base_url);
+        let url = format!("{}/rest/api/3/search/jql", self.base_url);
         let story_field = self.get_story_point_field().await?;
         // Request the story-point field explicitly when we know its key so
         // JIRA includes it; otherwise rely on `*all` to get every field.
@@ -332,41 +354,51 @@ impl JiraClient {
             None => vec!["*all".into()],
         };
 
+        let max_pages = max_results.div_ceil(SEARCH_PAGE_SIZE) + SEARCH_PAGE_BUDGET_SLACK;
         let mut out: Vec<JiraIssue> = Vec::new();
-        let mut start_at = 0u64;
+        let mut next_page_token: Option<String> = None;
+        let mut pages = 0usize;
         loop {
             let remaining = max_results.saturating_sub(out.len());
             if remaining == 0 {
                 break;
             }
             let page_size = remaining.min(SEARCH_PAGE_SIZE);
-            let body = json!({
+            let mut body = json!({
                 "jql": jql,
-                "startAt": start_at,
                 "maxResults": page_size,
                 "fields": fields,
             });
-            debug!(url = %url, %jql, start_at, "POST");
+            if let Some(token) = &next_page_token {
+                body["nextPageToken"] = Value::String(token.clone());
+            }
+            debug!(url = %url, %jql, paged = next_page_token.is_some(), "POST");
             let mut req = self.client.post(&url).json(&body);
             if let Some((user, token)) = &self.credentials {
                 req = req.basic_auth(user, Some(token));
             }
             let resp = req.send().await?.error_for_status()?;
             let parsed: SearchResponse = resp.json().await?;
-            let n = parsed.issues.len();
+            pages += 1;
             for issue in parsed.issues {
                 out.push(Self::convert_issue(issue, story_field.as_deref()));
                 if out.len() >= max_results {
                     break;
                 }
             }
-            if n < page_size {
+            // An absent token is the endpoint's only end-of-results signal:
+            // a short page no longer proves one (#6812).
+            let Some(token) = parsed.next_page_token else {
                 break;
+            };
+            if pages >= max_pages {
+                return Err(CollectError::PagingBudgetExceeded {
+                    endpoint: "search/jql",
+                    key: jql.to_string(),
+                    pages,
+                });
             }
-            start_at += n as u64;
-            if start_at >= parsed.total {
-                break;
-            }
+            next_page_token = Some(token);
         }
         Ok(out)
     }
@@ -446,16 +478,19 @@ impl JiraClient {
     /// issue's changelog `histories` inline, avoiding an N+1 per-issue
     /// `/changelog` call for the common case.
     ///
-    /// What: `POST /rest/api/3/search` with
-    /// `{ jql, startAt, maxResults, fields: ["project", "updated"],
-    /// expand: ["changelog"] }`, looping until `max_results` issues are
-    /// collected or the server reports no more pages. Each returned
+    /// What: `POST /rest/api/3/search/jql` with
+    /// `{ jql, maxResults, nextPageToken, fields: ["project", "updated"],
+    /// expand: "changelog" }`, looping until `max_results` issues are
+    /// collected or the server returns no continuation token. Atlassian
+    /// removed `/rest/api/3/search` (HTTP 410, CHANGE-2046, #6812); its
+    /// replacement takes `expand` as a comma-delimited string rather than an
+    /// array, and has no `startAt`. Each returned
     /// [`ChangelogIssue`] carries only the `status`-field changelog items;
     /// all other changelog item kinds (e.g. `assignee`, `priority`) are
     /// dropped since only status transitions are in scope for this fact
     /// table.
     ///
-    /// Pagination is **keyset**, not offset: the caller passes the sync
+    /// Pagination is **keyset**, not server-position: the caller passes the sync
     /// [`SyncScope`] rather than a pre-built JQL string so each page can
     /// re-anchor the `updated >=` window onto the previous page's maximum.
     /// Offset paging over `ORDER BY updated ASC` — paging on the same
@@ -496,7 +531,7 @@ impl JiraClient {
         scope: &SyncScope,
         max_results: usize,
     ) -> Result<ChangelogWalk> {
-        let url = format!("{}/rest/api/3/search", self.base_url);
+        let url = format!("{}/rest/api/3/search/jql", self.base_url);
         let fields = vec!["project".to_string(), "updated".to_string()];
         // Every JQL bound this walk emits — the initial scope and every
         // re-anchor — must be rendered in the account's zone, or the window
@@ -525,20 +560,25 @@ impl JiraClient {
                 },
                 tz,
             )?;
-            let body = json!({
+            let mut body = json!({
                 "jql": jql,
-                "startAt": request.start_at,
                 "maxResults": page_size,
                 "fields": fields,
-                "expand": ["changelog"],
+                // `/search/jql` reads `expand` as a comma-delimited string;
+                // the array the retired `/search` took is rejected there.
+                "expand": "changelog",
             });
-            debug!(url = %url, %jql, start_at = request.start_at, "POST (with changelog)");
+            if let Some(token) = &request.next_page_token {
+                body["nextPageToken"] = Value::String(token.clone());
+            }
+            debug!(url = %url, %jql, paged = request.next_page_token.is_some(), "POST (with changelog)");
             let parsed: ChangelogSearchResponse =
                 with_retry("search_with_changelog", &self.retry, &self.budget, || {
                     self.post(&url, &body)
                 })
                 .await?;
 
+            let next_page_token = parsed.next_page_token;
             // Conversion is pure — `from_api` records the truncation verdict
             // (issue #4084) but issues no request, so nothing in this walk can
             // fail on a single ticket's account.
@@ -548,7 +588,7 @@ impl JiraClient {
                 .map(ChangelogIssue::from_api)
                 .collect();
             let items: Vec<PagedItem> = issues.iter().map(|i| (i.key.clone(), i.updated)).collect();
-            let step = pager.record_page(&items, page_size);
+            let step = pager.record_page(&items, next_page_token.as_deref());
 
             for (issue, is_new) in issues.into_iter().zip(step.is_new) {
                 if !is_new {

--- a/crates/trusty-git-analytics/src/collect/jira/client_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/jira/client_tests.rs
@@ -10,17 +10,20 @@ use super::*;
 // exercising them stayed here.
 use crate::collect::jira::model::*;
 
-/// Confirm a JQL search response shape parses end-to-end.
+/// Confirm a `/rest/api/3/search/jql` response shape parses end-to-end.
 ///
-/// Why: `search_issues` terminates on `total`; if JIRA renames it our loop
-/// terminates incorrectly. `startAt` is deliberately not modelled (the
-/// client tracks its own offset), so an unmodelled `startAt` in the payload
-/// must simply be ignored rather than breaking the parse.
-/// What: parse a representative search payload with one issue.
-/// Test: assert `total` and inner issue fields all populate.
+/// Why: `search_issues` terminates on `nextPageToken`; if that field does not
+/// bind, every walk ends after one page and the loop reports a silent
+/// truncation as success. The retired `/rest/api/3/search` envelope's
+/// `startAt` and `total` are still accepted-and-ignored, so a JIRA Server/DC
+/// instance answering the old shape cannot break the parse.
+/// What: parse a representative search payload with one issue and a token.
+/// Test: assert the token and inner issue fields all populate.
 #[test]
 fn jira_search_response_deserializes() {
     let json = r#"{
+        "isLast": false,
+        "nextPageToken": "CAEaAggD",
         "startAt": 0,
         "total": 1,
         "issues": [
@@ -36,7 +39,7 @@ fn jira_search_response_deserializes() {
         ]
     }"#;
     let resp: SearchResponse = serde_json::from_str(json).expect("parses");
-    assert_eq!(resp.total, 1);
+    assert_eq!(resp.next_page_token.as_deref(), Some("CAEaAggD"));
     assert_eq!(resp.issues.len(), 1);
     let issue = JiraClient::convert_issue(
         resp.issues.into_iter().next().expect("one"),
@@ -345,6 +348,10 @@ mod paged_http {
 
     use crate::collect::jira::retry::RetryPolicy;
 
+    /// `(jql, nextPageToken)` recorded for each search request a fixture
+    /// serves, shared with the test that asserts over them.
+    type RecordedSearches = Arc<Mutex<Vec<(String, Option<String>)>>>;
+
     fn fast_retry() -> RetryPolicy {
         RetryPolicy {
             max_attempts: 3,
@@ -386,41 +393,44 @@ mod paged_http {
     /// Page 1 (no `updated >=` bound) returns PROJ-1..PROJ-50. Between pages,
     /// PROJ-3 is "edited" and re-sorts to the very end of the result set —
     /// the exact mutation that made offset pagination skip a ticket.
+    ///
+    /// Each request is recorded as `(jql, nextPageToken)` so the test can
+    /// assert both that the window re-anchored and that the token from the
+    /// previous query was not carried into it (#6812).
     struct ShiftingChangelog {
-        seen: Arc<Mutex<Vec<(String, u64)>>>,
+        seen: RecordedSearches,
     }
 
     impl Respond for ShiftingChangelog {
         fn respond(&self, request: &Request) -> ResponseTemplate {
             let body: serde_json::Value = serde_json::from_slice(&request.body).expect("json body");
             let jql = body["jql"].as_str().unwrap_or_default().to_string();
-            let start_at = body["startAt"].as_u64().unwrap_or_default();
-            self.seen
-                .lock()
-                .expect("lock")
-                .push((jql.clone(), start_at));
+            let token = body["nextPageToken"].as_str().map(str::to_string);
+            self.seen.lock().expect("lock").push((jql.clone(), token));
 
             if !jql.contains("updated >=") {
-                // First page: the unbounded window, 50 issues (a full page).
+                // First page: the unbounded window, 50 issues, with a token
+                // saying more remains.
                 let issues: Vec<serde_json::Value> = (1..=50)
                     .map(|i| issue(&format!("PROJ-{i}"), &at_minute(i)))
                     .collect();
-                return ResponseTemplate::new(200).set_body_json(json!({"issues": issues}));
+                return ResponseTemplate::new(200)
+                    .set_body_json(json!({"issues": issues, "nextPageToken": "page-2"}));
             }
 
             // Second page: the re-anchored window `updated >= 00:50`. Its
             // full contents are PROJ-50 (the boundary minute we already
             // hold), the unread tail, and PROJ-3 — which now sorts at the
-            // very end because of its mid-walk edit. The client's offset
-            // skips the boundary item; PROJ-3 must be deduplicated.
-            let mut issues: Vec<serde_json::Value> = vec![
+            // very end because of its mid-walk edit. Both repeats must be
+            // deduplicated by key, since the new window is read from its
+            // first page and `/search/jql` offers nothing to skip with.
+            let issues: Vec<serde_json::Value> = vec![
                 issue("PROJ-50", &at_minute(50)),
                 issue("PROJ-51", &at_minute(51)),
                 issue("PROJ-52", &at_minute(52)),
                 issue("PROJ-53", &at_minute(53)),
                 issue("PROJ-3", "2026-01-01T09:00:00.000+0000"),
             ];
-            issues.drain(..(start_at as usize).min(issues.len()));
             ResponseTemplate::new(200).set_body_json(json!({"issues": issues}))
         }
     }
@@ -437,7 +447,7 @@ mod paged_http {
         let server = MockServer::start().await;
         let seen = Arc::new(Mutex::new(Vec::new()));
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(ShiftingChangelog {
                 seen: Arc::clone(&seen),
             })
@@ -484,8 +494,9 @@ mod paged_http {
             requests[1].0
         );
         assert_eq!(
-            requests[1].1, 1,
-            "only the single item already held from the 00:50 minute is skipped"
+            requests[1].1, None,
+            "a continuation token addresses a position in the query that issued \
+             it, so re-anchoring the window must drop it"
         );
     }
 
@@ -991,6 +1002,153 @@ mod paged_http {
         }
     }
 
+    // ---- `/rest/api/3/search/jql` migration (issue #6812) ---------------
+
+    /// A minimal issue payload for the plain `search_issues` walk.
+    fn search_issue(key: &str) -> serde_json::Value {
+        json!({
+            "key": key,
+            "fields": {
+                "summary": "Fix bug",
+                "status": {"name": "Done"},
+                "issuetype": {"name": "Bug"},
+            }
+        })
+    }
+
+    /// Mount the story-point field lookup `search_issues` makes before its
+    /// first page. An empty list means "no story-point field on this
+    /// instance", which keeps these fixtures about pagination.
+    async fn mount_empty_field_list(server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/rest/api/3/field"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(server)
+            .await;
+    }
+
+    /// The regression: Atlassian removed `/rest/api/3/search` and answers it
+    /// with HTTP 410 (CHANGE-2046), so `tga jira sync` wrote zero rows while
+    /// only `tga jira freshness` noticed.
+    ///
+    /// Only `/search/jql` is mounted, so a client still posting to the
+    /// retired path gets wiremock's 404 and this fails — which is what it
+    /// does on `origin/main`.
+    #[tokio::test]
+    async fn search_issues_posts_to_the_jql_endpoint() {
+        let server = MockServer::start().await;
+        mount_empty_field_list(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/search/jql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "issues": [search_issue("PROJ-1")],
+            })))
+            .mount(&server)
+            .await;
+
+        let issues = client_for(&server)
+            .search_issues("project = PROJ", 10)
+            .await
+            .expect("the search must reach the endpoint Atlassian still serves");
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].key, "PROJ-1");
+    }
+
+    /// Serves two token-paginated pages, recording the `nextPageToken` each
+    /// request carried. Page 1 is deliberately SHORT (one issue against a
+    /// 50-item `maxResults`) — `/search/jql` may do that with more pages to
+    /// come, so a walk that stopped on page length would lose PROJ-2.
+    struct TokenPaged {
+        seen: Arc<Mutex<Vec<Option<String>>>>,
+    }
+
+    impl Respond for TokenPaged {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).expect("json body");
+            let token = body["nextPageToken"].as_str().map(str::to_string);
+            self.seen.lock().expect("lock").push(token.clone());
+            match token.as_deref() {
+                None => ResponseTemplate::new(200).set_body_json(json!({
+                    "issues": [search_issue("PROJ-1")],
+                    "nextPageToken": "page-2",
+                })),
+                Some("page-2") => ResponseTemplate::new(200).set_body_json(json!({
+                    "issues": [search_issue("PROJ-2")],
+                    "isLast": true,
+                })),
+                Some(other) => panic!("unexpected continuation token: {other}"),
+            }
+        }
+    }
+
+    /// The new pagination contract end to end: follow `nextPageToken` until
+    /// the server stops returning one, and send the token back verbatim.
+    #[tokio::test]
+    async fn search_issues_follows_the_next_page_token() {
+        let server = MockServer::start().await;
+        mount_empty_field_list(&server).await;
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/search/jql"))
+            .respond_with(TokenPaged {
+                seen: Arc::clone(&seen),
+            })
+            .mount(&server)
+            .await;
+
+        let issues = client_for(&server)
+            .search_issues("project = PROJ", 10)
+            .await
+            .expect("search succeeds");
+
+        let keys: Vec<&str> = issues.iter().map(|i| i.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            vec!["PROJ-1", "PROJ-2"],
+            "a short first page carrying a token must not end the walk"
+        );
+        assert_eq!(
+            seen.lock().expect("lock").clone(),
+            vec![None, Some("page-2".to_string())],
+            "page 2 must carry the token page 1 returned, unaltered"
+        );
+    }
+
+    /// The same path regression for the walk `tga jira sync` actually runs.
+    /// Mounting only `/search/jql` makes a client still posting to the
+    /// retired `/rest/api/3/search` fail here, as it does on `origin/main`.
+    #[tokio::test]
+    async fn changelog_walk_posts_to_the_jql_endpoint() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/search/jql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(search_body(1, vec![newest()])))
+            .mount(&server)
+            .await;
+
+        let walk = client_for(&server)
+            .search_with_changelog(&scope(), 10)
+            .await
+            .expect("the sync walk must reach the endpoint Atlassian still serves");
+
+        assert_eq!(walk.issues.len(), 1);
+        let requests = server.received_requests().await.expect("recorded");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url.path(), "/rest/api/3/search/jql");
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).expect("json body");
+        assert_eq!(
+            body["expand"],
+            json!("changelog"),
+            "`/search/jql` reads `expand` as a comma-delimited string, not the \
+             array the retired `/search` took"
+        );
+        assert!(
+            body.get("startAt").is_none(),
+            "the replacement endpoint has no offset parameter: {body}"
+        );
+    }
+
     /// Count how many requests the mock server saw for a path suffix.
     async fn hits(server: &MockServer, suffix: &str) -> usize {
         server
@@ -1013,7 +1171,7 @@ mod paged_http {
     async fn search_with_changelog_flags_a_truncated_embedded_changelog() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             // Claims 3 entries; embeds only the newest.
             .respond_with(ResponseTemplate::new(200).set_body_json(search_body(3, vec![newest()])))
             .mount(&server)
@@ -1043,7 +1201,7 @@ mod paged_http {
     async fn search_with_changelog_does_not_flag_a_complete_embedded_changelog() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(
                 ResponseTemplate::new(200).set_body_json(search_body(2, vec![middle(), newest()])),
             )
@@ -1077,7 +1235,7 @@ mod paged_http {
             }]
         });
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(body))
             .mount(&server)
             .await;
@@ -1310,7 +1468,7 @@ mod paged_http {
     async fn a_broken_changelog_endpoint_does_not_abort_the_search_walk() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(search_body(3, vec![newest()])))
             .mount(&server)
             .await;
@@ -1344,7 +1502,7 @@ mod paged_http {
 
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             // `newest()` appears in BOTH the embedded page and the full walk.
             .respond_with(ResponseTemplate::new(200).set_body_json(search_body(3, vec![newest()])))
             .mount(&server)

--- a/crates/trusty-git-analytics/src/collect/jira/model.rs
+++ b/crates/trusty-git-analytics/src/collect/jira/model.rs
@@ -311,14 +311,21 @@ impl JiraComment {
     }
 }
 
-/// Wire shape of `POST /rest/api/3/search` with `expand=changelog`.
+/// Wire shape of `POST /rest/api/3/search/jql` with `expand=changelog`.
 ///
-/// Neither `startAt` nor `total` is modelled: the keyset walk terminates on
-/// a short page and tracks its own window (see [`super::paging`]), so it
-/// depends on no server-side bookkeeping field.
+/// Neither `startAt` nor `total` exists on this endpoint — Atlassian removed
+/// `/rest/api/3/search` (HTTP 410, CHANGE-2046, issue #6812). The walk still
+/// tracks its own JQL window (see [`super::paging`]), so the one server field
+/// it depends on is the continuation token.
 #[derive(Debug, Deserialize)]
 pub(crate) struct ChangelogSearchResponse {
     pub(crate) issues: Vec<ChangelogApiIssue>,
+    /// Continuation token for the next page of the CURRENT window; absent on
+    /// the last page. This is the only end-of-window signal the endpoint
+    /// gives: it may return fewer items than the requested `maxResults` while
+    /// more pages remain, so page length proves nothing.
+    #[serde(rename = "nextPageToken", default)]
+    pub(crate) next_page_token: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/trusty-git-analytics/src/collect/jira/paging.rs
+++ b/crates/trusty-git-analytics/src/collect/jira/paging.rs
@@ -19,25 +19,32 @@
 //! longer read from and reappear later in the ordering, where we read them
 //! again.
 //!
-//! Why an offset survives at all: JQL date literals are minute-resolution
-//! (`"yyyy-MM-dd HH:mm"`, see [`super::sync::jql_date`](crate::collect::jira::jql_time::jql_date)), and JQL offers no
+//! Why a within-window cursor survives at all: JQL date literals are
+//! minute-resolution (`"yyyy-MM-dd HH:mm"`, see [`super::sync::jql_date`](crate::collect::jira::jql_time::jql_date)), and JQL offers no
 //! tiebreak key, so a pure keyset walk cannot make progress through a minute
 //! containing more tickets than one page. Inside a single minute the pager
-//! therefore falls back to offset paging — bounding the residual race to
-//! "one minute of tickets, edited in the seconds between two requests"
-//! rather than "the entire remaining walk".
+//! therefore follows the server's own page cursor — bounding the residual
+//! race to "one minute of tickets, edited in the seconds between two
+//! requests" rather than "the entire remaining walk".
+//!
+//! That cursor is `/rest/api/3/search/jql`'s `nextPageToken` (issue #6812).
+//! Atlassian removed the `startAt` offset this module was written against,
+//! so a within-window position is now an opaque token the server issues; the
+//! argument above is unchanged, because it was never about the offset's
+//! representation, only about paging inside one minute versus paging across
+//! the whole walk.
 //!
 //! Re-anchoring re-reads the boundary minute, so the caller must deduplicate;
 //! [`KeysetPager::record_page`] reports which items in a page are new.
 //!
 //! # Why the residual is reported, not clamped away
 //!
-//! Inside an offset-paged minute a concurrent edit can still drop exactly one
+//! Inside a cursor-paged minute a concurrent edit can still drop exactly one
 //! ticket, and that loss is permanent. The obvious remedy — hold the run's
 //! cursor at the start of such a minute so the next run re-reads it — is
 //! **not** safe: a minute containing more tickets than one page is precisely
-//! the case that triggers the offset branch, so every subsequent run would
-//! offset-page it again, clamp again, and never advance. That converts a
+//! the case that triggers the cursor branch, so every subsequent run would
+//! cursor-page it again, clamp again, and never advance. That converts a
 //! rare, bounded loss into a guaranteed permanent stall with no forward
 //! progress at all.
 //!
@@ -62,9 +69,10 @@ pub struct PageRequest {
     /// Lower bound for the JQL `updated >=` clause. `None` = no bound
     /// (first page of a full backfill).
     pub since: Option<DateTime<Utc>>,
-    /// Offset within that window, used only to walk through a minute
-    /// containing more tickets than one page.
-    pub start_at: u64,
+    /// `/rest/api/3/search/jql` continuation token for the CURRENT window,
+    /// used only to walk through a minute containing more tickets than one
+    /// page. `None` requests that window's first page.
+    pub next_page_token: Option<String>,
 }
 
 /// Result of feeding one fetched page back to the pager.
@@ -81,7 +89,7 @@ pub struct PageStep {
 #[derive(Debug)]
 pub struct KeysetPager {
     since: Option<DateTime<Utc>>,
-    start_at: u64,
+    next_page_token: Option<String>,
     seen: HashSet<String>,
     pages: usize,
     max_pages: usize,
@@ -100,7 +108,7 @@ impl KeysetPager {
     pub fn new(since: Option<DateTime<Utc>>, max_pages: usize) -> Self {
         Self {
             since,
-            start_at: 0,
+            next_page_token: None,
             seen: HashSet::new(),
             pages: 0,
             max_pages: max_pages.max(1),
@@ -108,16 +116,16 @@ impl KeysetPager {
         }
     }
 
-    /// The window/offset the next request should use.
+    /// The window and continuation token the next request should use.
     pub fn request(&self) -> PageRequest {
         PageRequest {
             since: self.since,
-            start_at: self.start_at,
+            next_page_token: self.next_page_token.clone(),
         }
     }
 
-    /// The earliest minute the walk had to traverse by offset rather than by
-    /// window re-anchoring, if any.
+    /// The earliest minute the walk had to traverse by following the server's
+    /// page cursor rather than by re-anchoring the window, if any.
     ///
     /// Why a caller wants this: inside such a minute the walk is exposed to
     /// the same shift-under-pagination race that keyset paging exists to
@@ -127,6 +135,13 @@ impl KeysetPager {
     /// unremarked. See the module header for why the window cannot simply be
     /// held back to this minute instead.
     ///
+    /// The name predates issue #6812, which replaced the `startAt` offset
+    /// with `/search/jql`'s `nextPageToken`. What it reports is unchanged:
+    /// the minute the walk had to page through as one server-driven sequence
+    /// instead of re-anchoring past it. Atlassian documents no snapshot
+    /// isolation across tokens, so the race the offset had is not proven
+    /// gone.
+    ///
     /// Test: `pager_reports_the_minute_it_offset_paged`.
     pub fn offset_paged_minute(&self) -> Option<DateTime<Utc>> {
         self.offset_paged_minute
@@ -134,20 +149,30 @@ impl KeysetPager {
 
     /// Record one fetched page and advance the window.
     ///
-    /// `page_size` is the `maxResults` that was requested; a page shorter
-    /// than that means the server has nothing further to give.
+    /// `next_page_token` is the token the server returned with this page.
+    /// `None` means it has nothing further to give in the current window,
+    /// and since that window is `updated >= since` with no upper bound,
+    /// exhausting it exhausts the walk.
+    ///
+    /// Page length is deliberately not consulted (issue #6812).
+    /// `/rest/api/3/search/jql` may return fewer items than the requested
+    /// `maxResults` while more pages remain, so the short page that ended
+    /// this walk against the retired `/rest/api/3/search` would now truncate
+    /// it silently.
     ///
     /// # Invariant
     ///
     /// Every call strictly advances the read position — either `since` moves
-    /// to a later minute (with `start_at` reset past the items already read
-    /// in that minute) or `start_at` grows — so the walk always terminates.
+    /// to a later minute (restarting that window at its first page, whose
+    /// already-held items deduplicate) or the walk follows the server's
+    /// continuation token — so the walk always terminates.
     ///
     /// Test: `pager_reanchors_window_on_a_later_minute`,
-    /// `pager_falls_back_to_offset_within_one_minute`,
+    /// `pager_falls_back_to_the_page_cursor_within_one_minute`,
     /// `pager_deduplicates_reread_boundary_items`,
-    /// `pager_stops_on_a_short_page`, `pager_stops_at_max_pages`.
-    pub fn record_page(&mut self, items: &[PagedItem], page_size: usize) -> PageStep {
+    /// `pager_stops_when_the_server_returns_no_token`,
+    /// `pager_does_not_stop_on_a_short_page`, `pager_stops_at_max_pages`.
+    pub fn record_page(&mut self, items: &[PagedItem], next_page_token: Option<&str>) -> PageStep {
         self.pages += 1;
 
         let mut is_new = Vec::with_capacity(items.len());
@@ -159,12 +184,12 @@ impl KeysetPager {
             }
         }
 
-        if items.len() < page_size {
+        let Some(token) = next_page_token else {
             return PageStep {
                 is_new,
                 more: false,
             };
-        }
+        };
         if self.pages >= self.max_pages {
             warn!(
                 pages = self.pages,
@@ -180,22 +205,22 @@ impl KeysetPager {
 
         match page_max {
             // The page reached a later minute than the current window start:
-            // re-anchor there, skipping past the items of that minute we
-            // already hold. The skip count can only ever be an UNDER-estimate
-            // (earlier pages may also hold items in that minute), which costs
-            // a deduplicated re-read — never a skipped ticket.
+            // re-anchor there and drop the token, since a token addresses a
+            // position in the query that produced it and the query is about
+            // to change. The new window is re-read from its first page, so
+            // the boundary minute's already-held items come back and
+            // deduplicate — the same cost the `startAt` skip this replaces
+            // was already paying, because that skip could only ever
+            // UNDER-estimate (earlier pages may hold items in that minute
+            // too).
             Some(max) if minute(Some(max)) > minute(self.since) => {
-                let skip = items
-                    .iter()
-                    .filter(|(_, u)| minute(*u) == minute(Some(max)))
-                    .count();
                 self.since = Some(max);
-                self.start_at = skip as u64;
+                self.next_page_token = None;
             }
-            // A full page that did not advance the minute (a bulk edit, or a
-            // page with no usable timestamps): keep offset-paging inside the
-            // current window so the walk still makes progress. Record it —
-            // this is the one band where the shift race survives, and the
+            // A page that did not advance the minute (a bulk edit, or a page
+            // with no usable timestamps): follow the server's cursor inside
+            // the current window so the walk still makes progress. Record it
+            // — this is the one band where the shift race survives, and the
             // caller surfaces it rather than letting it pass silently.
             _ => {
                 let stalled = minute(self.since).or_else(|| minute(page_max));
@@ -203,7 +228,7 @@ impl KeysetPager {
                     (Some(existing), Some(new)) => Some(existing.min(new)),
                     (existing, new) => existing.or(new),
                 };
-                self.start_at += items.len() as u64;
+                self.next_page_token = Some(token.to_string());
             }
         }
 
@@ -243,17 +268,31 @@ mod tests {
             pager.request(),
             PageRequest {
                 since: Some(dt("2026-01-01T00:00:00Z")),
-                start_at: 0,
+                next_page_token: None,
             }
         );
     }
 
     #[test]
-    fn pager_stops_on_a_short_page() {
+    fn pager_stops_when_the_server_returns_no_token() {
         let mut pager = KeysetPager::new(None, 10);
-        let step = pager.record_page(&[item("P-1", "2026-01-01T00:00:00Z")], 2);
-        assert!(!step.more, "a page shorter than page_size ends the walk");
+        let step = pager.record_page(&[item("P-1", "2026-01-01T00:00:00Z")], None);
+        assert!(!step.more, "an absent continuation token ends the walk");
         assert_eq!(step.is_new, vec![true]);
+    }
+
+    /// Issue #6812: `/rest/api/3/search/jql` may return fewer items than the
+    /// requested `maxResults` while more pages remain, so page length must
+    /// not end the walk. Ending on it truncated a run silently — the exact
+    /// failure family this module exists to prevent.
+    #[test]
+    fn pager_does_not_stop_on_a_short_page() {
+        let mut pager = KeysetPager::new(None, 10);
+        let step = pager.record_page(&[item("P-1", "2026-01-01T00:00:00Z")], Some("t1"));
+        assert!(
+            step.more,
+            "a short page carrying a token must not end the walk"
+        );
     }
 
     /// The core fix: after a full page the window re-anchors to the page's
@@ -266,39 +305,42 @@ mod tests {
             item("P-1", "2026-01-01T00:01:00Z"),
             item("P-2", "2026-01-01T00:02:00Z"),
         ];
-        let step = pager.record_page(&page, 2);
+        let step = pager.record_page(&page, Some("t1"));
         assert!(step.more);
         assert_eq!(
             pager.request(),
             PageRequest {
                 since: Some(dt("2026-01-01T00:02:00Z")),
-                // exactly one item of this page lives in the 00:02 minute
-                start_at: 1,
+                // The token addresses a position in the query that produced
+                // it, and that query is about to change, so it is dropped.
+                next_page_token: None,
             },
-            "the next window must start at the page's max updated, not at an \
-             absolute offset into a mutating result set"
+            "the next window must start at the page's max updated, not at a \
+             position carried over from a different query"
         );
     }
 
     /// More tickets in one minute than fit in a page: JQL cannot express a
-    /// sub-minute bound, so the pager must offset-page through that minute
-    /// instead of stalling (which would silently truncate the walk).
+    /// sub-minute bound, so the pager must follow the server's cursor through
+    /// that minute instead of stalling (which would silently truncate the
+    /// walk).
     #[test]
-    fn pager_falls_back_to_offset_within_one_minute() {
+    fn pager_falls_back_to_the_page_cursor_within_one_minute() {
         let mut pager = KeysetPager::new(Some(dt("2026-01-01T00:00:00Z")), 10);
         let page = vec![
             item("P-1", "2026-01-01T00:00:10Z"),
             item("P-2", "2026-01-01T00:00:20Z"),
         ];
-        let step = pager.record_page(&page, 2);
+        let step = pager.record_page(&page, Some("t1"));
         assert!(step.more);
         assert_eq!(
             pager.request(),
             PageRequest {
                 since: Some(dt("2026-01-01T00:00:00Z")),
-                start_at: 2,
+                next_page_token: Some("t1".to_string()),
             },
-            "a page confined to the window's own minute must advance by offset"
+            "a page confined to the window's own minute must advance by the \
+             server's continuation token"
         );
     }
 
@@ -311,14 +353,14 @@ mod tests {
             item("P-1", "2026-01-01T00:01:00Z"),
             item("P-2", "2026-01-01T00:02:00Z"),
         ];
-        pager.record_page(&first, 2);
+        pager.record_page(&first, Some("t1"));
 
         let second = vec![
             // P-2 comes back because the window re-anchored onto its minute.
             item("P-2", "2026-01-01T00:02:00Z"),
             item("P-3", "2026-01-01T00:03:00Z"),
         ];
-        let step = pager.record_page(&second, 2);
+        let step = pager.record_page(&second, Some("t2"));
         assert_eq!(step.is_new, vec![false, true]);
     }
 
@@ -329,18 +371,18 @@ mod tests {
             item("P-1", "2026-01-01T00:01:00Z"),
             item("P-2", "2026-01-01T00:02:00Z"),
         ];
-        assert!(pager.record_page(&page, 2).more);
+        assert!(pager.record_page(&page, Some("t1")).more);
         let page2 = vec![
             item("P-3", "2026-01-01T00:03:00Z"),
             item("P-4", "2026-01-01T00:04:00Z"),
         ];
         assert!(
-            !pager.record_page(&page2, 2).more,
+            !pager.record_page(&page2, Some("t2")).more,
             "the page cap must stop the walk rather than loop forever"
         );
     }
 
-    /// The offset branch is the one band where the shift race survives, so
+    /// The cursor branch is the one band where the shift race survives, so
     /// the pager must name the minute it happened in for the run summary.
     #[test]
     fn pager_reports_the_minute_it_offset_paged() {
@@ -351,7 +393,7 @@ mod tests {
             item("P-1", "2026-01-01T00:00:40Z"),
             item("P-2", "2026-01-01T00:00:50Z"),
         ];
-        pager.record_page(&page, 2);
+        pager.record_page(&page, Some("t1"));
         assert_eq!(
             pager.offset_paged_minute(),
             Some(dt("2026-01-01T00:00:00Z")),
@@ -368,18 +410,18 @@ mod tests {
             item("P-1", "2026-01-01T00:01:00Z"),
             item("P-2", "2026-01-01T00:02:00Z"),
         ];
-        pager.record_page(&page, 2);
+        pager.record_page(&page, Some("t1"));
         assert_eq!(pager.offset_paged_minute(), None);
     }
 
-    /// A full page with no parseable timestamps must still make progress
-    /// (offset branch) rather than re-requesting the same window forever.
+    /// A page with no parseable timestamps must still make progress (cursor
+    /// branch) rather than re-requesting the same window forever.
     #[test]
-    fn pager_advances_by_offset_when_a_page_has_no_timestamps() {
+    fn pager_advances_by_cursor_when_a_page_has_no_timestamps() {
         let mut pager = KeysetPager::new(Some(dt("2026-01-01T00:00:00Z")), 10);
         let page = vec![("P-1".to_string(), None), ("P-2".to_string(), None)];
-        let step = pager.record_page(&page, 2);
+        let step = pager.record_page(&page, Some("t1"));
         assert!(step.more);
-        assert_eq!(pager.request().start_at, 2);
+        assert_eq!(pager.request().next_page_token.as_deref(), Some("t1"));
     }
 }

--- a/crates/trusty-git-analytics/src/commands/jira/mod.rs
+++ b/crates/trusty-git-analytics/src/commands/jira/mod.rs
@@ -457,15 +457,16 @@ pub async fn run_sync(config: Config, db: &mut Database, args: JiraSyncArgs) -> 
     if let Some(minute) = walk.offset_paged_minute {
         println!(
             "  note: {} contained more tickets than one page, so that minute was walked by \
-             offset. A ticket edited during that walk could have been missed; re-cover it \
-             with `tga jira sync --project {project_key} --since {}` if in doubt.",
+             following the server's page cursor. A ticket edited during that walk could have \
+             been missed; re-cover it with `tga jira sync --project {project_key} --since {}` \
+             if in doubt.",
             minute.to_rfc3339(),
             minute.date_naive()
         );
         warn!(
             project = %project_key,
             minute = %minute.to_rfc3339(),
-            "walked a single minute by offset; see `collect::jira::paging` for the residual"
+            "walked a single minute by page cursor; see `collect::jira::paging` for the residual"
         );
     }
 

--- a/crates/trusty-git-analytics/src/commands/jira/tests.rs
+++ b/crates/trusty-git-analytics/src/commands/jira/tests.rs
@@ -409,7 +409,7 @@ mod sync_e2e {
     async fn run_sync_writes_transitions_comments_and_advances_cursor() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(search_response_body()))
             .mount(&server)
             .await;
@@ -467,7 +467,7 @@ mod sync_e2e {
     async fn run_sync_dry_run_fetches_comments_but_writes_nothing() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(search_response_body()))
             .mount(&server)
             .await;
@@ -531,7 +531,7 @@ mod sync_e2e {
     async fn run_sync_with_no_matching_tickets_leaves_cursor_untouched() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "startAt": 0,
                 "total": 0,
@@ -688,7 +688,7 @@ mod partial_failure {
     async fn server_with_failing_first_ticket(jqls: Arc<Mutex<Vec<String>>>) -> MockServer {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(WindowedSearch::new(jqls))
             .mount(&server)
             .await;
@@ -771,7 +771,7 @@ mod partial_failure {
         // Second run: same dataset, but PROJ-1's comments are now reachable.
         let healthy = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(WindowedSearch::new(Arc::clone(&jqls)))
             .mount(&healthy)
             .await;
@@ -886,7 +886,7 @@ mod partial_failure {
             }
         }
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(ManyTickets)
             .mount(&server)
             .await;
@@ -984,7 +984,7 @@ mod partial_failure {
 
         let server = MockServer::start().await;
         Mock::given(method("POST"))
-            .and(path("/rest/api/3/search"))
+            .and(path("/rest/api/3/search/jql"))
             .respond_with(TruncatedSearch)
             .mount(&server)
             .await;

--- a/docs/trusty-git-analytics/requirements/collection.md
+++ b/docs/trusty-git-analytics/requirements/collection.md
@@ -145,7 +145,9 @@ metrics fresh without re-fetching closed PRs.
 ## JIRA Data Collection
 
 - **Auth**: HTTP Basic Auth with `access_user` + `access_token`
-- **Endpoint**: `/rest/api/3/search` with JQL
+- **Endpoint**: `/rest/api/3/search/jql` with JQL. Atlassian removed
+  `/rest/api/3/search` (HTTP 410, CHANGE-2046, issue #6812); the replacement
+  paginates by an opaque `nextPageToken` and reports no `total`.
 - **Batch size**: 50 tickets per request
 - **JQL**: `project IN (KEY1, KEY2) AND updated >= "YYYY-MM-DD"`
 - **Story point field discovery**: GET `/rest/api/3/field`, match by name patterns


### PR DESCRIPTION
Atlassian removed `/rest/api/3/search` and answers it with HTTP 410
(CHANGE-2046), so every `tga jira sync` against a Jira Cloud site left
`fact_ticket_transitions` and `fact_jira_comment_detail` empty and wrote no
cursor. Only `tga jira freshness` noticed, and it reported STALE.

Both search call sites now post to `/rest/api/3/search/jql`.

## The new contract, and what each difference forced

Taken from the live Jira Cloud OpenAPI spec
(`developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json`), not from
prose: `SearchAndReconcileRequestBean` and `SearchAndReconcileResults`.

- **No `startAt`.** `search_issues` follows the response's `nextPageToken`.
  `search_with_changelog` keeps the `KeysetPager` JQL-window re-anchoring from
  #3966/#4067 and carries the token as the within-window position, dropping it
  whenever the window changes — a token addresses the query that issued it.
- **No `total`.** See below.
- **A short page no longer means the last page.** The spec says the endpoint may
  return fewer items than `maxResults` while more pages remain, so page length
  drives neither loop. That removed the only bound on `search_issues`, so it
  gains a page budget returning `PagingBudgetExceeded` rather than hanging on a
  server that issues a token with every empty page.
- **`expand` is a comma-delimited string,** not the array the retired endpoint
  took.

## How a caller that needed `total` is served now

Nothing needed it. `search_issues` read `total` only as a termination condition
(`if start_at >= parsed.total { break }`) and is bounded by the caller's own
`max_results`; it now stops on the absent token instead. `search_with_changelog`
never modelled `total` at all. A caller that genuinely wants a count asks
`POST /rest/api/3/search/approximate-count` (`{jql}` → `{count}`); no code in
this crate does.

## The `startAt` skip that disappeared

Re-anchoring used to set `start_at = skip` to step past the boundary minute's
already-held items. `/search/jql` has no offset, so the new window is read from
its first page and those items come back and deduplicate by key. That costs
exactly what the old skip cost: the skip could only ever under-estimate, since
earlier pages may hold items in that minute too — which the original comment
already said.

## No live Jira call was possible here

No credentials in this environment. Every claim rests on the wiremock fixtures
and the OpenAPI spec. Live verification against the Duetto site belongs to the
`status:merged` → `status:tested` step.

## Tests

Two fail on `origin/main` because they mount only `/search/jql`, so a client
still posting to the retired path gets wiremock's 404:

- `search_issues_posts_to_the_jql_endpoint`
- `changelog_walk_posts_to_the_jql_endpoint` — also asserts `expand ==
  "changelog"` (a string) and that no `startAt` appears in the body

Plus:

- `search_issues_follows_the_next_page_token` — two-page token walk. Page 1 is
  deliberately one issue against `maxResults: 50`, so it doubles as proof that a
  short page does not end the walk, and asserts page 2 carried page 1's token
  verbatim.
- `changelog_walk_survives_a_ticket_edited_mid_walk` — the #4067 HIGH
  regression, rebuilt on tokens. Still reads all 53 distinct tickets, and now
  asserts page 2 carries no token because the window changed.
- `paging.rs`: `pager_does_not_stop_on_a_short_page` (new),
  `pager_stops_when_the_server_returns_no_token`,
  `pager_falls_back_to_the_page_cursor_within_one_minute`.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                   EXIT=0
cargo clippy -p tga --all-targets -- -D warnings    EXIT=0
cargo test -p tga --no-fail-fast                    EXIT=0
  test result: ok. 1578 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out
  + 9 further targets, all ok (10 `test result` lines)
bash scripts/check_line_cap.sh            4541 tracked .rs file(s); 4 allowlisted, 0 violations
bash scripts/check_test_pointers.sh       31358 Test: citation(s); 0 dangling pointers
bash scripts/check_changelog_fragment.sh  OK trusty-git-analytics: fragment present and valid
bash scripts/check_workspace_dep_versions.sh  All 12 internal row(s) accept their member crate version
```

Version: `scripts/bump-version.sh trusty-git-analytics patch --no-changelog`,
7.1.1 → 7.1.2, `Cargo.lock` synced. Fragment at
`crates/trusty-git-analytics/changelog.d/6812-jira-search-jql.md`.

## Release-time note for local-ops

`collect::jira::paging` is a `pub mod` of a published crate, so
`PageRequest.start_at` → `next_page_token` and the `record_page` signature are a
public API break on a crate at 7.1.x. PATCH stays for now.
`cargo-semver-checks` runs in `preflight-publish.sh` CHECK 5 at release time and
will flag it; whether that becomes 8.0.0 is local-ops's call then. Nothing
in-tree consumes those items — `search_issues` has no in-crate caller at all —
so this is a publish-boundary question, not a build one.

Refs #6812

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
