### PR TITLE
fix(trusty-agents-common): a source-file read bypasses tool-output compression (#6986)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/6986-compress-source-passthrough.md
+++ b/crates/trusty-agents-common/changelog.d/6986-compress-source-passthrough.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `compress::classify_tool` no longer lets a file's own path choose the filter
+  that damages it. The tool name it receives is the wrapped command, so
+  `cat crates/x/src/tests.rs` matched the `test` substring branch and
+  `filter_test_runner` returned an empty string — the whole file, silently
+  gone — while `cat …/mod.rs` reached `filter_file_read`, which strips every
+  `//` line and so removed the doc comments being read. A read verb (`cat`,
+  `head`, `sed`, `bat`, `tail`, `nl`, `less`, `more`) applied to a path with a
+  source or prose extension now classifies as `None` and passes through
+  byte-for-byte. Gate captures keep their compression: `.txt`, `.log` and
+  `.out` are deliberately not source extensions (#6986).
+- `compress::compress_tool_output` returns the original whenever a filter
+  consumed every byte of a non-empty input, so a compression path can no
+  longer emit nothing at all (#6986).

--- a/crates/trusty-agents-common/src/compress/tool_output/mod.rs
+++ b/crates/trusty-agents-common/src/compress/tool_output/mod.rs
@@ -12,6 +12,7 @@
 //! Module layout (see #366 split):
 //! - `mod.rs` — classification, dispatch, and the native per-tool filters
 //! - `structured.rs` — JSON/YAML/TOML/CSV passthrough detection
+//! - `source_read.rs` — read-verb-on-a-source-file passthrough detection (#6986)
 //! - `strategy.rs` — generic `FilterLevel`/`Language`/`FilterStrategy`
 //! - `rtk.rs` — RTK subprocess delegation + async wrapper, plus
 //!   `CompressionPath` (issue #1956 stats-logging signal)
@@ -26,6 +27,7 @@
 //! Test: See `tests` — covers each filter and the dispatch table.
 
 mod rtk;
+mod source_read;
 mod strategy;
 mod structured;
 
@@ -38,6 +40,7 @@ pub use rtk::{
     CompressionPath, compress_tool_output_async, compress_tool_output_async_with_path,
     compress_via_rtk,
 };
+pub use source_read::is_source_file_read;
 pub use strategy::{
     AggressiveFilter, FilterLevel, FilterStrategy, Language, MinimalFilter, NoFilter, get_filter,
 };
@@ -91,16 +94,30 @@ pub enum ToolFilter {
 /// tool name". [`compress_tool_output`] dispatches on its result and
 /// [`has_filter_for`] tests it, so the coverage question has exactly one
 /// answer (#6566, and the common-entry-point rule).
-/// What: Substring match against the lowercased name, in the order the
-/// dispatch has always used — the `test`/`cargo` family first (with
-/// `check`/`clippy` inside it taking the cargo-check filter), then `diff`,
-/// `log`, `read`/`cat`. `grep`/`rg`/`find`/`ls` match on the FIRST
-/// whitespace token rather than a substring, because `rg` is a substring of
-/// unrelated names this sees (`cargo`, `git merge`) that must not misfire
-/// (#1957). `None` means no filter covers the name.
+/// What: [`is_source_file_read`] runs FIRST and short-circuits to `None`
+/// (#6986 — see below). After it, substring match against the lowercased
+/// name, in the order the dispatch has always used — the `test`/`cargo`
+/// family first (with `check`/`clippy` inside it taking the cargo-check
+/// filter), then `diff`, `log`, `read`/`cat`. `grep`/`rg`/`find`/`ls` match
+/// on the FIRST whitespace token rather than a substring, because `rg` is a
+/// substring of unrelated names this sees (`cargo`, `git merge`) that must
+/// not misfire (#1957). `None` means no filter covers the name.
+///
+/// 🔴 The substring branches match the PATH as well as the program, because
+/// `tm hook`'s rewrite passes the command's first two tokens as the tool
+/// name. `cat crates/x/src/tests.rs` therefore hit the `test` branch and
+/// `filter_test_runner` returned an empty string — the whole file, gone
+/// (#6986). Ordering the source-read check ahead of them is what keeps a
+/// file's own path from choosing the filter that destroys it.
 /// Test: `classify_tool_routes_known_tool_families`,
-/// `classify_tool_returns_none_for_uncovered_tools`.
+/// `classify_tool_returns_none_for_uncovered_tools`,
+/// `classify_tool_passes_through_source_reads`.
 pub fn classify_tool(tool_name: &str) -> Option<ToolFilter> {
+    // #6986: a read verb on a source file is an agent reading code, not gate
+    // output — no filter here can shorten it without damaging it.
+    if is_source_file_read(tool_name) {
+        return None;
+    }
     let n = tool_name.to_ascii_lowercase();
     if n.contains("test") || n.contains("cargo") {
         // Note: "cargo check"/"cargo clippy" go to the cargo_check filter
@@ -170,7 +187,14 @@ pub fn has_filter_for(tool_name: &str) -> bool {
 /// dispatch handles it — that is what keeps [`has_filter_for`] from drifting
 /// away from what the dispatch actually filters (#6566). Unknown tools pass
 /// through unchanged. Always infallible.
-/// Test: `compress_tool_output_dispatch_test` plus per-filter tests.
+///
+/// A filter that consumed every byte returns the ORIGINAL instead (#6986):
+/// emitting nothing loses the caller's output with no way to tell that from
+/// a command that genuinely printed nothing. This is a backstop, not the
+/// fix — [`classify_tool`] keeps source reads away from the filters in the
+/// first place.
+/// Test: `compress_tool_output_dispatch_test` plus per-filter tests;
+/// `dispatch_never_returns_empty_for_non_empty_input`.
 pub fn compress_tool_output(tool_name: &str, output: &str) -> String {
     // Size gate: very small outputs aren't worth touching.
     if output.len() < SIZE_GATE_BYTES {
@@ -181,7 +205,7 @@ pub fn compress_tool_output(tool_name: &str, output: &str) -> String {
     if is_structured_format(output) {
         return output.to_string();
     }
-    match classify_tool(tool_name) {
+    let compressed = match classify_tool(tool_name) {
         None => output.to_string(),
         Some(ToolFilter::TestRunner) => filter_test_runner(output),
         Some(ToolFilter::CargoCheck) => filter_cargo_check(output),
@@ -202,7 +226,13 @@ pub fn compress_tool_output(tool_name: &str, output: &str) -> String {
         }
         Some(ToolFilter::Grep) => filter_grep_output(output),
         Some(ToolFilter::Ls) => filter_ls_output(output),
+    };
+    // #6986: a filter that emptied a non-empty input destroyed the caller's
+    // output rather than shortening it. Hand back the original.
+    if compressed.trim().is_empty() && !output.trim().is_empty() {
+        return output.to_string();
     }
+    compressed
 }
 
 /// Strip passing test lines from `cargo test` output.

--- a/crates/trusty-agents-common/src/compress/tool_output/source_read.rs
+++ b/crates/trusty-agents-common/src/compress/tool_output/source_read.rs
@@ -1,0 +1,88 @@
+//! Source-file read detection for tool-output compression.
+//!
+//! Why: #6986 — the dispatch classifies by substring against a tool name that
+//! is the wrapped command's first two tokens, so `cat …/gh_cli/tests.rs`
+//! matched the `test` branch and `filter_test_runner` deleted every byte
+//! (`bytes_before=6037 bytes_after=0`), and `cat …/mod.rs` reached
+//! `filter_file_read`, which strips `//`-prefixed lines and so removed the
+//! doc comments the agent was reading. Those filters exist for gate output —
+//! a test runner's log, a compiler's log — not for source an agent is reading
+//! to edit it.
+//! What: [`is_source_file_read`], the predicate [`super::classify_tool`]
+//! consults first. It answers from the command alone: a read verb applied to
+//! a path with a source or prose extension. That is the reliable signal here
+//! because the tool name IS the command (`tm hook`'s rewrite passes
+//! `effective_tool_name`, e.g. `cat crates/x/src/tests.rs`), whereas output
+//! shape cannot separate a `.rs` file's contents from a compiler log that
+//! quotes source.
+//! Test: `is_source_file_read_*`, `classify_tool_passes_through_source_reads`,
+//! and `cat_of_a_rust_test_file_survives_compression_byte_for_byte` in
+//! `tool_output::tests`.
+
+/// Commands whose whole job is to print a file's bytes back to a reader.
+///
+/// Why: A read verb names the caller's intent — "show me this file" — which
+/// no substring of the path can override. `sed` and `tail` are listed for
+/// completeness even though `effective_tool_name` usually drops their path
+/// argument behind a flag (`sed -n`, `tail -f`); when a path does survive,
+/// the same passthrough must apply.
+/// What: Matched against the command's first token, with any directory
+/// prefix stripped, case-insensitively.
+/// Test: `is_source_file_read_requires_a_read_verb`.
+const READ_VERBS: &[&str] = &["cat", "bat", "head", "tail", "nl", "less", "more", "sed"];
+
+/// File extensions whose contents are source or prose read for editing.
+///
+/// Why: The extension is what separates "an agent is reading code" from "an
+/// agent is reading a gate's captured output". `.txt`, `.log` and `.out` are
+/// deliberately ABSENT: `<gate> > /tmp/gate.txt` is this project's documented
+/// capture pattern (`assets/agents/BASE-AGENT.md`), so a later
+/// `cat /tmp/gate.txt` is genuine gate output that must stay compressible.
+/// What: Lowercase, without the dot, compared against the final `.`-segment
+/// of a path token's basename.
+/// Test: `is_source_file_read_ignores_gate_capture_extensions`.
+const SOURCE_EXTENSIONS: &[&str] = &[
+    "rs", "toml", "md", "py", "ts", "tsx", "js", "jsx", "mjs", "cjs", "go", "java", "kt", "rb",
+    "php", "c", "h", "cc", "cpp", "hpp", "cs", "swift", "sh", "bash", "zsh", "sql", "svelte",
+    "vue", "css", "scss", "html", "yaml", "yml", "json", "tsv",
+];
+
+/// Whether `tool_name` is a read verb applied to a source or prose file.
+///
+/// Why: #6986 — such a command's output is the file itself, and every filter
+/// in this module would damage it: the test-runner filter drops any line that
+/// is not a failure, and the file-read filter drops every `//` and `#` line.
+/// The compressor is for gate output, so a source read must bypass it
+/// entirely rather than be compressed more gently.
+/// What: `true` when the first whitespace token (directory prefix stripped,
+/// lowercased) is in [`READ_VERBS`] and any later token's basename ends in a
+/// [`SOURCE_EXTENSIONS`] entry. A read verb with no source-file argument
+/// (`cat /tmp/gate.txt`, a bare `cat`) returns `false` and keeps its existing
+/// classification.
+/// Test: `is_source_file_read_matches_the_reported_shapes`,
+/// `is_source_file_read_requires_a_read_verb`,
+/// `is_source_file_read_ignores_gate_capture_extensions`.
+pub fn is_source_file_read(tool_name: &str) -> bool {
+    let mut tokens = tool_name.split_whitespace();
+    let Some(verb) = tokens.next() else {
+        return false;
+    };
+    let verb = verb.rsplit('/').next().unwrap_or(verb).to_ascii_lowercase();
+    if !READ_VERBS.contains(&verb.as_str()) {
+        return false;
+    }
+    tokens.any(has_source_extension)
+}
+
+/// Whether a command token names a file with a [`SOURCE_EXTENSIONS`] suffix.
+fn has_source_extension(token: &str) -> bool {
+    let basename = token.rsplit('/').next().unwrap_or(token);
+    let Some((stem, ext)) = basename.rsplit_once('.') else {
+        return false;
+    };
+    if stem.is_empty() {
+        // A dotfile (`.zshrc`) has no extension, only a leading dot.
+        return false;
+    }
+    SOURCE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str())
+}

--- a/crates/trusty-agents-common/src/compress/tool_output/tests.rs
+++ b/crates/trusty-agents-common/src/compress/tool_output/tests.rs
@@ -562,7 +562,13 @@ fn classify_tool_routes_known_tool_families() {
     assert_eq!(classify_tool("cargo clippy"), Some(ToolFilter::CargoCheck));
     assert_eq!(classify_tool("git diff"), Some(ToolFilter::GitDiff));
     assert_eq!(classify_tool("git log"), Some(ToolFilter::GitLog));
-    assert_eq!(classify_tool("cat file.rs"), Some(ToolFilter::FileRead));
+    // #6986: `cat file.rs` now short-circuits to `None` — a source read is a
+    // passthrough. The FileRead branch still routes for a read verb applied
+    // to something that is not source, which is what this line now pins.
+    assert_eq!(
+        classify_tool("cat /tmp/gate.txt"),
+        Some(ToolFilter::FileRead)
+    );
     assert_eq!(classify_tool("grep -n foo"), Some(ToolFilter::Grep));
     assert_eq!(classify_tool("rg foo"), Some(ToolFilter::Grep));
     assert_eq!(classify_tool("find ."), Some(ToolFilter::Grep));
@@ -645,4 +651,130 @@ fn uncovered_tool_output_passes_through_unchanged() {
         assert!(!has_filter_for(name));
         assert_eq!(compress_tool_output(name, &input), input, "{name}");
     }
+}
+
+// ── Source-file reads pass through (#6986) ─────────────────────────────
+
+/// A `.rs` file with doc comments and `#[test]` functions, `lines` lines long.
+fn rust_source_fixture(lines: usize) -> String {
+    let mut src = String::from("//! Module docs the agent needs to read.\n\n");
+    for i in 0..lines {
+        src.push_str(&format!("/// Why: item {i} exists for reason {i}.\n"));
+        src.push_str(&format!(
+            "#[test]\nfn checks_case_{i}() {{ assert!(true); }}\n\n"
+        ));
+    }
+    src
+}
+
+#[test]
+fn cat_of_a_rust_test_file_survives_compression_byte_for_byte() {
+    // The exact shape from #6986: `tm hook` derives the tool name from the
+    // command's first two tokens, so the PATH reached the substring dispatch
+    // and `tests.rs` matched the `test` branch. `filter_test_runner` found no
+    // `test result:` summary and returned an empty string —
+    // `bytes_before=6037 bytes_after=0 pct_reduction=100.0`.
+    let src = rust_source_fixture(40);
+    let tool = "cat crates/trusty-agents/src/ticketing/gh_cli/tests.rs";
+    assert!(src.len() > SIZE_GATE_BYTES);
+    let out = compress_tool_output(tool, &src);
+    assert!(!out.is_empty(), "compressor emptied a source read");
+    assert_eq!(out, src, "source read must round-trip byte-for-byte");
+}
+
+#[test]
+fn cat_of_a_rust_module_keeps_its_doc_comments() {
+    // The second symptom in #6986: `cat …/mod.rs` cleared the `test`/`cargo`
+    // substring branches, reached `FileRead`, and `filter_file_read` dropped
+    // every `//`-prefixed line — the doc comments were the point of the read.
+    let src = rust_source_fixture(120);
+    assert!(src.lines().count() > FILE_READ_LINE_GATE);
+    let out = compress_tool_output("cat crates/trusty-agents/src/ticketing/gh_cli/mod.rs", &src);
+    assert!(
+        out.contains("/// Why: item 0"),
+        "doc comments were stripped"
+    );
+    assert_eq!(out, src);
+}
+
+#[tokio::test]
+async fn native_fallback_passes_a_source_read_through_unchanged() {
+    // Ties the fix to the `compression_path=native_fallback` route the issue
+    // reported. `rtk` may be installed in this environment, so assert only on
+    // the run that actually took the native path.
+    let src = rust_source_fixture(40);
+    let tool = "cat crates/trusty-agents/src/ticketing/gh_cli/tests.rs";
+    let (text, path) = compress_tool_output_async_with_path(tool, &src).await;
+    if path == CompressionPath::NativeFallback {
+        assert_eq!(text, src);
+    }
+}
+
+#[test]
+fn classify_tool_passes_through_source_reads() {
+    // A path segment must never choose the filter: `tests.rs` picked the test
+    // runner, `logging.rs` would pick `git log`, `checks.rs` cargo-check.
+    for name in [
+        "cat crates/trusty-agents/src/ticketing/gh_cli/tests.rs",
+        "cat crates/trusty-mpm/src/logging.rs",
+        "cat crates/trusty-common/src/checks.rs",
+        "cat Cargo.toml",
+        "head crates/trusty-mpm/CHANGELOG.md",
+        "bat website/src/lib/tools.ts",
+    ] {
+        assert_eq!(classify_tool(name), None, "{name}");
+        assert!(!has_filter_for(name), "{name}");
+    }
+}
+
+#[test]
+fn is_source_file_read_matches_the_reported_shapes() {
+    assert!(is_source_file_read("cat crates/x/src/tests.rs"));
+    assert!(is_source_file_read("head -50 crates/x/src/mod.rs"));
+    assert!(is_source_file_read("sed -n 1,80p crates/x/build.rs"));
+    // Case-insensitive on both verb and extension, and a directory-qualified
+    // program name resolves to its basename.
+    assert!(is_source_file_read("/bin/CAT crates/x/src/Main.RS"));
+}
+
+#[test]
+fn is_source_file_read_requires_a_read_verb() {
+    // Same paths, non-read verbs — these keep their existing classification.
+    assert!(!is_source_file_read("cargo test crates/x/src/tests.rs"));
+    assert!(!is_source_file_read("grep -n foo crates/x/src/lib.rs"));
+    assert!(!is_source_file_read("rm crates/x/src/lib.rs"));
+    // A read verb with no file argument at all.
+    assert!(!is_source_file_read("cat"));
+    assert!(!is_source_file_read(""));
+}
+
+#[test]
+fn is_source_file_read_ignores_gate_capture_extensions() {
+    // `<gate> > /tmp/gate.txt` is this project's documented capture pattern,
+    // so reading one back is genuine gate output and stays compressible.
+    for name in [
+        "cat /tmp/gate.txt",
+        "cat /tmp/cargo-test.log",
+        "cat target/build.out",
+        "cat .zshrc",
+    ] {
+        assert!(!is_source_file_read(name), "{name}");
+    }
+}
+
+#[test]
+fn dispatch_never_returns_empty_for_non_empty_input() {
+    // The backstop behind the classification fix: any filter that consumed
+    // every byte hands the original back rather than emitting nothing.
+    let mut passing_only = String::new();
+    for i in 0..40 {
+        passing_only.push_str(&format!("test suite::case_{i} ... ok\n"));
+    }
+    // No `test result:` line, so `filter_test_runner` has no summary to fall
+    // back to and previously returned "".
+    assert_eq!(filter_test_runner(&passing_only), "");
+    assert_eq!(
+        compress_tool_output("cargo test", &passing_only),
+        passing_only
+    );
 }

--- a/crates/trusty-mpm/changelog.d/6986-compress-source-passthrough.md
+++ b/crates/trusty-mpm/changelog.d/6986-compress-source-passthrough.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `tm compress` passes a source-file read through untouched. Reading
+  `crates/x/src/tests.rs` with `cat` used to come back as zero bytes
+  (`bytes_before=6037 bytes_after=0 pct_reduction=100.0
+  compression_path=native_fallback`) because the path, not the program, chose
+  the filter; a sibling `mod.rs` came back with its doc comments stripped. The
+  classification fix lands in `trusty-agents-common`'s shared compression
+  module, which `tm compress` calls (#6986).


### PR DESCRIPTION
Refs #6986

## Root cause

`tm hook`'s Bash rewrite passes the wrapped command as the tool name
(`effective_tool_name` = program + first argument), and `classify_tool` matches
that name by **substring**. So the file's own path chose the filter:

- `cat crates/trusty-agents/src/ticketing/gh_cli/tests.rs` → `contains("test")`
  matched `tests.rs` → `TestRunner` → `filter_test_runner` kept only failure and
  summary lines, found no `test result:` line, and returned `""`. That is the
  reported `bytes_before=6037 bytes_after=0 pct_reduction=100.0`.
- `cat …/mod.rs` cleared that branch, fell to `FileRead`, and above the 200-line
  gate `filter_file_read` drops every line starting `//` or `#` — the doc
  comments the agent was reading.

`native_fallback` names the native filter chain; it did not fail, it ran as
written. The same misroute would send `cat …/logging.rs` to the `git log` filter
and `cat …/checks.rs` to the cargo-check filter.

## Fix — classify from the command, not the output shape

Output shape cannot separate a `.rs` file's contents from a compiler log that
quotes source; the command says what the caller asked for.

New `crates/trusty-agents-common/src/compress/tool_output/source_read.rs` —
`is_source_file_read`: first token (basename, lowercased) in
`cat`/`bat`/`head`/`tail`/`nl`/`less`/`more`/`sed`, **and** a later token whose
basename carries a source or prose extension. `classify_tool` consults it first
and returns `None`, so the read passes through byte-for-byte and `has_filter_for`
also stops `tm hook` wrapping it at all.

`.txt`, `.log` and `.out` are deliberately **not** source extensions —
`<gate> > /tmp/gate.txt` is the documented capture pattern, so reading one back
stays compressible. Genuine gate output is untouched: `cargo test`,
`cargo clippy`, `git log` and `git diff` classify exactly as before.

Second change, a backstop rather than the fix: `compress_tool_output` returns the
original when a filter consumed every byte of a non-empty input. Emitting nothing
is indistinguishable from a command that printed nothing.

## Regression evidence

Fix reverted at its two change sites (module and tests kept), on this branch:

```
---- classify_tool_passes_through_source_reads stdout ----
assertion `left == right` failed: cat crates/trusty-agents/src/ticketing/gh_cli/tests.rs
  left: Some(TestRunner)
 right: None
---- cat_of_a_rust_test_file_survives_compression_byte_for_byte stdout ----
panicked at tests.rs:676:5: compressor emptied a source read
---- cat_of_a_rust_module_keeps_its_doc_comments stdout ----
panicked at tests.rs:688:5: doc comments were stripped

failures:
    compress::tool_output::tests::cat_of_a_rust_module_keeps_its_doc_comments
    compress::tool_output::tests::cat_of_a_rust_test_file_survives_compression_byte_for_byte
    compress::tool_output::tests::classify_tool_passes_through_source_reads
    compress::tool_output::tests::dispatch_never_returns_empty_for_non_empty_input
    compress::tool_output::tests::native_fallback_passes_a_source_read_through_unchanged
test result: FAILED. 520 passed; 5 failed; 0 ignored
```

Restored, then green: `test result: ok. 525 passed; 0 failed; 0 ignored`.

One existing assertion changed, none deleted or `#[ignore]`d:
`classify_tool_routes_known_tool_families` asserted
`classify_tool("cat file.rs") == Some(FileRead)`, which is the exact behavior
being fixed. It now pins `classify_tool("cat /tmp/gate.txt") == Some(FileRead)` —
the FileRead branch still routes for a read verb on something that is not source.
Every cargo-test, clippy and git-log filter test is unchanged and passing.

## Gates — rung 4 (shared library, then each direct dependent)

`trusty-agents-common` is a shared library; its direct dependents are
`trusty-agents`, `trusty-code`, `trusty-kb` and `trusty-mpm`. All test runs used
`--no-fail-fast`, so the counts cover every target.

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0, 0 diffs |
| `cargo clippy -p trusty-agents-common --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-agents-common --no-fail-fast` | `ok. 525 passed; 0 failed; 0 ignored` |
| `cargo check --workspace --all-targets` | EXIT=0 |
| `cargo test -p trusty-mpm --no-fail-fast` | 54 targets, 10835 passed, 0 failed, 19 ignored |
| `cargo test -p trusty-agents --no-fail-fast` | 14 targets, 3674 passed, 0 failed, 16 ignored |
| `cargo test -p trusty-code --no-fail-fast` | 19 targets, 1846 passed, 0 failed, 4 ignored |
| `cargo test -p trusty-kb --no-fail-fast` | 5 targets, 119 passed, 0 failed, 0 ignored |
| `./scripts/check_line_cap.sh` | 4563 files, 0 violations |
| `./scripts/check_test_pointers.sh` | 31555 citations, 0 dangling |
| `./scripts/check_sld.sh` | 0 errors, 0 warnings |
| `./scripts/check_changelog_fragment.sh` | OK trusty-agents-common |
| `./scripts/check-pr-version-bump.sh` | clear, 0 warnings |
| `bash scripts/check_rustdoc_links.sh` | `SUMMARY 26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0` |

## Changelog fragments

`crates/trusty-agents-common/changelog.d/6986-compress-source-passthrough.md` is
the gate-required record — that crate's `src/**` is what changed.
`crates/trusty-mpm/changelog.d/6986-compress-source-passthrough.md` is also
present because `tm compress` is the surface a user sees change; it validates
against the assembler (`check_changelog_fragment.sh --file` → OK).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
