### PR TITLE
docs: PR-time semver/rustdoc jobs are advisory; post-commit gates; worktree guard note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,12 @@ change's blast radius. Risk labels map onto the rungs (1–2 Low, 3–4 Normal,
 - 🟡 **Do not use `gh pr merge --admin`** — the account is repo owner and the
   flag is not a no-op for `BLOCKED` or `BEHIND`. Every required context passing
   on the PR's own head remains the bar.
+- 🟡 **`Public API / SemVer` and `Rustdoc intra-doc links` are not required
+  contexts** (verified 2026-09-07 against the protection API) — a red run there
+  never blocks merge. PR #6981 merged with `Public API / SemVer` and its own
+  break self-test failing; #6981 and #6978 both merged with `Rustdoc intra-doc
+  links` failing. The one actual stop for a public-API break is
+  `preflight-publish.sh` CHECK 5 at release, run by `local-ops`.
 
 ### Baseline failures — the Rust specifics
 
@@ -399,6 +405,10 @@ crates/<crate>/changelog.d/<issue-or-pr-number>-<short-slug>.md
   fragment's placement, category line and body, no diff at all) — #6947; run the
   default gate after committing. `check_line_cap.sh` reads tracked
   `git ls-files`, so a new file needs `git add` first too.
+- 🟡 **`scripts/check-pr-version-bump.sh` is the second post-commit gate on the
+  same shape** — it diffs `merge-base..HEAD` and fails with `SCAN FLOOR` on a
+  diff that resolves to zero changed paths, so it too needs a real commit, not
+  the working tree.
 
 ## Cross-Crate Development Workflow
 
@@ -438,6 +448,12 @@ independently reviewable PR outcome, subagent confinement, cleanup — lives in
   ([ADR-0049](docs/adr/0049-docs-commits-are-permitted-in-a-main-checkout.md)).
 - Extended rationale and the throwaway-worktree fallback for a dirty checkout:
   [worktree-discipline.md](docs/reference/worktree-discipline.md).
+- 🟡 **The isolation-worktree guard's `git` detection can misfire on a path or a
+  heredoc body** — a shell loop over paths containing `git` (e.g.
+  `trusty-git-analytics`) or a `<<'PY'`-style scratch script can both be denied
+  as unverifiable inside the worktree ([#6982](https://github.com/bobmatnyc/trusty-tools/issues/6982),
+  open). Until it lands, write scratch scripts with the Write tool instead of a
+  shell heredoc, and avoid looping over such paths.
 
 ## Abbreviations & Aliases
 


### PR DESCRIPTION
Rung 1 (docs-only). Three verified additions to `CLAUDE.md`.

## Additions

1. **"What CI actually gates"** — `Public API / SemVer` and `Rustdoc intra-doc
   links` are not required contexts (verified live against
   `branches/main/protection`). PR #6981 merged with `Public API / SemVer` and
   its own `SemVer: BREAK` self-test red, plus `Rustdoc intra-doc links` red;
   #6978 also merged with `Rustdoc intra-doc links` red. The actual stop for a
   public-API break stays `preflight-publish.sh` CHECK 5 at release, run by
   `local-ops`.
2. **"Per-PR Changelog Fragment"** — extends the existing post-commit-gate
   bullet to name `scripts/check-pr-version-bump.sh` as a second gate on the
   same shape: it diffs `merge-base..HEAD` and fails with `SCAN FLOOR` on a
   diff that resolves to zero changed paths (confirmed in the script source).
3. **"Parallel Worktree Discipline"** — notes that the isolation-worktree
   guard's `git`-substring detection can misfire on a path containing `git`
   (e.g. `trusty-git-analytics`) or on a heredoc body, denying the command as
   unverifiable inside the worktree (#6982, open). I hit this myself mid-task:
   a `grep` command containing the literal text "git switch" was denied with
   that exact symptom.

## Dropped claim

The original ask included "the worktree guard refuses `git checkout -b`, use
`git switch -c` instead." I tested this directly in a live isolation
worktree — `git checkout -b <branch>` succeeded, exit 0, no refusal — and
`main_checkout.rs`'s own doc comment confirms `checkout -b` is deliberately
excluded from the destructive-command table it enforces. The claim does not
hold, so it is not in this PR.

## Gates

```
bash scripts/check_sld.sh                 EXIT=0 — 63 spec docs + 3685 code files, 0 errors
bash scripts/check_changelog_fragment.sh  EXIT=0 — docs-only, no fragment required
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools