### PR TITLE
fix(trusty-mpm): tm sessions start registers the CLI diagnostics subscriber (#6754)

### DIFF
--- a/crates/trusty-mpm/changelog.d/6754-sessions-start-cli-diagnostics.md
+++ b/crates/trusty-mpm/changelog.d/6754-sessions-start-cli-diagnostics.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `tm sessions start` now registers the CLI diagnostics subscriber, so the in-place deploy path's stray-skill sweep reports its removals and failed removals on stderr instead of dropping them (#6754).

--- a/crates/trusty-mpm/src/bin/tm/tracing_setup.rs
+++ b/crates/trusty-mpm/src/bin/tm/tracing_setup.rs
@@ -39,10 +39,18 @@ use crate::cli::{CatalogAction, Command, SessionAction};
 /// PRs #4848 / #4876 / #4908). With no subscriber those events went nowhere, so
 /// the file stayed stale forever with no signal on the four paths an operator
 /// runs by hand.
-/// What: true for `tm sessions instructions` and its deprecated singular alias;
-/// for bare `tm` (`None`), which deploys in-process on both the launch and the
-/// in-place relaunch path; for `tm doctor`, whose `--fix-skills` redeploys; and
-/// for `tm catalog apply`, which redeploys the manifest-selected roster.
+/// #6754 added `tm sessions start` for the same reason. In a project with no
+/// git remote that verb cannot reach the daemon, so it falls back to
+/// `start_session_in_place`, which runs `prepare_session_with_home` in this
+/// process — including the stray-skill sweep, whose removals and declines are
+/// `warn!` events (`core/session_launch/skills.rs`). Two live removal runs on
+/// tm 1.5.18 left no trace anywhere: not stderr, not `~/.trusty-mpm/logs`, not
+/// the daemon's `stderr.log`, even though files were moved on disk.
+/// What: true for `tm sessions instructions` and `tm sessions start`, each with
+/// its deprecated singular alias; for bare `tm` (`None`), which deploys
+/// in-process on both the launch and the in-place relaunch path; for
+/// `tm doctor`, whose `--fix-skills` redeploys; and for `tm catalog apply`,
+/// which redeploys the manifest-selected roster.
 /// Test: `wants_cli_diagnostics_covers_every_in_process_deploy_path`,
 /// `wants_cli_diagnostics_skips_paths_that_own_stdout`,
 /// `instructions_emits_override_diagnostics_on_stderr`.
@@ -55,11 +63,13 @@ fn wants_cli_diagnostics(command: &Option<Command>) -> bool {
             | Some(Command::Catalog {
                 action: CatalogAction::Apply { .. }
             })
+            // #6754: `start` deploys in-process when the daemon path is
+            // unavailable, and its sweep reports only via `tracing`.
             | Some(Command::Sessions {
-                action: SessionAction::Instructions { .. }
+                action: SessionAction::Instructions { .. } | SessionAction::Start { .. }
             })
             | Some(Command::Session {
-                action: SessionAction::Instructions { .. }
+                action: SessionAction::Instructions { .. } | SessionAction::Start { .. }
             })
     )
 }
@@ -273,6 +283,12 @@ mod tests {
             vec!["tm", "catalog", "apply", "--force", "--prune"],
             vec!["tm", "sessions", "instructions"],
             vec!["tm", "session", "instructions"],
+            // #6754: with no daemon reachable, `start` deploys in-process via
+            // `start_session_in_place` and its stray-skill sweep warns through
+            // `tracing`. RED before the fix — neither arm matched.
+            vec!["tm", "sessions", "start"],
+            vec!["tm", "sessions", "start", "--dir", "/tmp/project"],
+            vec!["tm", "session", "start"],
         ] {
             assert!(
                 wants_cli_diagnostics(&command_for(&argv)),


### PR DESCRIPTION
`tm sessions start --dir <proj>` in a project with no git remote cannot reach the daemon, so it falls back to `start_session_in_place`, which runs `prepare_session_with_home` in this process. That path's stray-skill sweep reports each removal and each failed removal as a `tracing` event (`crates/trusty-mpm/src/core/session_launch/skills.rs:113`). `wants_cli_diagnostics` covered bare `tm`, `doctor`, `catalog apply` and `sessions instructions` but not `start`, so no subscriber existed and every event was dropped.

Live on tm 1.5.18: two sweep runs moved files on disk and backed them up, and left no trace on stderr, in `~/.trusty-mpm/logs`, or in the daemon's `stderr.log`.

`SessionAction::Start` now matches in both the canonical `Command::Sessions` arm and the deprecated singular `Command::Session` alias. Nothing else changes. The default filter stays `warn`, so applied-deploy `info` narration and the sweep's `debug` refusals stay below it, and the sweep's summary is still gated on a non-zero removal count. A start with no stray copies gains no output.

## Test

`wants_cli_diagnostics_covers_every_in_process_deploy_path` gains the three `start` argv shapes. RED with only the `matches!` arms reverted to `origin/main`:

```
thread 'tracing_setup::tests::wants_cli_diagnostics_covers_every_in_process_deploy_path' panicked at crates/trusty-mpm/src/bin/tm/tracing_setup.rs:291:13:
["tm", "sessions", "start"] runs an in-process deploy and must get a subscriber
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2185 filtered out
```

## Gates — rung 3 (localized behavior inside one crate)

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | exit 0 |
| `cargo test -p trusty-mpm --no-fail-fast` | exit 0 — 52 targets, all `ok`, 0 failed; 6063 lib + 2185 bin (x2) + integration; 10 ignored, all pre-existing |
| `./scripts/check_line_cap.sh` | `measured 4562 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.` |
| `./scripts/check_test_pointers.sh` | `resolved 31546 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.` |
| `./scripts/check_sld.sh` | `scanned 63 spec doc(s) + 3696 code file(s); … 0 error(s), 0 warning(s)` |
| `./scripts/check_changelog_fragment.sh` | exit 0 — `OK trusty-mpm: changelog.d fragment present and valid` |
| `./scripts/check-pr-version-bump.sh` | exit 0 — `[ OK ] trusty-mpm 1.5.18 — src changed, version not yet published` |

`check_rustdoc_links.sh` fails on a pre-existing red main, not on this branch:

```
SUMMARY	25 crate(s) examined by rustdoc, 5 broken link(s), baseline 0, 5 diagnostic(s) examined
FAIL	UNBASELINED	trusty-code has 5 broken link(s) and no baseline row
```

All five are `crates/trusty-code/src/lib.rs:183`. trusty-mpm has 0 broken links, and this branch touches only `crates/trusty-mpm/`.

Refs #6754

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
