### PR TITLE
fix(tga): flag the near-miss identity split instead of passing it silently

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/6798-identity-merge-risk-near-miss.md
+++ b/crates/trusty-git-analytics/changelog.d/6798-identity-merge-risk-near-miss.md
@@ -1,0 +1,10 @@
+Fixed
+
+- Alias suggestion reaches two near-miss identity splits it used to pass over in
+  silence: a display name that matches only once punctuation and whitespace are
+  normalised (`ada.lovelace` beside `Ada Lovelace`, confidence 0.90), and a legacy GitHub
+  noreply address carrying no `<id>+` prefix (`login@users.noreply.github.com`).
+  Both are HIGH-confidence, so the authorship report raises
+  `identity_merge_risk` instead of understating bus factor and top-author share.
+  Nothing is merged without an operator confirming it, and two distinct people
+  whose names merely resemble each other are still never paired.

--- a/crates/trusty-git-analytics/src/collect/identity/suggest.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/suggest.rs
@@ -12,8 +12,10 @@
 //! Test: the `tests` module below.
 //!
 //! Signals (highest signal first):
-//! 1. Same observed `author_name` string under two different emails
-//!    (confidence 0.95).
+//! 1. Same observed `author_name` under two different emails — byte-identical
+//!    once lowercased (confidence 0.95), or identical once punctuation and
+//!    whitespace are normalised away, e.g. `ada.lovelace` beside `Ada Lovelace`
+//!    (confidence 0.90, #6798).
 //! 2. Edit distance ≤ 2 on the email local-part with identical or
 //!    near-identical domains (confidence 0.78 – 0.85).
 //! 3. Known noise patterns: `*.local` hostnames, GitHub noreply emails,
@@ -112,15 +114,45 @@ pub fn detect_all(
     Ok(dedupe_and_rank(out, floor))
 }
 
-/// Signal 1: identical observed display names under two different emails.
+/// A display name reduced to lowercase words separated by single spaces.
+///
+/// Why (#6798): git configs spell one person's name several ways — `Ada
+/// Lovelace`, `ada.lovelace`, `Ada  Lovelace`, `ada_lovelace`. Comparing the
+/// raw lowercased strings reads every one of those as a different person,
+/// which is the near-miss #6798 reports: two identities left unmerged with
+/// nothing on the report saying so. Punctuation and whitespace carry no
+/// identity, so both are normalised away before the comparison.
+/// What: lowercases, replaces every non-alphanumeric character with a space,
+/// then joins the remaining words with one space. Word ORDER is preserved, so
+/// `Lovelace Ada` never matches `Ada Lovelace` — a reorder is a different
+/// claim than a respelling and this function does not make it.
+/// Test: `tests::a_dotted_display_name_matches_its_spaced_form`.
+fn normalize_display_name(name: &str) -> String {
+    let spaced: String = name
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect();
+    spaced
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Signal 1: the same observed display name under two different emails.
 ///
 /// Why: the strongest hint short of an explicit user action; if two authors
 /// share `canonical_name` and only the email differs, they are almost
 /// certainly the same person.
-/// What: groups distinct `(canonical_name, canonical_email)` pairs by name
-/// and emits one suggestion per non-canonical email pointing at the
-/// alphabetically-first email for the name (a deterministic destination).
-/// Test: `tests::same_name_different_email_detected`.
+/// What: groups distinct `(canonical_name, canonical_email)` pairs by
+/// [`normalize_display_name`] and emits one suggestion per non-canonical email
+/// pointing at the alphabetically-first email for the group (a deterministic
+/// destination). A pair whose raw lowercased names are byte-identical scores
+/// 0.95; one that matches only after normalisation scores 0.90 — still above
+/// [`HIGH_CONFIDENCE_CUTOFF`], because the group is an exact match on the
+/// normalised form rather than a fuzzy one (#6798).
+/// Test: `tests::{same_name_different_email_detected,
+/// a_dotted_display_name_matches_its_spaced_form}`.
 fn detect_same_name_pairs(conn: &Connection) -> Result<Vec<Suggestion>> {
     let mut stmt = conn.prepare(
         "SELECT canonical_name, canonical_email FROM authors \
@@ -130,26 +162,40 @@ fn detect_same_name_pairs(conn: &Connection) -> Result<Vec<Suggestion>> {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
 
-    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    // #6798: keyed on the normalised name, with each email's raw lowercased
+    // name kept so an exact match still outranks a normalised-only one.
+    let mut groups: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
     for r in rows {
         let (name, email) = r?;
-        groups.entry(name.to_lowercase()).or_default().push(email);
+        let key = normalize_display_name(&name);
+        if key.is_empty() {
+            continue;
+        }
+        groups
+            .entry(key)
+            .or_default()
+            .push((email, name.to_lowercase()));
     }
 
     let mut out: Vec<Suggestion> = Vec::new();
-    for (_name, mut emails) in groups {
-        emails.sort();
-        emails.dedup();
-        if emails.len() < 2 {
+    for (_key, mut members) in groups {
+        members.sort();
+        members.dedup_by(|a, b| a.0 == b.0);
+        if members.len() < 2 {
             continue;
         }
-        let dst = emails[0].clone();
-        for src in emails.into_iter().skip(1) {
+        let (dst, dst_name) = members[0].clone();
+        for (src, src_name) in members.into_iter().skip(1) {
+            let exact = src_name == dst_name;
             out.push(Suggestion {
                 src,
                 dst: dst.clone(),
-                confidence: 0.95,
-                reason: "same canonical_name".to_string(),
+                confidence: if exact { 0.95 } else { 0.90 },
+                reason: if exact {
+                    "same canonical_name".to_string()
+                } else {
+                    "same canonical_name after normalisation".to_string()
+                },
             });
         }
     }
@@ -259,29 +305,33 @@ fn detect_noise_patterns(
 
         // 3b. GitHub noreply emails: `<id>+<login>@users.noreply.github.com`.
         if domain == "users.noreply.github.com" {
-            if let Some(login) = local.split_once('+').map(|(_, l)| l) {
-                for other in &emails {
-                    if other == email {
-                        continue;
-                    }
-                    let Some((other_local, _)) = split_email(other) else {
-                        continue;
-                    };
-                    if other_local == login {
-                        out.push(Suggestion {
-                            src: email.clone(),
-                            dst: other.clone(),
-                            confidence: 0.90,
-                            reason: format!("GitHub noreply login '{login}'"),
-                        });
-                    } else if other_local.contains(login) || login.contains(&other_local) {
-                        out.push(Suggestion {
-                            src: email.clone(),
-                            dst: other.clone(),
-                            confidence: 0.78,
-                            reason: format!("GitHub noreply login '{login}' (partial)"),
-                        });
-                    }
+            // #6798: the legacy form is `<login>@users.noreply.github.com`
+            // with no numeric `<id>+` prefix; requiring the `+` skipped that
+            // whole address, and no other pass reaches it either — the
+            // edit-distance pass drops identical local-parts and the domain is
+            // nowhere near a canonical one.
+            let login = local.split_once('+').map_or(local.as_str(), |(_, l)| l);
+            for other in &emails {
+                if other == email {
+                    continue;
+                }
+                let Some((other_local, _)) = split_email(other) else {
+                    continue;
+                };
+                if other_local == login {
+                    out.push(Suggestion {
+                        src: email.clone(),
+                        dst: other.clone(),
+                        confidence: 0.90,
+                        reason: format!("GitHub noreply login '{login}'"),
+                    });
+                } else if other_local.contains(login) || login.contains(&other_local) {
+                    out.push(Suggestion {
+                        src: email.clone(),
+                        dst: other.clone(),
+                        confidence: 0.78,
+                        reason: format!("GitHub noreply login '{login}' (partial)"),
+                    });
                 }
             }
         }
@@ -430,6 +480,60 @@ mod tests {
         assert_eq!(out.len(), 1, "exactly one pair expected, got {out:?}");
         assert!(out[0].confidence >= 0.9);
         assert!(out[0].reason.contains("same canonical_name"));
+    }
+
+    /// (#6798) One person spelling their name `Ada Lovelace` in one git config and
+    /// `ada.lovelace` in another must still pair — the dot is punctuation, not an
+    /// identity. The pair scores below the exact match but above the HIGH
+    /// cutoff, so it reaches the authorship report's risk flag.
+    #[test]
+    fn a_dotted_display_name_matches_its_spaced_form() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Ada Lovelace", "ada.lovelace@example.com");
+        insert_author(&db, "ada.lovelace", "ada.lovelace@users.noreply.github.com");
+        let out = detect_same_name_pairs(db.connection()).expect("detect");
+        assert_eq!(out.len(), 1, "exactly one pair expected, got {out:?}");
+        assert_eq!(out[0].src, "ada.lovelace@users.noreply.github.com");
+        assert_eq!(out[0].dst, "ada.lovelace@example.com");
+        assert!(
+            out[0].confidence >= HIGH_CONFIDENCE_CUTOFF,
+            "a normalised name match must stay HIGH, got {}",
+            out[0].confidence
+        );
+        assert!(out[0].reason.contains("normalisation"), "got {out:?}");
+    }
+
+    /// (#6798) Two different people whose display names merely resemble each
+    /// other must not pair — normalisation is an exact match on the normalised
+    /// form, never a fuzzy one.
+    #[test]
+    fn similar_but_distinct_display_names_are_not_paired() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "Ada Lovelace", "ada.lovelace@example.com");
+        insert_author(&db, "Ada Lovelaces", "ada.lovelaces@example.com");
+        let out = detect_same_name_pairs(db.connection()).expect("detect");
+        assert!(out.is_empty(), "two distinct people must not pair: {out:?}");
+    }
+
+    /// (#6798) The legacy GitHub noreply form carries no `<id>+` prefix; the
+    /// login is the whole local-part, and it routes to the identity whose
+    /// local-part matches.
+    #[test]
+    fn a_legacy_github_noreply_address_routes_to_its_login() {
+        let db = Database::open_in_memory().expect("open");
+        insert_author(&db, "A", "ada.lovelace@users.noreply.github.com");
+        insert_author(&db, "B", "ada.lovelace@example.com");
+        let out = detect_noise_patterns(db.connection(), Some("example.com")).expect("detect");
+        let hit = out
+            .iter()
+            .find(|s| s.src == "ada.lovelace@users.noreply.github.com")
+            .unwrap_or_else(|| panic!("expected a noreply suggestion, got {out:?}"));
+        assert_eq!(hit.dst, "ada.lovelace@example.com");
+        assert!(
+            hit.confidence >= HIGH_CONFIDENCE_CUTOFF,
+            "an exact login match must stay HIGH, got {}",
+            hit.confidence
+        );
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/report/authorship_tests.rs
+++ b/crates/trusty-git-analytics/src/report/authorship_tests.rs
@@ -881,3 +881,127 @@ fn the_wrapper_scans_its_own_suggestions() {
         "the wrapper must answer exactly as the delegating form does"
     );
 }
+
+/// Seed the near-miss pair issue #6798 reports: one person committing as
+/// `Ada Lovelace <ada.lovelace@example.com>` and as
+/// `ada.lovelace <ada.lovelace@users.noreply.github.com>`.
+///
+/// Why: before #6798 no pass reached this pair. The same-name pass compared
+/// the raw lowercased display names, which differ by one dot; the noreply pass
+/// required an `<id>+` prefix the legacy address does not carry; and the
+/// edit-distance pass drops identical local-parts. The report therefore read
+/// two authors and raised no flag, and the split was found only by hand.
+fn seed_near_miss_identity_pair(db: &Database) {
+    for (sha, name, email) in [
+        ("n1", "Ada Lovelace", "ada.lovelace@example.com"),
+        (
+            "n2",
+            "ada.lovelace",
+            "ada.lovelace@users.noreply.github.com",
+        ),
+    ] {
+        let id = insert_author(db, name, email);
+        insert_commit(
+            db,
+            sha,
+            name,
+            email,
+            "2026-01-15T00:00:00Z",
+            "repo",
+            false,
+            &["src/lib.rs"],
+        );
+        link_commit(db, sha, id);
+    }
+}
+
+/// (#6798) The near-miss pair must raise the risk flag rather than pass
+/// silently — and must still not be merged without an operator's confirmation.
+#[test]
+fn the_near_miss_split_identity_raises_the_risk_flag() {
+    let db = Database::open_in_memory().expect("open");
+    seed_near_miss_identity_pair(&db);
+
+    let summary = summary_for(db.connection(), "repo").expect("summary");
+    assert_eq!(
+        summary.distinct_authors, 2,
+        "a suggestion nobody confirmed must never be auto-merged"
+    );
+
+    let risk = summary
+        .identity_merge_risk
+        .as_ref()
+        .expect("the near-miss pair must raise the flag");
+    assert_eq!(risk.suggested_unmerged, 1);
+    assert!(
+        summary
+            .caveats
+            .iter()
+            .any(|c| c.contains("suggested for merge")),
+        "a caveat-only renderer must still see the flag: {:?}",
+        summary.caveats
+    );
+}
+
+/// (#6798) Two different people whose names merely resemble each other must
+/// not pair — the normalisation is an exact match on the normalised form, and
+/// their email local-parts sit outside the edit-distance window.
+///
+/// The second identity is `Ada Lovelington`, not the tighter `Ada Lovelaces`
+/// that `suggest::tests::similar_but_distinct_display_names_are_not_paired`
+/// uses: this test runs the WHOLE scan, and a one-character local-part
+/// difference is a 0.85 edit-distance pair — pre-existing behaviour this
+/// change does not touch.
+#[test]
+fn similar_names_from_distinct_people_do_not_raise_the_flag() {
+    let db = Database::open_in_memory().expect("open");
+    for (sha, name, email) in [
+        ("d1", "Ada Lovelace", "ada.lovelace@example.com"),
+        ("d2", "Ada Lovelington", "ada.lovelington@example.com"),
+    ] {
+        let id = insert_author(&db, name, email);
+        insert_commit(
+            &db,
+            sha,
+            name,
+            email,
+            "2026-01-15T00:00:00Z",
+            "repo",
+            false,
+            &["src/lib.rs"],
+        );
+        link_commit(&db, sha, id);
+    }
+
+    let summary = summary_for(db.connection(), "repo").expect("summary");
+    assert_eq!(summary.distinct_authors, 2, "two people, two authors");
+    assert!(
+        summary.identity_merge_risk.is_none(),
+        "distinct people must not be flagged for merge, got {:?}",
+        summary.identity_merge_risk
+    );
+}
+
+/// (#6798) Once the operator confirms the near-miss merge, the report applies
+/// it and stops reporting it — a confirmed pair is not an outstanding one.
+#[test]
+fn a_confirmed_near_miss_merge_is_not_reported_again() {
+    let db = Database::open_in_memory().expect("open");
+    seed_near_miss_identity_pair(&db);
+    record_confirmed_alias(
+        &db,
+        "ada.lovelace@example.com",
+        "ada.lovelace@users.noreply.github.com",
+    );
+
+    let summary = summary_for(db.connection(), "repo").expect("summary");
+    assert_eq!(
+        summary.distinct_authors, 1,
+        "a confirmed merge must collapse the two identities"
+    );
+    assert!(
+        summary.identity_merge_risk.is_none(),
+        "a confirmed merge must clear the flag, got {:?}",
+        summary.identity_merge_risk
+    );
+}


### PR DESCRIPTION
Refs #6798

Alias suggestion missed two shapes of same-person split, so the authorship report read two authors and raised no `identity_merge_risk` — the split named in #6798 was found only by hand.

## The two mechanisms

**Normalised-name grouping (0.90).** `detect_same_name_pairs` compared raw lowercased display names, so `jane.doe` and `Jane Doe` read as two people. It now groups on a normalised form: lowercase, every non-alphanumeric character to a space, runs collapsed. Word order is preserved, so a reorder is never treated as a respelling. A byte-identical lowercased match still scores 0.95 with reason `same canonical_name`; a normalised-only match scores 0.90 with reason `same canonical_name after normalisation` — above `HIGH_CONFIDENCE_CUTOFF` (0.85), because the group is an exact match on the normalised form rather than a fuzzy one.

**Legacy noreply login routing (0.90).** The GitHub-noreply arm required an `<id>+` prefix, so `login@users.noreply.github.com` was skipped entirely — and no other pass reaches it, since the edit-distance pass drops identical local-parts and the noreply domain is nowhere near a canonical one. The login is now the whole local-part when there is no `+`.

Nothing is merged automatically. Both changes only raise the flag; a merge still needs an operator to confirm it.

## Test coverage, and the negative-fixture split

`the_near_miss_split_identity_raises_the_risk_flag` is the regression test. It fails on `origin/main`:

```
test report::authorship::authorship_tests::the_near_miss_split_identity_raises_the_risk_flag ... FAILED
panicked at crates/trusty-git-analytics/src/report/authorship_tests.rs:934:10:
the near-miss pair must raise the flag
```

Two negatives, and they use **different fixtures on purpose**:

- `suggest::tests::similar_but_distinct_display_names_are_not_paired` calls `detect_same_name_pairs` alone, so it uses `Ada Lovelace` beside `Ada Lovelaces` — the tightest available probe that normalisation is an exact match on the normalised form and not a fuzzy one.
- `report::authorship_tests::similar_names_from_distinct_people_do_not_raise_the_flag` runs the WHOLE scan, so its second identity is `Ada Lovelington` instead. A one-character local-part difference is a 0.85 edit-distance pair — pre-existing behaviour this change does not touch — so `Ada Lovelaces` would flag there for a reason unrelated to this fix.

The report test's doc comment states that split and points at the unit test, so the two are not "simplified" back together later.

Third negative: `a_confirmed_near_miss_merge_is_not_reported_again` — once the merge is recorded in `authors.aliases`, `distinct_authors` collapses to 1 and the flag clears, so a confirmed pair is never double-reported.

All fixture identities are synthetic and use the RFC 2606 reserved `example.com`.

## Out of scope

The second half of #6798 — writing near-miss candidates to a review file a human confirms against — is a separate artifact and is **not** in this PR. This change only raises `identity_merge_risk` on the report. Tracked separately.

## Gates — rung 3 (localized behavior inside one crate)

| Command | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo check -p tga` | EXIT=0 |
| `cargo clippy -p tga --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p tga --no-fail-fast` | EXIT=0 — `test result: ok. 1584 passed; 0 failed; 7 ignored` on the lib target; 11 targets, all ok |
| `bash scripts/check_line_cap.sh crates/trusty-git-analytics/src/collect/identity/suggest.rs` | `0 violations — OK` |
| `bash scripts/check_test_pointers.sh` | `resolved 31391 Test: citation(s) — 0 dangling pointers — OK` |
| `bash scripts/check_sld.sh` | `0 error(s), 0 warning(s)` |
| `bash scripts/check_changelog_fragment.sh` | `OK trusty-git-analytics: changelog.d fragment present and valid` |
| `bash scripts/check-pr-version-bump.sh` | `[ OK ] tga 7.1.2 — src changed, version not yet published` — no bump owed |

`--no-fail-fast` was used on every `cargo test` run above, so the counts cover every target rather than only those issued before a first failure (#5354).

Consumers checked: `identity_merge_risk` / `unresolved_authors` appear nowhere in `trusty-audit`; the only cross-crate reader is `trusty-review`, which reads `unresolved_authors` (untouched). Ran both anyway — `cargo check -p trusty-audit` EXIT=0, `cargo test -p trusty-audit --no-fail-fast` EXIT=0 (`950 passed; 0 failed; 5 ignored` plus 9 further targets ok). No report-text change: the caveat string and the `IdentityMergeRisk` shape are unchanged; only which pairs reach them changed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
