### PR TITLE
chore(tga): 8.0.0 — public paging API changed in #6981

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10450,7 +10450,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "7.1.2"
+version = "8.0.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.11", defau
 # a row in scripts/semver-checks-crate-exclusions.tsv (#6300).
 # #6776: same drift as trusty-console, surfaced by the new gate — `^6.0.1`
 # cannot accept the crate's own 7.1.0.
-tga = { path = "crates/trusty-git-analytics", version = "7.1" }
+tga = { path = "crates/trusty-git-analytics", version = "8.0" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -59,7 +59,15 @@ name = "tga"
 # new config table; nothing existing is removed or changed. `src/**` changed
 # while 6.0.0 was already live on crates.io, so the `PR version bump vs
 # crates.io` gate (#4421) requires the bump.
-version = "7.1.2"
+# 7.1.2 -> 8.0.0 (#6812): MAJOR. Migrating the JIRA search off the retired
+# `/rest/api/3/search` moves `collect::jira::paging::PageRequest` from a
+# `startAt` offset to `/search/jql`'s continuation token, which
+# `cargo-semver-checks` reports as two breaks — `struct_pub_field_missing` on
+# `PageRequest.start_at` and `constructible_struct_adds_field` on
+# `PageRequest.next_page_token`. Post-1.0, a break sits in the MAJOR position.
+# Only trusty-analyze takes a Cargo edge on tga, and it pins by path with no
+# version requirement, so nothing in-workspace has to move with it.
+version = "8.0.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.94) per #254. Required for

--- a/crates/trusty-git-analytics/changelog.d/6812-jira-search-jql.md
+++ b/crates/trusty-git-analytics/changelog.d/6812-jira-search-jql.md
@@ -9,3 +9,8 @@ Fixed
   an array, and may return a page shorter than the requested `maxResults`
   while more pages remain — so both search walks now end on the absent token
   and never on page length (#6812).
+- **Breaking:** the public `collect::jira::paging` API paginates by token, which
+  is why this release is 8.0.0 and not a patch. `PageRequest.start_at: u64` is
+  replaced by `next_page_token: Option<String>`, and `KeysetPager::record_page`
+  takes the server's continuation token in place of the requested page size
+  (#6812).


### PR DESCRIPTION
#6981 merged the `/rest/api/3/search/jql` migration under tga 7.1.2. That
migration changes a public struct, so `main` now carries a breaking change
without the version that permits it. This lands the version.

## Why a major is owed

`cargo-semver-checks` refuses the merged state against the published 7.1.0
with two failures, both on `collect::jira::paging::PageRequest`:

```
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---
  field start_at of struct PageRequest, previously in .../tga-7.1.0/src/collect/jira/paging.rs:67
--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---
  field PageRequest.next_page_token in .../collect/jira/paging.rs:75
   Summary semver requires new major version: 2 major and 0 minor checks failed
```

`/rest/api/3/search/jql` has no `startAt`, so the within-window position had to
become the endpoint's `nextPageToken`. `PageRequest` is publicly constructible
and carries no `#[non_exhaustive]`, so a downstream struct literal stops
compiling. Post-1.0, a break sits in the MAJOR position. Both breaks are
intended; neither is incidental.

The `Public API / SemVer` job on #6981 reported this as red, but it is not in
`required_status_checks.contexts`, so auto-merge landed the PR anyway.

## What changed

- `crates/trusty-git-analytics/Cargo.toml`: 7.1.2 → 8.0.0 via
  `scripts/bump-version.sh trusty-git-analytics major --no-changelog`,
  `Cargo.lock` synced. Version-history entry added naming both flagged checks.
- Root `[workspace.dependencies]`: `tga = { …, version = "7.1" }` → `"8.0"`.
- The #6812 changelog fragment gains a `**Breaking:**` bullet naming the
  `PageRequest` field swap and the `KeysetPager::record_page` signature.

`trusty-analyze` is the only workspace crate taking a Cargo edge on tga, and it
pins by path with no version requirement, so nothing else moves. (`trusty-review`
does **not** depend on tga — its manifest mentions tga only in comments recording
that the edge was removed in #5466/#5468 and now runs tga → trusty-review.)

## Gates — rung 1 (manifest and changelog only; no `src/**` touched)

```
cargo check --workspace                             EXIT=0
bash scripts/check_workspace_dep_versions.sh        EXIT=0
  [ OK ] tga  req 8.0  accepts crate 8.0.0
  All 12 internal row(s) accept their member crate version.
bash scripts/check-pr-version-bump.sh               EXIT=0
  [ OK ] 4 changed path(s) examined; none under crates/<crate>/src/**
bash scripts/check_changelog_fragment.sh            EXIT=0
  no crate source changed (docs-only / CI-only / test-only) — OK
bash scripts/check_semver.sh --crate tga            EXIT=0
  INVENTORY tga: 7.1.0 -> 8.0.0 is already a breaking release — advisory
       Summary semver requires new major version: 2 major and 0 minor checks failed
  INVENTORY tga: breaking change(s) listed above — permitted by the major bump.
  semver gate: scanned (explicit); 0 checked, 0 skipped, 1 inventoried (advisory) — OK.
```

The gate now inventories the break as permitted rather than refusing it. The
crate's own `clippy`/`test` gates ran green on this exact tree under #6981 and
no `src/**` file changed here.

Refs #6812

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
