### PR TITLE
fix(trusty-audit): run index labels sampled coverage as sampled (#6138)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11493,7 +11493,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -17,7 +17,12 @@ name = "trusty-audit"
 # `search_evidence` here, which `cargo-semver-checks` reports as
 # `struct_missing_field` against 0.13.3; for a 0.y.z crate the breaking bump is
 # the MINOR position.
-version = "0.14.2"
+# 0.14.2 -> 0.14.3 (#6138): PATCH. 0.14.2 is already on crates.io and this PR
+# changes `src/**`. The public surface only GAINS items — the
+# `grounding::coverage_rollup::Sampling` enum plus `RepoCoverage::sampling` and
+# `Rollup::sampling` — so no existing signature or struct shape changed and
+# `cargo-semver-checks` has nothing to report against 0.14.2.
+version = "0.14.3"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/6138-sampled-coverage-label.md
+++ b/crates/trusty-audit/changelog.d/6138-sampled-coverage-label.md
@@ -1,0 +1,9 @@
+Changed
+
+- The run index's investigation-coverage section now says when its figure is a
+  sample rather than the whole estate: a partial pass renders a
+  `**Sampled, not exhaustive.**` line naming the sample size, the population and
+  the unread remainder. A run that read every tracked file renders exactly what
+  it did before. New public items `grounding::coverage_rollup::Sampling`,
+  `RepoCoverage::sampling` and `Rollup::sampling` carry the fact; no existing
+  signature or struct shape changed (issue #6138).

--- a/crates/trusty-audit/src/grounding/coverage_rollup.rs
+++ b/crates/trusty-audit/src/grounding/coverage_rollup.rs
@@ -23,6 +23,52 @@
 
 use std::path::{Path, PathBuf};
 
+/// Whether a coverage figure covers everything it counts, or a sample of it
+/// (#6138).
+///
+/// Why: the roll-up's percentage reads as a property of the whole estate, and a
+/// reader who takes it that way concludes the unread files were assessed and
+/// found clean. They were never opened. The distinction has to travel with the
+/// figure rather than be inferred from two counts sitting beside it.
+/// What: [`Sampling::Sampled`] carries the sample size and the population, so
+/// the renderer states both without recomputing them.
+/// Test: `super::coverage_rollup_tests::{a_sampled_rollup_is_labelled_sampled,
+/// an_exhaustive_rollup_carries_no_sampled_label}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Sampling {
+    /// Every file the denominator counts was read.
+    Exhaustive,
+    /// `read` of `population` files were read; the rest were never opened.
+    Sampled {
+        /// Files the pass actually read — the sample size.
+        read: usize,
+        /// Files it could have read — the population.
+        population: usize,
+    },
+}
+
+impl Sampling {
+    /// Which of the two a `read`-of-`population` pair is.
+    ///
+    /// A pass that read everything it could — `read >= population`, which
+    /// includes the degenerate empty repository — sampled nothing.
+    #[must_use]
+    pub fn of(read: usize, population: usize) -> Self {
+        if read < population {
+            Self::Sampled { read, population }
+        } else {
+            Self::Exhaustive
+        }
+    }
+
+    /// True when the figure is a sample rather than the whole population.
+    #[must_use]
+    pub fn is_sampled(self) -> bool {
+        matches!(self, Self::Sampled { .. })
+    }
+}
+
 /// One repository's investigation coverage, as its report recorded it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -56,6 +102,14 @@ impl RepoCoverage {
         #[allow(clippy::cast_precision_loss)]
         let share = (self.examined as f64 / self.eligible as f64) * 100.0;
         (share * 10.0).round() / 10.0
+    }
+
+    /// Whether this repository's figure is a sample or the whole of it (#6138).
+    ///
+    /// Test: `super::coverage_rollup_tests::a_sampled_rollup_is_labelled_sampled`.
+    #[must_use]
+    pub fn sampling(&self) -> Sampling {
+        Sampling::of(self.examined, self.eligible)
     }
 }
 
@@ -97,6 +151,29 @@ impl Rollup {
     #[must_use]
     pub fn analyze_lanes_dead(&self) -> usize {
         self.repos.iter().filter(|r| r.analyze_lane_dead).count()
+    }
+
+    /// Whether the estate figure is a sample or the whole of it (#6138).
+    ///
+    /// Why: one repository read at 6% makes the estate percentage a sample,
+    /// however complete the other 58 are. So the estate is exhaustive only when
+    /// every row is, and the sampled case carries the estate totals — the
+    /// numbers the renderer states.
+    /// What: the per-row predicate quantified over the rows, rather than
+    /// [`Sampling::of`] applied to the two sums, so a row that over-reports its
+    /// examined count cannot mask another row's shortfall.
+    /// Test: `super::coverage_rollup_tests::{a_sampled_rollup_is_labelled_sampled,
+    /// an_exhaustive_rollup_carries_no_sampled_label}`.
+    #[must_use]
+    pub fn sampling(&self) -> Sampling {
+        if self.repos.iter().any(|r| r.sampling().is_sampled()) {
+            Sampling::Sampled {
+                read: self.examined(),
+                population: self.eligible(),
+            }
+        } else {
+            Sampling::Exhaustive
+        }
     }
 }
 
@@ -247,9 +324,13 @@ pub const TOP_ROWS: usize = 15;
 /// [`super::osv_rollup::index_section`] draws.
 /// What: an empty roll-up renders the "not recorded" line, which is the state a
 /// bundle of reports written by a renderer too old to record coverage lands in.
-/// A populated one renders the estate totals and the worst [`TOP_ROWS`] rows.
+/// A populated one renders the estate totals and the worst [`TOP_ROWS`] rows,
+/// preceded by a sampled label when [`Rollup::sampling`] says the pass read less
+/// than it could have (#6138). An exhaustive run's wording is what it always
+/// was — the label is what a partial run adds, not a phrase every run carries.
 /// Test: `super::coverage_rollup_tests::{the_index_section_states_the_estate_share,
-/// a_bundle_with_no_coverage_records_says_so}`.
+/// a_bundle_with_no_coverage_records_says_so, a_sampled_rollup_is_labelled_sampled,
+/// an_exhaustive_rollup_carries_no_sampled_label}`.
 #[must_use]
 pub fn index_section(rollup: Option<&Rollup>) -> String {
     let Some(rollup) = rollup else {
@@ -277,6 +358,17 @@ pub fn index_section(rollup: Option<&Rollup>) -> String {
          the files that were read and states nothing about the rest.\n\n",
         repos = rollup.repos.len(),
     ));
+    // #6138: the share above reads as a property of the estate unless the
+    // section says which of the two it is.
+    if let Sampling::Sampled { read, population } = rollup.sampling() {
+        out.push_str(&format!(
+            "**Sampled, not exhaustive.** The pass read {read} of {population} tracked file(s) \
+             and never opened the remaining {unread}. Every coverage figure in this section is a \
+             sample size over a population, and says nothing about the files nobody read (issue \
+             #6138).\n\n",
+            unread = population.saturating_sub(read),
+        ));
+    }
     let dead = rollup.analyze_lanes_dead();
     if dead > 0 {
         out.push_str(&format!(

--- a/crates/trusty-audit/src/grounding/coverage_rollup_tests.rs
+++ b/crates/trusty-audit/src/grounding/coverage_rollup_tests.rs
@@ -8,7 +8,8 @@
 //! Test: this file.
 
 use super::coverage_rollup::{
-    ANALYZE_LANE_DEAD_HEADLINE, RepoCoverage, Rollup, index_section, read_coverage, rollup,
+    ANALYZE_LANE_DEAD_HEADLINE, RepoCoverage, Rollup, Sampling, index_section, read_coverage,
+    rollup,
 };
 
 /// A report JSON stating one repository's coverage, with the gap list given.
@@ -137,6 +138,86 @@ fn a_bundle_with_no_coverage_records_says_so() {
         index_section(None),
         "",
         "a producer with no reports to read must claim nothing either way"
+    );
+}
+
+/// #6138 regression. The section stated a share and left the reader to work out
+/// whether it covered the estate or a sample of it; a share reads as the former,
+/// so an unread file was easy to take for an assessed one.
+///
+/// Against `origin/main` at fa5ea71bf this fails on the rendered text:
+/// `index_section` writes no sampled label, so the first assertion finds nothing.
+#[test]
+fn a_sampled_rollup_is_labelled_sampled() {
+    let rolled = Rollup {
+        repos: vec![
+            RepoCoverage {
+                name: "Big".to_owned(),
+                examined: 40,
+                eligible: 3_000,
+                analyze_lane_dead: false,
+            },
+            RepoCoverage {
+                name: "Small".to_owned(),
+                examined: 30,
+                eligible: 60,
+                analyze_lane_dead: false,
+            },
+        ],
+    };
+
+    assert_eq!(
+        rolled.sampling(),
+        Sampling::Sampled {
+            read: 70,
+            population: 3_060,
+        },
+        "the estate figure carries its sample size and population"
+    );
+    assert!(rolled.repos[0].sampling().is_sampled());
+
+    let text = index_section(Some(&rolled));
+
+    assert!(
+        text.contains(
+            "**Sampled, not exhaustive.** The pass read 70 of 3060 tracked file(s) and never \
+             opened the remaining 2990."
+        ),
+        "the label names the sample size, the population and the unread remainder:\n{text}"
+    );
+    assert!(text.contains("#6138"), "{text}");
+}
+
+/// #6138. The label is what a partial run ADDS. A run that read every tracked
+/// file states the share it always stated, with nothing hedging it — a phrase on
+/// every run is a phrase readers stop seeing.
+#[test]
+fn an_exhaustive_rollup_carries_no_sampled_label() {
+    let rolled = Rollup {
+        repos: vec![RepoCoverage {
+            name: "Whole".to_owned(),
+            examined: 120,
+            eligible: 120,
+            analyze_lane_dead: false,
+        }],
+    };
+
+    assert_eq!(rolled.sampling(), Sampling::Exhaustive);
+    assert_eq!(
+        Sampling::of(0, 0),
+        Sampling::Exhaustive,
+        "nothing to sample"
+    );
+
+    let text = index_section(Some(&rolled));
+
+    assert!(
+        !text.to_lowercase().contains("sampl"),
+        "an exhaustive run's wording is unchanged:\n{text}"
+    );
+    assert!(
+        text.contains("read 120 of 120 tracked file(s)"),
+        "the estate line is still there:\n{text}"
     );
 }
 


### PR DESCRIPTION
The run index's investigation-coverage section stated a share of the estate and
left the reader to work out whether it covered everything. A share reads as
exhaustive, so a file the pass never opened was easy to take for one that was
assessed and found clean.

A partial pass now renders a sampled label naming the sample size, the
population and the unread remainder:

```
**Sampled, not exhaustive.** The pass read 70 of 3060 tracked file(s) and never opened the remaining 2990. Every coverage figure in this section is a sample size over a population, and says nothing about the files nobody read (issue #6138).
```

A pass that read every tracked file renders exactly what it rendered before —
`an_exhaustive_rollup_carries_no_sampled_label` asserts the rendered text
contains no `sampl` at all. The table is untouched, so no existing assertion
about the section moved.

## What carries the flag

`grounding::coverage_rollup` gains a `Sampling` enum
(`Exhaustive` / `Sampled { read, population }`) plus `RepoCoverage::sampling`
and `Rollup::sampling`. No existing signature changed and no field was added to
an existing struct. The estate is exhaustive only when every row is, so one
repository read at 6% labels the whole figure.

## Version

`0.14.2 -> 0.14.3`, PATCH. 0.14.2 is already on crates.io and this PR changes
`src/**`. The public surface only GAINS items, so `cargo-semver-checks` has
nothing to report against the 0.14.2 baseline.

## Gates — rung 3 (localized behavior inside one crate)

| Command | Result |
|---|---|
| `cargo fmt --check` | `EXIT=0` |
| `cargo clippy -p trusty-audit --all-targets -- -D warnings` | `EXIT=0` |
| `cargo test -p trusty-audit --no-fail-fast` | `EXIT=0` — all 10 targets ran; lib `952 passed; 0 failed; 5 ignored`, integration targets 3/5/4/4/8/9, 0 failed anywhere |
| `bash scripts/check_line_cap.sh` | `0 violations — OK` |
| `bash scripts/check_test_pointers.sh` | `31369 citation(s) — 0 dangling pointers — OK` |
| `bash scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |
| `bash scripts/check_changelog_fragment.sh` | `OK trusty-audit: changelog.d fragment present and valid` |
| `bash scripts/check-pr-version-bump.sh` | `[ OK ] trusty-audit — version bumped 0.14.2 -> 0.14.3` |
| `bash scripts/check_workspace_dep_versions.sh` | `All 12 internal row(s) accept their member crate version` |

## The regression test fails before the change

`a_sampled_rollup_is_labelled_sampled` asserts on report output, not on the new
type. Removing only the render block and re-running produced the text
`origin/main` renders:

```
thread '...a_sampled_rollup_is_labelled_sampled' panicked at coverage_rollup_tests.rs:181:5:
the label names the sample size, the population and the unread remainder:
## Investigation coverage

The investigation pass read 70 of 3060 tracked file(s) across 2 repositor(y/ies) — 2.3% of the estate. A finding set is evidence about the files that were read and states nothing about the rest.

Least-covered first:
...
test result: FAILED. 0 passed; 1 failed
```

Block restored, `test result: ok. 7 passed; 0 failed` on `--lib coverage_rollup`.

Refs #6138

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
