### PR TITLE
feat(trusty-search): MCP read tools answer an unresolvable index with a directory (#6317)

### DIFF
--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -768,17 +768,17 @@ this table is generated from it, not maintained by hand.
 | `get_call_chain` | `index_id`, `entry_point`, `direction?`, `include_source?`, `max_depth?` | Annotated call tree for a function entry point (issue #76). |
 | `grep` | `pattern`, `case_insensitive?`, `context?`, `context_after?`, `context_before?`, `files_with_matches?`, `fixed_strings?`, `glob?`, `index_id?`, `invert_match?`, `max_count?`, `max_results?`, `multiline?`, `word_regexp?` | Search indexed files using regex/literal patterns with ripgrep-compatible options. |
 | `index_file` | `index_id`, `path`, `content` | Add or update one file in an index |
-| `index_status` | `index_id` | Get stats for an index (chunk count, root path) |
+| `index_status` | `index_id?` | Get stats for an index (chunk count, root path). |
 | `list_chunks` | `index_id`, `after?`, `limit?`, `offset?` | Paginated enumeration of every chunk in an index (issue #54). |
 | `list_indexes` | — | List all registered indexes on this daemon |
 | `reindex` | `index_id`, `root_path?` | Trigger a full reindex of a collection (async, returns immediately) |
 | `remove_file` | `index_id`, `path` | Remove a file's chunks from an index |
-| `search` | `index_id`, `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Unified hybrid search (BM25+vector+KG+RRF) with mode-aware ranking (issue #77). |
+| `search` | `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `index_id?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Unified hybrid search (BM25+vector+KG+RRF) with mode-aware ranking (issue #77). |
 | `search_all` | `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `full_content?`, `index_id?`, `max_fanout_concurrency?`, `mode?`, `path_prefix?`, `repos?`, `serial?`, `top_k?` | When in doubt, use this. |
 | `search_health` | `index_id?` | Diagnose this session's search back-end (issue #5264). |
-| `search_kg` | `index_id`, `query`, `mode?`, `path_prefix?`, `refine_query?`, `repos?`, `top_k?` | Explore code structure from a known seed — either a chunk_id (from a previous search result) or a symbol name. |
-| `search_lexical` | `index_id`, `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Find code by exact symbol name, regex, or literal string. |
-| `search_semantic` | `index_id`, `query`, `exclude_archived?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Find code by meaning, not by literal text. |
+| `search_kg` | `query`, `index_id?`, `mode?`, `path_prefix?`, `refine_query?`, `repos?`, `top_k?` | Explore code structure from a known seed — either a chunk_id (from a previous search result) or a symbol name. |
+| `search_lexical` | `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `index_id?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Find code by exact symbol name, regex, or literal string. |
+| `search_semantic` | `query`, `exclude_archived?`, `index_id?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Find code by meaning, not by literal text. |
 | `search_similar` | `file`, `function?`, `index?`, `top_k?` | Find chunks semantically similar to a given file/function via HNSW (issue #31) |
 | `typeahead` | `query`, `index_id?`, `limit?`, `mode?` | Fast per-keystroke autocomplete suggestions for an index. |
 | `upgrade` | `check?`, `confirm?` | Check for or install a new version of trusty-search (issue #537). |

--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -589,17 +589,17 @@ this table is generated from it, not maintained by hand.
 | `get_call_chain` | `index_id`, `entry_point`, `direction?`, `include_source?`, `max_depth?` | Annotated call tree for a function entry point (issue #76). |
 | `grep` | `pattern`, `case_insensitive?`, `context?`, `context_after?`, `context_before?`, `files_with_matches?`, `fixed_strings?`, `glob?`, `index_id?`, `invert_match?`, `max_count?`, `max_results?`, `multiline?`, `word_regexp?` | Search indexed files using regex/literal patterns with ripgrep-compatible options. |
 | `index_file` | `index_id`, `path`, `content` | Add or update one file in an index |
-| `index_status` | `index_id` | Get stats for an index (chunk count, root path) |
+| `index_status` | `index_id?` | Get stats for an index (chunk count, root path). |
 | `list_chunks` | `index_id`, `after?`, `limit?`, `offset?` | Paginated enumeration of every chunk in an index (issue #54). |
 | `list_indexes` | — | List all registered indexes on this daemon |
 | `reindex` | `index_id`, `root_path?` | Trigger a full reindex of a collection (async, returns immediately) |
 | `remove_file` | `index_id`, `path` | Remove a file's chunks from an index |
-| `search` | `index_id`, `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Unified hybrid search (BM25+vector+KG+RRF) with mode-aware ranking (issue #77). |
+| `search` | `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `index_id?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Unified hybrid search (BM25+vector+KG+RRF) with mode-aware ranking (issue #77). |
 | `search_all` | `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `full_content?`, `index_id?`, `max_fanout_concurrency?`, `mode?`, `path_prefix?`, `repos?`, `serial?`, `top_k?` | When in doubt, use this. |
 | `search_health` | `index_id?` | Diagnose this session's search back-end (issue #5264). |
-| `search_kg` | `index_id`, `query`, `mode?`, `path_prefix?`, `refine_query?`, `repos?`, `top_k?` | Explore code structure from a known seed — either a chunk_id (from a previous search result) or a symbol name. |
-| `search_lexical` | `index_id`, `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Find code by exact symbol name, regex, or literal string. |
-| `search_semantic` | `index_id`, `query`, `exclude_archived?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Find code by meaning, not by literal text. |
+| `search_kg` | `query`, `index_id?`, `mode?`, `path_prefix?`, `refine_query?`, `repos?`, `top_k?` | Explore code structure from a known seed — either a chunk_id (from a previous search result) or a symbol name. |
+| `search_lexical` | `query`, `branch?`, `branch_boost?`, `branch_files?`, `exclude_archived?`, `index_id?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Find code by exact symbol name, regex, or literal string. |
+| `search_semantic` | `query`, `exclude_archived?`, `index_id?`, `mode?`, `path_prefix?`, `repos?`, `top_k?` | Find code by meaning, not by literal text. |
 | `search_similar` | `file`, `function?`, `index?`, `top_k?` | Find chunks semantically similar to a given file/function via HNSW (issue #31) |
 | `typeahead` | `query`, `index_id?`, `limit?`, `mode?` | Fast per-keystroke autocomplete suggestions for an index. |
 | `upgrade` | `check?`, `confirm?` | Check for or install a new version of trusty-search (issue #537). |

--- a/crates/trusty-search/changelog.d/6317-no-index-resolved-directory.md
+++ b/crates/trusty-search/changelog.d/6317-no-index-resolved-directory.md
@@ -1,0 +1,3 @@
+Changed
+
+- An MCP read tool called with no `index_id` on an unpinned session now returns the registered indexes plus a retry hint as a successful result, instead of erroring. Applies to `search`, `search_lexical`, `search_semantic`, `search_kg`, `typeahead`, and `index_status`; `grep` and `search_all` already fanned out. `index_id` is no longer `required` in those tools' schemas. The mutating tools — `index_file`, `remove_file`, `delete_index`, `reindex` — keep the error (#6317).

--- a/crates/trusty-search/src/mcp/tools/descriptors.rs
+++ b/crates/trusty-search/src/mcp/tools/descriptors.rs
@@ -18,10 +18,17 @@ use serde_json::Value;
 /// HTTP calls.
 /// What: returns a `Value::Array` containing one descriptor object per
 /// registered tool. Each object has `name`, `description`, and `inputSchema`.
+///
+/// #6317: the literal array below is the base; the read tools that answer an
+/// unresolvable index with a directory get `index_id` dropped from `required`
+/// and both descriptions annotated by
+/// [`super::index_directory::annotate_directory_tools`], which reads the same
+/// const the dispatcher does so the two cannot drift.
 /// Test: `test_tools_list_response` asserts every required tool is present and
-/// carries an `inputSchema`.
+/// carries an `inputSchema`; `directory_tools_drop_required_index_id` covers
+/// the annotation.
 pub fn tool_descriptors() -> Value {
-    serde_json::json!([
+    let mut defs = serde_json::json!([
         // Issue #138 — per-lane MCP tools. Tool descriptions are
         // first-class LLM prompts: each one opens with "when to use",
         // gives concrete fit/don't-fit examples, states the cost, and
@@ -442,7 +449,11 @@ pub fn tool_descriptors() -> Value {
                 ]
             }
         }
-    ])
+    ]);
+    // #6317: an unpinned read tool answers an omitted index_id with a directory,
+    // so the schema must let a client send the call without one.
+    super::index_directory::annotate_directory_tools(&mut defs);
+    defs
 }
 
 /// `tools/list` descriptors with the session's pinned index advertised (#1373).

--- a/crates/trusty-search/src/mcp/tools/index.rs
+++ b/crates/trusty-search/src/mcp/tools/index.rs
@@ -17,18 +17,22 @@ use super::{
     McpServer,
 };
 
-/// Resolve `index_id` for an index-management tool, defaulting to the pinned
-/// index (#1373) when the caller omits it.
+/// Resolve `index_id` for a MUTATING index-management tool, defaulting to the
+/// pinned index (#1373) when the caller omits it.
 ///
 /// Why: a pinned trusty-search session (`serve --index <id>`) should let the
-/// LLM run `index_status`, `reindex`, `list_chunks`, etc. without repeating the
-/// project's index id, exactly as the search tools do. Centralising the
-/// precedence here keeps every index arm consistent with `search`.
+/// LLM run `reindex`, `remove_file`, etc. without repeating the project's index
+/// id, exactly as the search tools do. Centralising the precedence here keeps
+/// every index arm consistent with `search`.
 /// What: returns the caller's non-empty `index_id` argument, else the session's
 /// pinned index, else an `InvalidParams` error naming the missing field AND the
 /// tool that lists valid values for it (#5213 — an error that says only "field
 /// missing" leaves the caller guessing an id, which is the failure #1373 pinned
-/// the session to avoid in the first place).
+/// the session to avoid in the first place). #6317 split the read tools off
+/// this path: `index_status` answers an unresolvable id with the index
+/// directory, while `index_file`, `remove_file`, `delete_index`, and `reindex`
+/// keep erroring here — writing to a guessed index is not recoverable, so
+/// there is nothing useful to return in place of the error.
 /// Test: `resolve_index_id_prefers_explicit_then_pinned` pins the precedence
 /// and `missing_index_id_error_names_list_indexes` the error text.
 fn required_index_id(server: &McpServer, args: &Value) -> Result<String, DispatchError> {
@@ -202,9 +206,10 @@ pub(super) async fn dispatch_index_tool(
             )
         }
         "index_status" => {
-            let index_id = match required_index_id(server, args) {
-                Ok(v) => v,
-                Err(e) => return Some(Err(e)),
+            // #6317: `index_status` is a read, so an unresolvable id answers
+            // with the indexes that exist rather than the write tools' error.
+            let Some(index_id) = server.resolve_index_id(args) else {
+                return Some(super::index_directory::index_directory(server, "index_status").await);
             };
             // #4715: `index_status` on a never-indexed pin 404'd the same way
             // `search` did; it gets the same honest not-ready answer.

--- a/crates/trusty-search/src/mcp/tools/index_directory.rs
+++ b/crates/trusty-search/src/mcp/tools/index_directory.rs
@@ -1,0 +1,165 @@
+//! The answer a read tool gives when no `index_id` resolves (issue #6317).
+//!
+//! Why: an unpinned session that omits `index_id` used to get
+//! [`super::types::MISSING_INDEX_ID`] — an error naming `list_indexes`. The
+//! caller then had to make a second call to learn what it could have been told
+//! in the first. Worse, a model that will not spend the round-trip guesses an
+//! id instead, which is the wrong-index failure #1373 exists to prevent. The
+//! owner ruling (2026-08-27) is that a read tool with nothing to resolve
+//! answers with an index of what exists, as a successful result.
+//! What: [`index_directory`] builds that answer from `GET /indexes?details=true`
+//! — the same rows `list_indexes` serves — plus a `hint` naming how to retry.
+//! [`annotate_directory_tools`] makes the advertised schema agree: `index_id`
+//! stops being `required` on those tools and both descriptions say what an
+//! omitted id does.
+//! Test: `tests_index_directory.rs`.
+
+use serde_json::Value;
+
+use super::{types::DispatchError, McpServer};
+
+/// The read tools that answer an unresolvable index with a directory (#6317).
+///
+/// Why: the issue names six — `search`, `search_lexical`, `search_semantic`,
+/// `typeahead`, `grep`, `index_status`. `grep` is absent here because it
+/// already satisfies the ruling: an unpinned `grep` with no id fans out over
+/// `POST /grep` rather than erroring (#3805). `search_kg` is present because it
+/// shares [`super::search::run_lane_search`] with the two named lanes, and a
+/// read lane that errors where its siblings answer would be the drift this
+/// module exists to prevent.
+/// What: the single list both the dispatcher and the descriptor annotation read,
+/// so behaviour and advertised schema cannot disagree. Every entry is
+/// `search.read` per [`crate::mcp::openrpc::scopes_for_tool`]; no mutating tool
+/// appears, and none may be added.
+/// Test: `directory_tools_are_all_read_scoped`,
+/// `unresolved_read_tools_return_the_index_directory`.
+pub(super) const DIRECTORY_TOOLS: &[&str] = &[
+    "search",
+    "search_lexical",
+    "search_semantic",
+    "search_kg",
+    "typeahead",
+    "index_status",
+];
+
+/// The `status` field marking a directory answer, so a caller can branch on it
+/// without matching prose.
+///
+/// Why: the payload is a SUCCESS, which means it reaches the model in the same
+/// shape as a hit list. Without a discriminator an orchestrator cannot tell
+/// "here are your options" from "here are your results" except by absence of a
+/// field, which is exactly the ambiguity #4715 rejected for `INDEX_NOT_READY`.
+/// What: a free constant, emitted as `status` on every directory payload.
+/// Test: `unresolved_read_tools_return_the_index_directory`.
+pub(super) const NO_INDEX_RESOLVED: &str = "no_index_resolved";
+
+/// Build the successful directory payload for a tool that resolved no index.
+///
+/// Why: see the module doc — the owner ruling requires the discovery answer
+/// inline rather than an error pointing at discovery.
+/// What: GETs `/indexes?details=true` (the `list_indexes` body: `id`,
+/// `root_path`, `size_bytes`, `repo_identity`, `last_used_unix`) and returns
+/// `{status, tool, hint, indexes}`. Chunk counts are deliberately absent — they
+/// live behind a per-index `GET /indexes/:id/status`, so including them would
+/// turn one call into N. A daemon that cannot answer the listing still yields a
+/// `Transport` error; this path invents nothing.
+/// Test: `unresolved_read_tools_return_the_index_directory`,
+/// `empty_daemon_directory_points_at_create_index`.
+pub(super) async fn index_directory(
+    server: &McpServer,
+    tool: &str,
+) -> Result<Value, DispatchError> {
+    let listed = server.get("/indexes?details=true").await?;
+    let indexes = listed
+        .get("indexes")
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let empty = indexes.as_array().is_none_or(Vec::is_empty);
+    let hint = if empty {
+        format!(
+            "`{tool}` resolved no index: this session has no pinned index, the call \
+             passed no `index_id`, and this daemon has no registered indexes. Register \
+             one with `create_index` (or `trusty-search index add <root>`), then retry."
+        )
+    } else {
+        format!(
+            "`{tool}` resolved no index: this session has no pinned index and the call \
+             passed no `index_id`, so here is what exists instead of an error. Retry \
+             with `index_id` set to one of `indexes[].id` below, or start the server \
+             pinned with `trusty-search serve --index <id>`."
+        )
+    };
+    Ok(serde_json::json!({
+        "status": NO_INDEX_RESOLVED,
+        "tool": tool,
+        "hint": hint,
+        "indexes": indexes,
+    }))
+}
+
+/// The sentence appended to each directory tool's own description.
+const TOOL_NOTE: &str = "Omitting `index_id` on an unpinned session is not an error: the call \
+                         returns the list of available indexes plus a hint to retry with one \
+                         of them (issue #6317).";
+
+/// The sentence appended to each directory tool's `index_id` property.
+const PROP_NOTE: &str = "Omitted, it resolves to this session's pinned index when one is set \
+                         (#1373); with no pin the call returns the available indexes and a \
+                         retry hint rather than failing (#6317).";
+
+/// Make the advertised schema agree with the dispatcher for [`DIRECTORY_TOOLS`].
+///
+/// Why: leaving `index_id` in `required` would keep a schema-obeying client from
+/// ever issuing the call the ruling makes valid — the feature would be
+/// unreachable from the surface that advertises it. Applying the edit from the
+/// same const the dispatcher reads is what keeps the two from drifting as tools
+/// are added.
+/// What: for every tool named in [`DIRECTORY_TOOLS`], drops `index_id` from
+/// `required` and appends [`PROP_NOTE`] / [`TOOL_NOTE`] to the `index_id`
+/// property and tool descriptions. Tools outside the list are untouched, so
+/// every mutating tool keeps `index_id` required.
+/// Test: `directory_tools_drop_required_index_id`,
+/// `mutating_tools_keep_required_index_id`.
+pub(super) fn annotate_directory_tools(defs: &mut Value) {
+    let Some(tools) = defs.as_array_mut() else {
+        return;
+    };
+    for tool in tools.iter_mut() {
+        let named = tool
+            .get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|n| DIRECTORY_TOOLS.contains(&n));
+        if !named {
+            continue;
+        }
+        if let Some(desc) = tool.get("description").and_then(Value::as_str) {
+            // Normalise the join to exactly one period + space, whether or not
+            // the base already ends in one — the same shape
+            // `tool_descriptors_pinned` uses for its note.
+            let base = desc.trim_end().trim_end_matches('.');
+            tool["description"] = Value::String(format!("{base}. {TOOL_NOTE}"));
+        }
+        let Some(schema) = tool.get_mut("inputSchema").and_then(Value::as_object_mut) else {
+            continue;
+        };
+        if let Some(required) = schema.get_mut("required").and_then(Value::as_array_mut) {
+            required.retain(|v| v.as_str() != Some("index_id"));
+        }
+        if let Some(prop) = schema
+            .get_mut("properties")
+            .and_then(Value::as_object_mut)
+            .and_then(|p| p.get_mut("index_id"))
+            .and_then(Value::as_object_mut)
+        {
+            let base = prop
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("Target index id (from `list_indexes`)");
+            let base = base.trim_end().trim_end_matches('.');
+            prop.insert(
+                "description".into(),
+                Value::String(format!("{base}. {PROP_NOTE}")),
+            );
+        }
+    }
+}

--- a/crates/trusty-search/src/mcp/tools/mod.rs
+++ b/crates/trusty-search/src/mcp/tools/mod.rs
@@ -20,6 +20,9 @@
 //! - [`not_ready`]   — the `INDEX_NOT_READY` contract (issue #4715): a daemon
 //!   404 on the index this session ADVERTISED means "not built yet", which is
 //!   retryable, not "no such index", which is permanent
+//! - [`index_directory`] — the no-index answer (issue #6317): a read tool with
+//!   no explicit id, no session pin, and no fan-out returns the indexes that
+//!   exist plus a retry hint, as a SUCCESS; mutating tools still error
 //! - [`unavailable`] — the `INDEX_UNAVAILABLE` contract (issue #5350): a daemon
 //!   503 carries a structured availability verdict, which must reach the caller
 //!   as data rather than as a flattened prose string
@@ -41,6 +44,7 @@ pub(crate) mod descriptors;
 pub(crate) mod health;
 pub(crate) mod http;
 pub(crate) mod index;
+pub(crate) mod index_directory;
 pub(crate) mod misc;
 pub(crate) mod not_ready;
 pub(crate) mod search;
@@ -390,3 +394,6 @@ mod tests_unavailable;
 // #5264: structured `search_health` diagnostics.
 #[cfg(test)]
 mod tests_health;
+// #6317: the NO_INDEX_RESOLVED directory answer, and the write tools it spares.
+#[cfg(test)]
+mod tests_index_directory;

--- a/crates/trusty-search/src/mcp/tools/search.rs
+++ b/crates/trusty-search/src/mcp/tools/search.rs
@@ -89,11 +89,11 @@ pub(super) async fn dispatch_search_tool(
             // (#1373); an explicit caller-supplied id still wins.
             let index_id = match server.resolve_index_id(args) {
                 Some(v) => v,
-                // #5213: name `list_indexes`, not just the missing field.
+                // #6317: nothing resolved — answer with the indexes that exist
+                // plus a retry hint, as a success. #5213's error named
+                // `list_indexes`; this returns what that call would have said.
                 None => {
-                    return Some(Err(DispatchError::InvalidParams(
-                        super::types::MISSING_INDEX_ID.into(),
-                    )))
+                    return Some(super::index_directory::index_directory(server, "search").await)
                 }
             };
             // Accept the spec form `{query: string, top_k?: int}` and
@@ -244,10 +244,11 @@ impl McpServer {
     ) -> Result<Value, DispatchError> {
         // Default `index_id` to the session's pinned index when omitted (#1373);
         // an explicit caller-supplied id still wins.
-        // #5213: name `list_indexes`, not just the missing field.
-        let index_id = self
-            .resolve_index_id(args)
-            .ok_or_else(|| DispatchError::InvalidParams(super::types::MISSING_INDEX_ID.into()))?;
+        // #6317: with neither, return the index directory as a success rather
+        // than #5213's error — these lanes are reads.
+        let Some(index_id) = self.resolve_index_id(args) else {
+            return super::index_directory::index_directory(self, lane.tool_name()).await;
+        };
         let query_text = require_str(args, "query")?;
 
         // Pre-flight stage check for lanes that need Stage 2 or Stage 3.

--- a/crates/trusty-search/src/mcp/tools/tests.rs
+++ b/crates/trusty-search/src/mcp/tools/tests.rs
@@ -457,20 +457,32 @@ fn blank_pin_is_treated_as_no_pin() {
     assert_eq!(s.resolve_index_id(&serde_json::json!({})), None);
 }
 
-/// Without a pin, `search` with no `index_id` fast-fails (unchanged).
+/// Without a pin, `search` with no `index_id` goes looking for the index
+/// directory instead of fast-failing (#6317).
 ///
-/// Why: backward-compatibility — the pre-#1373 contract requires `index_id`,
-/// and the fix must not relax that when no pin is configured.
-/// What: dispatches `search` (no index_id, no pin) and asserts INVALID_PARAMS.
+/// Why: this test asserted INVALID_PARAMS, which was the #1373 contract until
+/// the owner ruling of 2026-08-27 replaced the error with a listing of what
+/// exists. The behaviour it guards now is that the arm consults the daemon:
+/// against an unreachable daemon that surfaces as a transport failure, never as
+/// a parameter error. The success shape is asserted in
+/// `tests_index_directory::unresolved_read_tools_return_the_index_directory`,
+/// which drives a live mock.
+/// What: dispatches `search` (no index_id, no pin) at a dead port and asserts
+/// the error is INTERNAL_ERROR, not INVALID_PARAMS.
 /// Test: this is the test.
 #[tokio::test]
-async fn search_without_pin_requires_index_id() {
+async fn search_without_pin_consults_the_index_directory() {
     let server = McpServer::new("http://127.0.0.1:1");
     let resp = server
         .dispatch(req("search", serde_json::json!({ "query": "fn main" })))
         .await;
     let err = resp.error.expect("expected error");
-    assert_eq!(err.code, error_codes::INVALID_PARAMS);
+    assert_eq!(
+        err.code,
+        error_codes::INTERNAL_ERROR,
+        "an omitted index_id must reach the daemon listing, not fail on params: {}",
+        err.message
+    );
 }
 
 /// With a pin, `search` with no `index_id` targets the pinned index endpoint.

--- a/crates/trusty-search/src/mcp/tools/tests_index_directory.rs
+++ b/crates/trusty-search/src/mcp/tools/tests_index_directory.rs
@@ -1,0 +1,309 @@
+//! `NO_INDEX_RESOLVED` contract tests (issue #6317).
+//!
+//! Why: the owner ruling of 2026-08-27 is that a read tool with no resolvable
+//! index answers with an index of what exists, as a success. The properties
+//! that make that answer usable rather than merely non-failing are: it is a
+//! success (`isError: false`), it carries the ids a retry needs, it names how
+//! to retry, and it does NOT extend to the tools that would write to a guessed
+//! index. These tests pin all four, plus the schema that lets a client issue
+//! the call at all.
+//! What: drives `McpServer::dispatch` in the `tools/call` form against a mock
+//! daemon serving `GET /indexes` and `POST /grep`.
+//! Test: this file.
+
+use serde_json::Value;
+
+use super::index_directory::{DIRECTORY_TOOLS, NO_INDEX_RESOLVED};
+use super::tests::req;
+use super::McpServer;
+
+/// Spin up a mock daemon serving the listing and fan-out routes this contract
+/// touches.
+///
+/// Why: the directory answer is built from the daemon's own `GET /indexes`
+/// body, so a test that stubs the payload elsewhere would prove nothing about
+/// the round-trip. `spawn_mock_daemon` in `tests.rs` serves only the per-index
+/// status and search routes.
+/// What: returns the base URL of a loopback listener answering
+/// `GET /indexes` with `{"indexes": indexes}` and `POST /grep` with an empty
+/// match set.
+/// Test: used by every test in this file.
+async fn spawn_listing_daemon(indexes: Value) -> String {
+    use axum::extract::State;
+    use axum::routing::{get, post};
+    use axum::{Json, Router};
+
+    async fn list(State(s): State<Value>) -> Json<Value> {
+        Json(serde_json::json!({ "indexes": s }))
+    }
+    async fn grep() -> Json<Value> {
+        Json(serde_json::json!({ "matches": [], "truncated": false }))
+    }
+
+    let app = Router::new()
+        .route("/indexes", get(list))
+        .route("/grep", post(grep))
+        .with_state(indexes);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://{addr}")
+}
+
+/// Two registered indexes, shaped like the real `?details=true` rows.
+fn two_indexes() -> Value {
+    serde_json::json!([
+        { "id": "alpha", "root_path": "/repos/alpha", "size_bytes": 4096 },
+        { "id": "beta",  "root_path": "/repos/beta",  "size_bytes": 8192 },
+    ])
+}
+
+/// Pull the decoded tool payload and the `isError` flag out of a `tools/call`
+/// response.
+fn tool_result(resp: &super::Response) -> (Value, bool) {
+    let result = resp.result.as_ref().expect("tools/call returns a result");
+    let is_error = result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .expect("tools/call carries isError");
+    let text = result["content"][0]["text"]
+        .as_str()
+        .expect("one text content node");
+    let decoded = serde_json::from_str::<Value>(text).unwrap_or(Value::String(text.to_string()));
+    (decoded, is_error)
+}
+
+/// Build a `tools/call` request for `tool` with no `index_id`.
+fn call(tool: &str) -> super::Request {
+    req(
+        "tools/call",
+        serde_json::json!({ "name": tool, "arguments": { "query": "anything", "pattern": "x" } }),
+    )
+}
+
+/// Every read tool the ruling names answers an unresolvable index with the
+/// directory, as a SUCCESS.
+///
+/// Why (#6317): pre-fix each of these returned `isError: true` carrying
+/// `MISSING_INDEX_ID`, so both the `!is_error` assertion and the `status`
+/// assertion fail against the pre-fix commit. This is the primary test.
+/// What: dispatches every name in `DIRECTORY_TOOLS` against an unpinned server
+/// with no `index_id`, and asserts one shape for all of them — success, the
+/// `no_index_resolved` discriminator, the ids a retry needs, and a hint that
+/// names the field to set.
+/// Test: this test.
+#[tokio::test]
+async fn unresolved_read_tools_return_the_index_directory() {
+    let base = spawn_listing_daemon(two_indexes()).await;
+    // No pin, no explicit id, no fan-out: there is genuinely nothing to resolve.
+    let server = McpServer::new(base);
+
+    for tool in DIRECTORY_TOOLS {
+        let (payload, is_error) = tool_result(&server.dispatch(call(tool)).await);
+        assert!(
+            !is_error,
+            "{tool}: the directory answer is a success: {payload}"
+        );
+        assert_eq!(
+            payload.get("status").and_then(Value::as_str),
+            Some(NO_INDEX_RESOLVED),
+            "{tool}: a caller must be able to branch on the discriminator: {payload}"
+        );
+        assert_eq!(
+            payload.get("tool").and_then(Value::as_str),
+            Some(*tool),
+            "{tool}: the payload names the tool that asked: {payload}"
+        );
+        let ids: Vec<&str> = payload["indexes"]
+            .as_array()
+            .expect("indexes array")
+            .iter()
+            .filter_map(|e| e["id"].as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["alpha", "beta"],
+            "{tool}: the rows `list_indexes` serves must reach the caller: {payload}"
+        );
+        let hint = payload["hint"].as_str().expect("hint");
+        assert!(
+            hint.contains("index_id"),
+            "{tool}: the hint must name the field to set: {hint}"
+        );
+    }
+}
+
+/// A daemon with nothing registered points at registration, not at a retry it
+/// cannot satisfy.
+///
+/// Why: "retry with one of the ids below" is advice a caller cannot follow when
+/// the list is empty, which is the circular-advice trap #3805 named. The empty
+/// case has to say something different.
+/// What: serves an empty listing and asserts the hint names `create_index`.
+/// Test: this test.
+#[tokio::test]
+async fn empty_daemon_directory_points_at_create_index() {
+    let base = spawn_listing_daemon(serde_json::json!([])).await;
+    let server = McpServer::new(base);
+    let (payload, is_error) = tool_result(&server.dispatch(call("search")).await);
+    assert!(
+        !is_error,
+        "still a success with nothing registered: {payload}"
+    );
+    let hint = payload["hint"].as_str().expect("hint");
+    assert!(
+        hint.contains("create_index"),
+        "an empty daemon must not advise picking from an empty list: {hint}"
+    );
+}
+
+/// The tools that would WRITE to a guessed index still error.
+///
+/// Why (#6317): the ruling is about discovery, not about making every omitted
+/// argument recoverable. Indexing a file into, or reindexing, an index the
+/// caller never named is not undoable, so those arms keep #5213's error. This
+/// is the other side of the boundary
+/// `missing_index_id_error_names_list_indexes` asserts.
+/// What: dispatches each mutating arm with no `index_id` against the same live
+/// mock daemon the read tools succeed against, so a pass cannot come from the
+/// daemon being unreachable.
+/// Test: this test.
+#[tokio::test]
+async fn mutating_tools_still_error_when_no_index_resolves() {
+    let base = spawn_listing_daemon(two_indexes()).await;
+    let server = McpServer::new(base);
+    for tool in ["index_file", "remove_file", "delete_index", "reindex"] {
+        let (payload, is_error) = tool_result(&server.dispatch(call(tool)).await);
+        assert!(
+            is_error,
+            "{tool}: a write to an unnamed index must still fail: {payload}"
+        );
+        let text = payload.as_str().unwrap_or_default();
+        assert!(
+            text.contains("list_indexes"),
+            "{tool}: the error still points at discovery: {text}"
+        );
+    }
+}
+
+/// An unpinned `grep` with no `index_id` fans out instead of erroring, which is
+/// how it already satisfies the ruling.
+///
+/// Why (#6317): the issue lists `grep` among the six tools that must stop
+/// erroring, but `grep` never took that path — `resolve_index_id` returning
+/// `None` sends it to the global `POST /grep` (#3805). Returning a directory
+/// instead would delete that fan-out. This test states the reason `grep` is
+/// absent from `DIRECTORY_TOOLS` as an assertion rather than a comment.
+/// What: dispatches `grep` unpinned with no id and asserts a successful daemon
+/// answer, not a directory.
+/// Test: this test.
+#[tokio::test]
+async fn unpinned_grep_with_no_index_fans_out() {
+    let base = spawn_listing_daemon(two_indexes()).await;
+    let server = McpServer::new(base);
+    let (payload, is_error) = tool_result(&server.dispatch(call("grep")).await);
+    assert!(!is_error, "grep fan-out is a success: {payload}");
+    assert!(
+        payload.get("matches").is_some(),
+        "grep must reach the global endpoint, not the directory: {payload}"
+    );
+    assert!(
+        !DIRECTORY_TOOLS.contains(&"grep"),
+        "grep's ruling is met by fan-out; adding it here would delete that path"
+    );
+}
+
+/// Every tool that answers with a directory is classified read-only.
+///
+/// Why: `scopes_for_tool` is the existing authority on which tools mutate. If a
+/// mutating tool were ever added to `DIRECTORY_TOOLS`, the boundary above would
+/// silently move. Deriving the assertion from that authority means the two
+/// cannot disagree without a failing test.
+/// What: asserts every entry maps to `search.read`.
+/// Test: this test.
+#[test]
+fn directory_tools_are_all_read_scoped() {
+    for tool in DIRECTORY_TOOLS {
+        assert_eq!(
+            crate::mcp::openrpc::scopes_for_tool(tool),
+            vec!["search.read".to_string()],
+            "{tool} must be read-only to answer with a directory"
+        );
+    }
+}
+
+/// The advertised schema lets a client make the call the ruling permits.
+///
+/// Why (#6317): a tool whose `inputSchema` still lists `index_id` as `required`
+/// is one a schema-obeying client will never call without one, so the new
+/// behaviour would be unreachable from the surface that advertises it.
+/// Pre-fix `index_id` was required on `search`, so this fails against the
+/// pre-fix commit.
+/// What: asserts `index_id` is absent from `required` on every directory tool
+/// and that both descriptions state what an omitted id does.
+/// Test: this test.
+#[test]
+fn directory_tools_drop_required_index_id() {
+    let defs = super::tool_descriptors();
+    for tool in DIRECTORY_TOOLS {
+        let def = defs
+            .as_array()
+            .expect("descriptors are an array")
+            .iter()
+            .find(|t| t["name"] == *tool)
+            .unwrap_or_else(|| panic!("{tool} is registered"));
+        let required: Vec<&str> = def["inputSchema"]["required"]
+            .as_array()
+            .map(|a| a.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        assert!(
+            !required.contains(&"index_id"),
+            "{tool}: index_id must not be required: {required:?}"
+        );
+        let desc = def["description"].as_str().expect("description");
+        assert!(
+            desc.contains("#6317"),
+            "{tool}: the description must document the no-id path: {desc}"
+        );
+        let prop = def["inputSchema"]["properties"]["index_id"]
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("{tool}: index_id property description"));
+        assert!(
+            prop.contains("#6317"),
+            "{tool}: the parameter description must agree: {prop}"
+        );
+    }
+}
+
+/// A mutating tool's schema still requires `index_id`.
+///
+/// Why: the annotation is keyed off `DIRECTORY_TOOLS`, and a bug that applied
+/// it to every tool would advertise `reindex` as callable with no index — the
+/// exact call the dispatcher rejects. Schema and dispatcher must agree on the
+/// write side too.
+/// What: asserts `index_id` is still `required` on the four mutating arms.
+/// Test: this test.
+#[test]
+fn mutating_tools_keep_required_index_id() {
+    let defs = super::tool_descriptors();
+    for tool in ["index_file", "remove_file", "delete_index", "reindex"] {
+        let def = defs
+            .as_array()
+            .expect("descriptors are an array")
+            .iter()
+            .find(|t| t["name"] == tool)
+            .unwrap_or_else(|| panic!("{tool} is registered"));
+        let required: Vec<&str> = def["inputSchema"]["required"]
+            .as_array()
+            .map(|a| a.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        assert!(
+            required.contains(&"index_id"),
+            "{tool}: index_id stays required: {required:?}"
+        );
+    }
+}

--- a/crates/trusty-search/src/mcp/tools/tests_not_ready.rs
+++ b/crates/trusty-search/src/mcp/tools/tests_not_ready.rs
@@ -399,19 +399,24 @@ async fn not_ready_payload_points_at_list_indexes_not_only_a_fallback() {
     );
 }
 
-/// An unresolvable `index_id` names `list_indexes` in the error itself.
+/// An unresolvable `index_id` names `list_indexes` in a MUTATING tool's error.
 ///
 /// Why (#5213): "missing required string field: index_id" is true and
 /// unactionable. A caller that does not know a valid id guesses one — which is
 /// the wrong-index failure #1373 pinned the session to avoid, arriving by a
 /// different route. Pre-fix the message was the bare field name, so the
 /// `contains("list_indexes")` assertion fails against the pre-fix commit.
+/// #6317 moved `search`, `search_semantic`, and `index_status` off this path —
+/// they are reads and now answer with the index directory — so the tools
+/// asserted here are the writes that still error;
+/// `mutating_tools_still_error_when_no_index_resolves` guards that boundary
+/// from the other side.
 /// Test: this test.
 #[tokio::test]
 async fn missing_index_id_error_names_list_indexes() {
     // No pin, no explicit id: there is genuinely nothing to resolve.
     let server = McpServer::new("http://127.0.0.1:1");
-    for tool in ["search", "search_semantic", "index_status"] {
+    for tool in ["reindex", "index_file", "remove_file"] {
         let resp = server
             .dispatch(req(tool, serde_json::json!({ "query": "q" })))
             .await;

--- a/crates/trusty-search/src/mcp/tools/tests_tools_list.rs
+++ b/crates/trusty-search/src/mcp/tools/tests_tools_list.rs
@@ -109,11 +109,16 @@ async fn per_lane_tool_descriptions_carry_when_to_use_hooks() {
     }
 }
 
-/// Missing-arg fast-fail: every per-lane tool rejects an empty arg
-/// object before any HTTP round-trip.
+/// Missing-arg fast-fail: every per-lane tool rejects a missing `query`
+/// before any HTTP round-trip.
+///
+/// #6317: the server is pinned here because an unpinned lane with no
+/// `index_id` no longer fails — it fetches the index directory, which is an
+/// HTTP call and so cannot demonstrate a fast-fail. Pinning supplies the index
+/// and leaves `query` as the one missing argument this test is about.
 #[tokio::test]
 async fn per_lane_tools_require_index_id_and_query() {
-    let server = McpServer::new("http://127.0.0.1:1");
+    let server = McpServer::new("http://127.0.0.1:1").with_pinned_index("pinned-proj");
     for tool in ["search_lexical", "search_semantic", "search_kg"] {
         let resp = server.dispatch(req(tool, serde_json::json!({}))).await;
         let err = resp.error.expect("expected error");

--- a/crates/trusty-search/src/mcp/tools/typeahead.rs
+++ b/crates/trusty-search/src/mcp/tools/typeahead.rs
@@ -44,9 +44,11 @@ pub(super) async fn dispatch_typeahead_tool(
 /// issues a GET to `/indexes/{id}/typeahead?q=...&limit=...&mode=...`.
 /// Test: `tests_typeahead::typeahead_tool_returns_daemon_response`.
 async fn handle_typeahead(server: &McpServer, args: &Value) -> Result<Value, DispatchError> {
-    let index_id = server.resolve_index_id(args).ok_or_else(|| {
-        DispatchError::InvalidParams("missing required string field: index_id".into())
-    })?;
+    // #6317: an unpinned call with no id gets the indexes that exist plus a
+    // retry hint, as a success — typeahead is a read.
+    let Some(index_id) = server.resolve_index_id(args) else {
+        return super::index_directory::index_directory(server, "typeahead").await;
+    };
 
     let query = require_str(args, "query")?;
 
@@ -98,11 +100,15 @@ mod tests_typeahead {
     }
 
     #[test]
-    fn handle_typeahead_missing_index_id_returns_invalid_params() {
-        // Why: when neither an explicit `index_id` nor a session-pinned index
-        // is available, the tool must return `InvalidParams` (not panic).
+    fn handle_typeahead_missing_index_id_consults_the_directory() {
+        // Why (#6317): this asserted `InvalidParams`, which was the contract
+        // until the owner ruling made an unresolvable index answer with the
+        // indexes that exist. What it guards now is that the arm goes to the
+        // daemon for that listing — against a dead port that surfaces as
+        // `Transport`, never as a parameter error. The success shape is
+        // asserted in `tests_index_directory` against a live mock.
         // What: calls `dispatch_typeahead_tool` with `{"query": "fn"}` and no
-        // `index_id` on an unpinned server — expects `InvalidParams`.
+        // `index_id` on an unpinned server pointed at a dead port.
         // Test: this test.
         let server = McpServer::new("http://127.0.0.1:9999");
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -115,13 +121,8 @@ mod tests_typeahead {
             &json!({ "query": "fn" }),
         ));
         match result {
-            Some(Err(DispatchError::InvalidParams(msg))) => {
-                assert!(
-                    msg.contains("index_id"),
-                    "error must mention index_id: {msg}"
-                );
-            }
-            other => panic!("expected Some(Err(InvalidParams)), got {other:?}"),
+            Some(Err(DispatchError::Transport(_))) => {}
+            other => panic!("expected Some(Err(Transport)), got {other:?}"),
         }
     }
 

--- a/crates/trusty-search/src/mcp/tools/types.rs
+++ b/crates/trusty-search/src/mcp/tools/types.rs
@@ -58,7 +58,7 @@ pub(super) enum DispatchError {
     },
 }
 
-/// The one message every tool arm emits when it cannot resolve an `index_id`
+/// The message a MUTATING tool arm emits when it cannot resolve an `index_id`
 /// (issue #5213).
 ///
 /// Why: the previous text was "missing required string field: index_id" — true,
@@ -66,8 +66,10 @@ pub(super) enum DispatchError {
 /// valid id guesses one, which is the wrong-index failure (#1373) arriving by a
 /// different route. Naming `list_indexes` in the error is the owner's stated
 /// closure condition: an omitted id errors loudly AND points at discovery.
-/// What: a single constant so `search`, `search_lexical`/`_semantic`/`_kg`, and
-/// every index-management arm cannot drift apart.
+/// What: a single constant so every index-mutating arm cannot drift apart.
+/// #6317 narrowed the audience: the read tools now answer with
+/// [`super::index_directory::index_directory`] instead of this error, so what
+/// remains here is `index_file`, `remove_file`, `delete_index`, and `reindex`.
 /// Test: `missing_index_id_error_names_list_indexes`.
 pub(super) const MISSING_INDEX_ID: &str =
     "missing required string field: index_id — this session has no pinned index, \


### PR DESCRIPTION
Refs #6317

An unpinned MCP session that omitted `index_id` got `MISSING_INDEX_ID` — an error naming `list_indexes`, so the caller had to spend a second round-trip to learn what the first could have told it, and a model unwilling to spend it guessed an id instead. The owner ruling of 2026-08-27 is that a read tool with nothing to resolve returns an index of what exists.

## Read/write split, against the issue's ACs

The issue names six tools. Five take the new path; the sixth needs no change.

| Tool | Behaviour with no explicit id and no pin |
|---|---|
| `search`, `search_lexical`, `search_semantic`, `search_kg`, `typeahead`, `index_status` | Successful `{status: "no_index_resolved", tool, hint, indexes}` |
| `grep`, `search_all` | Unchanged — already fan out over the global endpoint |
| `index_file`, `remove_file`, `delete_index`, `reindex` | Unchanged — still `MISSING_INDEX_ID` |

`grep` is absent from the changed set because it never took the error path: `resolve_index_id` returning `None` sends it to `POST /grep` (#3805), which is already a successful result. Returning a directory there would delete that fan-out. `unpinned_grep_with_no_index_fans_out` states that as an assertion rather than a comment.

`search_kg` is in the changed set although the issue does not name it: it shares `run_lane_search` with `search_lexical` and `search_semantic`, and a read lane that errors where its siblings answer would be exactly the drift this change removes.

The mutating arms keep the error because writing to a guessed index is not recoverable, so there is nothing useful to return in its place. `directory_tools_are_all_read_scoped` derives that boundary from `mcp::openrpc::scopes_for_tool`, the existing authority on which tools mutate, so the two cannot disagree without a failing test. `list_chunks`, `chat`, and `get_call_chain` are reads the issue does not name and are left alone.

Pinned and explicit-id resolution is untouched: an explicit `index_id` still wins, then the session pin (#1373), and only when neither resolves does this path run.

## Schema

`index_id` is dropped from `required` on the six read tools, and both their descriptions state what an omitted id does. Without that a schema-obeying client could never issue the call the ruling makes valid. The annotation reads the same `DIRECTORY_TOOLS` const the dispatcher does, so behaviour and advertised schema cannot drift.

The generated MCP tool table in `crates/trusty-search/{CLAUDE.md,README.md}` is built from `tool_descriptors`, so `generated_docs` went red; regenerated with `UPDATE_DOCS=1 cargo test -p trusty-search --test generated_docs` and included here. The rows now read `index_id?` for `search`, `search_lexical`, `search_semantic`, `search_kg`, `index_status` (`typeahead` was already optional).

## Rung 6

MCP tool schemas changed, so this is a UI/API-surface change. Rung 3 gates plus a binary smoke run.

Isolated `HOME=/tmp/ts6317`, `TRUSTY_DATA_DIR` under scratch, root outside `/private/tmp`, daemon `--foreground --port 17931`, one index registered. The live daemon was not touched; the smoke daemon was verified down afterwards.

`trusty-search serve` (MCP stdio, **unpinned**), `tools/call` with no `index_id`:

```json
--- response id=2 ---
{"jsonrpc":"2.0","id":2,"result":{"content":[{"text":"{\n  \"hint\": \"`search` resolved no index: this session has no pinned index and the call passed no `index_id`, so here is what exists instead of an error. Retry with `index_id` set to one of `indexes[].id` below, or start the server pinned with `trusty-search serve --index <id>`.\",\n  \"indexes\": [\n    {\n      \"id\": \"ts6317-smoke\",\n      \"root_path\": \"/Users/masa/ts6317-smoke-repo\",\n      \"size_bytes\": 2113556\n    }\n  ],\n  \"status\": \"no_index_resolved\",\n  \"tool\": \"search\"\n}","type":"text"}],"isError":false}}
```

`index_status` (id=3) returns the same shape with `"tool": "index_status"`. The write tool still errors:

```json
--- response id=4 ---
{"jsonrpc":"2.0","id":4,"result":{"content":[{"text":"Error: missing required string field: index_id — this session has no pinned index, so there is no default to fall back to. Call `list_indexes` to see the ids that exist on this daemon, then retry with an explicit index_id.","type":"text"}],"isError":true}}
```

## The primary test fails on origin/main

With `search.rs`, `typeahead.rs`, `index.rs` and `descriptors.rs` restored from `origin/main` and the new test file kept:

```
test mcp::tools::tests_index_directory::unresolved_read_tools_return_the_index_directory ... FAILED
search: the directory answer is a success: "Error: missing required string field: index_id — this session has no pinned index, so there is no default to fall back to. Call `list_indexes` to see the ids that exist on this daemon, then retry with an explicit index_id."
test result: FAILED. 4 passed; 3 failed; 0 ignored; 0 measured; 2036 filtered out
```

The three that fail pre-fix are `unresolved_read_tools_return_the_index_directory` (table-driven over all six read tools), `empty_daemon_directory_points_at_create_index`, and `directory_tools_drop_required_index_id`. `mutating_tools_still_error_when_no_index_resolves` passes on both sides by design — it drives the write arms against the same live mock daemon the read tools succeed against, so it cannot pass merely because nothing was reachable.

Three existing tests encoded the old contract and were rewritten rather than deleted:

- `search_without_pin_requires_index_id` → `search_without_pin_consults_the_index_directory`, now asserting `INTERNAL_ERROR` against a dead port, which proves the arm reaches the daemon listing instead of failing on params.
- `handle_typeahead_missing_index_id_returns_invalid_params` → `..._consults_the_directory`, same reasoning.
- `per_lane_tools_require_index_id_and_query` now pins the server, so `query` is the one missing argument the fast-fail is about.
- `missing_index_id_error_names_list_indexes` kept its name and moved its tool list to the writes that still error.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `SKIP_UI_BUILD=1 cargo clippy -p trusty-search --all-targets -- -D warnings` | EXIT=0 |
| `SKIP_UI_BUILD=1 cargo test -p trusty-search --no-fail-fast` | EXIT=0 — 2592 passed, 0 failed, 41 ignored, across 35 targets |
| `scripts/check_line_cap.sh` | 4552 tracked files, 0 violations |
| `scripts/check_test_pointers.sh` | 31491 citations resolved, 0 dangling |
| `scripts/check_sld.sh` | 0 errors, 0 warnings |
| `scripts/check_changelog_fragment.sh --staged` | OK |
| `scripts/check-pr-version-bump.sh` | `[ OK ] trusty-search 0.54.0 — src changed, version not yet published` |

## Note

Chunk counts are not in the payload. `GET /indexes?details=true` carries `id`, `root_path`, `size_bytes`, `repo_identity` and `last_used_unix`, but a chunk count needs a per-index `GET /indexes/:id/status` — including it would turn one call into N. The AC asked for it "if cheap"; it is not.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
