### PR TITLE
feat(trusty-agents): permissions route reports the scopes CC-9 dropped (#4158)

### DIFF
--- a/crates/trusty-agents/changelog.d/4158-dropped-scopes-signal.md
+++ b/crates/trusty-agents/changelog.d/4158-dropped-scopes-signal.md
@@ -1,0 +1,17 @@
+Added
+
+- `GET /api/agents/{name}/permissions` now reports the legacy `[tools].scopes`
+  entries that DOC-57 CC-9 superseded, in a new top-level `dropped_scopes[]`
+  array carrying each entry's `pattern`, `source` (`declared` or
+  `inherited:<base>`) and `reason`
+  ([#4158](https://github.com/bobmatnyc/trusty-tools/issues/4158)). When an
+  agent declares both `[permissions].scopes` and legacy `[tools].scopes`, the
+  new declaration wins and the union is deliberately not taken — but until now
+  the only signal that anything was dropped was a server-side `tracing::warn!`
+  no API or GUI consumer reads, and the app-launched daemon writes its logs to
+  `/dev/null` ([#4111](https://github.com/bobmatnyc/trusty-tools/issues/4111)),
+  so in the shipped product that warning did not exist. The warning is
+  unchanged; this is its readable half, and the field is present only when
+  something was actually dropped, so an existing client sees the exact shape it
+  saw before. New `agents::permissions::dropped_scopes` computes the list; the
+  scope set the route reports as effective is unchanged, so nothing is widened.

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -52,9 +52,11 @@ pub use params::{
 };
 // #4172: the L0-only cross-project scope resolver (epic #4167).
 pub use cross_project::CrossProjectScope;
-// #3936: the `[permissions]` section (DOC-57 §7).
+// #3936: the `[permissions]` section (DOC-57 §7). #4158 adds `dropped_scopes`
+// — the operator-readable half of CC-9's silent supersession.
 pub use permissions::{
-    AutonomyMode, GrantMode, PermissionGrant, PermissionsConfig, effective_scopes,
+    AutonomyMode, GrantMode, PermissionGrant, PermissionsConfig, SCOPE_DROPPED_SUPERSEDED,
+    dropped_scopes, effective_scopes,
 };
 
 // Model resolution: `resolve_model` and `ModelSource` are part of the public

--- a/crates/trusty-agents/src/agents/permissions.rs
+++ b/crates/trusty-agents/src/agents/permissions.rs
@@ -13,7 +13,9 @@
 //! file declares both — the union is deliberately NOT taken, DOC-57 §9.4) is
 //! decided, so the persona-chat dispatch gate (`ctrl::pm_task::dispatch::persona`)
 //! and the `GET /api/agents/:name/permissions` route can never disagree about
-//! what is actually enforced.
+//! what is actually enforced. [`dropped_scopes`] is that decision's readable
+//! half (#4158) — the legacy entries CC-9 removed, so the route can report a
+//! drop the `tracing::warn!` alone never reaches an operator with.
 //! Test: `effective_scopes_prefers_permissions_over_legacy_tools_scopes`,
 //! `effective_scopes_falls_back_to_tools_scopes_when_permissions_absent`,
 //! `effective_scopes_absent_both_is_none`.
@@ -127,6 +129,49 @@ pub fn effective_scopes(
     tools.scopes.clone()
 }
 
+/// Why one legacy `[tools].scopes` entry is missing from the effective set.
+///
+/// Why: A bare list of dropped patterns tells an operator that something
+/// vanished, not what removed it. Naming the rule — and that CC-9 takes a
+/// winner rather than a union — is what makes the `/permissions` pane's
+/// `dropped_scopes[]` (#4158) actionable instead of merely alarming.
+/// What: the ONE reason a scope can be dropped today. A second drop rule
+/// would add a second constant beside this one rather than generalise its
+/// wording.
+/// Test: `dropped_scopes_lists_only_the_superseded_legacy_entries`.
+pub const SCOPE_DROPPED_SUPERSEDED: &str = concat!(
+    "declared in legacy [tools].scopes but absent from [permissions].scopes; ",
+    "DOC-57 CC-9 takes the winning declaration, not the union",
+);
+
+/// Legacy `[tools].scopes` entries that [`effective_scopes`] leaves out (#4158).
+///
+/// Why: CC-9's silent-drop is the exact silent-capability-loss class that has
+/// repeatedly cost investigation time here (#3844, #3987, #4093). Until this
+/// function existed the only signal was [`effective_scopes`]'s `tracing::warn!`,
+/// which no API or GUI consumer reads — and the app-launched daemon sends its
+/// logs to `/dev/null` (#4111), so in the shipped product that warning does not
+/// exist at all. This is the readable half of that same signal.
+/// What: the entries of `tools.scopes` that are not in `permissions.scopes`,
+/// in declaration order, when BOTH are declared; empty otherwise (nothing was
+/// superseded, so nothing was dropped). Deliberately NOT the same condition as
+/// the warning, which fires on any difference: a `[permissions].scopes` that
+/// only ADDS to the legacy list drops nothing and must report nothing.
+/// Pair each entry with [`SCOPE_DROPPED_SUPERSEDED`] when reporting it.
+/// Test: `dropped_scopes_lists_only_the_superseded_legacy_entries`,
+/// `dropped_scopes_is_empty_when_permissions_only_widens`,
+/// `dropped_scopes_is_empty_without_a_permissions_declaration`.
+pub fn dropped_scopes(tools: &ToolsConfig, permissions: &PermissionsConfig) -> Vec<String> {
+    let (Some(winning), Some(legacy)) = (&permissions.scopes, &tools.scopes) else {
+        return Vec::new();
+    };
+    legacy
+        .iter()
+        .filter(|pattern| !winning.contains(pattern))
+        .cloned()
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -179,6 +224,38 @@ mod tests {
         assert_eq!(
             effective_scopes(&tools, &permissions),
             Some(vec!["search.read".to_string()])
+        );
+    }
+
+    // #4158: the drop list must name exactly what CC-9 removed — not every
+    // legacy entry, and not one the new declaration restates.
+    #[test]
+    fn dropped_scopes_lists_only_the_superseded_legacy_entries() {
+        let tools = tools_with_scopes(Some(vec!["memory.read", "search.read"]));
+        let permissions = permissions_with_scopes(Some(vec!["search.read", "google.gmail.*"]));
+        assert_eq!(
+            dropped_scopes(&tools, &permissions),
+            vec!["memory.read".to_string()],
+            "search.read survives because the new declaration restates it"
+        );
+        assert!(!SCOPE_DROPPED_SUPERSEDED.is_empty());
+    }
+
+    #[test]
+    fn dropped_scopes_is_empty_when_permissions_only_widens() {
+        // `effective_scopes` WARNS here (the lists differ) but nothing is
+        // lost, so the operator-facing list must stay empty.
+        let tools = tools_with_scopes(Some(vec!["memory.read"]));
+        let permissions = permissions_with_scopes(Some(vec!["memory.read", "search.read"]));
+        assert!(dropped_scopes(&tools, &permissions).is_empty());
+    }
+
+    #[test]
+    fn dropped_scopes_is_empty_without_a_permissions_declaration() {
+        let tools = tools_with_scopes(Some(vec!["memory.read"]));
+        assert!(dropped_scopes(&tools, &permissions_with_scopes(None)).is_empty());
+        assert!(
+            dropped_scopes(&tools_with_scopes(None), &permissions_with_scopes(None)).is_empty()
         );
     }
 

--- a/crates/trusty-agents/src/api/server/agent_permissions.rs
+++ b/crates/trusty-agents/src/api/server/agent_permissions.rs
@@ -37,8 +37,18 @@
 //!   the pane rather than requiring a reader to simulate `merge_extends`.
 //!   Multi-level provenance is approximated to the IMMEDIATE base — see
 //!   [`permissions_at`]'s doc for why that is still a true statement.
+//! - `dropped_scopes[]` names every legacy `[tools].scopes` entry CC-9
+//!   superseded, with the `source` and `reason` for each (#4158). Before it
+//!   the only signal was `effective_scopes`'s `tracing::warn!`, which no API
+//!   or GUI consumer reads — and the app-launched daemon writes its logs to
+//!   `/dev/null` (#4111), so in the shipped product that warning does not
+//!   exist. A pane showing only the winning set is accurate and still hides
+//!   the drift this route was built (DOC-57) to make visible. Present only
+//!   when something was actually dropped, like `extends_warning`.
 //! - This route grants or widens nothing (C-06.4, PM-4) — it is a read
 //!   surface over `AgentConfig::by_name_in`'s existing resolution.
+//!   `dropped_scopes[]` reports patterns that are NOT in effect; it never
+//!   re-widens what CC-9 narrowed.
 //!
 //! What: [`agent_permissions_route`] is the axum shim; [`permissions_at`] is
 //! the testable core.
@@ -56,7 +66,9 @@ use serde_json::{Value, json};
 
 use super::agent_patch::resolve_agent_paths;
 use super::state::AppState;
-use crate::agents::permissions::{PermissionsConfig, effective_scopes};
+use crate::agents::permissions::{
+    PermissionsConfig, SCOPE_DROPPED_SUPERSEDED, dropped_scopes, effective_scopes,
+};
 use crate::agents::{AgentConfig, RbacConfig, ToolsConfig};
 use crate::rbac::ServiceTier;
 
@@ -112,7 +124,11 @@ pub(super) async fn agent_permissions_route(
 /// Test: `permissions_route_reports_declared_and_inherited_scopes`,
 /// `permissions_route_never_inherits_user_authority`,
 /// `permissions_route_degrades_on_malformed_toml`,
-/// `permissions_route_degrades_gracefully_on_unresolvable_extends`.
+/// `permissions_route_degrades_gracefully_on_unresolvable_extends`,
+/// `permissions_route_reports_dropped_legacy_scopes`,
+/// `permissions_route_attributes_an_inherited_dropped_scope_to_its_base`,
+/// `permissions_route_omits_dropped_scopes_when_nothing_is_superseded`,
+/// `permissions_route_old_wire_shape_still_parses`.
 pub(super) async fn permissions_at(dirs: &[PathBuf], name: &str) -> Response {
     if name.is_empty() || name.contains(['/', '\\']) || name == "." || name == ".." {
         return (
@@ -143,39 +159,56 @@ pub(super) async fn permissions_at(dirs: &[PathBuf], name: &str) -> Response {
     let (own_tools, own_permissions, extends_target, config_error) =
         parse_permission_sections(&raw);
     let own_scopes = effective_scopes(&own_tools, &own_permissions).unwrap_or_default();
+    // #4158: what THIS file's `[permissions].scopes` superseded, used below to
+    // attribute a dropped pattern to `declared` rather than the base.
+    let own_dropped = dropped_scopes(&own_tools, &own_permissions);
 
     // Resolve the full `extends` chain so inherited scopes/tiers/autonomy are
     // visible (PM-7). Falls back to the single-file view on ANY resolution
     // failure — the pane still renders this agent's own declarations rather
     // than going dark over an unrelated ancestor's typo.
     let resolved = AgentConfig::by_name_in(dirs, name).ok();
-    let (all_scopes, permissions, rbac) = match &resolved {
+    // #4158: `extends::merge_extends` leaves the resolved `tools.scopes` as the
+    // union of every level's LEGACY list and `permissions.scopes` as the union
+    // of every level's CC-9-resolved list, so `dropped_scopes` over the
+    // resolved pair is exactly the set no level's effective scopes kept — a
+    // pattern one level superseded but another still declares is correctly
+    // absent from it.
+    let (all_scopes, all_dropped, permissions, rbac) = match &resolved {
         Some(cfg) => (
             effective_scopes(&cfg.tools, &cfg.permissions).unwrap_or_default(),
+            dropped_scopes(&cfg.tools, &cfg.permissions),
             cfg.permissions.clone(),
             cfg.rbac.clone(),
         ),
         None => (
             own_scopes.clone(),
+            own_dropped.clone(),
             own_permissions.clone(),
             RbacConfig::default(),
         ),
     };
 
+    // PM-7 provenance, decided identically for an effective scope and a
+    // dropped one (#4158): `own` is whichever list THIS file contributed.
+    let source_of = |pattern: &String, own: &[String]| -> String {
+        if own.contains(pattern) {
+            "declared".to_string()
+        } else if let Some(base) = &extends_target {
+            format!("inherited:{base}")
+        } else {
+            // No `extends` on this file at all, yet the pattern isn't in
+            // `own` — only possible if `extends` resolution itself failed
+            // (see the doc comment); report it honestly rather than
+            // asserting a provenance we cannot back.
+            "declared".to_string()
+        }
+    };
+
     let scopes: Vec<Value> = all_scopes
         .iter()
         .map(|pattern| {
-            let source = if own_scopes.contains(pattern) {
-                "declared".to_string()
-            } else if let Some(base) = &extends_target {
-                format!("inherited:{base}")
-            } else {
-                // No `extends` on this file at all, yet the pattern isn't in
-                // `own_scopes` — only possible if `extends` resolution itself
-                // failed (see the doc comment); report it honestly rather
-                // than asserting a provenance we cannot back.
-                "declared".to_string()
-            };
+            let source = source_of(pattern, &own_scopes);
             json!({
                 "pattern": pattern,
                 "source": source,
@@ -220,6 +253,24 @@ pub(super) async fn permissions_at(dirs: &[PathBuf], name: &str) -> Response {
             "enforced": false,
         })).collect::<Vec<_>>(),
     });
+    // #4158: additive and conditional, matching `extends_warning` — a pane
+    // renders this only when a declaration actually lost, so an agent with no
+    // conflict carries no empty banner and an existing client sees the exact
+    // shape it saw before.
+    if !all_dropped.is_empty() {
+        body["dropped_scopes"] = Value::Array(
+            all_dropped
+                .iter()
+                .map(|pattern| {
+                    json!({
+                        "pattern": pattern,
+                        "source": source_of(pattern, &own_dropped),
+                        "reason": SCOPE_DROPPED_SUPERSEDED,
+                    })
+                })
+                .collect(),
+        );
+    }
     if let Some(err) = config_error {
         body["config_error"] = Value::String(err);
     } else if resolved.is_none() && extends_target.is_some() {

--- a/crates/trusty-agents/src/api/server/tests/agent_permissions.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_permissions.rs
@@ -88,6 +88,44 @@ max_tokens = 1024
 content = "test"
 "#;
 
+/// A base that supersedes its OWN legacy `[tools].scopes`, so a child which
+/// declares nothing still has a dropped entry to attribute to that base
+/// (#4158).
+const CC9_BASE_FIXTURE: &str = r#"[agent]
+name = "migrated-base"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[tools]
+scopes = ["memory.read"]
+
+[permissions]
+scopes = ["search.read"]
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#;
+
+const CC9_CHILD_FIXTURE: &str = r#"[agent]
+name = "migrated-child"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+extends = "migrated-base"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#;
+
 /// A base with `user_authority = true` and a child that extends it without
 /// declaring its own (PM-3: must never inherit `true`).
 const AUTHORITY_BASE_FIXTURE: &str = r#"[agent]
@@ -195,6 +233,135 @@ async fn permissions_route_permissions_scopes_supersedes_legacy_tools_scopes() {
     assert_eq!(scopes.len(), 1, "CC-9: the union is not taken, {scopes:?}");
     assert_eq!(scopes[0]["pattern"], "search.read");
     assert_eq!(scopes[0]["source"], "declared");
+}
+
+/// #4158: CC-9 drops the legacy entry, and until now the ONLY signal was a
+/// `tracing::warn!` no consumer reads — the app-launched daemon writes its
+/// logs to `/dev/null` (#4111), so in the shipped product it did not exist.
+/// `CC9_FIXTURE` is exactly the one-valid/one-dropped case.
+#[tokio::test]
+async fn permissions_route_reports_dropped_legacy_scopes() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("migrated.toml"), CC9_FIXTURE).unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "migrated").await;
+    let body = body_json(resp).await;
+
+    // The winning set is unchanged — this field ADDS a signal, it does not
+    // re-widen the scope set CC-9 narrowed (C-06.4).
+    let scopes = body["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 1, "CC-9: the union is still not taken");
+    assert_eq!(scopes[0]["pattern"], "search.read");
+
+    let dropped = body["dropped_scopes"].as_array().unwrap_or_else(|| {
+        panic!("a superseded legacy scope must be reported, not only logged: {body:?}")
+    });
+    assert_eq!(dropped.len(), 1, "{dropped:?}");
+    assert_eq!(dropped[0]["pattern"], "memory.read");
+    assert_eq!(dropped[0]["source"], "declared");
+    assert!(
+        dropped[0]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("[permissions].scopes"),
+        "each entry must carry the reason it lost: {dropped:?}"
+    );
+}
+
+/// A scope superseded by a BASE, on a child that declares nothing, must name
+/// the base rather than claim the child declared it (PM-7).
+#[tokio::test]
+async fn permissions_route_attributes_an_inherited_dropped_scope_to_its_base() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("migrated-base.toml"), CC9_BASE_FIXTURE).unwrap();
+    std::fs::write(dir.path().join("migrated-child.toml"), CC9_CHILD_FIXTURE).unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "migrated-child").await;
+    let body = body_json(resp).await;
+    let dropped = body["dropped_scopes"].as_array().unwrap();
+    assert_eq!(dropped.len(), 1, "{dropped:?}");
+    assert_eq!(dropped[0]["pattern"], "memory.read");
+    assert_eq!(dropped[0]["source"], "inherited:migrated-base");
+}
+
+/// The field is conditional, like `extends_warning` — an agent whose chain
+/// lost nothing must not render an empty drop banner. `CHILD_FIXTURE`
+/// declares `[permissions].scopes` and its base declares `[tools].scopes`, so
+/// the chain-level union keeps both.
+#[tokio::test]
+async fn permissions_route_omits_dropped_scopes_when_nothing_is_superseded() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("assistant.toml"), BASE_FIXTURE).unwrap();
+    std::fs::write(dir.path().join("cto-assistant.toml"), CHILD_FIXTURE).unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "cto-assistant").await;
+    let body = body_json(resp).await;
+    assert_eq!(body["scopes"].as_array().unwrap().len(), 2);
+    assert!(
+        body.get("dropped_scopes").is_none(),
+        "no declaration lost, so no drop list: {body:?}"
+    );
+}
+
+/// #4158 is additive: a client written against the pre-#4158 wire shape must
+/// still parse a response that now carries `dropped_scopes`, and every field
+/// it already read must be unchanged.
+#[tokio::test]
+async fn permissions_route_old_wire_shape_still_parses() {
+    #[derive(serde::Deserialize)]
+    struct OldScope {
+        pattern: String,
+        source: String,
+        enforced: bool,
+        enforced_on: Vec<String>,
+    }
+    #[derive(serde::Deserialize)]
+    struct OldFlag {
+        enforced: bool,
+    }
+    #[derive(serde::Deserialize)]
+    struct OldTiers {
+        default: String,
+        unauthenticated: String,
+        enforced: bool,
+    }
+    #[derive(serde::Deserialize)]
+    struct OldAutonomy {
+        mode: String,
+        enforced: bool,
+    }
+    #[derive(serde::Deserialize)]
+    struct OldBody {
+        scopes: Vec<OldScope>,
+        user_authority: OldFlag,
+        tiers: OldTiers,
+        autonomy: OldAutonomy,
+        grants: Vec<serde_json::Value>,
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("migrated.toml"), CC9_FIXTURE).unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "migrated").await;
+    let body = body_json(resp).await;
+    assert!(
+        body.get("dropped_scopes").is_some(),
+        "precondition: this fixture DOES carry the new field"
+    );
+
+    let old: OldBody = serde_json::from_value(body).unwrap();
+    assert_eq!(old.scopes.len(), 1);
+    assert_eq!(old.scopes[0].pattern, "search.read");
+    assert_eq!(old.scopes[0].source, "declared");
+    assert!(old.scopes[0].enforced);
+    assert_eq!(old.scopes[0].enforced_on, vec!["persona_chat".to_string()]);
+    assert!(!old.user_authority.enforced);
+    assert_eq!(old.tiers.default, "all");
+    assert_eq!(old.tiers.unauthenticated, "all");
+    assert!(!old.tiers.enforced);
+    assert_eq!(old.autonomy.mode, "ask-first");
+    assert!(!old.autonomy.enforced);
+    assert!(old.grants.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
`agents::permissions::effective_scopes` implements DOC-57 CC-9: when one agent
file declares both `[permissions].scopes` and legacy `[tools].scopes`, the new
declaration wins and the union is deliberately not taken. The legacy entries it
removes were signalled only by a server-side `tracing::warn!` that no API or GUI
consumer reads — and the app-launched daemon writes its logs to `/dev/null`
(#4111), so in the shipped product that warning did not exist. The
`/permissions` route served the winning set alone, which is accurate and still
hides the drift the route was built to make visible.

`GET /api/agents/{name}/permissions` now also carries `dropped_scopes[]`, one
entry per superseded legacy pattern with its `source` (`declared` or
`inherited:<base>`) and the `reason` it lost. The field is additive and
conditional, matching `extends_warning`: an agent whose chain lost nothing
carries no drop list, so a client written against the pre-#4158 shape reads
exactly what it read before. The effective scope set is unchanged — this reports
patterns that are NOT in effect and widens nothing (C-06.4). The warning stays.

New `agents::permissions::dropped_scopes` computes the list. It is deliberately
narrower than the warning, which fires on any difference: a
`[permissions].scopes` that only ADDS to the legacy list drops nothing and
reports nothing. Over a resolved `extends` chain it yields exactly the patterns
no level's effective set kept, because `merge_extends` leaves `tools.scopes` as
the union of every level's legacy list and `permissions.scopes` as the union of
every level's CC-9-resolved list.

## No UI change

Nothing in `crates/trusty-agents/ui` fetches this route.
`src/lib/agentConfig.ts` has six `fetch` calls (`/api/agents/:name`,
`/persona`, `/stores`, `/skills`, `/subagents`) and none for `/permissions`;
`AgentConfigPermissions.svelte` renders `parse_agent_toml`-derived props and its
own copy documents the route as not yet surfaced. The API field is the
deliverable.

## Baseline — the new tests fail on `origin/main`

Reverting only `agent_permissions.rs` to `origin/main` and re-running the route
tests:

```
test ...permissions_route_reports_dropped_legacy_scopes ... FAILED
test ...permissions_route_old_wire_shape_still_parses ... FAILED
test ...permissions_route_attributes_an_inherited_dropped_scope_to_its_base ... FAILED
test result: FAILED. 14 passed; 3 failed; 0 ignored; 0 measured; 3629 filtered out

panicked at crates/trusty-agents/src/api/server/tests/agent_permissions.rs:257:9:
a superseded legacy scope must be reported, not only logged: Object {"autonomy": ...,
"grants": Array [], "scopes": Array [Object {"enforced": Bool(true), "enforced_on":
Array [String("persona_chat")], "pattern": String("search.read"), "source":
String("declared")}], "tiers": ..., "user_authority": ...}
```

`permissions_route_omits_dropped_scopes_when_nothing_is_superseded` passes on
both branches by design — it is the additivity control, asserting the field is
absent when nothing was lost. `permissions_route_old_wire_shape_still_parses`
deserializes the response into a struct carrying only the pre-#4158 fields and
asserts each one, so an existing client is proven to still parse.

## Gates — rung 3 (localized behavior in one crate; the wire change is additive)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `SKIP_UI_BUILD=1 cargo clippy -p trusty-agents --all-targets -- -D warnings` | EXIT=0 |
| `SKIP_UI_BUILD=1 cargo test -p trusty-agents --no-fail-fast` | EXIT=0 — all 14 targets ran |
| `bash scripts/check_line_cap.sh` | 4550 tracked files, 0 violations |
| `bash scripts/check_test_pointers.sh` | 31492 citations, 0 dangling |
| `bash scripts/check_sld.sh` | 0 errors, 0 warnings |
| `bash scripts/check_changelog_fragment.sh` | fragment present and valid |
| `bash scripts/check-pr-version-bump.sh` | `[ OK ] trusty-agents 0.39.0 — src changed, version not yet published` |

Per-target counts from the `--no-fail-fast` run (the flag is named because
counts without it prove only the targets that ran, #5354):

```
unittests src/lib.rs                    ok. 3633 passed; 0 failed; 13 ignored
unittests src/main.rs                   ok. 0 passed; 0 failed
tests/api_e2e.rs                        ok. 6 passed; 0 failed; 3 ignored
tests/cli_project.rs                    ok. 4 passed; 0 failed
tests/config_mount.rs                   ok. 3 passed; 0 failed
tests/home_lock_discipline.rs           ok. 1 passed; 0 failed
tests/inference_shared_adapter_e2e.rs   ok. 2 passed; 0 failed
tests/persona_python_plugin_wiring.rs   ok. 1 passed; 0 failed
tests/plain_cli_repl.rs                 ok. 9 passed; 0 failed
tests/process_tracker_fail_open.rs      ok. 7 passed; 0 failed
tests/slack_wss_crypto_provider.rs      ok. 2 passed; 0 failed
tests/system_status_cli.rs              ok. 2 passed; 0 failed
tests/version_provenance.rs             ok. 4 passed; 0 failed
Doc-tests trusty_agents                 ok. 0 passed; 0 failed
```

Seven new tests: three unit (`dropped_scopes_lists_only_the_superseded_legacy_entries`,
`dropped_scopes_is_empty_when_permissions_only_widens`,
`dropped_scopes_is_empty_without_a_permissions_declaration`) and four route.

No version bump — `trusty-agents` 0.39.0 is unpublished.

Refs #4158

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
