### PR TITLE
feat(trusty-audit): the return package carries a scrubbed error digest (Refs #6032)

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -462,6 +462,16 @@ and two generated files: a `README.md` explaining what is inside, and a
 `package.toml` naming which repositories were covered and at which tool
 versions. The last line of the output is the path to send.
 
+It also carries `errors/digest.json`: every failure and degradation the run
+recorded — a repository whose child exited non-zero, a dimension a repository
+could not assess, a board the sweep could not collect, a config key this version
+does not act on — each as one entry naming the stage, whether the run stopped or
+carried on, the repository it concerns, when it was recorded, and the message. A
+run with none still ships the file with an empty `entries` array, so an empty
+digest means the collector ran and found nothing. Every message is scrubbed of
+the engagement's credentials before it is written; send the file back and the
+auditor can fix what it names.
+
 **It is unencrypted and has no password, deliberately.** You can open it and
 read exactly what you are about to send, which is the same premise as the
 readable engagement config. Encrypting it would defend against nobody — you hold

--- a/crates/trusty-audit/changelog.d/6032-return-package-error-digest.md
+++ b/crates/trusty-audit/changelog.d/6032-return-package-error-digest.md
@@ -1,0 +1,15 @@
+Added
+
+- The return package now carries `errors/digest.json`, a machine-readable record
+  of everything a run recorded as gone wrong: a repository whose `tga audit`
+  child failed, a dimension a repository could not assess, a board the sweep
+  could not collect, a target that never cloned, and a config key this version
+  does not act on. Each entry names the stage, whether the run stopped or carried
+  on, the repository it concerns, when it was recorded, and the message. It is
+  written on every run, empty `entries` array and all, so an empty digest states
+  that the collector ran rather than leaving the recipient to guess. Every
+  message is scrubbed of the engagement's configured secrets and the `gh`-derived
+  token before it is written, and the rendered document then goes through the
+  same credential refusal every other generated member does. New public items
+  `package::DIGEST_ENTRY` and `run::RepoRun::finished_at`; no existing member,
+  signature or struct shape changed (issue #6032).

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -1125,6 +1125,7 @@ mod cli_tests {
             gaps: vec!["Collection stage `jira sync` did not complete.".to_owned()],
             resumed: false,
             duration_ms: None,
+            finished_at: None,
             result,
         };
         let ok = run(RepoResult::Succeeded);
@@ -1180,6 +1181,7 @@ mod cli_tests {
             gaps: Vec::new(),
             resumed: false,
             duration_ms: None,
+            finished_at: None,
             result: RepoResult::Succeeded,
         };
         let gap = "linear:a1b2c3d4 was not audited — re-register it (#5982)";
@@ -1212,6 +1214,7 @@ mod cli_tests {
             gaps: Vec::new(),
             resumed,
             duration_ms: None,
+            finished_at: None,
             result: RepoResult::Succeeded,
         };
         let outcome = Outcome::Run(RunReport::of(vec![
@@ -1370,6 +1373,7 @@ mod cli_tests {
                 gaps: Vec::new(),
                 resumed: false,
                 duration_ms: None,
+                finished_at: None,
                 result: RepoResult::Succeeded,
             }]),
             package: ReturnPackage {

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -105,6 +105,11 @@ mod credential_scan;
 // the result.
 mod generated;
 
+// #6032: the run's failures and degradations, flattened into one machine-readable
+// member. Its own file for the same reason the two above are — this file decides
+// what goes into the archive; that one decides what the digest says.
+mod error_digest;
+
 use generated::{
     Generated, exclusions, render_failures, render_index, render_metadata, render_readme,
 };
@@ -142,6 +147,18 @@ pub const DEBT_ENTRY: &str = "reports/report.json";
 
 /// Directory inside the zip holding the tga extract databases (#5479).
 pub const EXTRACT_PREFIX: &str = "extract";
+
+/// The generated member carrying every failure the run recorded (#6032).
+///
+/// Why: the owner's directive is that the errors travel back with the package
+/// so the auditor can fix them. They were spread across `package.toml`,
+/// `failures/index.md` and the reports' own Gaps & Caveats, in three different
+/// shapes, and no reader could take them as a set. Written UNCONDITIONALLY,
+/// empty array and all — see [`error_digest`]'s module docs for why that
+/// differs from [`FAILURES_ENTRY`], which is absent on a clean sweep.
+/// Test: `super::package_tests::the_package_carries_an_error_digest_on_a_clean_run`,
+/// `super::package_tests::a_stage_failure_reaches_the_error_digest`.
+pub const DIGEST_ENTRY: &str = "errors/digest.json";
 
 /// Directory inside the zip holding the record of every repository that failed.
 ///
@@ -385,6 +402,13 @@ pub fn assemble(
         // #6245: `None` on a clean sweep — a `failures/` directory holding an
         // index that says "none" is worse than no directory.
         failures: render_failures(report, &collected),
+        // #6032: everything the run recorded as gone wrong, from the same
+        // `report` the members above render — so a gap in Gaps & Caveats and
+        // its digest entry are one string, not two derivations of it. Takes
+        // `unattempted` rather than the assembled `excluded`, because the
+        // digest keeps the sweep's own failures and the never-attempted targets
+        // as separate kinds where that list flattens them into prose.
+        digest: error_digest::render(report, config, unattempted, github_token)?,
     };
 
     write_archive(
@@ -693,6 +717,11 @@ fn fill_archive(
         (DEBT_ENTRY, Some(generated.debt)),
         // #6245: absent on a clean sweep — see `Generated::failures`.
         (FAILURES_ENTRY, generated.failures),
+        // #6032: written unconditionally, so an empty `entries` array is the
+        // positive signal that the collector ran. Its messages are already
+        // scrubbed; the refusal below is the second guard, for a secret too
+        // short for `scrub_secrets` to accept as a needle.
+        (DIGEST_ENTRY, Some(generated.digest)),
     ];
     for (entry, text) in members.into_iter().filter_map(|(e, t)| t.map(|t| (e, t))) {
         // #6245: this member quotes the reason strings recorded for each failed
@@ -883,6 +912,7 @@ trusty-review = "0.15.1"
             gaps: Vec::new(),
             resumed: false,
             duration_ms: None,
+            finished_at: None,
             result: RepoResult::Succeeded,
         }
     }
@@ -904,6 +934,7 @@ trusty-review = "0.15.1"
                 gaps: Vec::new(),
                 resumed: false,
                 duration_ms: None,
+                finished_at: None,
                 result: RepoResult::Succeeded,
             }
         }
@@ -962,6 +993,217 @@ trusty-review = "0.15.1"
         }
         assert!(package.total_bytes > 0);
         assert!(package.excluded.is_empty());
+    }
+
+    /// The digest document, parsed out of the finished zip.
+    fn digest(path: &Path) -> serde_json::Value {
+        serde_json::from_str(&read_entry(path, DIGEST_ENTRY)).expect("the digest is JSON")
+    }
+
+    /// Every entry in the digest, as `(stage, kind, target, message)`.
+    fn digest_rows(path: &Path) -> Vec<(String, String, String, String)> {
+        digest(path)["entries"]
+            .as_array()
+            .expect("entries is an array")
+            .iter()
+            .map(|e| {
+                let field = |name: &str| e[name].as_str().unwrap_or_default().to_owned();
+                (
+                    field("stage"),
+                    field("kind"),
+                    field("target"),
+                    field("message"),
+                )
+            })
+            .collect()
+    }
+
+    /// 🔴 #6032: a run that recorded nothing still ships the digest, with an
+    /// empty `entries` array. That is what distinguishes "the collector ran and
+    /// found nothing" from "this client is too old to write one" — an absent
+    /// file cannot say either, and the recipient has no other way to tell.
+    ///
+    /// Against `978367887` this fails on the first assertion: `errors/` is not a
+    /// member of the archive at all.
+    #[test]
+    fn the_package_carries_an_error_digest_on_a_clean_run() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+
+        let package =
+            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+
+        assert!(
+            entries(&destination).contains(&DIGEST_ENTRY.to_owned()),
+            "{:?}",
+            entries(&destination)
+        );
+        assert!(
+            package.files.iter().any(|f| f.entry == DIGEST_ENTRY),
+            "the digest must be reported as a member: {:?}",
+            package.files
+        );
+        let parsed = digest(&destination);
+        assert_eq!(
+            parsed["entries"].as_array().map(Vec::len),
+            Some(0),
+            "an empty array is the positive claim; an absent file is not: {parsed}"
+        );
+        assert!(
+            parsed["generated_at"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "{parsed}"
+        );
+        // The recipient is told what they are sending back and why.
+        let readme = read_entry(&destination, README_ENTRY);
+        assert!(readme.contains(DIGEST_ENTRY), "{readme}");
+    }
+
+    /// 🔴 #6032: a repository whose `tga audit` child failed, and a dimension a
+    /// repository could not assess, both reach the digest — the failure as a
+    /// `failure`, the gap as a `degradation`, each naming its stage, its
+    /// repository, and when the sweep recorded it.
+    ///
+    /// The gap assertion is the issue's fourth closure condition: the string in
+    /// the digest is the SAME string the report's Gaps & Caveats carries,
+    /// because both render from this one `RepoRun::gaps` entry.
+    ///
+    /// Against `978367887` this fails on the digest's absence, exactly as the
+    /// clean-run test does.
+    #[test]
+    fn a_stage_failure_reaches_the_error_digest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let mut broken = failed(&work, "01-acme-web", "acme-web");
+        broken.finished_at = Some("2026-09-07 01:02:03 -04:00".to_owned());
+        let mut degraded = audited(&work, "00-acme-api", "acme-api");
+        degraded.gaps = vec!["acme-api: trusty-analyze did not answer".to_owned()];
+        let report = RunReport::of(vec![degraded, broken]);
+        let destination = default_destination(&work);
+
+        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+
+        let rows = digest_rows(&destination);
+        assert!(
+            rows.contains(&(
+                "repository".to_owned(),
+                "degradation".to_owned(),
+                "acme-api".to_owned(),
+                "acme-api: trusty-analyze did not answer".to_owned()
+            )),
+            "{rows:?}"
+        );
+        let failure = rows
+            .iter()
+            .find(|(_, kind, _, _)| kind == "failure")
+            .unwrap_or_else(|| panic!("{rows:?}"));
+        assert_eq!(failure.0, "repository", "{rows:?}");
+        assert_eq!(failure.2, "acme-web", "{rows:?}");
+        assert!(failure.3.contains("exited with code 3"), "{rows:?}");
+        let stamped = digest(&destination)["entries"]
+            .as_array()
+            .expect("entries is an array")
+            .iter()
+            .find(|e| e["kind"] == "failure")
+            .and_then(|e| e["at"].as_str().map(str::to_owned));
+        assert_eq!(
+            stamped.as_deref(),
+            Some("2026-09-07 01:02:03 -04:00"),
+            "the entry carries the repository's own clock, not the digest's"
+        );
+    }
+
+    /// 🔴 #6032: a message the digest carries and NO other member does — a board
+    /// gap — is scrubbed rather than refused. The digest exists to carry error
+    /// text back, so refusing the whole package because one message quoted the
+    /// key would leave the auditor with neither the package nor the digest.
+    ///
+    /// This does not soften the refusal for anything else: the key in a
+    /// repository's failure reason still refuses the assembly through
+    /// `failures/index.md`, which
+    /// `a_failure_record_carrying_a_credential_is_refused` holds.
+    #[test]
+    fn a_credential_in_a_digest_message_is_scrubbed_rather_than_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let key = config().openrouter_key.expose().to_owned();
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")])
+            .stating(vec![format!("jira rejected the key {key}")]);
+        let destination = default_destination(&work);
+
+        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+
+        let text = read_entry(&destination, DIGEST_ENTRY);
+        assert!(!text.contains(&key), "the key reached the digest: {text}");
+        assert!(text.contains("[REDACTED]"), "{text}");
+        let rows = digest_rows(&destination);
+        assert!(
+            rows.iter()
+                .any(|(stage, kind, _, _)| stage == "boards" && kind == "degradation"),
+            "{rows:?}"
+        );
+    }
+
+    /// 🔴 #6032: the digest is ADDITIVE. Every member the package carried before
+    /// it is still there, under the same name, and `package.toml` grew no key —
+    /// a recipient's existing tooling reads the same bundle it always did.
+    #[test]
+    fn the_error_digest_leaves_the_rest_of_the_package_unchanged() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+
+        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+
+        let mut names = entries(&destination);
+        names.retain(|n| n != DIGEST_ENTRY);
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "README.md",
+                "extract/00-acme-api.db",
+                "package.toml",
+                "reports/00-acme-api/manifest.toml",
+                "reports/00-acme-api/report.md",
+                "reports/index.md",
+                "reports/report.json",
+            ],
+            "the digest is the only new member"
+        );
+        let metadata: toml::Value = read_entry(&destination, METADATA_ENTRY)
+            .parse()
+            .expect("package.toml is TOML");
+        let mut keys: Vec<&str> = metadata
+            .as_table()
+            .expect("a table")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "client",
+                "config_not_acted_on",
+                "generated_by",
+                "instructions",
+                "not_attempted",
+                "repositories",
+                "repositories_audited",
+                "repositories_excluded",
+                "tools",
+            ],
+            "the manifest grew no key"
+        );
     }
 
     /// 🔴 #6080: the RECIPIENT is the primary audience for an

--- a/crates/trusty-audit/src/package/error_digest.rs
+++ b/crates/trusty-audit/src/package/error_digest.rs
@@ -1,0 +1,240 @@
+//! Every failure and degradation the run recorded, as one machine-readable
+//! member of the return package.
+//!
+//! Why (#6032): the owner's directive is "let's also include any errors in the
+//! log so that the audit runner can send it back to us for fixing." A run
+//! recorded its failures in four different shapes and the recipient could reach
+//! none of them as a set. A repository that failed appeared in `package.toml`
+//! and in `failures/index.md` as prose; a leg that degraded appeared as one
+//! line inside the report's Gaps & Caveats; a board the sweep could not collect
+//! and a config key this version does not act on appeared only in the
+//! recipient's `excluded` list. Reading the whole picture meant opening four
+//! files and correlating them by eye, which is what an auditor asking "what
+//! went wrong on your machine" has to do at a distance.
+//!
+//! What: [`render`] flattens all four into one JSON document,
+//! [`super::DIGEST_ENTRY`], with a uniform entry shape — the phase that
+//! recorded it, whether the run stopped or continued, the target it concerns,
+//! when it was recorded, and the message itself. It derives from the sweep's
+//! own record rather than from a separate journal, so a degradation in the
+//! report's Gaps & Caveats and its digest entry are the SAME string from the
+//! same run, not two renderings that can come to disagree.
+//!
+//! ## Written even when nothing went wrong
+//!
+//! A run with no failures ships a digest whose `entries` array is empty. That
+//! is the same choice [`super::DEBT_ENTRY`] makes and for the same reason: an
+//! empty array states that the collector ran and found nothing, where an absent
+//! file leaves the recipient unable to tell that from a client too old to
+//! write one. It is the opposite choice from `failures/index.md`, which is
+//! absent on a clean sweep — that member is prose a human reads, and a page
+//! saying "none" is worse than no page; this one is a record a program reads.
+//!
+//! ## Scrubbed here, refused in `fill_archive`
+//!
+//! Every message is a string ANOTHER program produced — a child's exit text, a
+//! provider's error body, a leg's failure cause — so it can carry a credential
+//! the way any other quoted output can. Two guards, in this order:
+//!
+//! - [`trusty_common::credentials::scrub_secrets`] replaces each configured
+//!   secret and the `gh`-derived token with `[REDACTED]` as the entry is built.
+//!   Scrubbing rather than refusing is deliberate for this member alone: its
+//!   whole purpose is to carry error text back, and refusing the entire package
+//!   because one message quoted the key would leave the auditor with neither
+//!   the package nor the digest.
+//! - [`super::credential_scan::refuse_if_credential`] then scans the rendered
+//!   document in [`super::fill_archive`], exactly as it scans every other
+//!   generated member. It is not redundant: `scrub_secrets` declines a needle
+//!   shorter than its minimum, so a short secret survives the scrub and the
+//!   refusal is what still catches it.
+//!
+//! Test: `super::package_tests`.
+
+use serde::Serialize;
+
+use crate::config::EngagementConfig;
+use crate::error::AuditError;
+use crate::run::{RepoResult, RepoRun, RunReport};
+
+/// The phase of THIS client's pipeline that recorded an entry.
+///
+/// Not one of `tga audit`'s nine stages: those are the child's, and by the time
+/// a package is assembled the child's stage boundaries have been collapsed into
+/// its exit status and the gap lines its manifest states. These five are the
+/// phases this crate itself can attribute a record to.
+mod stage {
+    /// A target that never reached the sweep — it did not clone.
+    pub(super) const CLONE: &str = "clone";
+    /// Resolving the engagement's registered work-item boards.
+    pub(super) const BOARDS: &str = "boards";
+    /// One repository's `tga audit` child, and the legs that run around it.
+    pub(super) const REPOSITORY: &str = "repository";
+    /// The engagement config, as this version of the client reads it.
+    pub(super) const CONFIG: &str = "config";
+}
+
+/// Whether the run stopped for this entry or carried on with less.
+mod kind {
+    /// The run did not produce this target's report.
+    pub(super) const FAILURE: &str = "failure";
+    /// The run continued, with a dimension it could not assess.
+    pub(super) const DEGRADATION: &str = "degradation";
+    /// The target was never attempted, so there is no result to degrade.
+    pub(super) const NOT_ATTEMPTED: &str = "not-attempted";
+    /// The config asked for something this version does not act on.
+    pub(super) const NOT_ACTED_ON: &str = "not-acted-on";
+}
+
+/// The `errors/digest.json` document.
+#[derive(Debug, Serialize)]
+struct ErrorDigest {
+    generated_by: String,
+    /// When the digest was written — the package's clock, not the sweep's.
+    generated_at: String,
+    /// Every failure and degradation, in pipeline order. Empty on a clean run.
+    entries: Vec<DigestEntry>,
+}
+
+/// One thing that went wrong, in the shape every reader gets.
+#[derive(Debug, Serialize)]
+struct DigestEntry {
+    /// Which phase recorded it — see [`stage`].
+    stage: &'static str,
+    /// Whether the run stopped for it — see [`kind`].
+    kind: &'static str,
+    /// When the phase recorded it. The repository's own completion time where
+    /// the sweep recorded one; otherwise the digest's `generated_at`, which is
+    /// the case for a run-wide entry and for a checkpoint written before
+    /// [`RepoRun::finished_at`] existed.
+    at: String,
+    /// The repository or board this concerns, absent for a run-wide entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<String>,
+    /// What went wrong, scrubbed of every credential this process can name.
+    message: String,
+}
+
+/// Flatten everything the run recorded into the digest document.
+///
+/// # Postconditions
+/// On `Ok`, the returned text is a JSON object carrying an `entries` array —
+/// empty when the run recorded nothing, never absent — in which no configured
+/// secret and no `gh`-derived token appears in a scrubbable form.
+///
+/// What: one entry per failed repository, one per gap line any repository
+/// stated, one per board gap, one per `unattempted` target, and one per config
+/// key this version does not act on.
+///
+/// `github_token` is the same needle [`super::credential_scan::secret_needles`]
+/// takes, and for the same reason: it reaches this process from the recipient's
+/// `gh` keychain, so [`EngagementConfig::configured_secrets`] cannot name it.
+/// Test: `super::package_tests::the_package_carries_an_error_digest_on_a_clean_run`,
+/// `super::package_tests::a_stage_failure_reaches_the_error_digest`,
+/// `super::package_tests::a_credential_in_a_digest_message_is_scrubbed_rather_than_refused`,
+/// `super::package_tests::the_error_digest_leaves_the_rest_of_the_package_unchanged`.
+///
+/// # Errors
+///
+/// [`AuditError::Package`] when the document cannot be serialised, which needs
+/// a `serde_json` failure over plain owned strings.
+pub(super) fn render(
+    report: &RunReport,
+    config: &EngagementConfig,
+    unattempted: &[String],
+    github_token: Option<&str>,
+) -> Result<String, AuditError> {
+    let generated_at = crate::index_report::local_now();
+    let mut needles: Vec<String> = config
+        .configured_secrets()
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+    if let Some(token) = github_token {
+        needles.push(token.to_owned());
+    }
+    let scrub = |message: &str| trusty_common::credentials::scrub_secrets(message, &needles);
+
+    let mut entries = Vec::new();
+    for line in unattempted {
+        entries.push(DigestEntry {
+            stage: stage::CLONE,
+            kind: kind::NOT_ATTEMPTED,
+            at: generated_at.clone(),
+            target: None,
+            message: scrub(line),
+        });
+    }
+    for gap in &report.board_gaps {
+        entries.push(DigestEntry {
+            stage: stage::BOARDS,
+            kind: kind::DEGRADATION,
+            at: generated_at.clone(),
+            target: None,
+            message: scrub(gap),
+        });
+    }
+    for run in &report.repos {
+        entries.extend(repository_entries(run, &generated_at, &scrub));
+    }
+    for key in config.unsupported_keys() {
+        entries.push(DigestEntry {
+            stage: stage::CONFIG,
+            kind: kind::NOT_ACTED_ON,
+            at: generated_at.clone(),
+            target: None,
+            message: format!(
+                "the engagement config declares `{key}` — this version of trusty-audit does not \
+                 act on it"
+            ),
+        });
+    }
+
+    let digest = ErrorDigest {
+        generated_by: format!("trusty-audit {}", env!("CARGO_PKG_VERSION")),
+        generated_at,
+        entries,
+    };
+    serde_json::to_string_pretty(&digest).map_err(|e| AuditError::Package {
+        path: std::path::PathBuf::from(super::DIGEST_ENTRY),
+        source: std::io::Error::other(e),
+    })
+}
+
+/// One repository's failure, then every gap it stated.
+///
+/// The failure and the gaps carry the SAME `stage`, because by package time
+/// they are indistinguishable in provenance — `RepoRun::gaps` merges what the
+/// child's manifest stated with what the grounding, inference-record and OSV
+/// legs appended after it, and there is no marker that separates them. `kind`
+/// is what tells a reader whether the run stopped: a repository can state gaps
+/// and still succeed, which is the ordinary case (#6078).
+fn repository_entries(
+    run: &RepoRun,
+    generated_at: &str,
+    scrub: &impl Fn(&str) -> String,
+) -> Vec<DigestEntry> {
+    let at = run
+        .finished_at
+        .clone()
+        .unwrap_or_else(|| generated_at.to_owned());
+    let mut entries = Vec::new();
+    if let RepoResult::Failed { reason } = &run.result {
+        entries.push(DigestEntry {
+            stage: stage::REPOSITORY,
+            kind: kind::FAILURE,
+            at: at.clone(),
+            target: Some(run.repo.name.clone()),
+            message: scrub(reason),
+        });
+    }
+    for gap in &run.gaps {
+        entries.push(DigestEntry {
+            stage: stage::REPOSITORY,
+            kind: kind::DEGRADATION,
+            at: at.clone(),
+            target: Some(run.repo.name.clone()),
+            message: scrub(gap),
+        });
+    }
+    entries
+}

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -52,6 +52,13 @@ pub(super) struct Generated {
     /// `None` when the sweep had no failures: a `failures/` directory holding
     /// an index that says "none" reads worse than no directory at all (#6245).
     pub(super) failures: Option<String>,
+    /// [`super::DIGEST_ENTRY`] — every failure and degradation, machine-readable.
+    ///
+    /// Not an `Option`: a clean run ships a digest with an empty `entries`
+    /// array, which is what distinguishes "the collector ran and found nothing"
+    /// from "this client is too old to write one" (#6032). Rendered by
+    /// [`super::error_digest::render`].
+    pub(super) digest: String,
 }
 
 /// The generated `package.toml`.
@@ -386,7 +393,8 @@ pub(super) fn render_readme(
          | `package.toml` | which repositories were audited, at which tool versions |\n\
          | `reports/index.md` | start here — what every file below is, and a link to each report |\n\
          | `reports/<repo>/` | the rendered report and manifest for one repository |\n\
-         | `extract/<repo>.db` | the tga extract database those reports were computed from |\n\n\
+         | `extract/<repo>.db` | the tga extract database those reports were computed from |\n\
+         | `errors/digest.json` | every failure and degradation this run recorded — send it back so the auditor can fix them |\n\n\
          ## What is not inside\n\n\
          - **No credential.** The OpenRouter key in your engagement config never \
          reaches this package; every file was scanned for it while the zip was written.\n\

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -765,6 +765,10 @@ async fn run_one(
         gaps,
         resumed: false,
         duration_ms: Some(millis(started.elapsed())),
+        // #6032: the clock the return package's error digest stamps this
+        // repository's entries with. Read here, at the one point that knows
+        // this repository is finished.
+        finished_at: Some(crate::index_report::local_now()),
         result,
     })
 }
@@ -1640,6 +1644,7 @@ exit 0
             gaps: Vec::new(),
             resumed: false,
             duration_ms: None,
+            finished_at: None,
             result: RepoResult::Succeeded,
         };
         let bad = RepoRun {

--- a/crates/trusty-audit/src/run/report.rs
+++ b/crates/trusty-audit/src/run/report.rs
@@ -79,6 +79,24 @@ pub struct RepoRun {
     /// Test: `super::run_tests::a_swept_repository_records_how_long_it_took`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
+    /// When this repository's run ended, as a local timestamp (#6032).
+    ///
+    /// Why: the return package's error digest states WHEN each failure and each
+    /// degradation was recorded, so an auditor reading it at a distance can line
+    /// an entry up against the operator's own logs. `duration_ms` alone cannot
+    /// answer that — it says how long, never when. Recorded on the checkpoint
+    /// for the same reason `duration_ms` is: `super::checkpoint::plan`'s
+    /// `..entry.clone()` carries it over, so a RESUMED entry keeps the clock of
+    /// the run that actually did the work rather than the second it took to
+    /// verify the output.
+    ///
+    /// What: [`crate::index_report::local_now`]'s format, which is what every
+    /// other timestamp this crate writes uses. `None` for a repository no run
+    /// recorded one for — a checkpoint written before this field existed reads
+    /// that way, and the digest falls back to its own generation time.
+    /// Test: `crate::package::package_tests::a_stage_failure_reaches_the_error_digest`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<String>,
     /// How it ended.
     pub result: RepoResult,
 }

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -2003,6 +2003,7 @@ trusty-review = "0.0.0-never-published"
             gaps: Vec::new(),
             resumed: false,
             duration_ms: None,
+            finished_at: None,
             result: RepoResult::Succeeded,
         }];
         run::checkpoint::write_progress(
@@ -2059,6 +2060,7 @@ trusty-review = "0.0.0-never-published"
                     gaps: Vec::new(),
                     resumed: false,
                     duration_ms: None,
+                    finished_at: None,
                     result: RepoResult::Succeeded,
                 }],
                 run::github_issues::GithubCredentialRecord::NoToken,
@@ -2115,6 +2117,7 @@ trusty-review = "0.0.0-never-published"
             gaps: Vec::new(),
             resumed: false,
             duration_ms: None,
+            finished_at: None,
             result: RepoResult::Succeeded,
         }]);
         write_finished_progress(session.work_dir(), &report);


### PR DESCRIPTION
Refs #6032

The return package now carries `errors/digest.json`. A run recorded its failures
in four shapes and the recipient could reach none of them as a set: a failed
repository in `package.toml` and `failures/index.md`, a degraded leg as one line
inside the report's Gaps & Caveats, a board gap and an unacted-on config key only
in the printed `excluded` list. The digest flattens all four into one JSON
document — `stage`, `kind`, `at`, `target`, `message` per entry — so the operator
can send the errors back for fixing, which is the owner directive quoted in the
issue.

## Design

- **Derived from the sweep's own `RunReport`, not a new journal.** A gap in the
  report's Gaps & Caveats and its digest entry are the same string from the same
  run, which is closure condition 4 met by construction rather than by
  correlation.
- **Written on every run, empty `entries` array included**, so an empty digest
  states that the collector ran. That is the opposite choice from
  `failures/index.md`, which stays absent on a clean sweep — that member is prose
  a human reads, this one is a record a program reads.
- **Scrubbed, then refused.** Each message goes through
  `trusty_common::credentials::scrub_secrets` over `configured_secrets()` plus the
  `gh`-derived token as the entry is built; the rendered document then goes
  through `credential_scan::refuse_if_credential` in `fill_archive` like every
  other generated member. Not redundant: `scrub_secrets` declines a needle under
  8 characters, and the refusal is what still catches that one. Scrubbing rather
  than refusing is deliberate for this member alone — refusing the whole package
  because one error message quoted the key would leave the auditor with neither
  the package nor the digest. The refusal for every other member is unchanged,
  which `a_failure_record_carrying_a_credential_is_refused` still holds.
- `RepoRun::finished_at` records when each repository's run ended, so an entry
  carries the repository's own clock rather than the package's. `#[serde(default,
  skip_serializing_if)]`, so an existing `state/run-progress.toml` still parses,
  and `checkpoint::plan`'s `..entry.clone()` carries it over for a resumed entry.

Additive: `package::DIGEST_ENTRY` and `RepoRun::finished_at` are the only new
public items; no existing member, signature or struct shape changed.

## Review

`code-critic`: **APPROVE** on `28d1392bf`. Security scan: **CLEAN**.

## Gates — rung 5

```
cargo fmt --check                                          FMT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings  EXIT=0
cargo test -p trusty-audit --no-fail-fast                  EXIT=0
```

Per-target lines, every target run:

```
unittests src/lib.rs                  ok. 956 passed; 0 failed; 5 ignored
unittests src/main.rs (taudit)        ok.   0 passed
unittests src/main.rs (trusty_audit)  ok.   0 passed
tests/binary_names.rs                 ok.   3 passed; 0 failed; 0 ignored
tests/cli_end_to_end.rs               ok.   5 passed; 0 failed; 0 ignored
tests/guided_launch.rs                ok.   4 passed; 0 failed; 0 ignored
tests/install_fails_closed.rs         ok.   4 passed; 0 failed; 2 ignored
tests/render_zero_arg.rs              ok.   8 passed; 0 failed; 0 ignored
tests/run_fails_closed.rs             ok.   9 passed; 0 failed; 0 ignored
```

Doc and workflow gates:

```
line-cap: measured 4553 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.
test-pointers: resolved 31508 Test: citation(s) — 0 dangling pointers — OK.
sld-lint: scanned 63 spec doc(s) + 3692 code file(s); 0 error(s), 0 warning(s)
changelog-fragment gate: all 1 crate(s) with source changes are recorded.
check-pr-version-bump: clear (0 warning(s)).  [ OK ] trusty-audit 0.14.3 — src changed, version not yet published
```

## Negative control — the regression tests provably fail without the change

`(DIGEST_ENTRY, Some(generated.digest))` removed from `fill_archive`, everything
else identical:

```
test package::package_tests::a_credential_in_a_digest_message_is_scrubbed_rather_than_refused ... FAILED
test package::package_tests::a_stage_failure_reaches_the_error_digest ... FAILED
test package::package_tests::the_package_carries_an_error_digest_on_a_clean_run ... FAILED
test package::package_tests::the_error_digest_leaves_the_rest_of_the_package_unchanged ... ok
test result: FAILED. 3 passed; 3 failed; 0 ignored; 955 filtered out
```

with the clean-run assertion printing the pre-#6032 member set:

```
thread 'package::package_tests::the_package_carries_an_error_digest_on_a_clean_run'
panicked at crates/trusty-audit/src/package.rs:1039:9:
["README.md", "package.toml", "reports/index.md", "reports/report.json",
 "extract/00-acme-api.db", "reports/00-acme-api/manifest.toml",
 "reports/00-acme-api/report.md"]
```

The additive test passing under the control is correct — it asserts the *other*
members are unchanged, so it holds either way; it is the guard, not the proof.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
