### PR TITLE
fix(trusty-code): harden private state on every run, correct run-task help, exit nonzero on a refused import (#6999)

### DIFF
--- a/crates/trusty-code/README.md
+++ b/crates/trusty-code/README.md
@@ -150,8 +150,14 @@ Run `tcode paths show [--json]` to see which root won for each entry.
 Transcripts, logs, compression telemetry, daemon discovery files, and the
 workstream store are per-user runtime state, not project configuration. They
 live in `~/.trusty-code/`, which is created at mode `0700`; an existing
-directory with a permissive mode is tightened on the next run. `tcode paths
-show` reports whether the mode is currently owner-only.
+directory with a permissive mode is tightened on the next run. Every `tcode`
+run that resolves the directory applies both — not only `tcode paths import`
+(#6999). `tcode paths show` reports whether the mode is currently owner-only,
+and resolves the path without creating it.
+
+Files and subdirectories already inside `~/.trusty-code/` keep their own modes;
+only the root is chmod'd. `0700` on the root blocks the ordinary traversal path
+into them.
 
 ### Importing an existing `.claude/` catalog
 
@@ -174,6 +180,12 @@ Four sources are refused rather than copied, each named in the output:
 - `settings.json` carries a secret-bearing key, or will not parse. Put
   credentials in the environment or the secure store, never in a file the
   project commits.
+
+**Exit code.** A clean import exits `0`. If any entry was refused, the command
+exits `1` (#6999) — so a script can branch on it instead of parsing the plan.
+`--dry-run` reports the code the real run would, which keeps the preview and the
+run in agreement. Re-running a completed import therefore exits `1`: every
+target already exists, so every entry is refused.
 
 Plugins are deliberately not copied: their provenance cannot be vouched for, so
 `.claude/plugins/` stays discoverable in place through the compatibility root.

--- a/crates/trusty-code/changelog.d/6999-private-state-followups.md
+++ b/crates/trusty-code/changelog.d/6999-private-state-followups.md
@@ -1,0 +1,18 @@
+Fixed
+
+- **Every `tcode` run now tightens a permissive `~/.trusty-code` (#6999).** The
+  `0700` create-and-tighten was reachable only from `tcode paths import`, so the
+  README's "tightened on the next run" was false for every other subcommand.
+  `workstreams::default_data_dir` — the one resolver the workstream store,
+  `serve`'s router, and `agent_loop::telemetry` all reach the private-state root
+  through — now applies it, so no writer creates the directory at the process
+  umask first.
+- **`tcode run-task --help` describes the `.trusty-code` layout (#6999).** It
+  still said the project root "must contain a `.claude/` directory" and that
+  agents live in `.claude/agents/<name>.md`; both stopped being true in #5426.
+  `tcode serve --help` carried the same sentence and is corrected too.
+- **`tcode paths import` exits 1 when any entry was refused (#6999).** A symlink
+  escape, an executable, a secret-bearing `settings.json`, or an
+  already-existing target was printed as a `skip` line while the process still
+  exited 0. `--dry-run` reports the same code the real run would, so the preview
+  and the run cannot disagree.

--- a/crates/trusty-code/src/agent_loop/telemetry.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry.rs
@@ -80,9 +80,21 @@ pub(crate) static DATA_DIR_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex
 /// uses: [`DATA_DIR_ENV_VAR`] when set (test isolation), otherwise
 /// `crate::workstreams::default_data_dir()` (`~/.trusty-code`, production).
 pub fn default_data_dir() -> PathBuf {
-    std::env::var(DATA_DIR_ENV_VAR)
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| crate::workstreams::default_data_dir())
+    data_dir_override().unwrap_or_else(crate::workstreams::default_data_dir)
+}
+
+/// The directory [`DATA_DIR_ENV_VAR`] names, if it is set.
+///
+/// Why: #6999 gave `crate::workstreams::default_data_dir` a side effect — it
+/// creates and chmods `~/.trusty-code` — so a test that asserted on
+/// [`default_data_dir`] to check the UNSET branch did real I/O in whatever
+/// `$HOME` the run had. Reading the variable separately lets that branch be
+/// asserted without resolving, creating, or chmod'ing anything.
+/// What: the variable parsed as a `PathBuf`, or `None` when unset.
+/// Test: `agent_loop::telemetry_tests::default_data_dir_honors_env_override`,
+/// `agent_loop::telemetry_tests::default_data_dir_falls_back_to_workstreams_default_when_unset`.
+fn data_dir_override() -> Option<PathBuf> {
+    std::env::var(DATA_DIR_ENV_VAR).ok().map(PathBuf::from)
 }
 
 /// One JSONL line: a single compression/summarization event (issue #3867).

--- a/crates/trusty-code/src/agent_loop/telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry_tests.rs
@@ -507,5 +507,19 @@ fn default_data_dir_falls_back_to_workstreams_default_when_unset() {
     if std::env::var(DATA_DIR_ENV_VAR).is_ok() {
         return;
     }
-    assert_eq!(default_data_dir(), crate::workstreams::default_data_dir());
+    // #6999: this used to compare `default_data_dir()` with
+    // `workstreams::default_data_dir()`. Both now CREATE and chmod
+    // `~/.trusty-code`, so the comparison did real I/O in whatever `$HOME` the
+    // run had. The two halves are asserted separately instead: the override is
+    // unset, and the path the unset branch resolves is the private-state root.
+    assert_eq!(
+        data_dir_override(),
+        None,
+        "the override must be unset for the fallback branch to be the one taken"
+    );
+    assert_eq!(
+        crate::paths::private_state::private_state_dir().file_name(),
+        Some(std::ffi::OsStr::new(".trusty-code")),
+        "the fallback resolves the workstream private state root"
+    );
 }

--- a/crates/trusty-code/src/cli/paths.rs
+++ b/crates/trusty-code/src/cli/paths.rs
@@ -107,29 +107,49 @@ pub fn show(project_root: &Path, json: bool) -> Result<()> {
     Ok(())
 }
 
+/// The exit code `tcode paths import` uses when at least one entry was refused.
+///
+/// Why: #6999 — the refusal was printed but the process exited 0, so a caller
+/// scripting the import could not tell a clean migration from one that silently
+/// left a symlink escape, an executable, or a secret-bearing `settings.json`
+/// behind. A distinct nonzero code is the only signal a script can branch on.
+/// What: `1`. Deliberately outside the `run-task` ladder
+/// (`trusty_code::run_task::ExitCode` uses `0` and `2`–`6`), so no caller can
+/// confuse the two.
+/// Test: `tests/cli_e2e.rs::paths_import_exits_nonzero_when_an_entry_is_refused`.
+pub const IMPORT_REFUSED_EXIT_CODE: i32 = 1;
+
 /// Plan, print, and (unless `dry_run`) apply the `.claude/` → `.trusty-code/`
-/// import.
+/// import, returning the process exit code.
 ///
 /// Why: the plan is printed in both modes so `--dry-run` output and the real
 /// run's output describe the same work — the property that makes a dry run
-/// worth trusting.
+/// worth trusting. #6999 extends that property to the exit code: a plan holding
+/// a refusal reports [`IMPORT_REFUSED_EXIT_CODE`] in BOTH modes, so a dry run
+/// and the run it previews cannot disagree on whether the migration is clean.
 /// What: [`paths::import::plan_import`], printed one line per entry; with
 /// `dry_run` it stops there, otherwise it applies the plan and prints the
 /// created and refused counts. It also creates and tightens the private state
 /// directory, since that is the other half of the layout an operator running
-/// this command is adopting.
-/// Test: `tests/cli_e2e.rs::paths_import_dry_run_writes_nothing`.
-pub fn import(project_root: &Path, dry_run: bool) -> Result<()> {
+/// this command is adopting. Returns `0` when nothing was refused and
+/// [`IMPORT_REFUSED_EXIT_CODE`] otherwise — including the benign
+/// "target already exists" refusal, which is what a re-run of a completed
+/// import reports.
+/// Test: `tests/cli_e2e.rs::paths_import_dry_run_writes_nothing`,
+/// `tests/cli_e2e.rs::paths_import_exits_nonzero_when_an_entry_is_refused`.
+pub fn import(project_root: &Path, dry_run: bool) -> Result<i32> {
     let plan = paths::import::plan_import(project_root);
     if plan.entries.is_empty() {
         println!("nothing to import: no .claude/agents, .claude/skills, or .claude/settings.json");
     }
+    let mut refused = 0usize;
     for entry in &plan.entries {
         match &entry.action {
             paths::import::ImportAction::Copy => {
                 println!("copy    {}", entry.to.display());
             }
             paths::import::ImportAction::Refuse(reason) => {
+                refused += 1;
                 println!("skip    {} — {reason}", entry.from.display());
             }
         }
@@ -137,7 +157,8 @@ pub fn import(project_root: &Path, dry_run: bool) -> Result<()> {
 
     if dry_run {
         println!("\n--dry-run: nothing was written.");
-        return Ok(());
+        // #6999: the dry run reports the exit code the real run would.
+        return Ok(exit_code_for(refused));
     }
 
     let report = paths::import::apply_import(&plan);
@@ -156,5 +177,19 @@ pub fn import(project_root: &Path, dry_run: bool) -> Result<()> {
             println!("  {}", path.display());
         }
     }
-    Ok(())
+    Ok(exit_code_for(report.refused.len()))
+}
+
+/// Map a refusal count onto the import's exit code.
+///
+/// Why: the dry-run and applied paths must agree, so the mapping is written
+/// once (#6999).
+/// What: `0` for no refusals, [`IMPORT_REFUSED_EXIT_CODE`] otherwise.
+/// Test: `tests/cli_e2e.rs::paths_import_exits_nonzero_when_an_entry_is_refused`.
+fn exit_code_for(refused: usize) -> i32 {
+    if refused == 0 {
+        0
+    } else {
+        IMPORT_REFUSED_EXIT_CODE
+    }
 }

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -78,7 +78,10 @@ enum Command {
     /// be selected: `--stdio` XOR `--http` (they are independent modes, not
     /// simultaneous — see `trusty_code::serve` module docs).
     Serve {
-        /// Path to the project root (must contain a `.claude/` directory).
+        // #6999: same stale `.claude/`-only wording as `run-task` carried.
+        /// Path to the project root. Its configuration is read from
+        /// `.trusty-code/`, falling back to `.claude/` then `.open-mpm/`; none
+        /// of the three has to exist.
         ///
         /// OPTIONAL: omit it to serve PROJECTLESS — a first-class state for
         /// chat/planning before a project is chosen, and the state the shell's
@@ -154,14 +157,19 @@ enum Command {
     /// diff-report output, which the daemon-driven path does not (yet)
     /// compute.
     RunTask {
-        /// Agent name as declared in `.claude/agents/<name>.md` (e.g. `pm`).
+        // #6999: the pre-#5426 wording named `.claude/` as the only layout.
+        /// Agent name as declared in `.trusty-code/agents/<name>.md` (e.g.
+        /// `pm`), falling back to `.claude/agents/` then `.open-mpm/agents/`.
         agent: String,
 
         /// Free-form task description passed to the agent's system prompt.
         task: String,
 
-        /// Path to the project root (must contain a `.claude/` directory).
-        /// Defaults to the current working directory.
+        // #6999: a `.trusty-code`-only project runs; `.claude/` is a fallback.
+        /// Path to the project root. Its configuration is read from
+        /// `.trusty-code/`, falling back to `.claude/` then `.open-mpm/`; none
+        /// of the three has to exist. Defaults to the current working
+        /// directory.
         #[arg(long, short, value_name = "PATH", default_value = ".")]
         project: PathBuf,
 
@@ -347,6 +355,10 @@ enum PathsCommand {
 
     /// Import `.claude/agents`, `.claude/skills`, and `.claude/settings.json`
     /// into `.trusty-code/`, never overwriting an existing file.
+    ///
+    /// Exits 1 if any entry was refused — a symlink escape, an executable, a
+    /// secret-bearing `settings.json`, or a target that already exists (#6999).
+    /// `--dry-run` reports the same code the real run would.
     Import {
         /// Path to the project root.
         #[arg(long, short, value_name = "PATH", default_value = ".")]
@@ -587,7 +599,17 @@ async fn main() -> Result<()> {
         // `import`, writes only beneath `<project>/.trusty-code/`.
         Command::Paths { action } => match action {
             PathsCommand::Show { project, json } => cli::paths::show(&project, json),
-            PathsCommand::Import { project, dry_run } => cli::paths::import(&project, dry_run),
+            // #6999: a refused entry must reach the caller as an exit code, not
+            // only as a line of plan output.
+            PathsCommand::Import { project, dry_run } => {
+                match cli::paths::import(&project, dry_run) {
+                    Ok(code) => process::exit(code),
+                    Err(e) => {
+                        eprintln!("tcode paths import: {e:#}");
+                        process::exit(ExitCode::RunFailure.code());
+                    }
+                }
+            }
         },
 
         Command::Workstream { action } => match action {

--- a/crates/trusty-code/src/paths/private_state.rs
+++ b/crates/trusty-code/src/paths/private_state.rs
@@ -95,22 +95,42 @@ pub fn private_state_dir() -> PathBuf {
 /// `paths::private_state_tests::ensure_tightens_a_permissive_existing_dir`.
 pub fn ensure_private_state_dir_at(home: &Path) -> io::Result<PathBuf> {
     let dir = private_state_dir_at(home);
-    std::fs::create_dir_all(&dir)?;
-    harden(&dir);
+    ensure_dir(&dir)?;
     Ok(dir)
+}
+
+/// Create `dir` and tighten it, on an already-resolved path.
+///
+/// Why: #6999 — the create-and-tighten body was written twice, once per
+/// `ensure_*` wrapper, and [`crate::workstreams::default_data_dir`] needs a
+/// third caller that already holds the resolved path (its home resolution is
+/// [`private_state_dir`]'s job, including the no-home fallback). One body, three
+/// callers, rather than a copy per entry point.
+/// What: `create_dir_all` then [`harden`]. Errors only on the create — a
+/// failure to chmod is logged by [`harden`] and does not fail the call.
+/// Test: `paths::private_state_tests::ensure_creates_restrictive_dir`,
+/// `workstreams::path_tests::ensure_or_report_falls_back_when_the_path_is_a_file`.
+pub(crate) fn ensure_dir(dir: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    harden(dir);
+    Ok(())
 }
 
 /// Create and tighten the production `~/.trusty-code`.
 ///
 /// Why: the production wrapper over [`ensure_private_state_dir_at`], so callers
-/// never resolve the home directory themselves.
+/// never resolve the home directory themselves. #6999: `tcode paths import` was
+/// its only caller, so the mode guarantee applied to exactly one subcommand;
+/// [`crate::workstreams::default_data_dir`] now calls it too, which is the
+/// resolver every private-state writer already routes through.
 /// What: [`private_state_dir`] then the same create-and-tighten sequence.
 /// Test: covered hermetically by `ensure_private_state_dir_at`'s tests; the
 /// wrapper adds only home resolution.
+/// `tests/cli_e2e.rs::a_non_import_command_tightens_a_permissive_private_state_dir`
+/// covers the call from `default_data_dir`.
 pub fn ensure_private_state_dir() -> io::Result<PathBuf> {
     let dir = private_state_dir();
-    std::fs::create_dir_all(&dir)?;
-    harden(&dir);
+    ensure_dir(&dir)?;
     Ok(dir)
 }
 

--- a/crates/trusty-code/src/workstreams/path.rs
+++ b/crates/trusty-code/src/workstreams/path.rs
@@ -30,24 +30,62 @@ const HASH_LEN: usize = 8;
 /// store regardless of which directory `tcode serve` happened to start in.
 const PROJECTLESS_FILENAME: &str = "workstreams-projectless.json";
 
-/// Resolve `~/.trusty-code`, the trusty-code private state directory.
+/// Resolve `~/.trusty-code`, creating it at mode `0700` and tightening it if a
+/// previous run left it permissive.
 ///
 /// Why: mirrors `trusty-mpm`'s `~/.trusty-mpm` precedent
 /// (`crates/trusty-mpm/src/core/paths.rs`) rather than inventing a new
 /// resolution convention. #5426 moved the resolution itself into
 /// [`crate::paths::private_state`], which also owns the `0700` mode this
 /// directory must carry — a workstream store sitting beside transcripts and
-/// logs is private state, not an independent location.
-/// What: delegates to [`crate::paths::private_state::private_state_dir`]:
-/// `dirs::home_dir()/.trusty-code`, falling back to a relative `.trusty-code`
-/// (with a `warn`) if the home directory cannot be resolved. Never panics, and
-/// creates nothing — [`crate::paths::private_state::ensure_private_state_dir`]
-/// is the creating variant.
+/// logs is private state, not an independent location. #6999: this function is
+/// the ONE place every private-state writer resolves that root — the workstream
+/// store, `serve`'s router, and `agent_loop::telemetry`'s own `default_data_dir`
+/// all end here — so the mode guarantee is applied here rather than at each
+/// writer's own `create_dir_all`, which would apply the process umask and leave
+/// `0755`. Applying it anywhere else would be a second copy of the rule.
+/// What: delegates to [`crate::paths::private_state::ensure_private_state_dir`]:
+/// `dirs::home_dir()/.trusty-code`, created if missing and chmod'd to `0700` if
+/// any group or other bit is set. On an I/O failure it falls back to the plain
+/// [`crate::paths::private_state::private_state_dir`] path, logging at `warn` —
+/// a harness that cannot create its state directory should still report what it
+/// tried, not panic. Never panics.
 /// Test: `path_tests::default_data_dir_is_dot_trusty_code`,
+/// `path_tests::ensure_or_report_creates_and_tightens_a_permissive_dir`,
+/// `tests/cli_e2e.rs::a_non_import_command_tightens_a_permissive_private_state_dir`,
 /// `paths::private_state::private_state_tests::private_state_dir_matches_home_when_available`.
 pub fn default_data_dir() -> PathBuf {
-    // #5426: one resolver for the private state root, shared with its mode guard.
-    crate::paths::private_state::private_state_dir()
+    // #6999: the README promised an existing permissive `~/.trusty-code` is
+    // tightened on the next run; before this, only `tcode paths import` did it.
+    // `private_state_dir` owns home resolution, including the no-home fallback.
+    ensure_or_report(crate::paths::private_state::private_state_dir())
+}
+
+/// Create and tighten an already-resolved private-state root, or report why not.
+///
+/// Why: the hermetic core of [`default_data_dir`] (#6999), mirroring
+/// [`crate::paths::private_state::private_state_dir_at`]'s reason for existing —
+/// a test drives it with a temp directory, so no test creates, chmods, or
+/// reports on the developer's real `~/.trusty-code`.
+/// What: [`crate::paths::private_state::ensure_dir`], returning `dir` either
+/// way. On failure — the path is a regular file, the home directory is
+/// read-only, the filesystem is full — it logs at `warn` with the path and the
+/// error and hands back the same path, so a harness that cannot create its state
+/// directory still runs and still says what it tried. Never panics.
+/// Test: `path_tests::ensure_or_report_creates_and_tightens_a_permissive_dir`,
+/// `path_tests::ensure_or_report_falls_back_when_the_path_is_a_file`,
+/// `tests/cli_e2e.rs::an_unusable_private_state_path_warns_instead_of_panicking`.
+pub(crate) fn ensure_or_report(dir: PathBuf) -> PathBuf {
+    if let Err(e) = crate::paths::private_state::ensure_dir(&dir) {
+        tracing::warn!(
+            path = %dir.display(),
+            error = %e,
+            "could not create the trusty-code private state directory; \
+             continuing with the resolved path, which may not exist or may \
+             be readable by other users on this machine"
+        );
+    }
+    dir
 }
 
 /// Turn an arbitrary string into a filesystem-safe, lowercase, hyphenated

--- a/crates/trusty-code/src/workstreams/path_tests.rs
+++ b/crates/trusty-code/src/workstreams/path_tests.rs
@@ -4,10 +4,77 @@ use super::*;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
+/// The private-state root `default_data_dir` returns is named `.trusty-code`.
+///
+/// Why: #6999 made `default_data_dir` CREATE and chmod that directory, so
+/// calling it here did real I/O in whatever `$HOME` the test run happened to
+/// have. The path it returns is `private_state_dir()`'s verbatim — it only adds
+/// the create-and-tighten — so the name is asserted on the non-creating
+/// resolver, and the creating half is covered hermetically by the two
+/// `ensure_or_report` tests below.
 #[test]
 fn default_data_dir_is_dot_trusty_code() {
-    let dir = default_data_dir();
+    let dir = crate::paths::private_state::private_state_dir();
     assert_eq!(dir.file_name().unwrap(), ".trusty-code");
+}
+
+/// `ensure_or_report` creates the root at `0700` and tightens a permissive one.
+///
+/// Why: the guarantee #6999 moved onto every run, proven hermetically against a
+/// temp directory rather than through the CLI.
+/// What: asserts creation from nothing yields owner-only, then re-runs against a
+/// deliberately-chmod'd `0755` directory and asserts it comes back owner-only.
+#[cfg(unix)]
+#[test]
+fn ensure_or_report_creates_and_tightens_a_permissive_dir() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = TempDir::new().expect("home tempdir");
+    let root = home.path().join(".trusty-code");
+
+    let created = ensure_or_report(root.clone());
+    assert_eq!(created, root);
+    let mode = std::fs::metadata(&root).expect("stat").permissions().mode();
+    assert_eq!(
+        mode & 0o077,
+        0,
+        "created dir must be owner-only, saw {mode:o}"
+    );
+
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755))
+        .expect("loosen the existing dir");
+    let tightened = ensure_or_report(root.clone());
+    assert_eq!(tightened, root);
+    let mode = std::fs::metadata(&root).expect("stat").permissions().mode();
+    assert_eq!(
+        mode & 0o077,
+        0,
+        "an existing permissive dir must be tightened, saw {mode:o}"
+    );
+}
+
+/// `ensure_or_report` fails open when the path cannot be a directory.
+///
+/// Why: the fail-open arm #6999 added — a harness whose `~/.trusty-code` is a
+/// regular file, or whose home is read-only, must still resolve a usable path
+/// and keep running rather than panic on an `unwrap`.
+/// What: stages `<home>/.trusty-code` as a regular FILE, so `create_dir_all`
+/// cannot succeed, and asserts the same path comes back with the file
+/// untouched. The `warn` this also emits is asserted end to end by
+/// `tests/cli_e2e.rs::an_unusable_private_state_path_warns_instead_of_panicking`.
+#[test]
+fn ensure_or_report_falls_back_when_the_path_is_a_file() {
+    let home = TempDir::new().expect("home tempdir");
+    let root = home.path().join(".trusty-code");
+    std::fs::write(&root, "not a directory\n").expect("stage a file at the root path");
+
+    let resolved = ensure_or_report(root.clone());
+
+    assert_eq!(resolved, root, "the resolved path must still be returned");
+    assert!(
+        root.is_file(),
+        "the fallback must not have replaced or removed the existing file"
+    );
 }
 
 #[test]

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -52,6 +52,14 @@
 //! home directory — the same sandboxing `support::home_with_user_level_agents`
 //! already uses for agent resolution.
 //!
+//! `a_non_import_command_tightens_a_permissive_private_state_dir`,
+//! `run_task_help_names_trusty_code_first_and_claude_as_fallback`, and
+//! `paths_import_exits_nonzero_when_an_entry_is_refused` (#6999) close the
+//! three gaps #5426's live verification found: the `0700` guarantee reached
+//! only `tcode paths import`, `run-task --help` still described the
+//! pre-#5426 `.claude`-only layout, and a refused import printed its refusal
+//! while exiting 0.
+//!
 //! Test: this file IS the test; see `support` for the shared
 //! `project_with_agents` fixture.
 
@@ -979,5 +987,202 @@ fn paths_import_dry_run_writes_nothing() {
     assert!(
         !project.path().join(".trusty-code").exists(),
         "a dry run must not create .trusty-code/"
+    );
+}
+
+/// A tcode command that is NOT `paths import` tightens a permissive
+/// `~/.trusty-code` (#6999).
+///
+/// Why: the README promised an existing permissive private-state directory is
+/// tightened "on the next run", but `ensure_private_state_dir` was reachable
+/// only from `tcode paths import`. A `workstream list` — which resolves the
+/// same root to find its store — left a pre-existing `0755` directory `0755`.
+/// What: stages `$HOME/.trusty-code` at `0755`, runs `tcode workstream list`
+/// with `HOME` pinned there, and asserts every group and other bit is clear
+/// afterwards. `workstream list` is chosen because it reaches the root through
+/// `workstreams::path::default_data_dir`, the resolver every private-state
+/// writer shares — proving the guarantee at the shared entry point rather than
+/// at one subcommand.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn a_non_import_command_tightens_a_permissive_private_state_dir() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let state = home.path().join(".trusty-code");
+    std::fs::create_dir_all(&state).expect("mkdir private state");
+    std::fs::set_permissions(&state, std::fs::Permissions::from_mode(0o755))
+        .expect("stage a permissive private state dir");
+
+    let output = support::tcode_command()
+        .args([
+            "workstream",
+            "list",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream list");
+    assert!(
+        output.status.success(),
+        "workstream list must exit 0: {output:?}"
+    );
+
+    let mode = std::fs::metadata(&state)
+        .expect("stat private state")
+        .permissions()
+        .mode();
+    assert_eq!(
+        mode & 0o077,
+        0,
+        "a non-import run must tighten ~/.trusty-code to owner-only, saw {:o}",
+        mode & 0o777
+    );
+}
+
+/// `tcode run-task --help` describes the `.trusty-code` layout, not the
+/// pre-#5426 `.claude`-only one (#6999).
+///
+/// Why: the help still told operators the project root "must contain a
+/// `.claude/` directory" and that agents live in `.claude/agents/<name>.md`,
+/// both false since #5426 — a `.trusty-code`-only project runs.
+/// What: asserts the help names `.trusty-code` for both the agent argument and
+/// the project argument, keeps `.claude` only as a fallback, and no longer
+/// carries the "must contain" sentence.
+/// Test: this function IS the test.
+#[test]
+fn run_task_help_names_trusty_code_first_and_claude_as_fallback() {
+    let output = support::tcode_command()
+        .args(["run-task", "--help"])
+        .output()
+        .expect("spawn tcode run-task --help");
+    assert!(output.status.success(), "--help must exit 0: {output:?}");
+    let help = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        help.contains(".trusty-code/agents/<name>.md"),
+        "the agent argument must name the native agents directory: {help}"
+    );
+    assert!(
+        help.contains(".trusty-code/"),
+        "the project argument must name the native config root: {help}"
+    );
+    assert!(
+        help.contains(".claude/"),
+        "the fallback root must still be documented: {help}"
+    );
+    assert!(
+        !help.contains("must contain a `.claude/` directory"),
+        "the pre-#5426 requirement must be gone: {help}"
+    );
+    assert!(
+        !help.contains("declared in `.claude/agents/"),
+        "the pre-#5426 agent location must be gone: {help}"
+    );
+}
+
+/// `tcode paths import` exits nonzero when the plan refuses an entry (#6999).
+///
+/// Why: a symlink escape was printed as `skip ...` and the process still exited
+/// 0, so a caller scripting the migration could not tell a clean import from
+/// one that silently left a credential-bearing symlink behind.
+/// What: stages `.claude/agents/leak.md` as a symlink to a file outside the
+/// project, runs the real import (not `--dry-run`) with `HOME` pinned, and
+/// asserts the refusal is both printed AND reported as exit code
+/// `cli::paths::IMPORT_REFUSED_EXIT_CODE`. Then asserts `--dry-run` on the same
+/// tree reports the same code, since the preview and the run must not disagree.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn paths_import_exits_nonzero_when_an_entry_is_refused() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let secret = outside.path().join("id_rsa");
+    std::fs::write(&secret, "not really a key\n").expect("write outside file");
+
+    let project = tempfile::tempdir().expect("project tempdir");
+    let agents = project.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents).expect("mkdir agents");
+    std::os::unix::fs::symlink(&secret, agents.join("leak.md")).expect("symlink escape");
+
+    let project_arg = project.path().display().to_string();
+    let output = support::tcode_command()
+        .args(["paths", "import", "--project", &project_arg])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode paths import");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("skip") && stdout.contains("leak.md"),
+        "the refusal must still be printed: {stdout}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a refused entry must exit 1: {stdout}{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let dry = support::tcode_command()
+        .args(["paths", "import", "--project", &project_arg, "--dry-run"])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode paths import --dry-run");
+    assert_eq!(
+        dry.status.code(),
+        Some(1),
+        "the dry run must report the code the real run would: {}",
+        String::from_utf8_lossy(&dry.stdout)
+    );
+}
+
+/// A `~/.trusty-code` that cannot be a directory warns; it never panics (#6999).
+///
+/// Why: making every run create and chmod the private-state root added an error
+/// arm — the path is a regular file, the home directory is read-only, the disk
+/// is full. That arm must fail OPEN: the process gets the resolved path back and
+/// keeps going, with a `warn` naming what it tried. An `unwrap` there would kill
+/// a harness that is otherwise fine.
+/// What: pins `HOME` to a tempdir with `$HOME/.trusty-code` staged as a plain
+/// FILE, so `create_dir_all` cannot succeed, then runs `tcode workstream list` —
+/// which resolves the data dir through `workstreams::path::default_data_dir` —
+/// and asserts the process exits without a panic and emits the warning on
+/// stderr. The unit half is
+/// `workstreams::path_tests::ensure_or_report_falls_back_when_the_path_is_a_file`.
+/// Test: this function IS the test.
+#[test]
+fn an_unusable_private_state_path_warns_instead_of_panicking() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    std::fs::write(home.path().join(".trusty-code"), "not a directory\n")
+        .expect("stage a file where the private state root would be");
+
+    let output = support::tcode_command()
+        .args([
+            "workstream",
+            "list",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .env("HOME", home.path())
+        .env("RUST_LOG", "warn")
+        .output()
+        .expect("spawn tcode workstream list");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked at"),
+        "an unusable private state path must not panic the process: {stderr}"
+    );
+    assert!(
+        stderr.contains("could not create the trusty-code private state directory"),
+        "the fail-open arm must say what it tried: {stderr}"
+    );
+    assert!(
+        home.path().join(".trusty-code").is_file(),
+        "the staged file must be left alone"
     );
 }


### PR DESCRIPTION
## What changed

Three gaps the live verification of #5426 (PR #6980) found, all in one change.

**Private-state hardening reached one subcommand.** `ensure_private_state_dir`
was called only from `tcode paths import`, so the README's "an existing
directory with a permissive mode is tightened on the next run" was false for
every other invocation: a `run-task` writing transcripts into an existing 0755
`~/.trusty-code` left it 0755, and on a fresh machine a writer's own
`create_dir_all` created it under the process umask. The fix routes it through
`workstreams::default_data_dir`, the one resolver every private-state writer
already passes through — the workstream store, `serve`'s router, and
`agent_loop::telemetry`'s own `default_data_dir` all end there — rather than
adding a copy of the rule at each writer. `paths show` still resolves the path
without creating it.

**`run-task --help` described the pre-#5426 layout.** It said the project root
"must contain a `.claude/` directory" and that agents live in
`.claude/agents/<name>.md`; a `.trusty-code`-only project has run since #5426.
`serve --help` carried the same sentence and is corrected too.

**`paths import` printed a refusal and exited 0.** A symlink escape, an
executable, or a secret-bearing `settings.json` was reported as a `skip` line
while the process still exited 0, so a caller could not branch on it. Nothing in
the README or help promised a code, so this PR picks one and documents it rather
than changing code to match a doc: exit `1` when any entry was refused,
deliberately outside the `run-task` ladder (`0`, `2`–`6`). `--dry-run` reports
the code the real run would, keeping the preview and the run in agreement.

`check_native_write_target`'s root anchoring and the
`SECRET_KEY_HINTS`/`SECRET_KEY_EXEMPTIONS` rules from #6980 are untouched — the
diff has no change in `src/paths/mod.rs` or `src/paths/import.rs`.

## Rung and commands

**Rung 3** — localized behavior inside one crate.

```
cargo fmt --check                                          → 0
cargo clippy -p trusty-code --all-targets -- -D warnings    → 0
cargo test -p trusty-code --no-fail-fast                    → 0
bash scripts/check_line_cap.sh                              → 0   4562 files, 0 violations
bash scripts/check_test_pointers.sh                         → 0   31558 citations, 0 dangling
bash scripts/check_sld.sh                                   → 0   0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh    (post-commit)   → 0
bash scripts/check-pr-version-bump.sh       (post-commit)   → 0   0.5.2 not yet published
bash scripts/check_rustdoc_links.sh                         → 0   26 crates, 0 broken links, baseline 0
```

19 of 19 targets ran under `--no-fail-fast`; every line `test result: ok`, zero
`FAILED`. Lib 1754 (up from 1752 on `main` — the two new `ensure_or_report`
tests); `cli_e2e` 25 (up from 21 — three regression tests plus the fail-open
one).

Version: no bump. `check-pr-version-bump.sh` reports `trusty-code 0.5.2 — src
changed, version not yet published`.

## Regression evidence — one test per gap, each reverted and re-run

**Gap 1** — `git checkout origin/main -- crates/trusty-code/src/workstreams/path.rs`:

```
test a_non_import_command_tightens_a_permissive_private_state_dir ... FAILED
panicked at crates/trusty-code/tests/cli_e2e.rs:1038:5:
assertion `left == right` failed: a non-import run must tighten ~/.trusty-code to owner-only, saw 755
  left: 45
 right: 0
```

**Gap 2** — the two `run-task` doc-comment lines restored to their pre-fix text:

```
test run_task_help_names_trusty_code_first_and_claude_as_fallback ... FAILED
panicked at crates/trusty-code/tests/cli_e2e.rs:1065:5:
the agent argument must name the native agents directory: ...
  <AGENT>
          Agent name as declared in `.claude/agents/<name>.md` (e.g. `pm`)
  -p, --project <PATH>
          Path to the project root (must contain a `.claude/` directory). ...
```

**Gap 3** — `exit_code_for()` short-circuited to 0 in both the dry-run and
applied paths:

```
test paths_import_exits_nonzero_when_an_entry_is_refused ... FAILED
panicked at crates/trusty-code/tests/cli_e2e.rs:1122:5:
assertion `left == right` failed: a refused entry must exit 1: skip    .../.claude/agents/leak.md — source resolves outside .../.claude — refusing to import through a symlink
imported 0 file(s); skipped 1.
  left: Some(0)
 right: Some(1)
```

## code-critic WARN → resolved

The critic returned WARN on `b405f9528` with two required changes. Both are
addressed at `43edfd416`; each was verified rather than taken on faith.

### 1. The fail-open error arm was untested

`default_data_dir()` falls back to the plain resolver with a `warn` when
`ensure_private_state_dir()` errors, and nothing exercised that branch.

`default_data_dir` is now split into a production wrapper and a hermetic core,
mirroring `private_state_dir` / `private_state_dir_at`'s existing reason for
existing:

```rust
pub fn default_data_dir() -> PathBuf {
    ensure_or_report(crate::paths::private_state::private_state_dir())
}

pub(crate) fn ensure_or_report(dir: PathBuf) -> PathBuf { … }
```

`private_state_dir()` still owns home resolution including the no-home
fallback, so nothing is duplicated. The create-and-tighten body itself was
written twice before, once per `ensure_*` wrapper; it is now one
`private_state::ensure_dir` with three callers.

Two tests cover the arm:

- `workstreams::path_tests::ensure_or_report_falls_back_when_the_path_is_a_file` —
  hermetic, `<tempdir>/.trusty-code` staged as a regular file; asserts the same
  path comes back and the file is untouched.
- `tests/cli_e2e.rs::an_unusable_private_state_path_warns_instead_of_panicking` —
  `HOME` pinned to a tempdir with `.trusty-code` staged as a file,
  `RUST_LOG=warn`, `tcode workstream list`; asserts no `panicked at` on stderr,
  the warning text present, the file untouched.

The pre-fix commit cannot express this case: `origin/main` never calls
`ensure_private_state_dir` outside `paths import`, so there is no error arm to
be missing. Proven against a no-fallback variant instead
(`ensure_dir(&dir).expect(...)`):

```
test an_unusable_private_state_path_warns_instead_of_panicking ... FAILED
panicked at crates/trusty-code/tests/cli_e2e.rs:1176:5:
an unusable private state path must not panic the process: 
thread 'main' (24506096) panicked at crates/trusty-code/src/workstreams/path.rs:79:51:
private state dir: Os { code: 17, kind: AlreadyExists, message: "File exists" }
tcode workstream list: daemon connection closed unexpectedly
```

The `.expect()` was removed after that run; the committed code carries only the
`if let Err` form.

### 2. Two pre-existing unit tests did real I/O against `$HOME`

`workstreams::path_tests::default_data_dir_is_dot_trusty_code` now asserts on
`paths::private_state::private_state_dir()` — `dirs::home_dir()` plus a
`PathBuf::join`, no filesystem call. The creating half it gave up is covered
hermetically by `ensure_or_report_creates_and_tightens_a_permissive_dir`, which
creates from nothing at 0700, chmods to 0755, re-runs, and asserts owner-only
both times.

`agent_loop::telemetry_tests::default_data_dir_falls_back_to_workstreams_default_when_unset`
compared two functions that now both create. The env read is split out of
`telemetry::default_data_dir()` into a private `data_dir_override() ->
Option<PathBuf>`, and the test asserts the two halves separately: the override
is `None`, and the path the unset branch resolves is `private_state_dir()`,
named `.trusty-code`. Both calls are an env read and a join.

No HOME-redirect helper was added: this crate has none deliberately —
`private_state_dir_at(home)` exists precisely so tests never mutate `$HOME` —
and CLAUDE.md's no-process-global-env pitfall points the same way.

**One verification not run empirically.** The worktree-isolation guard refuses
any command that sets `HOME` ("injecting git configuration whose effect on where
git writes can't be verified"), so the critic's `HOME=/tmp/fakehome cargo test …
--exact` could not be reproduced from this worktree. The claim is structural and
checkable by reading three functions: `private_state_dir_at` is
`home.join(TRUSTY_CODE_DIRNAME)`, `private_state_dir` is a `match
dirs::home_dir()` around it, and `data_dir_override` is one `std::env::var`.
None touches the filesystem.

## Behavior notes for the reviewer

- Re-running a completed `tcode paths import` now exits 1: every target already
  exists, so every entry is refused. The README states this explicitly.
- `~/.trusty-code` is created at 0700 by any run that resolves it, including
  `tcode workstream list`. `tcode paths show` still does not create it.
- Files already inside `~/.trusty-code` keep their own modes; only the root is
  chmod'd. That limitation is now written in the README rather than implied —
  it is the non-recursive `harden()` follow-up #6980 noted.

Refs #6999. Refs #5426.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
