### PR TITLE
docs(trusty-code): qualify the paths module's intra-doc links (#7001)

### DIFF
--- a/crates/trusty-code/changelog.d/7001-rustdoc-links.md
+++ b/crates/trusty-code/changelog.d/7001-rustdoc-links.md
@@ -1,0 +1,7 @@
+Documentation
+
+- **`paths` module docs link to their own items again (#7001).** The five
+  intra-doc links in the module header (`resolve_project_entry`, `SEARCH_ROOTS`,
+  `ConfigSource`, `native_config_dir`, `check_native_write_target`) are now
+  written as `crate::paths::…` reference definitions, so rustdoc resolves them
+  instead of failing the intra-doc link gate.

--- a/crates/trusty-code/src/paths/mod.rs
+++ b/crates/trusty-code/src/paths/mod.rs
@@ -31,6 +31,17 @@
 //! Test: `paths::tests::*`, `paths::private_state_tests::*`,
 //! `paths::import_tests::*`.
 //!
+//! Every link below is written as a `crate::paths::…` reference definition
+//! rather than a bare `[`name`]`. This module carries outer `///` docs at its
+//! `pub mod paths;` declaration in `lib.rs` as well as these inner `//!` docs,
+//! and rustdoc resolves the merged block in the scope of its first fragment —
+//! the crate root — where none of these names exist. See #7001.
+//!
+//! [`resolve_project_entry`]: crate::paths::resolve_project_entry
+//! [`SEARCH_ROOTS`]: crate::paths::SEARCH_ROOTS
+//! [`ConfigSource`]: crate::paths::ConfigSource
+//! [`native_config_dir`]: crate::paths::native_config_dir
+//! [`check_native_write_target`]: crate::paths::check_native_write_target
 //! [`private_state`]: crate::paths::private_state
 //! [`import`]: crate::paths::import
 


### PR DESCRIPTION
Main's `Rustdoc intra-doc links` job has been red since #6980 with five unresolved links, identical on the last two main pushes. This turns it green.

## Root cause

The five links are not in `lib.rs`, where rustdoc reports them. They live in the `//!` header of `crates/trusty-code/src/paths/mod.rs` (lines 13-18), and all five items — `resolve_project_entry`, `SEARCH_ROOTS`, `ConfigSource`, `native_config_dir`, `check_native_write_target` — are defined in that same module.

They stopped resolving because #6980 added an outer `///` doc block at the `pub mod paths;` declaration in `lib.rs`. Rustdoc merges a module's outer and inner docs into one block and resolves the whole block in the scope of its **first fragment** — here the crate root, where none of these names exist. That is also why rustdoc reports every error against `lib.rs:183` rather than the file the links sit in, which is what makes this one hard to find by grep.

## Fix

The same file already carried the proof: its two links written as `crate::`-qualified reference definitions, `private_state` and `import`, resolve fine and never appeared in the failure list. The other five now get the same treatment, plus a note saying that rewriting them as bare links breaks the gate again.

Prose and code are unchanged, no reference is dropped, and `trusty-code` gains no baseline row — the ratchet stays at zero for this crate.

## Gates

```
bash scripts/check_rustdoc_links.sh                                   EXIT=0
SUMMARY	26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0, 0 diagnostic(s) examined

cargo fmt --check                                                     EXIT=0
cargo clippy -p trusty-code --all-targets -- -D warnings              EXIT=0
scripts/check_changelog_fragment.sh (post-commit)                     EXIT=0
scripts/check_test_pointers.sh   31542 citations, 0 dangling          EXIT=0
scripts/check_sld.sh             0 errors, 0 warnings                 EXIT=0
scripts/check_line_cap.sh        0 violations                         EXIT=0
```

Pre-fix reproduction, for contrast: `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p trusty-code --no-deps` exited 101 with all five `unresolved link to …` errors, each `= note: no item named … in scope`.

Rung 1 (docs and comments only) — no behaviour changes, so no Cargo test target is owed. Changelog fragment `crates/trusty-code/changelog.d/7001-rustdoc-links.md` is included because the gate demands one for any `src/**` change.

Refs #7001

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
