### PR TITLE
feat(scripts): changelog gate gains --staged and --file author modes

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -112,6 +112,17 @@ jobs:
       - name: Source-classification selftest (both gates share one definition)
         run: bash scripts/check_source_class_selftest.sh
 
+      # Author-mode selftest (#6947): the gate diffs `<base>..HEAD`, so before a
+      # commit exists it reports SCAN FLOOR and an author cannot check a
+      # fragment; after it, a shape error that was knowable when the file was
+      # written costs a commit-amend cycle. `--staged` and `--file` answer
+      # earlier. This proves both, and — the case that matters most here — that
+      # the DEFAULT verdict this job runs below is unchanged: a pre-flight that
+      # passes what the gate fails is worse than none, because it is the one an
+      # author runs first.
+      - name: Author-mode selftest (--staged and --file must not weaken the gate)
+        run: bash scripts/check_changelog_staged_selftest.sh
+
       # Bump-mode selftest (#5674): `bump-version.sh` used to consume this
       # crate's changelog.d/ fragments unconditionally, so a bump landing in the
       # same PR as its source change deleted the fragments THIS gate then failed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,9 +393,12 @@ crates/<crate>/changelog.d/<issue-or-pr-number>-<short-slug>.md
 
 - Format and category line: `Skill(skill="tm-workflow")`. Assembler and CI-gate
   specifics: [changelog-fragments.md](docs/reference/changelog-fragments.md).
-- 🟡 `check_changelog_fragment.sh` diffs `origin/main..HEAD`, so it sees nothing
-  until the change is committed; run it after committing. `check_line_cap.sh`
-  reads tracked `git ls-files`, so a new file needs `git add` first too.
+- 🟡 `check_changelog_fragment.sh` diffs `origin/main..HEAD`, so the default run
+  sees nothing until the change is committed. Before committing, use
+  `--staged` (the index plus untracked files) or `--file <path>` (one
+  fragment's placement, category line and body, no diff at all) — #6947; run the
+  default gate after committing. `check_line_cap.sh` reads tracked
+  `git ls-files`, so a new file needs `git add` first too.
 
 ## Cross-Crate Development Workflow
 

--- a/docs/reference/changelog-fragments.md
+++ b/docs/reference/changelog-fragments.md
@@ -47,6 +47,31 @@ four categories under `### Removed`). Split it: same number, different slug.
 The heading form (`## Changed`) counts as a second category too; anything inside
 a code fence does not, so a fragment may show example output freely.
 
+## Validate Before Committing
+
+The CI gate diffs `origin/main..HEAD`, so it sees nothing until the change is
+committed — and then rejects shape errors that were knowable the moment the file
+was written. Two flags answer earlier (#6947):
+
+```bash
+# one fragment: placement, category line and body — no git diff at all
+bash scripts/check_changelog_fragment.sh --file crates/<crate>/changelog.d/<n>-<slug>.md
+
+# the whole change: the index plus untracked files, attributed as the gate does
+bash scripts/check_changelog_fragment.sh --staged
+```
+
+`--file` delegates the content check to `scripts/assemble-changelog.sh
+--fragment`, the same validator the post-commit run reaches, so it prints the
+same `ERROR:` lines. `--staged` runs the same crate attribution, the same
+exemptions and the same exit codes as the default run; its scan floor is "at
+least one staged or untracked path".
+
+Both are pre-flights, not the verdict. `--staged` reads the working tree for a
+crate's `CHANGELOG.md` and `changelog.d/`, so an unstaged edit still counts as
+evidence, and it compares against `HEAD`, so the crate-dissolution exemption is
+unreachable. Run the default gate after committing.
+
 ## Preview the Pending Set
 
 ```bash

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -46,6 +46,11 @@
 #               section instead of inserting a second one (issue #5298)
 #   --stdout    render the section to stdout as `## [Unreleased]` for preview —
 #               no writes, no deletions
+#   --fragment  validate ONE fragment file (`--fragment <path>`) and stop. Takes
+#               a path, not a crate: it reads no crate directory and no
+#               CHANGELOG.md, so an author can check a fragment before it is
+#               staged or committed. `check_changelog_fragment.sh --file`
+#               delegates here so both print the same ERROR lines (#6947).
 #
 # Idempotency: a successful default run leaves changelog.d/ holding only its
 # tracked README.md placeholder, so a second run inserts nothing rather than an
@@ -123,12 +128,14 @@ PLAN_MARKER="@@CATEGORY"
 usage() {
   echo "Usage: scripts/assemble-changelog.sh <crate-dir> <version> [--check|--merge]" >&2
   echo "       scripts/assemble-changelog.sh <crate-dir> --stdout" >&2
+  echo "       scripts/assemble-changelog.sh --fragment <path>" >&2
   echo "" >&2
   echo "  <crate-dir>   directory under crates/ (e.g. trusty-mpm)" >&2
   echo "  <version>     released version for the new heading (e.g. 1.3.2)" >&2
   echo "  --check       validate fragments only; write nothing, delete nothing" >&2
   echo "  --merge       fold the fragments into an EXISTING [<version>] section" >&2
   echo "  --stdout      preview the pending section as [Unreleased]; no writes" >&2
+  echo "  --fragment    validate ONE fragment file; no crate, no writes" >&2
   exit 2
 }
 
@@ -657,6 +664,25 @@ merge_fragments() {
 }
 
 main() {
+  # #6947 --fragment: validate ONE file and say so. The author-facing mode of
+  # scripts/check_changelog_fragment.sh (`--file`) delegates here rather than
+  # re-deriving what a valid fragment is, for the same reason the CI gate asks
+  # for a `--stdout` preview instead of validating fragments itself — one
+  # validator, one set of ERROR messages, no way for the two to disagree.
+  # Reads no crate directory and no CHANGELOG.md, so it works on a fragment
+  # written anywhere, before it is staged or committed.
+  if [[ "${1:-}" == "--fragment" ]]; then
+    [[ $# -ne 2 ]] && usage
+    local frag="$2" parsed_line
+    if [[ ! -f "${frag}" ]]; then
+      echo "ERROR: no fragment file at ${frag}" >&2
+      exit 1
+    fi
+    parsed_line="$(parse_fragment "${frag}")" || exit 1
+    echo "OK: $(basename "${frag}") is a valid fragment (category: ${parsed_line%%$'\t'*})." >&2
+    return 0
+  fi
+
   [[ $# -lt 2 || $# -gt 3 ]] && usage
 
   local crate_dir="$1" version="$2" mode="${3:-write}"

--- a/scripts/check_changelog_fragment.sh
+++ b/scripts/check_changelog_fragment.sh
@@ -135,6 +135,32 @@
 #   There is deliberately NO "trivial change" escape hatch: adding a fragment is
 #   one new file, and the rule it enforces has never had one.
 #
+# AUTHOR MODES (#6947). The default diff is `<base>..HEAD`, so before the commit
+#   exists the gate reports SCAN FLOOR and an author cannot check a fragment at
+#   all; after it, a shape error the gate could have caught earlier costs a
+#   commit-amend cycle. Two engineers lost a cycle to that on 2026-09-07 — one to
+#   the empty pre-commit scan, one to a two-heading fragment rejected only after
+#   committing. Two modes answer the question earlier. Neither replaces the
+#   default run, which stays the gate CI enforces:
+#
+#     --staged       attribute the INDEX plus untracked-but-not-ignored files
+#                    instead of `<base>..HEAD`, against HEAD. Same attribution,
+#                    same evidence rules, same exit codes; the scan floor becomes
+#                    "at least one staged or untracked path".
+#     --file <path>  validate ONE fragment's placement, category line and body
+#                    with no git diff at all. The content check is delegated to
+#                    `assemble-changelog.sh --fragment`, which is the same
+#                    validator the post-commit path reaches through
+#                    `assemble-changelog.sh <crate> --stdout`, so it prints the
+#                    same ERROR lines.
+#
+#   Two ways --staged is weaker than the default run, which is why it is a
+#   pre-flight and not the verdict: it reads the WORKING TREE for a crate's
+#   CHANGELOG.md and changelog.d/, so an unstaged edit to either still counts as
+#   evidence; and it compares against HEAD, so the #3732 crate-dissolution
+#   exemption is unreachable — a staged `git rm` of `crates/<crate>/Cargo.toml`
+#   leaves the manifest present at HEAD.
+#
 # CI shape (issue #4468 caution): this job has NO `paths:` filter, so it always
 #   runs and always reports on every PR — including an exempt docs-only PR,
 #   where it reports SUCCESS. A `paths:`-filtered required check never reports on
@@ -172,9 +198,15 @@
 #   bash scripts/check_changelog_fragment.sh                  # base: origin/main
 #   bash scripts/check_changelog_fragment.sh --base <ref>     # explicit base
 #   CHANGELOG_GATE_BASE=<ref> bash scripts/check_changelog_fragment.sh
+#   bash scripts/check_changelog_fragment.sh --staged         # before committing
+#   bash scripts/check_changelog_fragment.sh --file <path>    # one fragment only
+#
+#   --staged, --file and --base are mutually exclusive; passing two is exit 2.
 #
 # Exit: 0 when every crate with source changes has evidence (or is exempt);
-#   non-zero with a per-crate summary on stderr when one does not.
+#   non-zero with a per-crate summary on stderr when one does not. --file exits
+#   0 when the fragment is valid and 1 when it is not. Exit 2 is a usage error
+#   in every mode.
 #
 # Test: scripts/check_changelog_base_selftest.sh replays the #5018 shape on a
 #   synthetic repo — a branch touching crate A only, with crate B's src/**
@@ -192,6 +224,10 @@
 #   scripts/assemble_changelog_selftest.sh, the scan floor by
 #   scripts/check_scan_floor_selftest.sh, and the shared test-file
 #   classification by scripts/check_source_class_selftest.sh.
+#   scripts/check_changelog_staged_selftest.sh covers the #6947 author modes:
+#   --staged with and without a fragment, --file on a valid fragment, a
+#   two-heading fragment and one with no category line, and that a default run
+#   over the same tree is unchanged.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
 #   only — `git`, `grep`, `sed`, `sort`.
@@ -199,6 +235,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
+# --file takes a path from the caller, who typed it relative to THEIR cwd, not
+# to the repo root this script is about to move to.
+ORIG_PWD="$PWD"
 # The shared source/test path classification (#5765). Sourced from this script's
 # OWN directory, not from $REPO_ROOT, so a copy of the gate run out of tree
 # picks up the library beside it rather than a different checkout's.
@@ -206,6 +245,11 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/source_class.sh"
 cd "$REPO_ROOT"
 
+# base | staged | file — see AUTHOR MODES in the header (#6947).
+MODE="base"
+MODE_FLAGS=0
+BASE_EXPLICIT=0
+FILE_TARGET=""
 BASE="${CHANGELOG_GATE_BASE:-origin/main}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -215,11 +259,27 @@ while [[ $# -gt 0 ]]; do
         exit 2
       }
       BASE="$2"
+      BASE_EXPLICIT=1
+      shift 2
+      ;;
+    --staged)
+      MODE="staged"
+      MODE_FLAGS=$((MODE_FLAGS + 1))
+      shift
+      ;;
+    --file)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --file needs a path to a fragment" >&2
+        exit 2
+      }
+      MODE="file"
+      FILE_TARGET="$2"
+      MODE_FLAGS=$((MODE_FLAGS + 1))
       shift 2
       ;;
     -h | --help)
-      # Through the exemption list — keep this range in step with the header.
-      sed -n '2,130p' "$0" >&2
+      # Through the author-mode notes — keep this range in step with the header.
+      sed -n '2,162p' "$0" >&2
       exit 0
       ;;
     *)
@@ -229,7 +289,105 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if ! MERGE_BASE="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
+# A caller who asked for two modes at once gets neither. `--staged --file x`
+# ran only the one that parsed last, and `--base` names a ref neither author
+# mode reads — reporting a verdict the flags did not ask for is how a pre-flight
+# starts being trusted as the gate. `CHANGELOG_GATE_BASE` is NOT a conflict: CI
+# exports it for every run, and `--staged` locally must not trip over that.
+if [[ "$MODE_FLAGS" -gt 1 ]]; then
+  echo "ERROR: --staged and --file are different questions; pass one" >&2
+  exit 2
+fi
+if [[ "$MODE_FLAGS" -eq 1 && "$BASE_EXPLICIT" -eq 1 ]]; then
+  echo "ERROR: --base names a base ref, which neither --staged nor --file reads." >&2
+  echo "       --staged compares the index against HEAD; --file reads no git" >&2
+  echo "       history at all. Pass --base or an author mode, not both." >&2
+  exit 2
+fi
+
+# Why: `case` globs let `*` span `/`, so the pattern `crates/*/changelog.d/*.md`
+# also matches `crates/a/b/changelog.d/x.md` and a naive sed extraction then
+# emits a whole path where a crate name belongs. Extract first, then verify the
+# reconstructed path — which only holds when there is exactly one directory level
+# under crates/ and the fragment sits directly in changelog.d/.
+# What: prints the crate name for a depth-1 fragment path, or fails.
+#
+# Defined here rather than beside the other evidence helpers because --file
+# reaches it BEFORE any git diff runs (#6947).
+fragment_crate() {
+  local path="$1" crate
+  crate="$(printf '%s' "$path" | sed -E 's#^crates/([^/]+)/changelog\.d/[^/]+\.md$#\1#')"
+  [[ "$crate" == "$path" ]] && return 1
+  [[ "$crate" == */* ]] && return 1
+  echo "$crate"
+}
+
+# #6947 --file. Validates ONE fragment with no diff, no base ref and no merge
+# base, so it answers before the commit exists. Placement is checked here —
+# `fragment_crate` is the same depth-1 rule the evidence arm applies — and the
+# CONTENT check is delegated to the assembler, so this mode and the post-commit
+# path cannot disagree about what a valid fragment is.
+if [[ "$MODE" == "file" ]]; then
+  case "$FILE_TARGET" in
+    /*) frag_path="$FILE_TARGET" ;;
+    *)
+      if [[ -e "${ORIG_PWD}/${FILE_TARGET}" ]]; then
+        frag_path="${ORIG_PWD}/${FILE_TARGET}"
+      else
+        frag_path="${REPO_ROOT}/${FILE_TARGET}"
+      fi
+      ;;
+  esac
+  # Resolve both sides before comparing them. macOS reaches $TMPDIR through the
+  # /var -> /private/var symlink, and `git rev-parse --show-toplevel` and `$PWD`
+  # need not hand back the same spelling of the same directory; comparing them
+  # unresolved made an IN-repo fragment look like an outside path and skipped
+  # the placement check, which passed a nested fragment the release would drop.
+  frag_dir="$(cd "$(dirname "$frag_path")" 2>/dev/null && pwd -P || true)"
+  [[ -n "$frag_dir" ]] && frag_path="${frag_dir}/${frag_path##*/}"
+  repo_root_phys="$(cd "$REPO_ROOT" && pwd -P)"
+  frag_rel="${frag_path#"$repo_root_phys"/}"
+
+  if [[ ! -f "$frag_path" ]]; then
+    echo "FAIL ${frag_rel}: no such file. --file validates a fragment you have" >&2
+    echo "       already written; it does not create one." >&2
+    exit 1
+  fi
+  if [[ "${frag_path##*/}" == "README.md" ]]; then
+    echo "FAIL ${frag_rel}: changelog.d/README.md is the tracked directory" >&2
+    echo "       placeholder that keeps changelog.d/ alive between releases. The" >&2
+    echo "       assembler skips it forever, so it is never a fragment." >&2
+    exit 1
+  fi
+  if [[ "$frag_rel" == crates/* ]] && ! fragment_crate "$frag_rel" >/dev/null; then
+    echo "FAIL ${frag_rel}: not a fragment path. A fragment is exactly" >&2
+    echo "       crates/<crate>/changelog.d/<issue-or-pr-number>-<slug>.md, sitting" >&2
+    echo "       DIRECTLY in changelog.d/ — a nested one is rejected at release" >&2
+    echo "       time and would never reach the CHANGELOG." >&2
+    exit 1
+  fi
+
+  if frag_err="$(bash "${REPO_ROOT}/scripts/assemble-changelog.sh" \
+    --fragment "$frag_path" 2>&1 >/dev/null)"; then
+    echo "OK   ${frag_rel}: valid changelog fragment"
+    exit 0
+  fi
+  echo "FAIL ${frag_rel}: the release assembler rejects this fragment" >&2
+  printf '%s\n' "$frag_err" | sed 's/^/       /' >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "staged" ]]; then
+  # The index is compared against HEAD, so HEAD is what every later rev probe
+  # (the transitional assembler probe, crate attribution, the release-window
+  # base changelog) reads. A repo with no commits has no HEAD; the empty tree
+  # is the only honest base there and every probe accepts a tree-ish.
+  if git rev-parse --verify --quiet HEAD >/dev/null; then
+    MERGE_BASE="$(git rev-parse HEAD)"
+  else
+    MERGE_BASE="$(git hash-object -t tree /dev/null)"
+  fi
+elif ! MERGE_BASE="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
   echo "ERROR: cannot find a merge base between '$BASE' and HEAD." >&2
   echo "       Fetch the base ref first (CI must check out with fetch-depth: 0):" >&2
   echo "         git fetch origin main" >&2
@@ -260,7 +418,10 @@ fi
 #     is not stale;
 #   - BASE differs from HEAD^1: passing the merge ref's own base parent by SHA
 #     is exact, not stale, and stays allowed.
-if [[ "$BASE_IS_REF" -eq 0 ]] &&
+#
+# --staged reads no base ref at all, so there is no base to be stale (#6947).
+if [[ "$MODE" != "staged" ]] &&
+  [[ "$BASE_IS_REF" -eq 0 ]] &&
   git rev-parse --verify --quiet 'HEAD^2' >/dev/null &&
   git merge-base --is-ancestor "$BASE" 'HEAD^1' &&
   [[ "$(git rev-parse "$BASE")" != "$(git rev-parse 'HEAD^1')" ]]; then
@@ -284,8 +445,23 @@ fi
 # deleted fragment or changelog is the opposite of evidence — the presence-only
 # check counted `git rm crates/X/changelog.d/*.md` as a record while destroying
 # the one that existed.
-CHANGED="$(git diff --name-only --no-renames "$MERGE_BASE" HEAD)"
-PRESENT="$(git diff --name-only --no-renames --diff-filter=d "$MERGE_BASE" HEAD)"
+#
+# #6947 --staged takes the same two views of the INDEX against HEAD, then adds
+# every untracked-but-not-ignored path to both. An untracked path exists and was
+# not deleted, so it belongs in each view; and a fragment the author wrote but
+# has not `git add`-ed yet is exactly the evidence this mode exists to see.
+if [[ "$MODE" == "staged" ]]; then
+  UNTRACKED="$(git ls-files --others --exclude-standard)"
+  CHANGED="$(printf '%s\n%s\n' \
+    "$(git diff --cached --name-only --no-renames "$MERGE_BASE")" "$UNTRACKED" |
+    grep -v '^[[:space:]]*$' | LC_ALL=C sort -u || true)"
+  PRESENT="$(printf '%s\n%s\n' \
+    "$(git diff --cached --name-only --no-renames --diff-filter=d "$MERGE_BASE")" "$UNTRACKED" |
+    grep -v '^[[:space:]]*$' | LC_ALL=C sort -u || true)"
+else
+  CHANGED="$(git diff --name-only --no-renames "$MERGE_BASE" HEAD)"
+  PRESENT="$(git diff --name-only --no-renames --diff-filter=d "$MERGE_BASE" HEAD)"
+fi
 
 # #4618: the scan floor. "No changes at all against the base" used to exit 0 as
 # "nothing to check" — indistinguishable from a gate that examined the whole PR
@@ -294,10 +470,20 @@ PRESENT="$(git diff --name-only --no-renames --diff-filter=d "$MERGE_BASE" HEAD)
 # clean. Report the number examined so a future regression is visible in the log.
 CHANGED_COUNT="$(printf '%s\n' "$CHANGED" | grep -c '[^[:space:]]' || true)"
 if [[ "${CHANGED_COUNT:-0}" -lt 1 ]]; then
-  echo "FAIL: SCAN FLOOR — the diff ${MERGE_BASE}..HEAD lists 0 changed path(s)." >&2
-  echo "      Nothing was examined, so this gate could not have failed. Check that" >&2
-  echo "      '${BASE}' is the right base and that CI checked out with fetch-depth: 0." >&2
-  echo "      A gate that scans nothing is not a passing gate (issue #4618)." >&2
+  if [[ "$MODE" == "staged" ]]; then
+    # The floor is the same rule with the same exit code; only what counts as a
+    # scanned path differs (#6947). A clean index with no untracked file means
+    # the author has written nothing yet, not that the tree is recorded.
+    echo "FAIL: SCAN FLOOR — the index against HEAD plus untracked files lists 0" >&2
+    echo "      path(s). Nothing was examined, so this run could not have failed." >&2
+    echo "      Write the change (and its fragment) first, or stage it: git add -A" >&2
+    echo "      A gate that scans nothing is not a passing gate (issue #4618)." >&2
+  else
+    echo "FAIL: SCAN FLOOR — the diff ${MERGE_BASE}..HEAD lists 0 changed path(s)." >&2
+    echo "      Nothing was examined, so this gate could not have failed. Check that" >&2
+    echo "      '${BASE}' is the right base and that CI checked out with fetch-depth: 0." >&2
+    echo "      A gate that scans nothing is not a passing gate (issue #4618)." >&2
+  fi
   exit 1
 fi
 
@@ -419,18 +605,18 @@ resolve_source_crate() {
   [[ -n "$SOURCE_CRATE" ]]
 }
 
-# Why: `case` globs let `*` span `/`, so the pattern `crates/*/changelog.d/*.md`
-# also matches `crates/a/b/changelog.d/x.md` and a naive sed extraction then
-# emits a whole path where a crate name belongs. Extract first, then verify the
-# reconstructed path — which only holds when there is exactly one directory level
-# under crates/ and the fragment sits directly in changelog.d/.
-# What: prints the crate name for a depth-1 fragment path, or fails.
-fragment_crate() {
-  local path="$1" crate
-  crate="$(printf '%s' "$path" | sed -E 's#^crates/([^/]+)/changelog\.d/[^/]+\.md$#\1#')"
-  [[ "$crate" == "$path" ]] && return 1
-  [[ "$crate" == */* ]] && return 1
-  echo "$crate"
+# `fragment_crate` is defined near the top of this script — --file reaches it
+# before any diff runs (#6947).
+
+# The CHANGELOG.md-bullet evidence diff, per mode. #6947: in --staged the record
+# lives in the index, not in a commit, so `<base> HEAD` would report the file as
+# unchanged and drop real evidence.
+changelog_evidence_diff() {
+  if [[ "$MODE" == "staged" ]]; then
+    git diff --cached --unified=0 --no-renames "$MERGE_BASE" -- "$1"
+  else
+    git diff --unified=0 --no-renames "$MERGE_BASE" HEAD -- "$1"
+  fi
 }
 
 # Prints the body of a CHANGELOG's `## [<version>]` section, or nothing.
@@ -643,7 +829,7 @@ while IFS= read -r path; do
       crate="$(printf '%s' "$path" | sed -E 's#^crates/([^/]+)/CHANGELOG.md$#\1#')"
       [[ "$crate" == */* ]] && continue
       # A whitespace-only touch is not a changelog entry.
-      if git diff --unified=0 --no-renames "$MERGE_BASE" HEAD -- "$path" |
+      if changelog_evidence_diff "$path" |
         grep -qE '^\+[[:space:]]*-[[:space:]]'; then
         has_changelog="${has_changelog}${crate}"$'\n'
       fi
@@ -653,8 +839,14 @@ done <<<"$PRESENT"
 
 needs="$(printf '%s' "$needs" | grep -v '^$' | LC_ALL=C sort -u || true)"
 
+# #6947: name the mode on a --staged run so its verdict is never pasted as the
+# gate's. Empty in the default mode, which keeps that line byte-for-byte as it
+# was.
+MODE_LABEL=""
+[[ "$MODE" == "staged" ]] && MODE_LABEL=" --staged (index + untracked):"
+
 if [[ -z "$needs" ]]; then
-  echo "changelog-fragment gate: scanned ${CHANGED_COUNT} changed path(s); attributed ${attributed_count} crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK."
+  echo "changelog-fragment gate:${MODE_LABEL} scanned ${CHANGED_COUNT} changed path(s); attributed ${attributed_count} crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK."
   exit 0
 fi
 
@@ -733,4 +925,4 @@ EOF
 fi
 
 crate_count="$(printf '%s\n' "$needs" | grep -c '[^[:space:]]' || true)"
-echo "changelog-fragment gate: scanned ${CHANGED_COUNT} changed path(s); attributed ${attributed_count} crate-source path(s); all ${crate_count} crate(s) with source changes are recorded."
+echo "changelog-fragment gate:${MODE_LABEL} scanned ${CHANGED_COUNT} changed path(s); attributed ${attributed_count} crate-source path(s); all ${crate_count} crate(s) with source changes are recorded."

--- a/scripts/check_changelog_staged_selftest.sh
+++ b/scripts/check_changelog_staged_selftest.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+#
+# check_changelog_staged_selftest.sh — the author modes of
+# scripts/check_changelog_fragment.sh (issue #6947).
+#
+# Why: the gate diffs `<base>..HEAD`, so before a commit exists it reports
+#   `SCAN FLOOR — 0 changed path(s)` and an author cannot check a fragment at
+#   all; after the commit it rejects shape errors — `carries a second category
+#   inside its bullet body` is the live one — that were knowable the moment the
+#   file was written. Two engineers lost a cycle to that on 2026-09-07, one to
+#   each half. `--staged` and `--file` answer both questions earlier.
+#
+#   Neither mode may weaken the gate. `--staged` must still fail a staged source
+#   change with no fragment, still reject a malformed one, and still leave the
+#   default `<base>..HEAD` verdict untouched — a pre-flight that passes what the
+#   gate would fail is worse than no pre-flight, because it is the one an author
+#   runs first.
+#
+# What: builds a throwaway git repo and drives both modes over it.
+#
+#   --staged cases:
+#     staged-src-no-fragment-fails    a staged crates/demo/src/** change with no
+#                                     fragment FAILS naming `demo`. This is the
+#                                     case that reports SCAN FLOOR against the
+#                                     default mode, which is the whole defect.
+#     staged-untracked-fragment-ok    the same staged change with the fragment
+#                                     written but NOT `git add`-ed passes. An
+#                                     untracked-not-ignored path is evidence:
+#                                     an author writes the file before staging
+#                                     it, and that is when they want the answer.
+#     staged-fragment-ok              the same with the fragment staged too.
+#     staged-invalid-fragment-fails   a staged two-category fragment FAILS with
+#                                     the assembler's own rejection, in the same
+#                                     words the post-commit path prints.
+#     staged-docs-only-exempt         a staged docs-only change passes, so the
+#                                     mode inherits the exemptions rather than
+#                                     re-deriving them.
+#     staged-empty-index-scan-floor   a clean tree with nothing staged and
+#                                     nothing untracked FAILS with SCAN FLOOR.
+#                                     The floor is relaxed to "at least one
+#                                     staged or untracked path", never removed —
+#                                     a run that scans nothing is still not a
+#                                     pass (#4618).
+#     staged-ignored-file-not-scanned an ignored untracked file is not a scanned
+#                                     path, so a tree holding only one still
+#                                     hits the floor.
+#     default-mode-unlabelled         the default run over the same repo reports
+#                                     its ordinary summary with no mode label —
+#                                     the CI verdict is byte-for-byte what it
+#                                     was.
+#
+#   --file cases:
+#     file-valid-fragment             exit 0.
+#     file-two-headings-fails         exit 1 naming the second category. This is
+#                                     the error that cost a commit-amend cycle.
+#     file-missing-category-fails     exit 1 naming the unknown category.
+#     file-empty-fails                exit 1 — an empty file is not a fragment.
+#     file-nested-path-fails          a fragment one directory too deep is
+#                                     rejected on PLACEMENT, before its content
+#                                     is read; the assembler drops one silently
+#                                     from the release.
+#     file-readme-placeholder-fails   changelog.d/README.md is the tracked
+#                                     directory placeholder, never evidence.
+#     file-missing-file-fails         a path that does not exist.
+#     file-needs-no-git-history       --file works with the base ref absent and
+#                                     the fragment uncommitted — the mode's
+#                                     entire point is answering before there is
+#                                     anything to diff.
+#
+#   Usage cases: two author modes at once, and an author mode with --base, are
+#   both exit 2. A mode conflict that silently ran one of the two is how a
+#   verdict gets attributed to flags nobody passed.
+#
+# Usage:
+#   bash scripts/check_changelog_staged_selftest.sh
+#   bash scripts/check_changelog_staged_selftest.sh --gate /path/to/gate.sh
+#
+#   `--gate` runs the cases against an ALTERNATE copy of the gate. Pointing it
+#   at the pre-#6947 script is how the mutation is demonstrated: that run must
+#   FAIL here, proving these cases are not passing by construction.
+#
+# Exit: 0 when every case holds; 1 (naming the case) when one does not.
+#
+# Test: this IS the test. It is wired into
+#   .github/workflows/changelog-fragment.yml ahead of the real gate run.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
+#   only. Same constraints as the script under test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+GATE_SOURCE="$SCRIPT_DIR/check_changelog_fragment.sh"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --gate)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --gate needs a path" >&2
+        exit 2
+      }
+      GATE_SOURCE="$2"
+      shift 2
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ -f "$GATE_SOURCE" ]] || {
+  echo "ERROR: no gate script at '$GATE_SOURCE'" >&2
+  exit 2
+}
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/changelog-staged-selftest.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+REPO="$TMP_ROOT/repo"
+GATE="scripts/check_changelog_fragment.sh"
+fail=0
+
+g() { git -C "$REPO" "$@"; }
+
+# ---------------------------------------------------------------------------
+# Fixture: one crate, plus the docs path used by the exemption case.
+# ---------------------------------------------------------------------------
+mkdir -p "$REPO/scripts/lib" "$REPO/crates/demo/src" \
+  "$REPO/crates/demo/changelog.d" "$REPO/docs"
+cp "$GATE_SOURCE" "$REPO/scripts/check_changelog_fragment.sh"
+cp "$SCRIPT_DIR/assemble-changelog.sh" "$REPO/scripts/"
+# #5765: the gate sources its path classification from `scripts/lib/` beside
+# itself, so the library travels with it into the synthetic repo.
+cp "$SCRIPT_DIR/lib/source_class.sh" "$REPO/scripts/lib/"
+
+printf 'pub fn v() -> u32 { 1 }\n' >"$REPO/crates/demo/src/lib.rs"
+printf '[package]\nname = "demo"\nversion = "0.1.0"\n' >"$REPO/crates/demo/Cargo.toml"
+printf '# Changelog\n\n---\n' >"$REPO/crates/demo/CHANGELOG.md"
+printf 'Placeholder keeping changelog.d/ tracked between releases.\n' \
+  >"$REPO/crates/demo/changelog.d/README.md"
+printf '# Docs\n' >"$REPO/docs/notes.md"
+printf 'target/\n*.log\n' >"$REPO/.gitignore"
+
+g init -q -b main
+g config user.email selftest@example.invalid
+g config user.name "changelog staged self-test"
+g add -A
+g commit -qm "M0: demo crate"
+# `main` stays parked at the fixture commit and is the base every case diffs
+# against; the work happens on `work`. A case that COMMITS (the default-mode
+# one) needs a base that is not its own branch tip — with both on `main` the
+# merge base is HEAD and the default run reports SCAN FLOOR, which is the
+# defect under test rather than a verdict.
+BASE_SHA="$(g rev-parse HEAD)"
+
+# ---------------------------------------------------------------------------
+# Fragment bodies. Written with printf, not a heredoc, so every byte is visible
+# at the call site and the file ends exactly where it is meant to.
+# ---------------------------------------------------------------------------
+write_valid_fragment() { printf 'Fixed\n\n- a user-visible change\n' >"$1"; }
+write_two_heading_fragment() {
+  printf 'Fixed\n\n- a user-visible change\n\nChanged\n\n- a second one\n' >"$1"
+}
+write_no_category_fragment() { printf -- '- a bullet with no category above it\n' >"$1"; }
+
+# ---------------------------------------------------------------------------
+# assert_gate: name, expected exit status, ERE the output must match, ERE it
+# must NOT match ("" to skip either), then the gate's arguments.
+#
+# Capture, then match. NOT `... | grep -q`: under `set -o pipefail` the gate's
+# own (expected) non-zero exit becomes the pipeline's status even when grep
+# matched, so every rejection assertion would read as a miss.
+# ---------------------------------------------------------------------------
+assert_gate() {
+  local name="$1" want_rc="$2" want_re="$3" deny_re="$4" out rc=0
+  shift 4
+  out="$(cd "$REPO" && CHANGELOG_GATE_BASE=main bash "$GATE" "$@" 2>&1)" || rc=$?
+  if [ "$rc" -ne "$want_rc" ]; then
+    echo "FAIL: $name -> exit $rc (expected $want_rc)" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  if [ -n "$want_re" ] && ! grep -qE "$want_re" <<<"$out"; then
+    echo "FAIL: $name -> exit $rc as expected, but output does not match /$want_re/" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  if [ -n "$deny_re" ] && grep -qE "$deny_re" <<<"$out"; then
+    echo "FAIL: $name -> exit $rc as expected, but output MATCHES forbidden /$deny_re/" >&2
+    printf '%s\n' "$out" | sed 's/^/       /' >&2
+    fail=1
+    return
+  fi
+  echo "PASS: $name -> exit $rc${want_re:+, matched /$want_re/}"
+}
+
+# reset_tree: a fresh `work` branch at the fixture commit with no staged,
+# unstaged or untracked change, so each case starts from the same place.
+reset_tree() {
+  g checkout -q -B work "$BASE_SHA"
+  g reset -q --hard
+  g clean -qfd
+}
+
+# ===========================================================================
+# --staged
+# ===========================================================================
+
+# 1. THE #6947 DEFECT, first half. Staged source, no fragment anywhere. The
+#    default mode reports SCAN FLOOR here because nothing is committed; this
+#    mode must report the real verdict.
+reset_tree
+printf 'pub fn v() -> u32 { 2 }\n' >"$REPO/crates/demo/src/lib.rs"
+g add -A
+assert_gate staged-src-no-fragment-fails 1 \
+  'FAIL demo: crates/demo/src/\*\* changed with no changelog record' \
+  'SCAN FLOOR' \
+  --staged
+
+# 2. An untracked fragment is evidence. This is the state an author is in
+#    between writing the file and staging it.
+reset_tree
+printf 'pub fn v() -> u32 { 3 }\n' >"$REPO/crates/demo/src/lib.rs"
+g add crates/demo/src/lib.rs
+write_valid_fragment "$REPO/crates/demo/changelog.d/6947-staged-mode.md"
+assert_gate staged-untracked-fragment-ok 0 \
+  'OK   demo: changelog.d fragment present and valid' \
+  'FAIL' \
+  --staged
+
+# 3. The fully staged shape, and the mode label that keeps a --staged verdict
+#    from being pasted as the gate's.
+reset_tree
+printf 'pub fn v() -> u32 { 4 }\n' >"$REPO/crates/demo/src/lib.rs"
+write_valid_fragment "$REPO/crates/demo/changelog.d/6947-staged-mode.md"
+g add -A
+assert_gate staged-fragment-ok 0 \
+  'changelog-fragment gate: --staged \(index \+ untracked\):' \
+  'FAIL' \
+  --staged
+
+# 4. THE #6947 DEFECT, second half. The shape error is caught while the change
+#    is still staged, in the assembler's own words.
+reset_tree
+printf 'pub fn v() -> u32 { 5 }\n' >"$REPO/crates/demo/src/lib.rs"
+write_two_heading_fragment "$REPO/crates/demo/changelog.d/6947-two-categories.md"
+g add -A
+assert_gate staged-invalid-fragment-fails 1 \
+  'carries a second category inside its bullet body' \
+  '' \
+  --staged
+
+# 5. The exemptions are inherited, not re-derived.
+reset_tree
+printf '# Docs\n\nchanged\n' >"$REPO/docs/notes.md"
+g add -A
+assert_gate staged-docs-only-exempt 0 \
+  'no crate source changed \(docs-only / CI-only / test-only\) — OK' \
+  'FAIL' \
+  --staged
+
+# 6. The floor is relaxed, not removed (#4618). Nothing staged, nothing
+#    untracked: a run that examined nothing is not a passing run.
+reset_tree
+assert_gate staged-empty-index-scan-floor 1 \
+  'SCAN FLOOR — the index against HEAD plus untracked files lists 0' \
+  '' \
+  --staged
+
+# 7. An ignored file is not a scanned path. `--exclude-standard` is what makes
+#    a build directory full of artefacts fail to satisfy the floor.
+reset_tree
+mkdir -p "$REPO/target"
+printf 'artefact\n' >"$REPO/target/out.bin"
+printf 'noise\n' >"$REPO/debug.log"
+assert_gate staged-ignored-file-not-scanned 1 \
+  'SCAN FLOOR' \
+  '' \
+  --staged
+
+# 8. THE DEFAULT VERDICT IS UNTOUCHED. Same repo, committed, default mode: the
+#    summary carries no mode label, so what CI reports is what it always was.
+reset_tree
+printf 'pub fn v() -> u32 { 6 }\n' >"$REPO/crates/demo/src/lib.rs"
+write_valid_fragment "$REPO/crates/demo/changelog.d/6947-staged-mode.md"
+g add -A
+g commit -qm "source change with a fragment"
+assert_gate default-mode-unlabelled 0 \
+  'changelog-fragment gate: scanned [0-9]+ changed path\(s\)' \
+  '\-\-staged'
+
+# ===========================================================================
+# --file
+# ===========================================================================
+reset_tree
+
+FRAG_DIR="$TMP_ROOT/frags"
+mkdir -p "$FRAG_DIR"
+write_valid_fragment "$FRAG_DIR/valid.md"
+write_two_heading_fragment "$FRAG_DIR/two-headings.md"
+write_no_category_fragment "$FRAG_DIR/no-category.md"
+: >"$FRAG_DIR/empty.md"
+
+assert_gate file-valid-fragment 0 \
+  'OK   .*valid\.md: valid changelog fragment' \
+  'FAIL' \
+  --file "$FRAG_DIR/valid.md"
+
+assert_gate file-two-headings-fails 1 \
+  'carries a second category inside its bullet body' \
+  '' \
+  --file "$FRAG_DIR/two-headings.md"
+
+assert_gate file-missing-category-fails 1 \
+  "has an unknown category" \
+  '' \
+  --file "$FRAG_DIR/no-category.md"
+
+assert_gate file-empty-fails 1 \
+  'is empty — the first non-blank line must be a category' \
+  '' \
+  --file "$FRAG_DIR/empty.md"
+
+# Placement, checked before the content is read: a nested fragment is dropped
+# from the release by the assembler, so a green here would be a lie.
+mkdir -p "$REPO/crates/demo/changelog.d/sub"
+write_valid_fragment "$REPO/crates/demo/changelog.d/sub/6947-nested.md"
+assert_gate file-nested-path-fails 1 \
+  'not a fragment path' \
+  'OK ' \
+  --file crates/demo/changelog.d/sub/6947-nested.md
+
+assert_gate file-readme-placeholder-fails 1 \
+  'tracked directory' \
+  'OK ' \
+  --file crates/demo/changelog.d/README.md
+
+assert_gate file-missing-file-fails 1 \
+  'no such file' \
+  '' \
+  --file crates/demo/changelog.d/6947-not-written-yet.md
+
+# The mode reads no git history: the base ref does not exist, the fragment is
+# untracked, and the answer is still correct.
+reset_tree
+write_valid_fragment "$REPO/crates/demo/changelog.d/6947-uncommitted.md"
+file_out=""
+file_rc=0
+file_out="$(cd "$REPO" && CHANGELOG_GATE_BASE=refs/heads/no-such-base \
+  bash "$GATE" --file crates/demo/changelog.d/6947-uncommitted.md 2>&1)" || file_rc=$?
+if [ "$file_rc" -eq 0 ] && grep -q 'valid changelog fragment' <<<"$file_out"; then
+  echo "PASS: file-needs-no-git-history -> exit 0 with an absent base ref"
+else
+  echo "FAIL: file-needs-no-git-history -> exit $file_rc" >&2
+  printf '%s\n' "$file_out" | sed 's/^/       /' >&2
+  fail=1
+fi
+
+# ===========================================================================
+# Usage. A mode conflict must refuse, never pick one silently.
+# ===========================================================================
+reset_tree
+assert_gate usage-two-modes-refused 2 \
+  'are different questions' \
+  '' \
+  --staged --file "$FRAG_DIR/valid.md"
+
+assert_gate usage-staged-with-base-refused 2 \
+  'neither --staged nor --file reads' \
+  '' \
+  --staged --base main
+
+assert_gate usage-file-with-base-refused 2 \
+  'neither --staged nor --file reads' \
+  '' \
+  --file "$FRAG_DIR/valid.md" --base main
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "check_changelog_staged_selftest: FAILED — the author modes do not hold" >&2
+  echo "  (issue #6947). Gate under test: ${GATE_SOURCE}" >&2
+  exit 1
+fi
+echo "check_changelog_staged_selftest: all author-mode cases passed."


### PR DESCRIPTION
The gate diffs `<base>..HEAD`, so before a commit exists it reports `SCAN FLOOR — 0 changed path(s)` and an author cannot check a fragment at all; after the commit it rejects shape errors — `carries a second category inside its bullet body` is the live one — that were knowable the moment the file was written. Two engineers lost a cycle to that on 2026-09-07, one to each half.

## What changed

`scripts/check_changelog_fragment.sh`

- `--staged` takes the same two diff views of the INDEX against HEAD (`git diff --cached`), adds `git ls-files --others --exclude-standard` to both, then runs the unchanged crate attribution, exemptions and evidence rules. Same exit codes. The scan floor keeps exit 1 and only its message and its counted set change: "at least one staged or untracked path".
- `--file <path>` validates one fragment with no git diff at all. Placement uses the existing depth-1 `fragment_crate` rule (moved up in the file, unchanged); the content check is delegated to the assembler, so it prints the same `ERROR:` lines the post-commit path prints under the same `FAIL <path>:` header.
- `--staged`, `--file` and `--base` are mutually exclusive (exit 2). `CHANGELOG_GATE_BASE` is not a conflict, since CI exports it on every run.
- `MODE_LABEL` is empty in the default mode, so both summary lines are byte-identical to what CI reported before.

`scripts/assemble-changelog.sh` — new `--fragment <path>` mode calling the existing `parse_fragment`. One validator, so `--file` and the CI gate cannot disagree about what a valid fragment is — the same reason the gate asks for a `--stdout` preview instead of validating fragments itself.

Docs: `docs/reference/changelog-fragments.md` gains a "Validate Before Committing" section naming both flags and their two limits; the `CLAUDE.md` line about the gate seeing only committed changes now points at `--staged`.

## Test ladder: rung 2

Shell scripts and docs — no crate `src/**` changed, so no changelog fragment is owed. The gate's own attribution confirms it:

```
$ bash scripts/check_changelog_fragment.sh
changelog-fragment gate: scanned 6 changed path(s); attributed 0 crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
```

### New self-test

```bash
bash scripts/check_changelog_staged_selftest.sh
```

`EXIT=0`, 19 cases:

```
PASS: staged-src-no-fragment-fails -> exit 1, matched /FAIL demo: crates/demo/src/\*\* changed with no changelog record/
PASS: staged-untracked-fragment-ok -> exit 0, matched /OK   demo: changelog.d fragment present and valid/
PASS: staged-fragment-ok -> exit 0, matched /changelog-fragment gate: --staged \(index \+ untracked\):/
PASS: staged-invalid-fragment-fails -> exit 1, matched /carries a second category inside its bullet body/
PASS: staged-docs-only-exempt -> exit 0, matched /no crate source changed \(docs-only / CI-only / test-only\) — OK/
PASS: staged-empty-index-scan-floor -> exit 1, matched /SCAN FLOOR — the index against HEAD plus untracked files lists 0/
PASS: staged-ignored-file-not-scanned -> exit 1, matched /SCAN FLOOR/
PASS: default-mode-unlabelled -> exit 0, matched /changelog-fragment gate: scanned [0-9]+ changed path\(s\)/
PASS: file-valid-fragment -> exit 0, matched /OK   .*valid\.md: valid changelog fragment/
PASS: file-two-headings-fails -> exit 1, matched /carries a second category inside its bullet body/
PASS: file-missing-category-fails -> exit 1, matched /has an unknown category/
PASS: file-empty-fails -> exit 1, matched /is empty — the first non-blank line must be a category/
PASS: file-nested-path-fails -> exit 1, matched /not a fragment path/
PASS: file-readme-placeholder-fails -> exit 1, matched /tracked directory/
PASS: file-missing-file-fails -> exit 1, matched /no such file/
PASS: file-needs-no-git-history -> exit 0 with an absent base ref
PASS: usage-two-modes-refused -> exit 2, matched /are different questions/
PASS: usage-staged-with-base-refused -> exit 2, matched /neither --staged nor --file reads/
PASS: usage-file-with-base-refused -> exit 2, matched /neither --staged nor --file reads/

check_changelog_staged_selftest: all author-mode cases passed.
```

It is wired into `.github/workflows/changelog-fragment.yml` ahead of the real gate run, next to the six self-tests already there.

### Mutation check

Run against `origin/main`'s copy of the gate, the self-test fails 18 of its 19 cases:

```
$ bash scripts/check_changelog_staged_selftest.sh --gate /tmp/gate-pre6947.sh
EXIT=1   (18 FAIL)
FAIL: staged-src-no-fragment-fails -> exit 2 (expected 1)
FAIL: file-two-headings-fails -> exit 2 (expected 1)
...
PASS: default-mode-unlabelled -> exit 0, matched /changelog-fragment gate: scanned [0-9]+ changed path\(s\)/
```

The one it passes is `default-mode-unlabelled`, which asserts the default summary carries no mode label. It must pass on both gates — that is the claim below.

### Default mode is byte-identical

Every existing self-test, run before and after the change, exit 0 both times with the same output:

| Self-test | Before | After |
|---|---|---|
| `check_scan_floor_selftest.sh changelog_fragment changelog_fragment_tool_error` | `2 gate(s) correctly refuse a vacuous scan — OK.` | same |
| `check_changelog_attribution_selftest.sh` | `all crate-attribution cases passed.` (7 PASS) | same |
| `check_changelog_base_selftest.sh` | `all base-attribution cases passed.` (5 PASS) | same |
| `check_changelog_release_window_selftest.sh` | `all release-window cases passed.` (9 PASS) | same |
| `check_source_class_selftest.sh` | `31 case(s), all pass` | same |
| `assemble_changelog_selftest.sh` | `all fragment-validation cases passed.` (51 PASS) | same |
| `bump_version_selftest.sh` | — | `23 case(s), all pass` |

Plus `default-mode-unlabelled` in the new self-test, which asserts the summary line directly and passes against both gates.

### Other gates

- `bash scripts/check_sld.sh` → exit 0, `0 error(s), 0 warning(s)`
- `bash scripts/check_line_cap.sh` → exit 0, `0 violations`
- `bash -n` clean on all three scripts; `shellcheck --shell=bash` reports only the pre-existing SC1091 info on the `source_class.sh` source line

CI runs no general `shellcheck` over `scripts/` — the only shellcheck steps in `.github/workflows/` are the `trusty-audit-install` job's.

## Two bugs the self-test caught in the first cut

- `--file` skipped the placement check for in-repo paths, because `git rev-parse --show-toplevel` and `$PWD` disagree across the macOS `/var → /private/var` symlink. A nested fragment — one the assembler drops from the release — passed. Both sides are now resolved with `pwd -P` before comparison.
- The `default-mode-unlabelled` case needed a base branch distinct from the work branch; with both on `main` the merge base is HEAD and the default run reports SCAN FLOOR, which is the defect under test rather than a verdict.

Refs #6947

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
