### PR TITLE
fix(trusty-common): price the Claude 5 Fable/Mythos tier (#6972)

### DIFF
--- a/crates/trusty-common/changelog.d/6972-claude-5-fable-pricing.md
+++ b/crates/trusty-common/changelog.d/6972-claude-5-fable-pricing.md
@@ -1,0 +1,4 @@
+Added
+
+- `inference::pricing` now prices the Claude 5 Fable/Mythos tier: any slug containing `claude-fable` or `claude-mythos` (so `claude-fable-5`, `claude-fable-5-1` and `claude-mythos-5-1`, with or without a routing prefix) returns $10.00 input / $50.00 output and $0.25 cache-read per million tokens. That tier names none of `opus`/`sonnet`/`haiku`, so before this it fell through every Claude arm and returned `None` — and a `None` is not cosmetic downstream: trusty-mpm's divert savings ledger declines to write a row for a model it cannot price, so a session running on `claude-fable-5-1` recorded no savings at all (#6972).
+- The Fable/Mythos arm is matched before opus/sonnet/haiku, and no existing rate moved. `claude-opus-5` and `claude-sonnet-5` already priced through the bare `claude-opus` / `claude-sonnet` substrings and still resolve to the same figures they did; `claude_5_opus_and_sonnet_keep_their_existing_rates` pins that (#6972).

--- a/crates/trusty-common/src/inference/registry/pricing.rs
+++ b/crates/trusty-common/src/inference/registry/pricing.rs
@@ -10,8 +10,8 @@
 //! What: [`Pricing`] (USD per MILLION tokens, four buckets) and [`pricing`], a
 //! substring lookup returning `Some(Pricing)` for known families, `None`
 //! otherwise.
-//! Test: inline `tests` — `claude_family_rates`, `gpt5_and_gemini_rates`,
-//! `unknown_model_is_none`, `estimate_matches_hand_calc`.
+//! Test: inline `tests` — `claude_family_rates`, `claude_5_fable_and_mythos_rates`,
+//! `gpt5_and_gemini_rates`, `unknown_model_is_none`, `estimate_matches_hand_calc`.
 
 /// USD-per-million-tokens pricing for one model family.
 ///
@@ -63,14 +63,37 @@ impl Pricing {
 /// slugs) keeps version-stamped point releases priced without a table churn.
 /// What: returns `Some(Pricing)` for the Claude, GPT-5, and Gemini families this
 /// project uses; `None` for anything unrecognised (the caller then relies on the
-/// provider's authoritative cost or reports "unknown"). Claude rates are from
-/// tcode `perf::pricing`; GPT-5/Gemini rates from trusty-review
-/// `llm::openrouter` (OpenRouter pricing page, best-effort, 2026 snapshot).
-/// Test: `claude_family_rates`, `gpt5_and_gemini_rates`, `unknown_model_is_none`.
+/// provider's authoritative cost or reports "unknown"). Claude opus/sonnet/haiku
+/// rates are from tcode `perf::pricing`; the Fable/Mythos rates are from the
+/// bundled `claude-api` skill's published model table (see the arm's comment);
+/// GPT-5/Gemini rates from trusty-review `llm::openrouter` (OpenRouter pricing
+/// page, best-effort, 2026 snapshot).
+/// Test: `claude_family_rates`, `claude_5_fable_and_mythos_rates`,
+/// `gpt5_and_gemini_rates`, `unknown_model_is_none`.
 pub fn pricing(model: &str) -> Option<Pricing> {
     let m = model.to_ascii_lowercase();
 
-    // ── Claude family (source: tcode perf::pricing) ──
+    // ── Claude family ──
+    // #6972: the Fable/Mythos tier carries no `opus`/`sonnet`/`haiku` substring,
+    // so before this arm existed a `claude-fable-5-1` parent session priced as
+    // `None` and the divert savings ledger declined every row. Rates are the
+    // published Anthropic first-party figures for `claude-fable-5`,
+    // `claude-fable-5-1` and `claude-mythos-5-1` — $10.00 input / $50.00 output
+    // per million tokens — from the bundled `claude-api` skill's model table
+    // (cached 2026-06-24); Mythos 5.1 is the same underlying model at the same
+    // price. `cache_read` is Fable 5.1's published $0.25/Mtok; Mythos 5.1's is
+    // open at launch and inherits it rather than a fabricated figure. No
+    // cache-write rate is published for the family, so it stays 0.0 under this
+    // module's documented convention. Matched FIRST because it is the most
+    // specific Claude arm.
+    if m.contains("claude-fable") || m.contains("claude-mythos") {
+        return Some(Pricing {
+            input: 10.0,
+            output: 50.0,
+            cache_read: 0.25,
+            cache_write: 0.0,
+        });
+    }
     if m.contains("claude-haiku") || m.contains("haiku-3") || m.contains("haiku-4") {
         return Some(Pricing {
             input: 0.80,
@@ -184,6 +207,44 @@ mod tests {
         assert_eq!(sonnet.input, 3.0);
         let opus = pricing("claude-opus-4-1").expect("opus priced");
         assert_eq!(opus.output, 75.0);
+    }
+
+    /// Why (#6972): the Claude 5 Fable/Mythos tier names no
+    /// `opus`/`sonnet`/`haiku` family word, so it fell through every Claude arm
+    /// and priced as `None`. A `None` here is not a cosmetic gap — trusty-mpm's
+    /// divert savings ledger declines to write a row for a model it cannot
+    /// price, so a Fable parent session recorded no savings at all.
+    /// Test: itself.
+    #[test]
+    fn claude_5_fable_and_mythos_rates() {
+        for slug in [
+            "claude-fable-5-1",
+            "claude-fable-5",
+            "claude-mythos-5-1",
+            "anthropic/claude-fable-5-1",
+            "bedrock/us.anthropic.claude-mythos-5-1",
+        ] {
+            let p = pricing(slug).unwrap_or_else(|| panic!("{slug} must be priced, not None"));
+            assert_eq!(p.input, 10.0, "{slug} input rate");
+            assert_eq!(p.output, 50.0, "{slug} output rate");
+            assert_eq!(p.cache_read, 0.25, "{slug} cache-read rate");
+        }
+    }
+
+    /// Why (#6972): the Fable arm is matched before opus/sonnet/haiku, so it must
+    /// not swallow a slug from another tier — and adding it must not have moved
+    /// any existing Claude rate. Opus 5 and Sonnet 5 already priced through the
+    /// bare `claude-opus` / `claude-sonnet` substrings before this change; this
+    /// pins that they still resolve to the same rates they did.
+    /// Test: itself.
+    #[test]
+    fn claude_5_opus_and_sonnet_keep_their_existing_rates() {
+        let opus = pricing("claude-opus-5").expect("opus 5 priced");
+        assert_eq!(opus.input, 15.0);
+        assert_eq!(opus.output, 75.0);
+        let sonnet = pricing("claude-sonnet-5").expect("sonnet 5 priced");
+        assert_eq!(sonnet.input, 3.0);
+        assert_eq!(sonnet.output, 15.0);
     }
 
     /// Why: the GPT-5 and Gemini families must price via substring, most-specific

--- a/crates/trusty-mpm/changelog.d/6972-fable-divert-savings.md
+++ b/crates/trusty-mpm/changelog.d/6972-fable-divert-savings.md
@@ -1,0 +1,3 @@
+Fixed
+
+- A diversion from a parent session running on `claude-fable-5-1` now records a savings row instead of declining one. The producer prices at the parent model's input rate and writes nothing for a model the shared table cannot price; that table had no Fable/Mythos entry, so every diversion from the tier wrote nothing. The fix is in `trusty-common`'s pricing table — this crate gains the regression test that drives the real table rather than a stand-in (#6972).

--- a/crates/trusty-mpm/src/core/savings_divert.rs
+++ b/crates/trusty-mpm/src/core/savings_divert.rs
@@ -45,6 +45,7 @@
 //! `no_row_when_the_summary_is_not_smaller_than_the_files`,
 //! `divert_row_carries_the_named_technique`,
 //! `no_row_when_the_parent_model_cannot_be_priced`,
+//! `a_fable_parent_session_produces_a_priced_row`,
 //! `a_ledger_write_failure_does_not_fail_the_diversion`,
 //! `parent_model_precedence_table`, `divert_row_names_the_model_source`.
 

--- a/crates/trusty-mpm/src/core/savings_divert_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_divert_tests.rs
@@ -25,6 +25,25 @@ fn sonnet_price() -> Option<ParentModel> {
     })
 }
 
+/// The real price lookup, pinned to a Fable parent session.
+///
+/// Why (#6972): this is `resolve_session_price`'s tail with the model fixed
+/// instead of resolved from the three sources, so the test exercises the shared
+/// table rather than a stand-in. Before #6972 the table returned `None` for this
+/// slug and the closure declined, which is exactly what the test below rejects.
+/// What: `claude-fable-5-1` and its table input rate, attributed to the
+/// statusline record — the source a real Fable session prices from.
+/// Test: `a_fable_parent_session_produces_a_priced_row`.
+fn fable_price() -> Option<ParentModel> {
+    let model = "claude-fable-5-1".to_string();
+    let pricing = trusty_common::inference::pricing(&model)?;
+    Some(ParentModel {
+        input_per_million: pricing.input,
+        id: model,
+        source: MODEL_SOURCE_STATUSLINE,
+    })
+}
+
 /// Why (#6959 acceptance criterion 1): the hand-computed delta is the whole
 /// claim. 400,000 file bytes are 100,000 tokens at four bytes each; a 4,000-byte
 /// summary is 1,000; the delta is 99,000 tokens, which at Sonnet's $3/Mtok input
@@ -96,6 +115,47 @@ fn no_row_when_the_parent_model_cannot_be_priced() {
         }))
         .is_none(),
         "a zero rate must write no row"
+    );
+}
+
+/// Why (#6972): the owner's daily-driver parent session runs on
+/// `claude-fable-5-1`, and that slug carries none of the `opus`/`sonnet`/`haiku`
+/// family words the shared table matched on. It therefore priced as `None`, the
+/// producer took its "unpriceable parent model" decline branch, and the session
+/// that generates the most diversions recorded no savings at all — which is the
+/// one case the statusline segment exists to show. Driving the REAL table
+/// (rather than a stand-in) is what makes this test fail on a table without the
+/// Fable arm.
+/// Test: itself.
+#[test]
+fn a_fable_parent_session_produces_a_priced_row() {
+    let row = divert_row("sess-fable", 400_000, 4_000, 0.02, fable_price)
+        .expect("a Fable parent session must produce a priced row, not a decline");
+    assert_eq!(row.tokens_saved, 99_000);
+    // 99,000 tokens at Fable's $10/Mtok input rate is $0.99, less the worker's
+    // own $0.02 — $0.97.
+    assert!(
+        (row.cost_saved_usd - 0.97).abs() < 1e-9,
+        "cost was {}",
+        row.cost_saved_usd
+    );
+    assert!(
+        row.basis.contains("claude-fable-5-1"),
+        "the basis must name the parent model it priced at: {}",
+        row.basis
+    );
+    assert_eq!(row.model_source, MODEL_SOURCE_STATUSLINE);
+
+    // And the written row comes back out of the fold the statusline reads with.
+    let dir = tempfile::tempdir().expect("temp dir");
+    record_divert_with(dir.path(), "sess-fable", 400_000, 4_000, 0.02, fable_price);
+    let ledger = savings_log_in(dir.path());
+    let total = fold_session(&ledger, "sess-fable");
+    assert_eq!(total.rows, 1, "the Fable diversion must fold as one row");
+    assert!(
+        (total.cost_saved_usd - 0.97).abs() < 1e-9,
+        "folded cost was {}",
+        total.cost_saved_usd
     );
 }
 


### PR DESCRIPTION
`inference::pricing` matched Claude models on the family words `opus`/`sonnet`/`haiku`. The Claude 5 Fable tier carries none of them, so `claude-fable-5-1` and `claude-mythos-5-1` fell through every arm and returned `None`.

That `None` is not cosmetic. trusty-mpm's divert savings ledger prices a diversion at the parent session's input rate and declines to write a row for a model it cannot price, never guessing a rate (#6959). A parent session running on `claude-fable-5-1` therefore recorded no savings at all — the session the 💸 statusline segment exists to report on.

## The change

One arm in `crates/trusty-common/src/inference/registry/pricing.rs`, matched before opus/sonnet/haiku because it is the most specific: any slug containing `claude-fable` or `claude-mythos` prices at **$10.00 input / $50.00 output** and **$0.25 cache-read** per million tokens.

Those are the published Anthropic first-party rates from the bundled `claude-api` skill's model table (cached 2026-06-24), which covers `claude-fable-5`, `claude-fable-5-1` and `claude-mythos-5-1` at one price. No cache-write rate is published for the family, so that bucket stays `0.0` under this module's documented convention ("Providers that publish no separate cache rate use `0.0`"). Mythos 5.1's cache-read rate is open at launch per the same source; it inherits Fable's $0.25 rather than a fabricated figure.

Nothing in the repo names these rates — a grep across `*.rs`/`*.md`/`*.toml`/`*.json`/`*.ts`/`*.tsv`/`*.svelte`/`*.yaml` for `fable|mythos` returns only unrelated taxonomy and quarantine strings.

**No existing rate moved.** `claude-opus-5` and `claude-sonnet-5` already priced through the bare `claude-opus` / `claude-sonnet` substrings and still resolve to the same figures; `claude_5_opus_and_sonnet_keep_their_existing_rates` pins that.

Those two figures are stale — the same published table puts Opus 5 at $5/$25 and Sonnet 5 at $2/$10, against the $15/$75 and $3/$15 this table carries, and `trusty-mpm/src/core/sm/providers/pricing.rs` and `trusty-code/src/perf/pricing.rs` carry the same Claude 4 numbers. Correcting them would lower existing rates, which is out of scope here; **tracked in a separate issue being filed alongside this PR.**

## Red-test proof

Stashed only `pricing.rs` (restoring the `origin/main` table), left the new trusty-mpm test in place, ran it:

```
test core::savings_divert::tests::a_fable_parent_session_produces_a_priced_row ... FAILED
panicked at crates/trusty-mpm/src/core/savings_divert_tests.rs:119:10:
a Fable parent session must produce a priced row, not a decline
test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 6062 filtered out
```

`git stash pop` restored the fix. The trusty-common test and the fix live in the same file, so this one test is the red proof for both — it fails precisely because `pricing("claude-fable-5-1")` returned `None`. `fable_price()` is `resolve_session_price`'s body with the model fixed, so it drives the real shared table rather than a stand-in and cannot pass against a table without the arm.

## Test ladder: rung 4

`trusty-common` is a shared library, so rung 3 on the library plus `check --workspace` and each direct dependent that consumes pricing.

| Gate | Exit | Result |
|---|---|---|
| `cargo fmt --check` | 0 | no drift |
| `cargo test -p trusty-common --features inference-client --no-fail-fast` | 0 | 10 targets; `702 passed; 0 failed; 12 ignored` (lib), 19 across integration targets |
| `cargo clippy -p trusty-common --all-targets --features inference-client -- -D warnings` | 0 | clean |
| `SKIP_UI_BUILD=1 cargo check --workspace --all-targets` | 0 | clean |
| `cargo test -p trusty-mpm --no-fail-fast` | 0 | **54 targets**, 10836 passed, 0 failed, 19 ignored |
| `cargo test -p trusty-review --no-fail-fast` | 0 | **15 targets**, 2317 passed, 0 failed, 5 ignored |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | 0 | clean |
| `check_line_cap.sh` / `check_test_pointers.sh` / `check_sld.sh` / `check_rustdoc_links.sh` | 0 | staged tree |
| `check_changelog_fragment.sh` | 0 | two fragments |
| `check-pr-version-bump.sh` | 0 | `trusty-common 0.49.1` and `trusty-mpm 1.5.18` — src changed, version not yet published; no bump owed |

`--no-fail-fast` on every suite (#5354). `inference::registry` sits behind `inference-client`, which implies `credentials` — a bare `cargo test -p trusty-common` is a `compile_error!` (#4901).

## Tests added

- `claude_5_fable_and_mythos_rates` — five slugs including prefixed forms (`anthropic/claude-fable-5-1`, `bedrock/us.anthropic.claude-mythos-5-1`) price at $10/$50/$0.25.
- `claude_5_opus_and_sonnet_keep_their_existing_rates` — the new arm sits ahead of opus/sonnet/haiku and must not swallow another tier's slug.
- `a_fable_parent_session_produces_a_priced_row` — a Fable diversion produces a row worth $0.97 (99,000 tokens at $10/Mtok, less a $0.02 worker), and it folds back out of the ledger under the session id the statusline reads with.

Refs #6972

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
