### PR TITLE
fix(trusty-agents): gh ticketing lists labels with an explicit --limit

### DIFF
--- a/crates/trusty-agents/changelog.d/6953-label-list-limit.md
+++ b/crates/trusty-agents/changelog.d/6953-label-list-limit.md
@@ -1,0 +1,9 @@
+Fixed
+
+- The `gh` CLI ticketing backend reads every label on a repository. `list_available_tags`
+  ran `gh label list` with no `--limit`, so `gh` returned its default first 30 and said
+  nothing about the rest — on a repo with more labels than that, every label past the first
+  page read as absent and the ensure-labels path re-created labels that already existed.
+  The listing now asks for 1000 labels through one named argv builder, and a page that comes
+  back exactly that full is an error rather than a set treated as complete
+  ([#6953](https://github.com/bobmatnyc/trusty-tools/issues/6953)).

--- a/crates/trusty-agents/src/ticketing/gh_cli/client_impl.rs
+++ b/crates/trusty-agents/src/ticketing/gh_cli/client_impl.rs
@@ -14,7 +14,8 @@ use serde_json::Value;
 use trusty_common::gh::GhCommand;
 
 use super::{
-    GhCliClient, LIST_JSON_FIELDS, TICKET_JSON_FIELDS, gh_issue_to_ticket, plan_gh_issue_edit_calls,
+    GhCliClient, LABEL_LIST_LIMIT, LIST_JSON_FIELDS, TICKET_JSON_FIELDS, gh_issue_to_ticket,
+    labels_from_json, plan_gh_issue_edit_calls,
 };
 use crate::ticketing::TicketingClient;
 use crate::ticketing::types::{
@@ -184,27 +185,10 @@ impl TicketingClient for GhCliClient {
     async fn list_available_tags(&self) -> Result<Vec<Tag>> {
         // #5475: `json` is the entry point's parse combinator — its failure
         // message names the argv, which the bare `from_str` context did not.
-        let arr: Vec<Value> = GhCommand::new(["label", "list", "--json", "name,color,description"])
-            .repo(self.repo())
-            .json()
-            .await?;
-        let out = arr
-            .iter()
-            .filter_map(|l| {
-                let name = l.get("name").and_then(Value::as_str)?.to_string();
-                let color = l.get("color").and_then(Value::as_str).map(String::from);
-                let description = l
-                    .get("description")
-                    .and_then(Value::as_str)
-                    .map(String::from);
-                Some(Tag {
-                    name,
-                    color,
-                    description,
-                })
-            })
-            .collect();
-        Ok(out)
+        // #6953: the argv now comes from `list_labels_argv`, which carries the
+        // `--limit` this call omitted, and the page is checked for truncation.
+        let arr: Vec<Value> = self.label_list_command().json().await?;
+        labels_from_json(&arr, LABEL_LIST_LIMIT)
     }
 
     async fn assign(&self, id: &str, assignee: &str) -> Result<Ticket> {

--- a/crates/trusty-agents/src/ticketing/gh_cli/mod.rs
+++ b/crates/trusty-agents/src/ticketing/gh_cli/mod.rs
@@ -25,7 +25,84 @@ use anyhow::{Result, anyhow};
 use serde_json::Value;
 use trusty_common::gh::GhCommand;
 
-use super::types::{Ticket, TicketStatus, UpdateTicketReq};
+use super::types::{Tag, Ticket, TicketStatus, UpdateTicketReq};
+
+/// The page size every `gh label list` in this adapter asks for.
+///
+/// Why: `gh label list` returns 30 labels by default and says nothing when it
+/// truncates, so a repo with more labels than that read as missing every label
+/// past the first page — the ensure-labels path then re-created labels that
+/// already existed (#6953; trusty-tools carries 89). Large enough that no
+/// realistic repo truncates, and a page that comes back exactly this full is
+/// treated as a possibly-truncated read rather than a complete one.
+/// Test: `label_list_command_requests_more_than_the_gh_default`.
+pub(super) const LABEL_LIST_LIMIT: usize = 1000;
+
+/// gh's own default page size for `gh label list`.
+///
+/// Why: the number [`LABEL_LIST_LIMIT`] has to beat, named so the regression
+/// test asserts against gh's documented default rather than a magic literal.
+pub(super) const GH_DEFAULT_LABEL_PAGE: usize = 30;
+
+/// The `gh label list …` argv — the adapter's single spelling of that command.
+///
+/// Why: #6953 — an omitted `--limit` is exactly the flag that goes missing when
+/// a command line is spelled inline at a call site, so the argv lives in one
+/// named place with a test on it. Mirrors trusty-mpm's
+/// `core::policy_labels::list_labels_argv` (#6952), which is private to that
+/// crate's library and so cannot be shared through `trusty-common` without
+/// moving it; the `--repo` selector is omitted here because callers apply it
+/// through [`GhCommand::repo`].
+/// What: `label list --limit <limit> --json name,color,description` — those
+/// JSON fields are exactly [`Tag`]'s, so the output feeds [`labels_from_json`]
+/// directly.
+/// Test: `label_list_command_requests_more_than_the_gh_default`.
+pub(super) fn list_labels_argv(limit: usize) -> Vec<String> {
+    vec![
+        "label".to_string(),
+        "list".to_string(),
+        "--limit".to_string(),
+        limit.to_string(),
+        "--json".to_string(),
+        "name,color,description".to_string(),
+    ]
+}
+
+/// Parse a `gh label list --json name,color,description` page into [`Tag`]s.
+///
+/// Why: #6953 — a page that comes back exactly `limit` long may have been
+/// truncated by `gh`, and a partial label set read as complete is the defect
+/// being fixed, so it is an error rather than a set the caller trusts.
+/// What: maps each entry with a `name` into a [`Tag`], dropping entries without
+/// one; refuses a full page before mapping anything.
+/// Test: `labels_from_json_reads_past_the_default_label_page`,
+/// `labels_from_json_rejects_a_full_page`,
+/// `labels_from_json_skips_entries_without_a_name`.
+pub(super) fn labels_from_json(arr: &[Value], limit: usize) -> Result<Vec<Tag>> {
+    if arr.len() >= limit {
+        return Err(anyhow!(
+            "`gh label list` returned {} label(s), the full requested page — \
+             the repository may carry more than this adapter can read in one call",
+            arr.len()
+        ));
+    }
+    Ok(arr
+        .iter()
+        .filter_map(|l| {
+            let name = l.get("name").and_then(Value::as_str)?.to_string();
+            let color = l.get("color").and_then(Value::as_str).map(String::from);
+            let description = l
+                .get("description")
+                .and_then(Value::as_str)
+                .map(String::from);
+            Some(Tag {
+                name,
+                color,
+                description,
+            })
+        })
+        .collect())
+}
 
 /// Check if `gh` is on PATH and authenticated.
 ///
@@ -73,6 +150,19 @@ impl GhCliClient {
     /// The configured `owner/repo`, if any.
     pub(super) fn repo(&self) -> Option<&str> {
         self.repo.as_deref()
+    }
+
+    /// The `gh label list` invocation this client runs, repo selector included.
+    ///
+    /// Why: #6953 — the label listing had its argv spelled inline inside the
+    /// `TicketingClient` impl, where no test could see whether it carried a
+    /// `--limit`. Building it here makes the command the test's subject.
+    /// What: [`list_labels_argv`] at [`LABEL_LIST_LIMIT`], with `--repo`
+    /// prepended when this client targets a specific repository.
+    /// Test: `label_list_command_requests_more_than_the_gh_default`,
+    /// `label_list_command_carries_the_repo_selector`.
+    pub(super) fn label_list_command(&self) -> GhCommand {
+        GhCommand::new(list_labels_argv(LABEL_LIST_LIMIT)).repo(self.repo())
     }
 
     /// Run a `gh` command, prepending `--repo <repo>` if configured.

--- a/crates/trusty-agents/src/ticketing/gh_cli/tests.rs
+++ b/crates/trusty-agents/src/ticketing/gh_cli/tests.rs
@@ -171,6 +171,84 @@ fn plan_gh_issue_edit_calls_empty_label_vecs_are_noop() {
     assert!(plan_gh_issue_edit_calls("1", &req).is_empty());
 }
 
+/// #6953: `gh label list` pages at 30 by default and never says it truncated,
+/// so the listing must ask for an explicit, much larger `--limit`. Against the
+/// pre-fix argv (`label list --json name,color,description`) this fails: the
+/// `--limit` lookup finds nothing.
+#[test]
+fn label_list_command_requests_more_than_the_gh_default() {
+    let argv: Vec<String> = GhCliClient::new(None)
+        .label_list_command()
+        .argv_display()
+        .split(' ')
+        .map(str::to_string)
+        .collect();
+    let limit: usize = argv
+        .iter()
+        .position(|a| a == "--limit")
+        .and_then(|i| argv.get(i + 1))
+        .unwrap_or_else(|| panic!("`gh label list` argv must carry an explicit --limit: {argv:?}"))
+        .parse()
+        .expect("--limit is a number");
+    assert_eq!(limit, LABEL_LIST_LIMIT);
+    assert!(
+        limit > GH_DEFAULT_LABEL_PAGE,
+        "the listing must ask for more than gh's default {GH_DEFAULT_LABEL_PAGE}-label page"
+    );
+}
+
+/// #6953: adding `--limit` must not cost the repo selector.
+#[test]
+fn label_list_command_carries_the_repo_selector() {
+    let argv = GhCliClient::new(Some("owner/repo".to_string()))
+        .label_list_command()
+        .argv_display();
+    assert_eq!(
+        argv,
+        "--repo owner/repo label list --limit 1000 --json name,color,description"
+    );
+}
+
+/// #6953: the 31st label of a 35-label repo — the first one gh's default page
+/// drops — must come back from the parse.
+#[test]
+fn labels_from_json_reads_past_the_default_label_page() {
+    let page: Vec<Value> = (1..=35)
+        .map(|n| json!({"name": format!("label-{n}"), "color": "ededed"}))
+        .collect();
+    let tags = labels_from_json(&page, LABEL_LIST_LIMIT).expect("a 35-label page is not truncated");
+    assert_eq!(tags.len(), 35);
+    assert!(
+        tags.iter().any(|t| t.name == "label-31"),
+        "the 31st label must survive the parse"
+    );
+    assert_eq!(tags[34].name, "label-35");
+}
+
+/// #6953: a page exactly as long as the requested limit may itself have been
+/// truncated, so it is an error rather than a set treated as complete.
+#[test]
+fn labels_from_json_rejects_a_full_page() {
+    let page: Vec<Value> = (0..LABEL_LIST_LIMIT)
+        .map(|n| json!({"name": format!("label-{n}")}))
+        .collect();
+    let err =
+        labels_from_json(&page, LABEL_LIST_LIMIT).expect_err("a full page must not be trusted");
+    assert!(
+        err.to_string().contains("full requested page"),
+        "unexpected error: {err}"
+    );
+}
+
+/// An entry with no `name` is dropped, not fatal.
+#[test]
+fn labels_from_json_skips_entries_without_a_name() {
+    let page = vec![json!({"color": "ededed"}), json!({"name": "bug"})];
+    let tags = labels_from_json(&page, LABEL_LIST_LIMIT).expect("parses");
+    assert_eq!(tags.len(), 1);
+    assert_eq!(tags[0].name, "bug");
+}
+
 /// Title + add_labels emits a combined main edit AND a separate
 /// add-label call (deltas are never folded into the main edit).
 #[test]


### PR DESCRIPTION
`gh label list` returns 30 labels by default and never signals that it truncated, so `GhCliClient::list_available_tags` read a partial set on any larger repo. On bobmatnyc/trusty-tools, which carries 89 labels, every label past the first page reported as absent and the ensure-labels path re-created labels that already existed.

The listing now builds its argv with `gh_cli::list_labels_argv` at `LABEL_LIST_LIMIT` (1000). A page that comes back exactly that full may itself be truncated, so `labels_from_json` treats it as an error rather than a complete set — reading a partial label set as complete is the defect.

## Shared-builder decision

trusty-mpm fixed the same defect in `core::policy_labels::list_labels_argv` (#6952). That function is private to the trusty-mpm library, and trusty-agents does not depend on trusty-mpm — sharing it would mean moving it into `trusty-common`, which is a boundary this change cannot cross without touching trusty-mpm. `trusty-common/src/gh.rs` carries no label helper today. So the builder here mirrors that one, and both the doc comment and the commit body say so.

## Regression coverage — fails against the pre-fix argv

`label_list_command_requests_more_than_the_gh_default` and `label_list_command_carries_the_repo_selector` assert on the command the client actually builds. With `label_list_command` reverted to main's exact inline argv:

```
test ticketing::gh_cli::tests::label_list_command_carries_the_repo_selector ... FAILED
test ticketing::gh_cli::tests::label_list_command_requests_more_than_the_gh_default ... FAILED

  left: "--repo owner/repo label list --json name,color,description"
 right: "--repo owner/repo label list --limit 1000 --json name,color,description"

`gh label list` argv must carry an explicit --limit: ["label", "list", "--json", "name,color,description"]

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 3637 filtered out
```

This client has no mock-gh harness (`GhCommand` exposes no injectable runner), so the 35-label repo is covered at the parse boundary: `labels_from_json_reads_past_the_default_label_page` asserts label 31 — the first one gh's default page drops — survives the parse. `labels_from_json_rejects_a_full_page` and `labels_from_json_skips_entries_without_a_name` cover the truncation guard and the nameless-entry case.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                                            EXIT=0
SKIP_UI_BUILD=1 cargo clippy -p trusty-agents --all-targets -- -D warnings   EXIT=0
SKIP_UI_BUILD=1 cargo test -p trusty-agents --no-fail-fast                   EXIT=0
```

All 14 test targets ran under `--no-fail-fast`; largest is `test result: ok. 3626 passed; 0 failed; 13 ignored`. The five new tests pass.

Script gates:

```
line-cap: measured 4541 tracked .rs file(s) — 0 violations — OK.
test-pointers: resolved 31361 Test: citation(s) — 0 dangling pointers — OK.
OK   trusty-agents: changelog.d fragment present and valid
[ OK ] trusty-agents 0.39.0 — src changed, version not yet published
```

No version bump: `scripts/check-pr-version-bump.sh` (#4421) confirms 0.39.0 is unpublished.

Refs #6953

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools