### PR TITLE
refactor(trusty-review): route Bedrock region and client through the shared adapter (Refs #5469)

### DIFF
--- a/crates/trusty-common/changelog.d/5469-bedrock-adapter-consumer-knobs.md
+++ b/crates/trusty-common/changelog.d/5469-bedrock-adapter-consumer-knobs.md
@@ -1,0 +1,3 @@
+Added
+
+- `inference::bedrock` exposes the three pieces a consumer with its own Converse call path needs: `resolve_bedrock_region` and the pure `resolve_region_from` walk behind it, the `DEFAULT_REGION` constant, `BedrockAdapter::client` (the lazily-built Converse client), and `BedrockAdapter::with_client` (an injection seam for a pre-built, credential-free client). trusty-review's `BedrockProvider` routes through these instead of resolving the region and building an AWS client itself

--- a/crates/trusty-common/src/inference/bedrock/mod.rs
+++ b/crates/trusty-common/src/inference/bedrock/mod.rs
@@ -62,28 +62,57 @@ const ENV_REGION_TRUSTY: &str = "TRUSTY_AWS_REGION";
 /// Region env var: standard AWS fallback.
 const ENV_REGION_AWS: &str = "AWS_REGION";
 /// Default AWS region when neither env var is set.
-const DEFAULT_REGION: &str = "us-east-1";
+///
+/// #5469: public so a consumer that reports the resolved region — trusty-review's
+/// `BedrockProvider` — names this constant rather than repeating the literal.
+pub const DEFAULT_REGION: &str = "us-east-1";
 
 /// Resolve the AWS region for the Bedrock client.
 ///
 /// Why: operators may specify region via either `TRUSTY_AWS_REGION`
 /// (trusty-specific) or `AWS_REGION` (standard); the trusty var takes precedence.
-/// What: returns the first non-empty value, in priority order: `explicit`, then
-/// `TRUSTY_AWS_REGION`, then `AWS_REGION`, else `"us-east-1"`.
-/// Test: `super::tests::region_resolution_*`.
-pub(crate) fn resolve_bedrock_region(explicit: Option<&str>) -> String {
+/// #5469: public so trusty-review resolves the region through this walk instead
+/// of its own copy of it.
+/// What: reads the two env tiers and hands them to [`resolve_region_from`], which
+/// returns the first non-empty value in priority order: `explicit`, then
+/// `TRUSTY_AWS_REGION`, then `AWS_REGION`, else [`DEFAULT_REGION`].
+/// Test: `super::tests::region_resolution_explicit_wins`,
+/// `super::tests::region_resolution_trusty_env_wins_over_aws_env`,
+/// `super::tests::region_resolution_aws_env_fallback`,
+/// `super::tests::region_resolution_defaults_to_us_east_1`.
+pub fn resolve_bedrock_region(explicit: Option<&str>) -> String {
+    let trusty_env = std::env::var(ENV_REGION_TRUSTY).ok();
+    let aws_env = std::env::var(ENV_REGION_AWS).ok();
+    resolve_region_from(explicit, trusty_env.as_deref(), aws_env.as_deref())
+}
+
+/// Pick the first non-empty region among the four precedence tiers.
+///
+/// Why: [`resolve_bedrock_region`] reads process-wide env vars, so a test of its
+/// precedence either inherits the developer's `AWS_REGION` or has to mutate
+/// global state and race every other test in the binary. Taking the two env
+/// tiers as arguments makes the ordering provable with neither hazard (#5706,
+/// where trusty-review first drew this split; #5469 moved it here so the two
+/// crates share one walk).
+/// What: returns `explicit` > `trusty_env` > `aws_env` > [`DEFAULT_REGION`].
+/// An empty `explicit` counts as unset; an env tier is trimmed first, so a
+/// whitespace-only value counts as unset too.
+/// Test: `super::tests::region_precedence_walk_tiers`.
+pub fn resolve_region_from(
+    explicit: Option<&str>,
+    trusty_env: Option<&str>,
+    aws_env: Option<&str>,
+) -> String {
     if let Some(r) = explicit.filter(|s| !s.is_empty()) {
         return r.to_string();
     }
-    for var in [ENV_REGION_TRUSTY, ENV_REGION_AWS] {
-        if let Ok(val) = std::env::var(var) {
-            let val = val.trim().to_string();
-            if !val.is_empty() {
-                return val;
-            }
-        }
-    }
-    DEFAULT_REGION.to_string()
+    [trusty_env, aws_env]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_REGION)
+        .to_string()
 }
 
 /// AWS Bedrock Converse API inference adapter.
@@ -126,6 +155,27 @@ impl BedrockAdapter {
         }
     }
 
+    /// Construct a `BedrockAdapter` around an already-built Converse client.
+    ///
+    /// Why (#5469): a consumer that drives the Converse API itself —
+    /// trusty-review's `BedrockProvider`, which keeps its own error mapping,
+    /// pricing, and tool-use extraction — needs to inject a client built with
+    /// `no_credentials()` so its unit tests exercise provider logic with no AWS
+    /// reachable. The lazy `OnceCell` has no other seam for that, and without
+    /// this knob the consumer keeps a private client field, which is the
+    /// duplication this adapter exists to remove.
+    /// What: stores `region` verbatim (no env walk — the caller has already
+    /// resolved it) and pre-fills the client cell, so [`Self::client`] returns
+    /// the injected client and never loads AWS config.
+    /// Test: `super::tests::with_client_prefills_the_lazy_cell`.
+    pub fn with_client(region: impl Into<String>, client: BedrockRuntimeClient) -> Self {
+        Self {
+            region: region.into(),
+            client: OnceCell::new_with(Some(client)),
+            capabilities: *capabilities(ProviderId::Bedrock),
+        }
+    }
+
     /// The AWS region this adapter is configured for.
     ///
     /// Why: exposed for diagnostics and the region-resolution tests.
@@ -140,11 +190,15 @@ impl BedrockAdapter {
     /// Why: AWS credential/region resolution is async and must never run for an
     /// adapter that is built but never used; `OnceCell::get_or_try_init`
     /// guarantees at most one build and lets a failed attempt be retried on the
-    /// next `chat` rather than poisoning the adapter.
+    /// next `chat` rather than poisoning the adapter. #5469: public because a
+    /// consumer with its own Converse call path (trusty-review) borrows this
+    /// client rather than constructing a second one.
     /// What: loads AWS config pinned to [`Self::region`] via the standard
-    /// credential chain and builds a `BedrockRuntimeClient` on first use.
-    /// Test: exercised indirectly by the `#[ignore]`-gated live Converse call.
-    async fn client(&self) -> Result<&BedrockRuntimeClient, InferenceError> {
+    /// credential chain and builds a `BedrockRuntimeClient` on first use; an
+    /// adapter built by [`Self::with_client`] returns the injected client.
+    /// Test: `super::tests::with_client_prefills_the_lazy_cell`; the build path
+    /// is exercised by the `#[ignore]`-gated live Converse call.
+    pub async fn client(&self) -> Result<&BedrockRuntimeClient, InferenceError> {
         self.client
             .get_or_try_init(|| async {
                 let config = aws_config::defaults(BehaviorVersion::latest())

--- a/crates/trusty-common/src/inference/bedrock/tests.rs
+++ b/crates/trusty-common/src/inference/bedrock/tests.rs
@@ -12,6 +12,7 @@
 
 use std::collections::VecDeque;
 
+use aws_sdk_bedrockruntime::Client as BedrockRuntimeClient;
 use aws_sdk_bedrockruntime::operation::converse::ConverseOutput as ConverseOutputResponse;
 use aws_sdk_bedrockruntime::types::{
     CachePointType, ContentBlock, ContentBlockDelta as SdkContentBlockDelta,
@@ -30,7 +31,10 @@ use super::convert::{
     document_to_json_string, json_to_document,
 };
 use super::stream::{ConverseEventSource, drive};
-use super::{BedrockAdapter, bedrock_model_id, build_converse_parts, resolve_bedrock_region};
+use super::{
+    BedrockAdapter, DEFAULT_REGION, bedrock_model_id, build_converse_parts, resolve_bedrock_region,
+    resolve_region_from,
+};
 use crate::inference::adapter::InferenceAdapter;
 use crate::inference::error::InferenceError;
 use crate::inference::streaming::{ChatStreamEvent, StreamAssembly, ToolCallDelta};
@@ -165,6 +169,83 @@ async fn region_resolution_defaults_to_us_east_1() {
         assert_eq!(resolve_bedrock_region(None), "us-east-1");
     })
     .await;
+}
+
+/// The pure precedence walk pins explicit > `TRUSTY_AWS_REGION` > `AWS_REGION` >
+/// default without touching the environment.
+///
+/// Why (#5469): trusty-review resolved the Bedrock region with its own copy of
+/// this walk and now calls this one; the ordering it relied on has to stay
+/// provable here, at the single definition, and provable without the env
+/// mutation the four tests above need. Reorder the tiers in
+/// [`super::resolve_region_from`] and every assertion below fails.
+/// What: drives each tier with both env tiers passed as arguments — explicit
+/// winning, an empty explicit falling through, the trusty tier beating the AWS
+/// tier, the AWS tier as the last env stop, the default when nothing is set,
+/// and the trim that makes a whitespace-only env value count as unset.
+/// Test: this test.
+#[test]
+fn region_precedence_walk_tiers() {
+    assert_eq!(
+        resolve_region_from(Some("eu-west-1"), Some("ap-south-1"), Some("us-west-2")),
+        "eu-west-1",
+        "explicit must win over both env tiers"
+    );
+    assert_eq!(
+        resolve_region_from(Some(""), Some("ap-south-1"), Some("us-west-2")),
+        "ap-south-1",
+        "an empty explicit falls through to TRUSTY_AWS_REGION"
+    );
+    assert_eq!(
+        resolve_region_from(None, None, Some("us-west-2")),
+        "us-west-2",
+        "AWS_REGION is used when TRUSTY_AWS_REGION is unset"
+    );
+    assert_eq!(
+        resolve_region_from(None, None, None),
+        DEFAULT_REGION,
+        "nothing set reaches the default"
+    );
+    assert_eq!(
+        resolve_region_from(Some(""), Some("  "), Some("\t")),
+        DEFAULT_REGION,
+        "a whitespace-only env var counts as unset"
+    );
+    assert_eq!(
+        resolve_region_from(None, Some(" eu-central-1 "), None),
+        "eu-central-1",
+        "an env tier is trimmed before use"
+    );
+}
+
+/// `with_client` seeds the lazy cell so `client()` never loads AWS config.
+///
+/// Why (#5469): the injection seam trusty-review's unit tests depend on — they
+/// build a `no_credentials()` client and expect the adapter to hand back exactly
+/// that one. A `with_client` that left the cell empty would silently fall back
+/// to the credential chain and make those tests reach for real AWS config.
+/// What: builds a credential-free client, wraps it with `with_client`, and
+/// asserts the cell is already populated and that `client()` resolves without
+/// error against the region passed verbatim.
+/// Test: this test.
+#[tokio::test]
+async fn with_client_prefills_the_lazy_cell() {
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(aws_types::region::Region::new("eu-west-1"))
+        .no_credentials()
+        .load()
+        .await;
+    let adapter = BedrockAdapter::with_client("eu-west-1", BedrockRuntimeClient::new(&config));
+
+    assert!(
+        adapter.client.get().is_some(),
+        "with_client must pre-fill the lazy client cell"
+    );
+    assert_eq!(adapter.region(), "eu-west-1", "region is stored verbatim");
+    assert!(
+        adapter.client().await.is_ok(),
+        "client() must return the injected client"
+    );
 }
 
 // ─── Message conversion ─────────────────────────────────────────────────────

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -202,7 +202,11 @@ clap         = { workspace = true }
 # it: the serve transport depends on `uds::server` directly now, and an implied
 # feature is one refactor away from disappearing under a consumer that never
 # said it needed it.
-trusty-common = { workspace = true, features = ["intent-source", "config-cli", "webhook-relay", "gh-cli", "uds", "uds-supervisor", "redb-open"] }  # `redb-open` (#5063): the workspace's single redb corruption classifier, which `store::redb_error_is_incompatible_format` delegates to
+# `bedrock-client` (#5469): the shared `inference::bedrock::BedrockAdapter`,
+# which owns AWS region resolution and Converse-client construction for this
+# crate's `llm::bedrock` provider — the one implementation of both, per
+# CLAUDE.md's common-entry-point rule.
+trusty-common = { workspace = true, features = ["intent-source", "bedrock-client", "config-cli", "webhook-relay", "gh-cli", "uds", "uds-supervisor", "redb-open"] }  # `redb-open` (#5063): the workspace's single redb corruption classifier, which `store::redb_error_is_incompatible_format` delegates to
 # JSON-RPC / MCP primitives (ADR-0040, #5803). Optional: only the `mcp` feature
 # compiles `src/mcp/`.
 trusty-mcp = { workspace = true, optional = true }
@@ -220,9 +224,10 @@ chrono       = { workspace = true }
 
 # ── AWS Bedrock (Converse API) ─────────────────────────────────────────────
 # Reuses the same versions already pinned by trusty-analyze in [workspace.dependencies].
-# aws-sdk-bedrockruntime: Converse (non-streaming) API for LLM calls.
-# aws-config: standard credential chain (env / ~/.aws / IAM / SSO).
-# aws-types: Region type for region_provider construction.
+# aws-sdk-bedrockruntime: Converse (non-streaming) API request/response types.
+# aws-config / aws-types: #5469 moved client construction to trusty-common's
+# shared adapter, so these two are now only used by the `no_credentials()` client
+# the `llm::bedrock` unit tests inject.
 aws-sdk-bedrockruntime = { workspace = true }
 aws-config             = { workspace = true }
 aws-types              = { workspace = true }

--- a/crates/trusty-review/changelog.d/5469-bedrock-shared-adapter.md
+++ b/crates/trusty-review/changelog.d/5469-bedrock-shared-adapter.md
@@ -1,0 +1,3 @@
+Changed
+
+- `BedrockProvider` builds its region and Converse client through `trusty_common::inference::BedrockAdapter` rather than its own copy of the region walk and its own `aws_config::defaults(...)` call. Region precedence (explicit > `TRUSTY_AWS_REGION` > `AWS_REGION` > `us-east-1`), the error text, the retry policy, cost estimation, and tool-use extraction are unchanged. `BedrockProvider::new` is now synchronous and takes only the model id — the AWS client is built lazily on the first call, and the explicit-region parameter every caller passed `None` for is gone

--- a/crates/trusty-review/src/commands/mcp_stdio.rs
+++ b/crates/trusty-review/src/commands/mcp_stdio.rs
@@ -170,8 +170,9 @@ pub async fn cmd_mcp_stdio(config: ReviewConfig, args: McpArgs) -> Result<()> {
 ///
 /// Why: the MCP tool surface shares the review pipeline's dependency set with
 /// every other caller; building it here keeps the stdio entry point's startup
-/// sequencing in one place. Async because `BedrockProvider::new` loads AWS
-/// credentials asynchronously.
+/// sequencing in one place. Async because it resolves the search index from the
+/// daemon (#5469: no longer because of `BedrockProvider::new`, whose AWS client
+/// is built lazily on first use).
 /// What: builds the reviewer and verifier LLM providers, resolves the search
 /// index from the daemon, constructs the search/analyze clients, and wraps them
 /// in `AppState`. `dedup_need` is `NotNeeded` for this surface (#5064) — it

--- a/crates/trusty-review/src/commands/run.rs
+++ b/crates/trusty-review/src/commands/run.rs
@@ -420,8 +420,9 @@ pub fn dedup_need_for(diff_source: &DiffSource, allow_posting: bool) -> DedupNee
 /// Build the injected service dependencies from `ReviewConfig` and a model id.
 ///
 /// Why: both `run` and `compare` need the same set of deps; building them from
-/// config in one place avoids repetition.  Async because `BedrockProvider::new`
-/// loads AWS credentials asynchronously.
+/// config in one place avoids repetition.  Async because the search and dedup
+/// dependencies it opens are async (#5469: no longer because of
+/// `BedrockProvider::new`, whose AWS client is built lazily on first use).
 /// What: uses `build_provider` (which resolves the `bedrock/`/`openrouter/`
 /// prefix), builds the optional verifier, constructs search/analyze clients, and
 /// opens the dedup store when `dedup_need` says this invocation can post

--- a/crates/trusty-review/src/llm/bedrock/mod.rs
+++ b/crates/trusty-review/src/llm/bedrock/mod.rs
@@ -42,24 +42,16 @@ pub use tool_use::{build_tool_config, document_to_json_string, json_to_document}
 use std::time::Instant;
 
 use async_trait::async_trait;
-use aws_config::BehaviorVersion;
-use aws_sdk_bedrockruntime::Client as BedrockClient;
 use aws_sdk_bedrockruntime::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_bedrockruntime::types::{
     ContentBlock, ConversationRole, InferenceConfiguration, Message, SystemContentBlock,
 };
 use tracing::{debug, warn};
+use trusty_common::inference::BedrockAdapter;
 
 use super::{LlmProvider, LlmRequest, LlmResponse, error::LlmError};
 
 // ─── Constants ────────────────────────────────────────────────────────────────
-
-/// Region env var: trusty-specific override.
-const ENV_REGION_TRUSTY: &str = "TRUSTY_AWS_REGION";
-/// Region env var: standard AWS fallback.
-const ENV_REGION_AWS: &str = "AWS_REGION";
-/// Default AWS region when neither env var is set.
-const DEFAULT_REGION: &str = "us-east-1";
 
 /// Required prefix for Bedrock cross-region inference profiles.
 ///
@@ -81,47 +73,10 @@ const MAX_RETRIES: u32 = 3;
 
 // ─── Region resolution ────────────────────────────────────────────────────────
 
-/// Resolve the AWS region for the Bedrock client.
-///
-/// Why: operators may specify region via either `TRUSTY_AWS_REGION` (trusty-specific)
-/// or `AWS_REGION` (standard); the trusty var takes precedence.
-/// What: returns the first non-empty value of `explicit` > `TRUSTY_AWS_REGION`
-///       > `AWS_REGION` > `"us-east-1"`.
-/// Test: `bedrock_region_resolution`.
-pub fn resolve_bedrock_region(explicit: Option<&str>) -> String {
-    // #5706: read the env here so the precedence walk itself stays pure and
-    // testable without inheriting or mutating the ambient environment.
-    let trusty_env = std::env::var(ENV_REGION_TRUSTY).ok();
-    let aws_env = std::env::var(ENV_REGION_AWS).ok();
-    resolve_region_from(explicit, trusty_env.as_deref(), aws_env.as_deref())
-}
-
-/// Pick the first non-empty region among the four precedence tiers.
-///
-/// Why (#5706): [`resolve_bedrock_region`] reads process-wide env vars, so a
-/// test of its precedence either inherits the developer's `AWS_REGION` or has
-/// to mutate global state and race every other test in the binary. Taking the
-/// two env tiers as arguments makes the ordering provable with neither hazard.
-/// What: returns `explicit` > `trusty_env` > `aws_env` > [`DEFAULT_REGION`].
-/// An empty `explicit` counts as unset; an env tier is trimmed first, so a
-/// whitespace-only value counts as unset too.
-/// Test: `bedrock_region_resolution`.
-fn resolve_region_from(
-    explicit: Option<&str>,
-    trusty_env: Option<&str>,
-    aws_env: Option<&str>,
-) -> String {
-    if let Some(r) = explicit.filter(|s| !s.is_empty()) {
-        return r.to_string();
-    }
-    [trusty_env, aws_env]
-        .into_iter()
-        .flatten()
-        .map(str::trim)
-        .find(|s| !s.is_empty())
-        .unwrap_or(DEFAULT_REGION)
-        .to_string()
-}
+// #5469: the region precedence walk (explicit > TRUSTY_AWS_REGION > AWS_REGION >
+// us-east-1) lives in the shared Bedrock adapter now; this crate re-exports the
+// resolver so the public path callers already use keeps resolving.
+pub use trusty_common::inference::bedrock::resolve_bedrock_region;
 
 // ─── Model id validation ──────────────────────────────────────────────────────
 
@@ -156,22 +111,24 @@ fn validate_model_id(model_id: &str) -> Result<(), LlmError> {
 /// Why: satisfies the [`LlmProvider`] trait using Bedrock so the review
 /// pipeline works without an OpenRouter API key; uses IAM-based auth suitable
 /// for production AWS deployments.
-/// What: holds a pre-built `BedrockClient` and the resolved model id and
-/// region.  `complete` calls `Converse` (non-streaming), extracts text + token
-/// usage from the response, measures latency, computes cost, and retries up to
-/// [`MAX_RETRIES`] times for transient errors.  When `response_schema` is set,
-/// the `Converse` call includes a `ToolConfiguration` that forces the model to
-/// call the named tool; the `toolUse.input` JSON is returned as
+/// What: holds the shared [`BedrockAdapter`] — which owns region resolution and
+/// the lazily-built Converse client — plus the default model id.  `complete`
+/// calls `Converse` (non-streaming) on the adapter's client, extracts text +
+/// token usage from the response, measures latency, computes cost, and retries
+/// up to [`MAX_RETRIES`] times for transient errors.  When `response_schema` is
+/// set, the `Converse` call includes a `ToolConfiguration` that forces the model
+/// to call the named tool; the `toolUse.input` JSON is returned as
 /// `LlmResponse.text`.
 /// Test: `bedrock_converse_request_construction`,
 /// `bedrock_no_credentials_returns_error`,
 /// `bedrock_request_includes_tool_config_when_schema_set`.
 pub struct BedrockProvider {
-    client: BedrockClient,
+    /// #5469: region resolution and Converse-client construction both come from
+    /// the shared adapter; this crate keeps only the review-specific mapping.
+    adapter: BedrockAdapter,
     /// Default model id; used in error messages and as fallback when the request
     /// does not override the model.
     pub model: String,
-    region: String,
 }
 
 impl BedrockProvider {
@@ -181,55 +138,47 @@ impl BedrockProvider {
     /// (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`),
     /// `~/.aws/credentials` profiles, IMDS v2, and SSO — covering both local
     /// dev and production deployments without code changes.
-    /// What: validates the model id (requires an inference-profile prefix),
-    /// resolves the region, loads AWS config, and builds a `BedrockClient`.
-    /// Returns `LlmError::Validation` if the model id is invalid.
-    /// Async because credential loading may touch the filesystem or IMDS.
+    /// What: validates the model id (requires an inference-profile prefix) and
+    /// builds a [`BedrockAdapter`] for the ambient region (`TRUSTY_AWS_REGION` >
+    /// `AWS_REGION` > `us-east-1`).  Returns `LlmError::Validation` if the model
+    /// id is invalid.  #5469: synchronous, because the adapter builds its AWS
+    /// client lazily on the first `Converse` call; the explicit-region parameter
+    /// went with it, since every caller passed `None`.
     /// Test: `bedrock_us_prefix_validation` (validation path, no network);
     /// real-credentials path tested in ignored integration tests.
-    pub async fn new(model: impl Into<String>, region: Option<&str>) -> Result<Self, LlmError> {
+    pub fn new(model: impl Into<String>) -> Result<Self, LlmError> {
         let model = model.into();
         validate_model_id(&model)?;
-
-        let region_str = resolve_bedrock_region(region);
-        let config = aws_config::defaults(BehaviorVersion::latest())
-            .region(aws_config::meta::region::RegionProviderChain::first_try(
-                aws_types::region::Region::new(region_str.clone()),
-            ))
-            .load()
-            .await;
-        let client = BedrockClient::new(&config);
         Ok(Self {
-            client,
+            adapter: BedrockAdapter::new(None),
             model,
-            region: region_str,
         })
     }
 
-    /// Construct from a pre-built `BedrockClient` (for testing).
+    /// Construct from a pre-built Converse client (for testing).
     ///
     /// Why: tests can inject a client built with `no_credentials()` to verify
     /// provider logic without touching AWS.
-    /// What: stores the client verbatim; skips model-id validation so tests
-    /// can pass any id.
-    /// Test: used by `bedrock_converse_request_construction` and
+    /// What: wraps the client in a [`BedrockAdapter`] via
+    /// `BedrockAdapter::with_client`, which pins `region` verbatim; skips
+    /// model-id validation so tests can pass any id.
+    /// Test: used by `bedrock_provider_stores_model_and_region` and
     /// `bedrock_no_credentials_returns_error`.
     #[cfg(test)]
     pub fn from_client(
-        client: BedrockClient,
+        client: aws_sdk_bedrockruntime::Client,
         model: impl Into<String>,
         region: impl Into<String>,
     ) -> Self {
         Self {
-            client,
+            adapter: BedrockAdapter::with_client(region, client),
             model: model.into(),
-            region: region.into(),
         }
     }
 
     /// The AWS region the client is configured for.
     pub fn region(&self) -> &str {
-        &self.region
+        self.adapter.region()
     }
 
     /// Execute a single Converse call and return the response.
@@ -242,6 +191,16 @@ impl BedrockProvider {
     /// the `toolUse.input` is extracted and returned as `LlmResponse.text`.
     /// Test: called by `complete`; error-mapping tested in unit tests.
     async fn call_once(&self, req: &LlmRequest) -> Result<LlmResponse, LlmError> {
+        // #5469: the adapter builds its AWS client on first use; take it before
+        // the latency clock starts so the one-off config load is not billed as
+        // model latency.
+        let client = self.adapter.client().await.map_err(|e| {
+            LlmError::Transport(format!(
+                "Bedrock client construction failed (region={}): {e}",
+                self.adapter.region()
+            ))
+        })?;
+
         let start = Instant::now();
 
         // #6123: one resolver decides the model for all three providers; this
@@ -280,8 +239,7 @@ impl BedrockProvider {
             .temperature(req.temperature)
             .build();
 
-        let mut sdk_req = self
-            .client
+        let mut sdk_req = client
             .converse()
             .model_id(model)
             .inference_config(inference)
@@ -314,7 +272,7 @@ impl BedrockProvider {
                     "AWS Bedrock access denied (model={model}, region={}): {msg}. \
                      Ensure AWS credentials are configured and the account has \
                      bedrock:InvokeModel permission.",
-                    self.region
+                    self.adapter.region()
                 ))
             } else if lower.contains("validationexception") || lower.contains("validation") {
                 LlmError::Validation(msg)
@@ -337,7 +295,7 @@ impl BedrockProvider {
             } else {
                 LlmError::Transport(format!(
                     "Bedrock Converse SDK error (model={model}, region={}): {msg}",
-                    self.region
+                    self.adapter.region()
                 ))
             }
         })?;
@@ -394,7 +352,7 @@ impl LlmProvider for BedrockProvider {
         debug!(
             model = %req.effective_model(&self.model),
             provider = "bedrock",
-            region = %self.region,
+            region = %self.adapter.region(),
             structured = req.response_schema.is_some(),
             "bedrock complete request"
         );

--- a/crates/trusty-review/src/llm/bedrock/tests.rs
+++ b/crates/trusty-review/src/llm/bedrock/tests.rs
@@ -14,9 +14,11 @@ use aws_sdk_bedrockruntime::operation::converse::ConverseError;
 use aws_sdk_bedrockruntime::types::error::ResourceNotFoundException;
 use aws_smithy_types::error::ErrorMetadata;
 
+use trusty_common::inference::bedrock::{DEFAULT_REGION, resolve_region_from};
+
 use super::{
-    BedrockProvider, DEFAULT_REGION, LlmRequest, describe_sdk_error, estimate_bedrock_cost_usd,
-    normalize_model_family, resolve_bedrock_region, resolve_region_from, validate_model_id,
+    BedrockProvider, LlmRequest, describe_sdk_error, estimate_bedrock_cost_usd,
+    normalize_model_family, resolve_bedrock_region, validate_model_id,
 };
 use crate::llm::bedrock::tool_use::build_tool_config;
 use crate::llm::{ChatMessage, LlmError, LlmProvider, ResponseSchema};
@@ -30,7 +32,9 @@ use crate::llm::{ChatMessage, LlmError, LlmProvider, ResponseSchema};
 /// deployment contexts, so the ordering must stay stable. #5706: this test used
 /// to call `resolve_bedrock_region` and assert that an empty explicit region
 /// reaches the default, which skips the two env tiers and fails outright on any
-/// machine with `AWS_REGION` exported.
+/// machine with `AWS_REGION` exported. #5469: the walk itself now lives in
+/// `trusty_common::inference::bedrock`, so this test drives the SHARED
+/// implementation — reorder its tiers and these assertions fail.
 /// What: drives the pure `resolve_region_from` walk with both env tiers passed
 /// as arguments, so every case is deterministic. The one `resolve_bedrock_region`
 /// assertion left exercises the tier that is env-independent by construction.

--- a/crates/trusty-review/src/llm/mod.rs
+++ b/crates/trusty-review/src/llm/mod.rs
@@ -518,7 +518,9 @@ pub async fn build_provider(
     let (provider, bare_model) = resolve_provider_and_model(model, default_provider)?;
     match provider {
         Provider::Bedrock => {
-            let p = BedrockProvider::new(bare_model, None).await?;
+            // #5469: synchronous now — the shared adapter builds its AWS client
+            // lazily on the first Converse call.
+            let p = BedrockProvider::new(bare_model)?;
             Ok(Arc::new(p))
         }
         Provider::OpenRouter => {

--- a/crates/trusty-review/src/pipeline/diff_analyzer/hunk_classifier.rs
+++ b/crates/trusty-review/src/pipeline/diff_analyzer/hunk_classifier.rs
@@ -420,8 +420,7 @@ mod tests {
     #[ignore]
     async fn stage_c_live_bedrock() {
         use crate::llm::BedrockProvider;
-        let provider = BedrockProvider::new(DEFAULT_CLASSIFIER_MODEL.to_string(), None)
-            .await
+        let provider = BedrockProvider::new(DEFAULT_CLASSIFIER_MODEL.to_string())
             .expect("BedrockProvider must build");
         let classifier = HunkClassifier::new(
             Arc::new(provider),


### PR DESCRIPTION
Refs #5469

`crates/trusty-review/src/llm/bedrock/mod.rs` resolved the AWS region with its own copy of the precedence walk and built its own Converse client via `aws_config::defaults(...)`, duplicating `trusty_common::inference::bedrock` — the shared adapter tcode, tga and trusty-mpm already consume.

## What changed

`BedrockProvider` holds a `BedrockAdapter` and borrows its lazily-built client. Region precedence (explicit > `TRUSTY_AWS_REGION` > `AWS_REGION` > `us-east-1`), every error string, the retry policy, cost estimation and tool-use extraction are unchanged; #6969's `describe_sdk_error` is untouched. The client is taken before `Instant::now()`, so the one-off AWS config load is not billed as model latency.

`BedrockProvider::new` is synchronous now and takes only the model id — the AWS client is built on the first call, and the dead explicit-region parameter every caller passed `None` for is gone. Two doc comments that justified their own `async` by "`BedrockProvider::new` loads AWS credentials" now name the real reason.

trusty-common gained the knobs that made this possible rather than a second copy: `resolve_bedrock_region` and the pure `resolve_region_from` walk behind it are public, `DEFAULT_REGION` is public, `BedrockAdapter::client` is public, and `BedrockAdapter::with_client` pre-fills the lazy cell so a consumer can inject a `no_credentials()` client for its unit tests.

## Precedence is pinned at the single definition

Mutating the shared walk from `[trusty_env, aws_env]` to `[aws_env, trusty_env]` fails in both crates:

```
test inference::bedrock::tests::region_precedence_walk_tiers ... FAILED
test inference::bedrock::tests::region_resolution_trusty_env_wins_over_aws_env ... FAILED
assertion `left == right` failed: an empty explicit falls through to TRUSTY_AWS_REGION
test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 762 filtered out
```

```
test llm::bedrock::tests::bedrock_region_resolution ... FAILED
assertion `left == right` failed: empty explicit should fall through to TRUSTY_AWS_REGION
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2205 filtered out
```

`bedrock_region_resolution` keeps its assertion body byte-for-byte and now drives the shared function, so trusty-review's contract cannot regress silently.

## Rung 4 (cross-crate library change)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-review --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-common --features bedrock-client --all-targets -- -D warnings` | EXIT=0 |
| `cargo check --workspace --all-targets` | EXIT=0 |
| `cargo test -p trusty-review --no-fail-fast` | `ok. 2201 passed; 0 failed; 5 ignored` + 13 further targets ok |
| `cargo test -p trusty-common --features bedrock-client --no-fail-fast` | `ok. 753 passed; 0 failed; 14 ignored` + 10 further targets ok |
| `cargo test -p trusty-code --no-fail-fast` | `ok. 1752 passed; 0 failed; 4 ignored`, 19 targets ok |
| `cargo test -p tga --features bedrock --no-fail-fast` | `ok. 1582 passed; 0 failed; 7 ignored`, all targets ok |
| `cargo test -p trusty-mpm --features bedrock --no-fail-fast` | see flake note |
| `./scripts/check_line_cap.sh` | 4556 files, 4 allowlisted, 0 violations |
| `./scripts/check_test_pointers.sh` | 31511 citations, 0 dangling |
| `./scripts/check_sld.sh` | 0 errors, 0 warnings |
| `./scripts/check_changelog_fragment.sh` | both crates with source changes recorded |
| `./scripts/check-pr-version-bump.sh` | `trusty-common 0.49.1` and `trusty-review 0.35.1` — src changed, version not yet published; no bump owed |

Direct dependents of `inference::bedrock` were taken from the manifests, not just a grep: trusty-code (feature always on), tga and trusty-mpm (behind their own `bedrock` feature). All three were tested with that feature enabled.

## The one red, and why it is not this branch's

`cargo test -p trusty-mpm --features bedrock --no-fail-fast` reported `FAILED. 6061 passed; 1 failed; 8 ignored` on the `--lib` target; every other target passed. The harness compressed the run's output and dropped the failing test's name before it could be read. Re-running the same target: `test result: ok. 6062 passed; 0 failed; 8 ignored`.

`git status --porcelain -- crates/trusty-mpm/` is empty — this branch touches no trusty-mpm file, and the three shared items it adds are new or visibility-only. A flake, but an unnamed one.

## Still outstanding

No live Bedrock smoke run in this branch. #5469 asks for one as rung-4 evidence and this worktree has no AWS credentials; a QA agent is running the `#[ignore]`-gated live paths (`stage_c_live_bedrock`, trusty-common's `live_bedrock_call`) against the machine's profile. Draft until that lands.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
