### PR TITLE
feat(trusty-code): materialize the agent roster to .trusty-code/agents with provenance (#2074)

### DIFF
--- a/crates/trusty-code/changelog.d/2074-s1-roster-deploy.md
+++ b/crates/trusty-code/changelog.d/2074-s1-roster-deploy.md
@@ -1,0 +1,24 @@
+Added
+
+- **The embedded agent roster is materialized to `<project>/.trusty-code/agents/`
+  with a manifest and recorded provenance (#2074).** A run against a project
+  whose agents directory resolves to Trusty Code's own root now writes one `.md`
+  per shipped role plus a `.trusty-mpm-manifest.json` ledger recording each
+  file's resolved inheritance chain, checksum, deploy time, and origin — so an
+  operator can read, diff, and edit the prompt an agent actually runs instead of
+  inferring it from a compiled-in table. The write goes through
+  `trusty_agents_common::agents::deployer::deploy_agents_filtered` unchanged,
+  which brings atomic write-temp-then-rename, strict-YAML validation of every
+  composed agent, per-agent compose-failure isolation, and a refusal to proceed
+  on a corrupt ledger rather than silently resetting it to empty. The five
+  `BASE-*` composition templates are staged so `extends:` chains resolve, but are
+  never deployed as dispatchable agents. Two policies sit on top of the shared
+  deployer: a project whose `.claude/agents/` or `.open-mpm/agents/` currently
+  wins discovery is skipped, so materializing never silently demotes an existing
+  catalog; and a deployed file the user has hand-edited is deselected before the
+  deploy runs, so the edit survives byte-identical while pristine files still
+  refresh. A projectless session writes nothing and keeps the in-memory embedded
+  roster, and any deploy failure degrades to that same in-memory roster with a
+  loud error rather than aborting the run. `tcode paths show` reports the
+  ledger's state — absent, present with a tracked-file count, or corrupt with the
+  underlying detail — in both its human and `--json` renderings.

--- a/crates/trusty-code/src/agents/deploy.rs
+++ b/crates/trusty-code/src/agents/deploy.rs
@@ -1,0 +1,664 @@
+//! Materialize the embedded agent roster to `<project>/.trusty-code/agents/`
+//! with a manifest and recorded provenance (#2074, epic #2892).
+//!
+//! Why: before this, `crate::assets::DEFAULT_AGENTS` existed only in memory.
+//! An operator could not read the prompt an agent actually runs, diff it, or
+//! edit it, and nothing on disk recorded which files Trusty Code wrote versus
+//! which the project owns. #2074 requires source provenance for every shipped
+//! role, and provenance needs a file and a ledger to attach to.
+//!
+//! What: [`ensure_roster_deployed`] stages the compiled-in agent sources into a
+//! throwaway directory and hands that directory to
+//! `trusty_agents_common::agents::deployer::deploy_agents_filtered` — the same
+//! writer trusty-mpm's `~/.claude/agents/` deploy uses, unchanged. That
+//! deployer already takes `source_dir`/`target_dir` as plain parameters, so
+//! pointing it at `<project>/.trusty-code/agents/` needed no shared-library
+//! change. It brings the atomic write-temp-then-rename, the strict-YAML
+//! validation of every composed agent, the per-agent compose-failure isolation,
+//! the `.trusty-mpm-manifest.json` ledger with a recorded checksum and
+//! [`Origin`], and the refusal to proceed on a corrupt ledger.
+//!
+//! ## Two policies this module adds on top of the shared deployer
+//!
+//! **A compatibility root that currently wins is never shadowed.** `.claude/`
+//! and `.open-mpm/` remain readable discovery INPUTS (#5426), and
+//! `crate::paths::agents_dir` prefers `.trusty-code/agents` over both. Writing
+//! the roster into `.trusty-code/agents` while a project's `.claude/agents/`
+//! holds its real catalog would silently demote that catalog, so the deploy is
+//! skipped in that case — [`SkipReason::CompatRootWins`].
+//!
+//! **A hand-edited deployed file is authoritative.** The shared deployer treats
+//! a checksum mismatch on an [`Origin::Bundled`] entry as corruption and repairs
+//! it (#4408) — correct for trusty-mpm's machine-global `~/.claude/agents/`,
+//! wrong for a project-local directory whose whole contract is
+//! `load_all_agents`' "disk wins, never merged". This module therefore selects
+//! against the ledger before deploying: a tracked file whose on-disk content no
+//! longer matches its recorded checksum is deselected, so the deployer never
+//! composes or writes it. Pristine files still refresh, and an UNTRACKED file is
+//! left to the deployer's own adopt-or-skip branch. No deployer change was
+//! needed for either policy.
+//!
+//! Test: `agents::deploy::tests::*`,
+//! `tests/roster_deploy_e2e.rs`.
+//!
+//! [`Origin`]: trusty_agents_common::agents::manifest::Origin
+//! [`Origin::Bundled`]: trusty_agents_common::agents::manifest::Origin::Bundled
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use trusty_agents_common::agents::builder::AgentBuildError;
+use trusty_agents_common::agents::deployer::{DeployResult, deploy_agents_filtered};
+use trusty_agents_common::agents::manifest::{AgentManifest, MANIFEST_FILE, ManifestLoad};
+
+use crate::assets::{DEFAULT_AGENTS, EMBEDDED_TM_AGENT_SOURCES, EmbeddedAgent};
+use crate::paths::{self, WriteTargetError};
+
+/// The `agents` subdirectory name, shared by every configuration root.
+///
+/// Why: named once so the write target cannot drift from the read target
+/// `crate::paths::agents_dir` resolves.
+/// What: `"agents"`.
+/// Test: `roster_target_is_under_the_native_config_dir`.
+pub const AGENTS_DIRNAME: &str = "agents";
+
+/// Why a roster deploy could not run.
+///
+/// Why: each variant has a different fix, and collapsing them into one string
+/// would hide which. A refused write target means the project layout is wrong; a
+/// corrupt ledger means ownership cannot be established and must be repaired
+/// before anything is written.
+/// What: the four failure modes [`ensure_roster_deployed`] can return.
+/// Test: `corrupt_manifest_is_reported_and_nothing_is_written`.
+#[derive(Debug, thiserror::Error)]
+pub enum RosterDeployError {
+    /// The computed target is not a legal Trusty Code write target.
+    #[error("refusing to materialize the agent roster: {0}")]
+    WriteTarget(#[from] WriteTargetError),
+    /// The deployed-agent ledger exists but could not be read as one.
+    #[error(
+        "the deployed-agent manifest at {path} could not be read ({detail}); \
+         refusing to deploy, because treating it as empty would reclassify every \
+         managed file as user-owned. Repair or delete that file to continue."
+    )]
+    ManifestCorrupt {
+        /// The ledger's path.
+        path: PathBuf,
+        /// The underlying parse or I/O failure.
+        detail: String,
+    },
+    /// Staging the compiled-in sources into a scratch directory failed.
+    #[error("staging the embedded agent roster failed: {0}")]
+    Stage(#[source] std::io::Error),
+    /// The shared deployer itself failed.
+    #[error("deploying the embedded agent roster failed: {0}")]
+    Deploy(#[source] AgentBuildError),
+}
+
+/// Why a deploy was skipped rather than attempted.
+///
+/// Why: "nothing was written" is a legitimate outcome the caller must be able to
+/// log accurately, and it is not an error.
+/// What: the single skip condition today — a compatibility root currently
+/// resolves the agents directory.
+/// Test: `deploy_is_skipped_when_claude_agents_dir_wins`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    /// `.claude/agents/` or `.open-mpm/agents/` currently wins discovery.
+    CompatRootWins,
+}
+
+/// What one [`ensure_roster_deployed`] call did.
+///
+/// Why: the caller logs a different line for each, and a test asserts on which
+/// branch ran rather than inferring it from the filesystem.
+/// What: either a skip with its reason, or the deployer's own
+/// [`DeployResult`] alongside the directory it wrote into.
+/// Test: `fresh_project_materializes_the_whole_roster`,
+/// `deploy_is_skipped_when_claude_agents_dir_wins`.
+#[derive(Debug)]
+pub enum RosterDeploy {
+    /// Nothing was written.
+    Skipped(SkipReason),
+    /// The shared deployer ran against `target`.
+    Deployed {
+        /// `<project>/.trusty-code/agents`.
+        target: PathBuf,
+        /// The deployer's per-file outcome lists. Boxed because
+        /// `DeployResult` is two orders of magnitude larger than the skip
+        /// variant, which `clippy::large_enum_variant` denies.
+        result: Box<DeployResult>,
+    },
+}
+
+/// What the deployed-agent ledger looks like right now.
+///
+/// Why: `tcode paths show` answers "which root wins"; after #2074 it must also
+/// answer "is there a deployed roster, and is its ledger readable" — the
+/// question an operator debugging a stale or hand-edited agent asks next.
+/// What: absent (nothing deployed yet), present with a managed-file count, or
+/// corrupt with the underlying detail.
+/// Test: `manifest_status_reports_absent_then_present`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManifestStatus {
+    /// No ledger file exists — the roster has not been deployed here.
+    Absent,
+    /// The ledger parsed; `managed` files are tracked.
+    Present {
+        /// How many deployed files the ledger tracks.
+        managed: usize,
+    },
+    /// The ledger exists but could not be read.
+    Corrupt {
+        /// The underlying parse or I/O failure.
+        detail: String,
+    },
+}
+
+impl ManifestStatus {
+    /// A stable lowercase token for logs, JSON diagnostics, and CLI output.
+    ///
+    /// Why: the human and JSON renderings of `tcode paths show` must agree, and
+    /// a `Debug` rendering is not a wire contract.
+    /// What: `"absent"`, `"present"`, `"corrupt"`.
+    /// Test: `manifest_status_reports_absent_then_present`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Absent => "absent",
+            Self::Present { .. } => "present",
+            Self::Corrupt { .. } => "corrupt",
+        }
+    }
+}
+
+/// The ledger path and its current state for a project.
+///
+/// Why: `tcode paths show` needs both, and deriving the path a second time at
+/// the call site would be a second implementation of the layout rule.
+/// What: `<project>/.trusty-code/agents/.trusty-mpm-manifest.json` and what
+/// reading it yields. Absence is distinguished from an empty ledger by testing
+/// the file itself — `AgentManifest::load_checked` reports both as `Ok`.
+/// Test: `manifest_status_reports_absent_then_present`,
+/// `manifest_status_reports_corrupt`.
+pub fn roster_manifest_status(project_root: &Path) -> (PathBuf, ManifestStatus) {
+    let path = roster_target(project_root).join(MANIFEST_FILE);
+    if !path.exists() {
+        return (path, ManifestStatus::Absent);
+    }
+    let status = match AgentManifest::load_checked(&roster_target(project_root)) {
+        ManifestLoad::Ok(m) => ManifestStatus::Present {
+            managed: m.managed.len(),
+        },
+        ManifestLoad::Corrupt(detail) => ManifestStatus::Corrupt { detail },
+    };
+    (path, status)
+}
+
+/// `<project>/.trusty-code/agents` — the only directory this module writes.
+///
+/// Why: the write target is deliberately NOT `crate::paths::agents_dir`'s
+/// result, which may legitimately resolve into `.claude/`. The read path and the
+/// write path are different functions on purpose (#5426).
+/// What: [`crate::paths::native_child`] for [`AGENTS_DIRNAME`].
+/// Test: `roster_target_is_under_the_native_config_dir`.
+pub fn roster_target(project_root: &Path) -> PathBuf {
+    paths::native_child(project_root, AGENTS_DIRNAME)
+}
+
+/// Materialize the embedded roster into `<project>/.trusty-code/agents/`.
+///
+/// Why: #2074's provenance requirement — every shipped role needs a file, a
+/// recorded checksum, and an [`Origin`] on disk, not just an in-memory
+/// projection. `crate::agents::load_embedded_default_agents` stays the zero-disk
+/// fallback for a projectless session, which has no project root to write to.
+///
+/// What, in order:
+/// 1. Skip when `.claude/agents/` or `.open-mpm/agents/` currently wins
+///    discovery — see this module's docs.
+/// 2. Refuse a target that is not genuinely beneath `<project>/.trusty-code/`
+///    ([`crate::paths::check_native_write_target`], symlink-safe).
+/// 3. Refuse to proceed on a corrupt ledger, naming the file. Never reset it.
+/// 4. Stage every compiled-in source into a scratch directory, including the
+///    five `BASE-*` templates so the deployer's own `extends:` composer resolves
+///    the chains from disk exactly as it does for trusty-mpm.
+/// 5. Deploy, selecting the dispatchable roster only, and deselecting any
+///    tracked file the user has since edited.
+///
+/// Test: `fresh_project_materializes_the_whole_roster`,
+/// `hand_edited_agent_survives_a_second_deploy`,
+/// `corrupt_manifest_is_reported_and_nothing_is_written`,
+/// `deploy_is_skipped_when_claude_agents_dir_wins`,
+/// `base_templates_are_never_deployed`,
+/// `tests/roster_deploy_e2e.rs`.
+///
+/// [`Origin`]: trusty_agents_common::agents::manifest::Origin
+pub fn ensure_roster_deployed(project_root: &Path) -> Result<RosterDeploy, RosterDeployError> {
+    if !paths::agents_dir(project_root).source.is_native() {
+        return Ok(RosterDeploy::Skipped(SkipReason::CompatRootWins));
+    }
+
+    let target = roster_target(project_root);
+    paths::check_native_write_target(project_root, &target)?;
+
+    // Establish ownership BEFORE staging or writing anything. The deployer makes
+    // the same check under its own lock; doing it here too is what lets a
+    // corrupt ledger be reported without a scratch directory ever being built.
+    let manifest = match AgentManifest::load_checked(&target) {
+        ManifestLoad::Ok(m) => m,
+        ManifestLoad::Corrupt(detail) => {
+            return Err(RosterDeployError::ManifestCorrupt {
+                path: target.join(MANIFEST_FILE),
+                detail,
+            });
+        }
+    };
+
+    let staged = stage_embedded_sources()?;
+    let roster: HashSet<&str> = DEFAULT_AGENTS.iter().map(EmbeddedAgent::name).collect();
+
+    let result = deploy_agents_filtered(staged.path(), &target, |stem| {
+        roster.contains(stem) && !is_user_edited(&manifest, &target, stem)
+    })
+    .map_err(RosterDeployError::Deploy)?;
+
+    Ok(RosterDeploy::Deployed {
+        target,
+        result: Box::new(result),
+    })
+}
+
+/// Run [`ensure_roster_deployed`] for a bound project and log what happened.
+///
+/// Why: two entry points materialize the roster — the daemon's router build and
+/// the legacy in-process `run-task` — and both want the same behaviour: deploy
+/// if we can, report loudly if we cannot, and never abort the run. A failed
+/// deploy is recoverable, because `crate::agents::load_embedded_default_agents`
+/// still answers every resolution from memory; aborting would turn a repairable
+/// ledger into an unusable harness.
+/// What: `None` when `project_root` is `None` (a projectless session writes
+/// nothing and keeps the in-memory embed). Otherwise the outcome, with a
+/// `tracing::error!` naming the failure when one occurred. #2074.
+/// Test: `deploy_and_log_is_a_no_op_without_a_project`,
+/// `deploy_and_log_reports_a_corrupt_ledger_without_panicking`.
+pub fn deploy_and_log(project_root: Option<&Path>) -> Option<RosterDeploy> {
+    let root = project_root?;
+    match ensure_roster_deployed(root) {
+        Ok(RosterDeploy::Skipped(reason)) => {
+            tracing::debug!(
+                project = %root.display(),
+                ?reason,
+                "agent roster not materialized"
+            );
+            Some(RosterDeploy::Skipped(reason))
+        }
+        Ok(RosterDeploy::Deployed { target, result }) => {
+            tracing::info!(
+                target = %target.display(),
+                deployed = result.deployed.len(),
+                unchanged = result.unchanged.len(),
+                preserved = result.skipped.len(),
+                failed = result.failed.len(),
+                "agent roster materialized (#2074)"
+            );
+            Some(RosterDeploy::Deployed { target, result })
+        }
+        Err(e) => {
+            tracing::error!(
+                project = %root.display(),
+                "could not materialize the agent roster; continuing with the \
+                 in-memory embedded roster: {e}"
+            );
+            None
+        }
+    }
+}
+
+/// Whether a tracked deployed file has been edited since Trusty Code wrote it.
+///
+/// Why: the "hand-edited file is authoritative" policy from this module's docs.
+/// The shared deployer would repair such a file (#4408); a project-local
+/// directory must preserve it instead.
+/// What: `true` only when the ledger tracks `<stem>.md` AND the file on disk no
+/// longer matches its recorded checksum. An untracked file returns `false` so
+/// the deployer's own adopt-or-skip branch decides; an unreadable or absent file
+/// returns `false` so it is (re)deployed.
+/// Test: `hand_edited_agent_survives_a_second_deploy`,
+/// `untracked_file_is_left_to_the_deployer`.
+fn is_user_edited(manifest: &AgentManifest, target: &Path, stem: &str) -> bool {
+    let filename = format!("{stem}.md");
+    if !manifest.is_managed(&filename) {
+        return false;
+    }
+    match std::fs::read_to_string(target.join(&filename)) {
+        Ok(current) => !manifest.checksum_matches(&filename, &current),
+        Err(_) => false,
+    }
+}
+
+/// Write every compiled-in agent source into a throwaway directory.
+///
+/// Why: the shared deployer composes from a source DIRECTORY, and tcode's roster
+/// is a set of `&'static str`s. Staging them is what lets the deployer be reused
+/// verbatim instead of growing a second, pre-composed entry point — a shared
+/// library change this slice deliberately avoided.
+/// What: one `.md` per [`EMBEDDED_TM_AGENT_SOURCES`] entry (keyed by its
+/// original filename, so `extends: base-qa` resolves against `BASE-QA.md`) plus
+/// one per [`EmbeddedAgent::Direct`] in [`DEFAULT_AGENTS`]. The `TempDir` is
+/// returned so the caller keeps it alive across the deploy; dropping it removes
+/// the scratch tree.
+/// Test: `staged_sources_cover_every_roster_name_and_base_template`.
+fn stage_embedded_sources() -> Result<tempfile::TempDir, RosterDeployError> {
+    let dir = tempfile::tempdir().map_err(RosterDeployError::Stage)?;
+    for (filename, content) in EMBEDDED_TM_AGENT_SOURCES {
+        std::fs::write(dir.path().join(filename), content).map_err(RosterDeployError::Stage)?;
+    }
+    for embedded in DEFAULT_AGENTS {
+        if let EmbeddedAgent::Direct { name, md } = embedded {
+            std::fs::write(dir.path().join(format!("{name}.md")), md)
+                .map_err(RosterDeployError::Stage)?;
+        }
+    }
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trusty_agents_common::agents::manifest::Origin;
+
+    /// Every dispatchable roster name, for the count assertions below.
+    fn roster_names() -> Vec<&'static str> {
+        DEFAULT_AGENTS.iter().map(EmbeddedAgent::name).collect()
+    }
+
+    /// `.md` filenames actually present in a deployed target directory.
+    fn deployed_md_files(target: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(target)
+            .expect("read_dir on the deploy target")
+            .flatten()
+            .filter_map(|e| e.file_name().to_str().map(str::to_string))
+            .filter(|n| n.ends_with(".md"))
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn roster_target_is_under_the_native_config_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            roster_target(tmp.path()),
+            tmp.path().join(".trusty-code").join(AGENTS_DIRNAME)
+        );
+    }
+
+    #[test]
+    fn staged_sources_cover_every_roster_name_and_base_template() {
+        let staged = stage_embedded_sources().expect("stage");
+        for name in roster_names() {
+            assert!(
+                staged.path().join(format!("{name}.md")).is_file(),
+                "roster agent '{name}' must have a staged source file"
+            );
+        }
+        for base in crate::assets::BASE_AGENT_NAMES {
+            let map = trusty_agents_common::agents::builder::build_source_map(staged.path());
+            assert!(
+                map.contains_key(*base),
+                "base template '{base}' must be stageable for extends resolution"
+            );
+        }
+    }
+
+    #[test]
+    fn fresh_project_materializes_the_whole_roster() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let outcome = ensure_roster_deployed(project.path()).expect("deploy must succeed");
+        let RosterDeploy::Deployed { target, result } = outcome else {
+            panic!("a clean project must deploy, got: {outcome:?}");
+        };
+
+        assert!(result.failed.is_empty(), "no agent may fail: {result:?}");
+        // Asserted from the filesystem, not from the deployer's own report.
+        let on_disk = deployed_md_files(&target);
+        assert_eq!(
+            on_disk.len(),
+            roster_names().len(),
+            "every roster agent must land on disk, got: {on_disk:?}"
+        );
+        for name in roster_names() {
+            assert!(
+                target.join(format!("{name}.md")).is_file(),
+                "'{name}.md' must exist on disk after the first deploy"
+            );
+        }
+
+        // The manifest exists beside them and records framework ownership.
+        let (manifest_path, status) = roster_manifest_status(project.path());
+        assert!(manifest_path.is_file(), "the ledger must exist beside them");
+        assert_eq!(
+            status,
+            ManifestStatus::Present {
+                managed: roster_names().len()
+            }
+        );
+        assert_eq!(
+            AgentManifest::load(&target).managed["engineer.md"].origin,
+            Origin::Bundled
+        );
+    }
+
+    #[test]
+    fn base_templates_are_never_deployed() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        ensure_roster_deployed(project.path()).expect("deploy");
+        for base in crate::assets::BASE_AGENT_NAMES {
+            let deployed = deployed_md_files(&roster_target(project.path()));
+            assert!(
+                !deployed
+                    .iter()
+                    .any(|n| n.to_lowercase() == format!("{base}.md")),
+                "composition base '{base}' must never be deployed as a dispatchable agent"
+            );
+        }
+    }
+
+    #[test]
+    fn second_deploy_of_an_untouched_roster_writes_nothing() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        ensure_roster_deployed(project.path()).expect("first deploy");
+        let outcome = ensure_roster_deployed(project.path()).expect("second deploy");
+        let RosterDeploy::Deployed { result, .. } = outcome else {
+            panic!("second deploy must still run, got: {outcome:?}");
+        };
+        assert!(
+            result.deployed.is_empty(),
+            "an untouched roster must need no rewrite: {result:?}"
+        );
+        assert_eq!(result.unchanged.len(), roster_names().len());
+    }
+
+    #[test]
+    fn hand_edited_agent_survives_a_second_deploy() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        ensure_roster_deployed(project.path()).expect("first deploy");
+        let target = roster_target(project.path());
+        let edited = target.join("engineer.md");
+
+        let hand_edit = "---\nname: engineer\nmodel: marker/hand-edited\n---\n\nMine now.\n";
+        std::fs::write(&edited, hand_edit).expect("hand-edit the deployed agent");
+
+        // Twice, to prove the preservation is stable rather than one-shot.
+        for _ in 0..2 {
+            let outcome = ensure_roster_deployed(project.path()).expect("re-deploy");
+            let RosterDeploy::Deployed { result, .. } = outcome else {
+                panic!("re-deploy must run, got: {outcome:?}");
+            };
+            assert!(
+                !result.deployed.contains(&"engineer.md".to_string())
+                    && !result.repaired.contains(&"engineer.md".to_string()),
+                "a hand-edited agent must never be rewritten: {result:?}"
+            );
+            assert_eq!(
+                std::fs::read_to_string(&edited).expect("read back"),
+                hand_edit,
+                "the hand edit must survive byte-identical"
+            );
+        }
+
+        // Its neighbours are untouched by the carve-out.
+        assert!(target.join("rust-engineer.md").is_file());
+    }
+
+    #[test]
+    fn untracked_file_is_left_to_the_deployer() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let target = roster_target(project.path());
+        std::fs::create_dir_all(&target).expect("mkdir target");
+        let squatter = "---\nname: engineer\n---\n\nProject-owned, never deployed by us.\n";
+        std::fs::write(target.join("engineer.md"), squatter).expect("write untracked file");
+
+        let outcome = ensure_roster_deployed(project.path()).expect("deploy");
+        let RosterDeploy::Deployed { result, .. } = outcome else {
+            panic!("deploy must run, got: {outcome:?}");
+        };
+        assert!(
+            result
+                .untracked_modified
+                .contains(&"engineer.md".to_string()),
+            "an untracked, differing file is the deployer's own skip branch: {result:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("engineer.md")).expect("read back"),
+            squatter
+        );
+    }
+
+    #[test]
+    fn corrupt_manifest_is_reported_and_nothing_is_written() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let target = roster_target(project.path());
+        std::fs::create_dir_all(&target).expect("mkdir target");
+        std::fs::write(target.join(MANIFEST_FILE), b"not valid json{{{").expect("corrupt ledger");
+
+        let err = ensure_roster_deployed(project.path()).expect_err("must refuse");
+        assert!(
+            matches!(err, RosterDeployError::ManifestCorrupt { .. }),
+            "got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("refusing to deploy"),
+            "the message must say nothing was written: {err}"
+        );
+        assert!(
+            deployed_md_files(&target).is_empty(),
+            "a corrupt ledger must leave the directory untouched"
+        );
+        // And the ledger itself was never reset.
+        assert_eq!(
+            std::fs::read_to_string(target.join(MANIFEST_FILE)).expect("read back"),
+            "not valid json{{{"
+        );
+    }
+
+    #[test]
+    fn manifest_status_reports_absent_then_present() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let (path, status) = roster_manifest_status(project.path());
+        assert_eq!(status, ManifestStatus::Absent);
+        assert_eq!(status.as_str(), "absent");
+        assert!(!path.exists());
+
+        ensure_roster_deployed(project.path()).expect("deploy");
+        let (_, status) = roster_manifest_status(project.path());
+        assert_eq!(status.as_str(), "present");
+        assert!(matches!(status, ManifestStatus::Present { managed } if managed > 0));
+    }
+
+    #[test]
+    fn manifest_status_reports_corrupt() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let target = roster_target(project.path());
+        std::fs::create_dir_all(&target).expect("mkdir target");
+        std::fs::write(target.join(MANIFEST_FILE), b"{{{").expect("corrupt ledger");
+        let (_, status) = roster_manifest_status(project.path());
+        assert_eq!(status.as_str(), "corrupt");
+    }
+
+    #[test]
+    fn deploy_is_skipped_when_claude_agents_dir_wins() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let claude = project.path().join(".claude").join(AGENTS_DIRNAME);
+        std::fs::create_dir_all(&claude).expect("mkdir .claude/agents");
+        std::fs::write(
+            claude.join("engineer.md"),
+            "---\nname: engineer\n---\n\nProject catalog.\n",
+        )
+        .expect("write .claude agent");
+
+        let outcome = ensure_roster_deployed(project.path()).expect("skip is not an error");
+        assert!(
+            matches!(outcome, RosterDeploy::Skipped(SkipReason::CompatRootWins)),
+            "a winning .claude/agents/ must never be shadowed, got: {outcome:?}"
+        );
+        assert!(
+            !roster_target(project.path()).exists(),
+            "nothing may be written when the deploy is skipped"
+        );
+    }
+
+    #[test]
+    fn deploy_and_log_is_a_no_op_without_a_project() {
+        assert!(deploy_and_log(None).is_none());
+    }
+
+    #[test]
+    fn deploy_and_log_reports_a_corrupt_ledger_without_panicking() {
+        crate::test_support::begin_capture();
+
+        let project = tempfile::tempdir().expect("project tempdir");
+        let target = roster_target(project.path());
+        std::fs::create_dir_all(&target).expect("mkdir target");
+        std::fs::write(target.join(MANIFEST_FILE), b"{{{").expect("corrupt ledger");
+        assert!(
+            deploy_and_log(Some(project.path())).is_none(),
+            "a corrupt ledger must degrade to the in-memory roster, not abort"
+        );
+
+        // Degrading silently is the failure this branch exists to prevent, so
+        // the assertion is on the ERROR event itself — downgrading it to
+        // `debug!` must fail this test, not just change a log line.
+        let errors = crate::test_support::captured_at_least(tracing::Level::ERROR);
+        assert!(
+            errors
+                .iter()
+                .any(|m| m.contains("could not materialize the agent roster")),
+            "the corrupt ledger must be reported at ERROR level, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn deployed_agents_load_back_through_the_disk_loader() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        ensure_roster_deployed(project.path()).expect("deploy");
+        let loaded = crate::agents::load_all_agents(&roster_target(project.path()));
+        assert_eq!(
+            loaded.len(),
+            roster_names().len(),
+            "every deployed file must parse through the disk loader"
+        );
+        let restricted = loaded
+            .iter()
+            .find(|c| c.agent.name == "code-critic")
+            .expect("code-critic must be deployed");
+        let allowed = restricted
+            .tools
+            .as_ref()
+            .and_then(|t| t.allowed.as_ref())
+            .expect("code-critic carries a tcode-local tool allowlist");
+        assert!(
+            !allowed.contains(&"write_file".to_string()),
+            "the tcode-local read-only restriction must survive materialization: {allowed:?}"
+        );
+    }
+}

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -31,6 +31,10 @@
 //! [`discover_agents`]: crate::agents::discover_agents
 
 pub mod config;
+// #2074: materialize the embedded roster to `<project>/.trusty-code/agents/`
+// with a manifest and recorded provenance, reusing trusty-agents-common's
+// deployer unchanged.
+pub mod deploy;
 pub mod md_loader;
 pub mod protocol;
 

--- a/crates/trusty-code/src/cli/legacy_run_task.rs
+++ b/crates/trusty-code/src/cli/legacy_run_task.rs
@@ -93,6 +93,10 @@ pub async fn run(
         }
     };
 
+    // #2074: same materialization the daemon path runs in `serve::build_router`,
+    // so the in-process legacy path does not silently skip provenance.
+    trusty_code::agents::deploy::deploy_and_log(Some(&project_root));
+
     let agents_dir = trusty_code::agents::locate_agents_dir(&project_root);
 
     // Engineer-model override (#1035): CLI flag wins, then the env var; an empty

--- a/crates/trusty-code/src/cli/paths.rs
+++ b/crates/trusty-code/src/cli/paths.rs
@@ -21,6 +21,7 @@
 use std::path::Path;
 
 use anyhow::Result;
+use trusty_code::agents::deploy::{ManifestStatus, roster_manifest_status};
 use trusty_code::paths::{self, EntryKind, private_state};
 
 /// The entries `tcode paths show` reports, in display order.
@@ -41,15 +42,20 @@ const REPORTED: &[(&str, &str, EntryKind)] = &[
 ///
 /// Why: the diagnostic #5426 asks for — "report the winning source and target".
 /// What: one line per [`REPORTED`] entry as `<label>  <source>  <path>`, then
-/// the write root and the private state directory with its privacy status. With
-/// `json`, the same facts as one object on stdout so a script can assert on
-/// them. Unreadable candidates that were skipped are listed too — they already
-/// warned to stderr, and a diagnostic that hid them would be the wrong tool for
-/// the job it exists to do.
-/// Test: `tests/cli_e2e.rs::paths_show_reports_the_winning_source`.
+/// the deployed-roster manifest's state (#2074), the write root, and the private
+/// state directory with its privacy status. With `json`, the same facts as one
+/// object on stdout so a script can assert on them. Unreadable candidates that
+/// were skipped are listed too — they already warned to stderr, and a diagnostic
+/// that hid them would be the wrong tool for the job it exists to do.
+/// Test: `tests/cli_e2e.rs::paths_show_reports_the_winning_source`,
+/// `tests/roster_deploy_e2e.rs::paths_show_reports_the_roster_manifest`.
 pub fn show(project_root: &Path, json: bool) -> Result<()> {
     let state_dir = private_state::private_state_dir();
     let private_ok = private_state::is_restrictive(&state_dir).ok();
+    // #2074: the deployed roster's ledger — absent, present with a count, or
+    // corrupt. An operator debugging a stale or hand-edited agent asks this
+    // immediately after "which root wins?".
+    let (manifest_path, manifest_status) = roster_manifest_status(project_root);
 
     if json {
         let entries: serde_json::Map<String, serde_json::Value> = REPORTED
@@ -76,6 +82,18 @@ pub fn show(project_root: &Path, json: bool) -> Result<()> {
             "private_state_dir": state_dir.display().to_string(),
             "private_state_restrictive": private_ok,
             "entries": entries,
+            "roster_manifest": {
+                "path": manifest_path.display().to_string(),
+                "status": manifest_status.as_str(),
+                "managed": match &manifest_status {
+                    ManifestStatus::Present { managed } => Some(*managed),
+                    _ => None,
+                },
+                "detail": match &manifest_status {
+                    ManifestStatus::Corrupt { detail } => Some(detail.clone()),
+                    _ => None,
+                },
+            },
         });
         println!("{}", serde_json::to_string_pretty(&doc)?);
         return Ok(());
@@ -93,6 +111,25 @@ pub fn show(project_root: &Path, json: bool) -> Result<()> {
         for skipped in &r.unreadable {
             println!("{:<10} {:<12} {}", "", "unreadable", skipped.display());
         }
+    }
+    println!();
+    println!(
+        "roster manifest   {:<12} {}",
+        manifest_status.as_str(),
+        manifest_path.display()
+    );
+    match &manifest_status {
+        ManifestStatus::Absent => println!(
+            "{:<18}no roster deployed here yet — one lands on the next run",
+            ""
+        ),
+        ManifestStatus::Present { managed } => {
+            println!("{:<18}{managed} deployed agent file(s) tracked", "")
+        }
+        ManifestStatus::Corrupt { detail } => println!(
+            "{:<18}UNREADABLE — repair or delete it; deploys refuse until then ({detail})",
+            ""
+        ),
     }
     println!();
     println!("private state     {}", state_dir.display());

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -183,6 +183,10 @@ async fn build_router_at(
     data_dir: &std::path::Path,
 ) -> Result<(Router, Arc<SessionRegistry>, SharedWorkstreamStore)> {
     let sessions = Arc::new(SessionRegistry::new());
+    // #2074: materialize the embedded roster to `<project>/.trusty-code/agents/`
+    // before resolving the agents directory, so every shipped role has a file, a
+    // manifest entry, and a recorded origin. Projectless daemons write nothing.
+    crate::agents::deploy::deploy_and_log(binding.root());
     let agents_dir = binding.agents_dir();
 
     let mut workstream_store = WorkstreamStore::load_for_binding(data_dir, &binding)

--- a/crates/trusty-code/tests/roster_deploy_e2e.rs
+++ b/crates/trusty-code/tests/roster_deploy_e2e.rs
@@ -1,0 +1,171 @@
+//! Black-box proof that a real `tcode` run materializes the agent roster to
+//! `<project>/.trusty-code/agents/` with a manifest (#2074, epic #2892).
+//!
+//! Why: `agents::deploy`'s unit tests call `ensure_roster_deployed` directly, so
+//! they prove the deployer adapter works but not that it is WIRED into a path a
+//! user drives. The acceptance bar #2074 names is the filesystem after a real
+//! run, read with `std::fs::read_dir` rather than through `agents.list` — a
+//! catalog listing would report the same names from the in-memory embed and
+//! could not tell a materialized roster from an unmaterialized one.
+//!
+//! What: [`run_task_materializes_the_roster_to_disk`] runs the real binary
+//! against a clean tempdir with no `.trusty-code/`, `.claude/`, or `.open-mpm/`
+//! and asserts every roster file plus the manifest exist afterwards.
+//! [`hand_edited_agent_file_survives_a_second_run`] hand-edits one deployed file
+//! and proves a second run leaves it byte-identical.
+//! [`compat_root_is_never_shadowed`] proves a project whose `.claude/agents/`
+//! currently wins gets nothing written, so its catalog keeps driving.
+//! [`paths_show_reports_the_roster_manifest`] proves the diagnostic surface
+//! reports the ledger.
+//! Test: this file IS the test.
+
+mod support;
+
+use std::path::Path;
+
+/// Every `.md` filename directly inside `dir`, sorted. Empty when absent.
+fn md_files(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter_map(|e| e.file_name().to_str().map(str::to_string))
+        .filter(|n| n.ends_with(".md"))
+        .collect();
+    names.sort();
+    names
+}
+
+/// Run `tcode run-task engineer "say hi" --project <dir> --json` offline.
+fn run_task(project: &Path) -> std::process::Output {
+    let output = support::tcode_command()
+        .args([
+            "run-task",
+            "engineer",
+            "say hi",
+            "--project",
+            &project.display().to_string(),
+            "--json",
+        ])
+        .env("TCODE_MOCK_LLM", "echo")
+        .output()
+        .expect("spawn tcode run-task");
+    assert!(
+        output.status.success(),
+        "tcode run-task must exit 0, got {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+#[test]
+fn run_task_materializes_the_roster_to_disk() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let agents_dir = project.path().join(".trusty-code").join("agents");
+    assert!(
+        md_files(&agents_dir).is_empty(),
+        "the fixture must start with no deployed roster"
+    );
+
+    run_task(project.path());
+
+    let on_disk = md_files(&agents_dir);
+    assert!(
+        on_disk.len() >= 30,
+        "the whole roster must land on disk, got {} file(s): {on_disk:?}",
+        on_disk.len()
+    );
+    for expected in ["engineer.md", "pm.md", "rust-engineer.md", "code-critic.md"] {
+        assert!(
+            on_disk.contains(&expected.to_string()),
+            "'{expected}' must be materialized: {on_disk:?}"
+        );
+    }
+    assert!(
+        !on_disk
+            .iter()
+            .any(|n| n.to_lowercase().starts_with("base-")),
+        "composition bases must never be deployed: {on_disk:?}"
+    );
+    assert!(
+        agents_dir.join(".trusty-mpm-manifest.json").is_file(),
+        "a manifest must exist beside the deployed files"
+    );
+}
+
+#[test]
+fn hand_edited_agent_file_survives_a_second_run() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    run_task(project.path());
+
+    let edited = project
+        .path()
+        .join(".trusty-code")
+        .join("agents")
+        .join("rust-engineer.md");
+    let hand_edit = "---\nname: rust-engineer\nmodel: marker/hand-edited\n---\n\nMine now.\n";
+    std::fs::write(&edited, hand_edit).expect("hand-edit a deployed agent");
+
+    run_task(project.path());
+
+    assert_eq!(
+        std::fs::read_to_string(&edited).expect("read back"),
+        hand_edit,
+        "a hand-edited deployed agent must survive a second run byte-identical"
+    );
+}
+
+#[test]
+fn compat_root_is_never_shadowed() {
+    let project = support::project_with_agents();
+    run_task(project.path());
+
+    assert!(
+        md_files(&project.path().join(".trusty-code").join("agents")).is_empty(),
+        "a project whose .claude/agents/ wins must have nothing written into \
+         .trusty-code/agents/, or its own catalog would be silently demoted"
+    );
+}
+
+#[test]
+fn paths_show_reports_the_roster_manifest() {
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let before = support::tcode_command()
+        .args([
+            "paths",
+            "show",
+            "--project",
+            &project.path().display().to_string(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn tcode paths show");
+    assert!(before.status.success(), "paths show must exit 0");
+    let doc: serde_json::Value =
+        serde_json::from_slice(&before.stdout).expect("paths show --json must emit one document");
+    assert_eq!(doc["roster_manifest"]["status"], "absent");
+
+    run_task(project.path());
+
+    let after = support::tcode_command()
+        .args([
+            "paths",
+            "show",
+            "--project",
+            &project.path().display().to_string(),
+            "--json",
+        ])
+        .output()
+        .expect("spawn tcode paths show");
+    let doc: serde_json::Value =
+        serde_json::from_slice(&after.stdout).expect("paths show --json must emit one document");
+    assert_eq!(doc["roster_manifest"]["status"], "present");
+    assert!(
+        doc["roster_manifest"]["managed"].as_u64().unwrap_or(0) >= 30,
+        "the ledger must track the deployed roster: {doc}"
+    );
+}

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -150,6 +150,9 @@ pub struct StdioSession {
     child: Child,
     stdin: ChildStdin,
     lines: Lines<BufReader<ChildStdout>>,
+    /// Kept alive so a session that owns its project root (see [`Self::spawn`])
+    /// removes that root on drop. `None` when the caller supplied the root.
+    _project: Option<tempfile::TempDir>,
 }
 
 impl StdioSession {
@@ -157,12 +160,21 @@ impl StdioSession {
     ///
     /// Why: `env!("CARGO_BIN_EXE_tcode")` resolves to the freshly-built
     /// binary for this exact test run — no separate install step needed.
-    /// What: `--project .` (any existing directory works; `session.*` does
-    /// not require a `.claude/` root), stdin/stdout piped, stderr discarded
-    /// (logs aren't asserted on here), `kill_on_drop` so a panicking test
-    /// still reaps the child instead of leaking a process.
+    /// What: a throwaway tempdir as `--project` (any existing directory works;
+    /// `session.*` does not require a configuration root), stdin/stdout piped,
+    /// stderr discarded (logs aren't asserted on here), `kill_on_drop` so a
+    /// panicking test still reaps the child instead of leaking a process. The
+    /// tempdir is owned by the returned session and removed with it.
+    ///
+    /// #2074: this used to pass `--project .`, which is the CRATE directory
+    /// when a test binary runs. `tcode serve` now materializes the agent roster
+    /// into its project's `.trusty-code/agents/`, so `.` wrote 33 agent files
+    /// and a manifest into the repository on every run.
     pub fn spawn() -> Self {
-        Self::spawn_inner(Some(std::path::Path::new(".")), None, None, &[], &[])
+        let project = tempfile::tempdir().expect("throwaway project root");
+        let mut session = Self::spawn_inner(Some(project.path()), None, None, &[], &[]);
+        session._project = Some(project);
+        session
     }
 
     /// Spawn `tcode serve --stdio` rooted at `project`, with
@@ -304,6 +316,7 @@ impl StdioSession {
             child,
             stdin,
             lines,
+            _project: None,
         }
     }
 
@@ -401,6 +414,10 @@ pub struct HttpDaemon {
     /// The daemon's own isolated data directory. Held so it outlives the
     /// daemon; dropping it removes the tree.
     pub data_dir: tempfile::TempDir,
+    /// Kept alive so a daemon that owns its project root (see
+    /// [`spawn_http_daemon`]) removes that root on drop. `None` when the caller
+    /// supplied the root.
+    _project: Option<tempfile::TempDir>,
 }
 
 /// Spawn `tcode serve --http --port 0` and discover its ephemeral bound
@@ -409,11 +426,19 @@ pub struct HttpDaemon {
 /// Why: `--port 0` avoids test-suite port collisions; the daemon logs the
 /// real bound `host:port` to stderr (never stdout) on startup, which this
 /// helper parses.
-/// What: thin wrapper over [`spawn_http_daemon_with_env`] rooted at `.`
-/// with no extra env vars — the shape every pre-#2062 caller
-/// (`tests/session_e2e.rs`) needs.
+/// What: thin wrapper over [`spawn_http_daemon_with_env`] rooted at a throwaway
+/// tempdir the returned daemon owns, with no extra env vars — the shape every
+/// pre-#2062 caller (`tests/session_e2e.rs`) needs.
+///
+/// #2074: this used to root at `.`, which is the CRATE directory when a test
+/// binary runs. `tcode serve` now materializes the agent roster into its
+/// project's `.trusty-code/agents/`, so `.` wrote 33 agent files and a manifest
+/// into the repository on every run.
 pub async fn spawn_http_daemon() -> HttpDaemon {
-    spawn_http_daemon_with_env(std::path::Path::new("."), &[]).await
+    let project = tempfile::tempdir().expect("throwaway project root");
+    let mut daemon = spawn_http_daemon_with_env(project.path(), &[]).await;
+    daemon._project = Some(project);
+    daemon
 }
 
 /// Spawn `tcode serve --http --port 0` rooted at `project`, with `envs` set
@@ -509,6 +534,7 @@ pub async fn spawn_http_daemon_with_env(
         base_url,
         token,
         data_dir,
+        _project: None,
     }
 }
 


### PR DESCRIPTION
Slice 1 of 4 on #2074: the 33-agent roster becomes files on disk with a manifest and recorded provenance, so #2074's "expose source provenance" requirement has something to attach to and Slices 3–4 have a manifest to report.

## What changed

`crates/trusty-code/src/agents/deploy.rs` stages the 34 `EMBEDDED_TM_AGENT_SOURCES` entries plus the four `EmbeddedAgent::Direct` sources into a `tempfile::TempDir`, then calls `trusty_agents_common::agents::deployer::deploy_agents_filtered(staged, <project>/.trusty-code/agents, select)`. The five `BASE-*` templates are staged so `compose_agent` resolves `extends:` chains from disk, and the select predicate keeps them out of the deployed set.

**The shared deployer is untouched.** `git diff --stat origin/main -- crates/trusty-agents-common/` is empty. It already took `source_dir`/`target_dir` as plain parameters, so pointing it at a project-local directory needed no signature change. Atomic write-temp-then-rename, strict-YAML validation of every composed agent, per-agent compose-failure isolation, and the refusal to proceed on a corrupt ledger all come from it unchanged.

Wired at the two entry points that resolve a project's agents directory: `serve::build_router_at` (the daemon, which the default `tcode run-task` spawns) and `cli::legacy_run_task::run`. Both go through `deploy::deploy_and_log`.

`tcode paths show` gains a `roster manifest` line — absent, present with a tracked-file count, or corrupt with the detail — in both the human and `--json` renderings.

## Decisions taken

**Deploy only when project-bound.** A projectless session (`~/.claude`-only) writes nothing and keeps `load_embedded_default_agents` as the zero-disk fallback. Any deploy failure degrades to that same in-memory roster with a `tracing::error!` rather than aborting the run — a repairable ledger must not produce an unusable harness.

**A compat root that wins discovery is never shadowed.** `paths::agents_dir` prefers `.trusty-code/agents` over `.claude/agents` (#5426), so deploying unconditionally would demote every existing project's catalog. `ensure_roster_deployed` returns `Skipped(CompatRootWins)` when the resolved source is not native.

**Hand-edits are preserved by pre-deploy deselection.** `deploy_agents` writes `Origin::Bundled`, and #4408 makes a checksum mismatch on a framework-owned entry a *repair* that overwrites the edit (`deployer_tests.rs:70`). That is right for trusty-mpm's machine-global `~/.claude/agents/` and wrong for a project-local directory whose contract is `load_all_agents`' "disk wins, never merged". Rather than change the shared deployer, tcode reads the ledger through its public API (`AgentManifest::load_checked` + `checksum_matches`) and deselects a tracked-but-edited file before the deploy runs. Pristine files still refresh; an untracked file is left to the deployer's own adopt-or-skip branch.

## Test-fixture defect this surfaced

`tests/support/mod.rs` rooted `StdioSession::spawn()` and `spawn_http_daemon()` at `--project .`, which under a test binary is `crates/trusty-code/`. With the deploy wired in, the suite wrote 33 agent files and a manifest into the repository. Both helpers now own a throwaway `TempDir`.

## Open question for the owner

**No `.gitignore` rule covers `<project>/.trusty-code/`.** `grep -n "trusty-code\|\.trusty" .gitignore` returns only `.trusty-search`, `.trusty-agents/`, and the `**/.trusty-mpm/*` family. So a project running `tcode` sees 33 agent files plus `.trusty-mpm-manifest.json` as untracked — and in this repo, anyone running `tcode` at the repo root gets them in the working tree. This PR edits no `.gitignore`. Committing them is arguably right (they are the project's own reviewable agent definitions), which is DOC-61 §10's open "gitignore precedent for deployed artifacts" question.

Separately, the manifest filename is `.trusty-mpm-manifest.json` — a `pub const` in the shared crate. It reads oddly inside `.trusty-code/agents/`, but renaming it is a shared-library change with a trusty-mpm migration attached.

## Gates — rung 4

Cross-crate: this consumes a `trusty-agents-common` write path tcode had never called. Per the ladder that is rung 3 on tcode plus `check --workspace` and the shared crate's own suite.

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-code --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-code --no-fail-fast` | 20 targets, every one `ok`; lib `1766 passed; 0 failed; 4 ignored`, integration targets 21+3+1+2+7+21+2+7+4+2+5+2+1+4+1+2+6+7+0 passed, 0 failed |
| `cargo test -p trusty-code --no-fail-fast agents::deploy` | `ok. 14 passed; 0 failed` |
| `cargo test -p trusty-agents-common --no-fail-fast` | `ok. 525 passed; 0 failed` — crate unmodified |
| `cargo check --workspace --all-targets` | EXIT=0 |
| `check_line_cap.sh` | 4565 files, 0 violations |
| `check_test_pointers.sh` | 31577 citations, 0 dangling |
| `check_sld.sh` | 0 errors, 0 warnings |
| `check_agent_assets.sh` | 4 pinned deviations match the shared source, OK |
| `check_changelog_fragment.sh` | OK (post-commit) |
| `check-pr-version-bump.sh` | clear, 0 warnings |
| `check_rustdoc_links.sh` | 0 broken links, baseline 0 |

### Every acceptance criterion fails without this change

Reverting only the three wiring files to the branch base and re-running the e2e:

```
test paths_show_reports_the_roster_manifest ... FAILED
test run_task_materializes_the_roster_to_disk ... FAILED
test hand_edited_agent_file_survives_a_second_run ... FAILED
test compat_root_is_never_shadowed ... ok
test result: FAILED. 1 passed; 3 failed
  panicked at tests/roster_deploy_e2e.rs:76: the whole roster must land on disk, got 0 file(s): []
```

The new-file assertion reads `std::fs::read_dir` directly, not `agents.list` — a catalog listing reports the same names from the in-memory embed and cannot tell a materialized roster from an unmaterialized one.

The corrupt-ledger test asserts the ERROR event fired, not just that the call returned `None`. Downgrading that `tracing::error!` to `debug!` fails it:

```
panicked at crates/trusty-code/src/agents/deploy.rs:632:9:
  the corrupt ledger must be reported at ERROR level, got: []
```

## Review

Security scan CLEAN. `code-critic` APPROVE, with one MEDIUM folded in before push: the corrupt-ledger test now asserts on the ERROR event via `test_support::begin_capture()` / `captured_at_least(tracing::Level::ERROR)`, verified by the downgrade above.

Refs #2074

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
