### PR TITLE
feat(trusty-memory): palace_verify_embedded falls back to a palace index (#6318)

### DIFF
--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -296,7 +296,7 @@ this table is generated from it, not maintained by hand.
 | `palace_reembed` | `palace`, `dry_run?`, `limit?` | #4906: report drawers that have no vector (durable but unfindable), and optionally re-embed them. |
 | `palace_unalias` | `palace`, `dry_run?` | #5005: free drawers whose vector was destroyed by an id collision (`palace_reembed` reports these as `aliased`), so a re-embed can repair… |
 | `palace_update` | `palace_id`, `name` | Update the display name of an existing palace. |
-| `palace_verify_embedded` | `palace`, `drawer_ids` | #5000: answer whether YOUR OWN drawer ids are vector-findable. |
+| `palace_verify_embedded` | `drawer_ids`, `palace?` | #5000: answer whether YOUR OWN drawer ids are vector-findable. |
 | `remove_prompt_fact` | `subject`, `predicate` | Retract the active triple for a (subject, predicate) pair from the prompt-facts surface. |
 | `room_create` | `palace`, `label`, `description?`, `wing?` | Create a room in a palace, or return the existing one (ADR-0027). |
 | `room_list` | `palace?`, `wing?` | List every room registered in a palace (ADR-0027). |

--- a/crates/trusty-memory/changelog.d/6318-verify-embedded-index-fallback.md
+++ b/crates/trusty-memory/changelog.d/6318-verify-embedded-index-fallback.md
@@ -1,0 +1,6 @@
+Changed
+
+- **`palace_verify_embedded` called with no palace now returns the same palace index the other read tools return.** It was the one palace-scoped READ tool left out of the first wave, because `embed_audit.rs` was being changed concurrently; it now calls the same `resolve_palace_or_index` helper and answers a call with no `palace` argument and no `--palace` default with a successful, structured index — every palace on the host, ordered most-recently-used first, with drawer / room / wing counts, a row per room, and a `hint` naming the retry. Before this it returned `Err("palace_verify_embedded: missing 'palace' (no --palace default configured)")` (owner ruling 2026-08-27, [#6318](https://github.com/bobmatnyc/trusty-tools/issues/6318))
+  - The index is decided before `drawer_ids` is validated, so a caller who does not yet know which palace to name is told which palaces exist rather than that its ids are missing
+  - `palace` is gone from the tool's `inputSchema` `required` list on both schema branches, so a compliant MCP client can omit it; `drawer_ids` stays required
+  - Behaviour with an explicit or a defaulted palace is unchanged, and `palace_embed_sweep` — which never took a palace — is untouched. A `verified: true` gate cannot be passed by an index, so `tm memory import --refresh` still fails closed

--- a/crates/trusty-memory/src/tools/embed_audit.rs
+++ b/crates/trusty-memory/src/tools/embed_audit.rs
@@ -39,7 +39,10 @@ use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use super::helpers::{open_palace_handle, resolve_palace};
+use super::helpers::open_palace_handle;
+// #6318: `palace_verify_embedded` reads, so it falls back to a palace index.
+// `palace_embed_sweep` takes no palace at all, so nothing there changes.
+use super::palace_index::{resolve_palace_or_index, PalaceScope};
 use crate::AppState;
 
 /// Read a palace's coverage into the shape both handlers report.
@@ -99,18 +102,29 @@ fn audit_state(audit: &trusty_common::memory_core::retrieval::AliasAudit) -> &'s
 /// clean, so an id-collision victim (which HAS a vector key and is still
 /// unreachable) cannot pass.
 ///
+/// #6318: this reads, so a call with no `palace` argument and no `--palace`
+/// default succeeds with the palace index instead of erroring. The index is
+/// decided before `drawer_ids` is validated, so a caller who does not yet know
+/// which palace to name learns that first rather than being told its ids are
+/// missing.
+///
 /// # Errors
 ///
-/// When the palace cannot be resolved or opened, or when `drawer_ids` is absent,
-/// empty, or holds a value that is not a UUID. A malformed id is refused rather
-/// than skipped: a caller about to delete files must not have one of its ids
+/// When a NAMED palace cannot be opened, or when `drawer_ids` is absent, empty,
+/// or holds a value that is not a UUID. A malformed id is refused rather than
+/// skipped: a caller about to delete files must not have one of its ids
 /// silently dropped from the answer.
 ///
 /// Test: `verify_embedded_names_the_unembedded_id`,
 /// `verify_embedded_separates_an_unknown_id_from_an_unembedded_one`,
-/// `verify_embedded_refuses_a_malformed_id`.
+/// `verify_embedded_refuses_a_malformed_id`,
+/// `every_read_tool_returns_an_index_with_no_palace`.
 pub(crate) async fn handle_palace_verify_embedded(state: &AppState, args: Value) -> Result<Value> {
-    let palace = resolve_palace(state, &args, "palace_verify_embedded")?;
+    // #6318: no palace and no default is answered with an index, not an error.
+    let palace = match resolve_palace_or_index(state, &args, "palace_verify_embedded").await? {
+        PalaceScope::Palace(p) => p,
+        PalaceScope::Index(index) => return Ok(index),
+    };
     let raw = args
         .get("drawer_ids")
         .and_then(|v| v.as_array())

--- a/crates/trusty-memory/src/tools/embed_audit_definitions.rs
+++ b/crates/trusty-memory/src/tools/embed_audit_definitions.rs
@@ -5,10 +5,13 @@
 //! adding to it fails the build with `recursion limit reached while expanding
 //! json_internal`. Splicing is the pattern the task, chat, room and wing groups
 //! already use, for the 500-SLOC cap; this group joins it for a second reason.
-//! What: returns `[palace_verify_embedded, palace_embed_sweep]`, conditioned on
-//! `has_default` the same way every other group is.
+//! What: returns `[palace_verify_embedded, palace_embed_sweep]`. It keeps every
+//! other group's `has_default` parameter for a uniform splice signature and
+//! ignores it: #6318 made `palace` optional for the reading tool, and the
+//! sweeping one never took a palace, so neither schema varies by branch.
 //! Test: spliced into `tool_definitions_with`; covered by
-//! `tool_definitions_lists_all_tools` in `tools::tests`.
+//! `tool_definitions_lists_all_tools` in `tools::tests` and
+//! `read_tool_schemas_never_require_palace` in `tools::tests::palace_index_tests`.
 
 use serde_json::{json, Value};
 
@@ -19,17 +22,17 @@ use serde_json::{json, Value};
 /// a proxy for "is it findable", `console_metrics` as a health sweep. The schema
 /// is where a model reads that, so it says which cheaper answer is wrong and
 /// what to use instead.
-/// Test: `tool_definitions_lists_all_tools`.
-pub(super) fn embed_audit_tool_definitions(has_default: bool) -> Vec<Value> {
-    let palace_required: Vec<&str> = if has_default {
-        vec!["drawer_ids"]
-    } else {
-        vec!["palace", "drawer_ids"]
-    };
+/// Test: `tool_definitions_lists_all_tools`, `read_tool_schemas_never_require_palace`.
+pub(super) fn embed_audit_tool_definitions(_has_default: bool) -> Vec<Value> {
+    // #6318: `palace_verify_embedded` reads, so `palace` is never required —
+    // with neither an argument nor a `--palace` default it answers with a
+    // palace index. `drawer_ids` stays required on both branches, which leaves
+    // this group with nothing left to condition on `has_default`.
+    let verify_required: Vec<&str> = vec!["drawer_ids"];
     vec![
         json!({
             "name": "palace_verify_embedded",
-            "description": "#5000: answer whether YOUR OWN drawer ids are vector-findable. Gate a migration or deletion on the single `verified` boolean — it is true only when every id you asked about is embedded AND the alias audit is clean, so a drawer lost to an id collision (which has a vector key and is still unreachable) cannot pass it. The three lists say why: `missing` exists with no vector, `unknown` is not a drawer in this palace at all. `memory_recall` is NOT a substitute — it can hit lexically and pass on a drawer no vector search will ever return. Reach for `palace_reembed` instead when you want the palace's whole missing set rather than an answer about specific ids.",
+            "description": "#5000: answer whether YOUR OWN drawer ids are vector-findable. Gate a migration or deletion on the single `verified` boolean — it is true only when every id you asked about is embedded AND the alias audit is clean, so a drawer lost to an id collision (which has a vector key and is still unreachable) cannot pass it. The three lists say why: `missing` exists with no vector, `unknown` is not a drawer in this palace at all. `memory_recall` is NOT a substitute — it can hit lexically and pass on a drawer no vector search will ever return. Reach for `palace_reembed` instead when you want the palace's whole missing set rather than an answer about specific ids. #6318: with no `palace` and no server default this returns a palace index (ids, counts, rooms, `hint`) as a successful result instead of an error.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -40,7 +43,7 @@ pub(super) fn embed_audit_tool_definitions(has_default: bool) -> Vec<Value> {
                         "description": "Drawer UUIDs to verify. A malformed entry is refused, never skipped."
                     }
                 },
-                "required": palace_required,
+                "required": verify_required,
             }
         }),
         json!({

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -133,7 +133,9 @@ fn tool_definitions_drops_palace_required_when_default_set() {
         ("palace_unalias", true),
         // #5000: `palace_embed_sweep` is absent on purpose — it takes no
         // arguments at all, so it has no conditional `palace` to drop.
-        ("palace_verify_embedded", true),
+        // #6318: `palace_verify_embedded` reads, so `palace` is required on
+        // neither branch.
+        ("palace_verify_embedded", false),
         ("kg_assert", true),
         ("kg_query", false),
         // Issue #664: add_alias and discover_aliases now include `palace`

--- a/crates/trusty-memory/src/tools/tests/palace_index_tests.rs
+++ b/crates/trusty-memory/src/tools/tests/palace_index_tests.rs
@@ -16,8 +16,7 @@ use crate::tools::palace_index::PALACE_INDEX_DETAIL_LIMIT;
 /// The palace-scoped READ tools that answer a no-palace call with an index.
 ///
 /// Why: one list, so a new read tool is added here rather than growing a
-/// fourteenth near-identical test. `palace_verify_embedded` is absent on
-/// purpose — it is being changed under #6836 and joins this list there.
+/// fifteenth near-identical test.
 /// What: every tool name whose handler calls `resolve_palace_or_index`.
 const READ_TOOLS: &[&str] = &[
     "memory_recall",
@@ -33,6 +32,10 @@ const READ_TOOLS: &[&str] = &[
     "chat_session_get",
     "chat_session_list",
     "chat_session_recall",
+    // #6318: deferred from the first wave while #6995 held `embed_audit.rs`.
+    // Its empty-args dispatch also pins that the index is decided before
+    // `drawer_ids` is validated.
+    "palace_verify_embedded",
 ];
 
 /// The mutating tools that still refuse a no-palace call.


### PR DESCRIPTION
PR #6998 converted thirteen palace-scoped READ tools to `resolve_palace_or_index`, so a call with no `palace` argument and no `--palace` default answers with a structured index of the palaces on the host instead of erroring. `palace_verify_embedded` was left out of that wave because #6995 was changing `embed_audit.rs` at the same time. Both are on main, so it joins them here — same helper, same payload shape.

The index is decided before `drawer_ids` is validated, matching the other thirteen: a caller who does not yet know which palace to name learns which palaces exist rather than being told its ids are missing. `palace_index_tests` already pins that ordering for the whole read roster.

`palace` is gone from the tool's `inputSchema` `required` list on both schema branches, so a compliant MCP client can omit it. `drawer_ids` stays required, which leaves the embed-audit group with nothing to condition on `has_default`. The README's generated tool table was regenerated to match.

Behaviour with an explicit or a defaulted palace is unchanged, and `palace_embed_sweep` — which never took a palace — is untouched. The one cross-crate consumer, `trusty-mpm`'s `memory_import::refresh`, always passes an explicit palace; if it ever reached this path an index carries no `verified: true`, so `tm memory import --refresh` fails closed.

## Regression proof

With only `embed_audit.rs` and `embed_audit_definitions.rs` reverted to `origin/main`, `cargo test -p trusty-memory --lib palace_index_tests`:

```
test result: FAILED. 6 passed; 2 failed; 0 ignored; 0 measured; 856 filtered out

panicked at crates/trusty-memory/src/tools/tests/palace_index_tests.rs:101:33:
palace_verify_embedded must not error with no palace: palace_verify_embedded: missing 'palace' (no --palace default configured)

panicked at crates/trusty-memory/src/tools/tests/palace_index_tests.rs:304:13:
palace_verify_embedded still requires palace: ["palace", "drawer_ids"]
```

Same command with the change restored: `ok. 8 passed; 0 failed`.

## Gates — rung 3 (localized behavior inside one crate)

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `SKIP_UI_BUILD=1 cargo clippy -p trusty-memory --all-targets -- -D warnings` | pass |
| `SKIP_UI_BUILD=1 cargo test -p trusty-memory --no-fail-fast` | 31 targets ran; 860 lib + 13 bin + 113 integration passed, 0 failed, 10 ignored (pre-existing ONNX/perf) |
| `./scripts/check_line_cap.sh` | 4559 files, 0 violations |
| `./scripts/check_test_pointers.sh` | 31527 citations, 0 dangling |
| `./scripts/check_sld.sh` | 0 errors, 0 warnings |
| `./scripts/check_changelog_fragment.sh` | fragment present and valid |
| `./scripts/check-pr-version-bump.sh` | clear, no bump required |

Refs #6318

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
