### PR TITLE
test(trusty-common): give each file_stamp test its own TempDir (Refs #6974)

### DIFF
--- a/crates/trusty-common/changelog.d/6974-file-stamp-test-isolation.md
+++ b/crates/trusty-common/changelog.d/6974-file-stamp-test-isolation.md
@@ -1,0 +1,3 @@
+Fixed
+
+- give each `migrations::file_stamp` test its own `tempfile::TempDir`. The old scratch-directory name was `trusty-common-stamp-test-{pid}-{nanos}`, and every test in the module runs in one process, so two tests that started inside the same clock tick shared a directory and overwrote each other's stamp file. Test-only; no production behaviour changed

--- a/crates/trusty-common/src/migrations/file_stamp.rs
+++ b/crates/trusty-common/src/migrations/file_stamp.rs
@@ -14,7 +14,7 @@
 //!
 //! Test: `file_stamp_roundtrip`, `read_returns_unversioned_when_missing`,
 //! `read_returns_unversioned_on_corrupt_payload`,
-//! `write_is_atomic_via_tmp_rename`.
+//! `write_is_atomic_via_tmp_rename`, `concurrent_scratch_dirs_never_collide`.
 
 use std::path::Path;
 
@@ -114,22 +114,73 @@ pub fn write_version_to_file(path: &Path, version: SchemaVersion) -> Result<()> 
 mod tests {
     use super::*;
 
-    fn tempdir() -> std::path::PathBuf {
-        let pid = std::process::id();
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let p = std::env::temp_dir().join(format!("trusty-common-stamp-test-{pid}-{nanos}"));
-        std::fs::create_dir_all(&p).expect("create scratch dir");
-        p
+    /// A scratch directory private to one test, removed when the returned
+    /// handle drops.
+    ///
+    /// Why (#6974): the previous helper named the directory
+    /// `trusty-common-stamp-test-{pid}-{nanos}` and returned a bare
+    /// `PathBuf`. Every test in this module runs in ONE process under
+    /// `cargo test`, so the pid is a constant, and `SystemTime::now()` has a
+    /// platform tick coarser than a nanosecond — two tests starting inside the
+    /// same tick got the same path and trampled each other's stamp file. The
+    /// name also leaked: nothing ever removed the directory.
+    /// What: `tempfile::TempDir` picks the name from the OS random source and
+    /// creates the directory with `O_EXCL`, so a collision cannot occur even
+    /// across concurrent processes; dropping the handle removes the tree.
+    /// Test: every test in this module.
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("trusty-common-stamp-test-")
+            .tempdir()
+            .expect("create scratch dir")
+    }
+
+    #[test]
+    fn concurrent_scratch_dirs_never_collide() {
+        // Why (#6974): the tests below all call `tempdir()` and all run in one
+        // process on the shared cargo test thread pool. The old pid+nanos name
+        // gave two simultaneous callers the same directory, so one test's
+        // stamp file became another's. Assert the property the helper now
+        // guarantees: distinct paths, and a file written under one path stays
+        // readable at the value its own thread wrote.
+        let threads: Vec<_> = (0..8u32)
+            .map(|i| {
+                std::thread::spawn(move || {
+                    // The handle is returned, not dropped here, so every
+                    // directory is still on disk while the assertions run.
+                    let dir = tempdir();
+                    let path = dir.path().join("schema_version.json");
+                    write_version_to_file(&path, SchemaVersion(i)).expect("write");
+                    let got = read_version_from_file(&path).expect("read");
+                    (i, dir, got)
+                })
+            })
+            .collect();
+
+        // Join everything before asserting, so all eight directories are held
+        // open at once — a name a `TempDir` still owns cannot be handed out
+        // again.
+        let results: Vec<_> = threads
+            .into_iter()
+            .map(|t| t.join().expect("thread panicked"))
+            .collect();
+
+        let mut paths = std::collections::HashSet::new();
+        for (i, dir, got) in &results {
+            assert_eq!(*got, SchemaVersion(*i), "thread {i} read another's stamp");
+            assert!(
+                paths.insert(dir.path()),
+                "duplicate scratch dir {:?}",
+                dir.path()
+            );
+        }
     }
 
     #[test]
     fn file_stamp_roundtrip() {
         // Why: baseline — write a version, read it back, expect equality.
         let dir = tempdir();
-        let path = dir.join("schema_version.json");
+        let path = dir.path().join("schema_version.json");
         write_version_to_file(&path, SchemaVersion(7)).expect("write succeeds");
         let got = read_version_from_file(&path).expect("read succeeds");
         assert_eq!(got, SchemaVersion(7));
@@ -140,7 +191,7 @@ mod tests {
         // Why: a brand-new store has no stamp on disk yet. The reader must
         // map that to UNVERSIONED so the runner applies every step.
         let dir = tempdir();
-        let path = dir.join("missing.json");
+        let path = dir.path().join("missing.json");
         let got = read_version_from_file(&path).expect("missing file is not an error");
         assert_eq!(got, SchemaVersion::UNVERSIONED);
     }
@@ -149,7 +200,7 @@ mod tests {
     fn read_returns_unversioned_on_corrupt_payload() {
         // Why: a hand-edited / truncated stamp must not crash the daemon.
         let dir = tempdir();
-        let path = dir.join("schema_version.json");
+        let path = dir.path().join("schema_version.json");
         std::fs::write(&path, b"this is not json").expect("write garbage");
         let got = read_version_from_file(&path).expect("corrupt file is not an error");
         assert_eq!(got, SchemaVersion::UNVERSIONED);
@@ -161,7 +212,7 @@ mod tests {
         // rename) is what actually happens. Catches a future refactor that
         // accidentally switches to a direct write.
         let dir = tempdir();
-        let path = dir.join("schema_version.json");
+        let path = dir.path().join("schema_version.json");
         write_version_to_file(&path, SchemaVersion(3)).expect("write");
         // The `.tmp` file must not linger after a successful write.
         let tmp = {
@@ -182,7 +233,7 @@ mod tests {
         // Why: callers often pass a path under a not-yet-created data dir.
         // The writer must materialise the parent before writing.
         let dir = tempdir();
-        let nested = dir.join("a").join("b").join("c");
+        let nested = dir.path().join("a").join("b").join("c");
         let path = nested.join("schema_version.json");
         write_version_to_file(&path, SchemaVersion(1))
             .expect("nested write creates intermediate dirs");
@@ -194,7 +245,7 @@ mod tests {
         // Why: every successful migration step overwrites the stamp. Confirm
         // the second write replaces the first cleanly (no append, no error).
         let dir = tempdir();
-        let path = dir.join("schema_version.json");
+        let path = dir.path().join("schema_version.json");
         write_version_to_file(&path, SchemaVersion(1)).expect("first write");
         write_version_to_file(&path, SchemaVersion(2)).expect("second write");
         assert_eq!(


### PR DESCRIPTION
## Root cause

`crates/trusty-common/src/migrations/file_stamp.rs` named its test scratch directory `trusty-common-stamp-test-{pid}-{nanos}` and returned a bare `PathBuf`. Neither component is unique.

Every test in `migrations::file_stamp::tests` runs as a thread of one binary under `cargo test`, so `std::process::id()` is a constant across them. The only varying component is `SystemTime::now()`, whose platform tick is coarser than a nanosecond, so two threads entering the helper inside one tick compute the same string. `create_dir_all` is not `O_EXCL` and succeeds for both, and the two tests then share a directory — one test's `schema_version.json` becomes another's. That is the pair of failures #6974 recorded: `left: SchemaVersion(1) right: SchemaVersion(0)`, and `rename ...: No such file or directory (os error 2)`, both on the one path `trusty-common-stamp-test-16564-1788750284682112000`.

Under `cargo nextest` the pid does differ per test process, which is why the pre-publish shards never showed it. That makes the pid a coincidental guard rather than a designed one — nothing in the scheme makes two calls distinct.

The directories also leaked. Nothing ever removed one.

## Fix

`tempfile::TempDir`, already a `[dev-dependencies]` entry of this crate. It draws the name from the OS random source and creates the directory with `O_EXCL`, so two callers cannot share one even across processes, and dropping the handle removes the tree. All six call sites moved to `dir.path().join(...)`.

`concurrent_scratch_dirs_never_collide` pins the property: eight threads each take a directory, write their own `SchemaVersion`, and read it back. All eight handles are joined before the assertions run, so no name is released mid-check.

No production code changed — `read_version_from_file` and `write_version_to_file` are untouched.

## Rung 2 (test-only stabilization)

The new test against the OLD helper, 40 runs:

```
pre-fix: 17 / 40 runs FAILED concurrent_scratch_dirs_never_collide
```

First failure, raw — the issue's own error string and path shape:

```
thread '<unnamed>' (22295859) panicked at crates/trusty-common/src/migrations/file_stamp.rs:135:68:
write: rename schema stamp into place at /var/folders/.../T/trusty-common-stamp-test-31922-1788763783668418000/schema_version.json

Caused by:
    No such file or directory (os error 2)
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 478 filtered out
```

A standalone binary running the old helper body alone from 8 threads, 200 rounds, isolates the mechanism from the test harness: `rounds with a colliding directory name: 6 / 200`.

After the fix, `cargo test -p trusty-common --features migrations file_stamp --no-fail-fast`, **30 consecutive runs, 30 clean** (three loops of 10; the issue's closure condition asks for 20):

```
run 1:  exit=0 file_stamp_tests_ran=7 | test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 472 filtered out
...
run 10: exit=0 file_stamp_tests_ran=7 | test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 472 filtered out
```

`file_stamp_tests_ran` is counted from the lib target's own `test ...` lines, so the filter provably matched rather than silently selecting nothing (#4307).

## Gates

```
cargo fmt --check                                                       EXIT=0
cargo clippy -p trusty-common --features migrations --all-targets
  -- -D warnings                                                        EXIT=0
cargo test -p trusty-common --features migrations --no-fail-fast        EXIT=0
  9 targets; 481 passed, 0 failed, 6 ignored
scripts/check_line_cap.sh          4562 files, 0 violations             EXIT=0
scripts/check_test_pointers.sh     31547 citations, 0 dangling          EXIT=0
scripts/check_sld.sh               0 errors, 0 warnings                 EXIT=0
scripts/check_changelog_fragment.sh  trusty-common fragment valid       EXIT=0
scripts/check-pr-version-bump.sh
  [ OK ] trusty-common 0.49.1 — src changed, version not yet published  EXIT=0
bash scripts/check_rustdoc_links.sh
  SUMMARY 26 crate(s) examined, 0 broken link(s), baseline 0            EXIT=0
```

`--features migrations` is named on every Cargo run: `trusty-common`'s default feature set is empty and the `migrations` module is gated behind it (#4901).

The branch is rebased onto `08152e307` (#7008). On the earlier base, `check_rustdoc_links.sh` reported the five `trusty-code/src/lib.rs:183` links that #7008 fixed; nothing in `trusty-code` is touched here either way.

Refs #6974

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
