### PR TITLE
feat(tga): plumb the audit window from config into the sweep (#5482)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5482-audit-window-config.md
+++ b/crates/trusty-git-analytics/changelog.d/5482-audit-window-config.md
@@ -1,0 +1,8 @@
+Added
+
+- `tga audit` reads its lookback window from a new `audit.window_weeks` config
+  field, defaulting to 52 weeks when nothing declares one. `--weeks` still wins,
+  and the collect, classify, and pr-metrics stages are handed one resolved value
+  rather than each applying its own fallback. Previously the window was reachable
+  only through `--weeks`, so `trusty-audit` — which spawns `tga audit` without
+  it — collected unbounded history (#5482).

--- a/crates/trusty-git-analytics/src/audit/sweep.rs
+++ b/crates/trusty-git-analytics/src/audit/sweep.rs
@@ -44,14 +44,23 @@ pub(crate) const TOTAL_STAGES: usize = 9;
 /// they are deliberately the only ones — DOC-67 §2 forbids a mid-run choice,
 /// and §9 fixes the stale-refs policy rather than exposing it as an option.
 /// What: the directory reports are written to, and an optional lookback
-/// window in ISO weeks applied to collection and PR metrics.
-/// Test: `super::tests::sweep_writes_reports_into_the_requested_directory`.
+/// window in ISO weeks applied to collection and PR metrics. Both are
+/// OVERRIDES — an unset field falls back to `Config`, never to "no bound"
+/// (#5482).
+/// Test: `super::tests::sweep_writes_reports_into_the_requested_directory`,
+/// `super::tests::the_sweep_window_falls_back_to_the_config_field`.
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct SweepOptions {
     /// Directory for the stage-3 report output. `None` uses the config default.
     pub output: Option<PathBuf>,
-    /// Limit collection and PR metrics to the last N ISO weeks.
+    /// Override the lookback window applied to collection and PR metrics.
+    ///
+    /// #5482: `None` no longer means "unbounded" — it means "the caller stated
+    /// nothing", and the sweep falls back to [`Config::audit_window_weeks`]
+    /// (the `audit.window_weeks` config field, itself defaulting to
+    /// [`crate::core::config::DEFAULT_AUDIT_WINDOW_WEEKS`]). Set it only to
+    /// override the config.
     pub weeks: Option<u32>,
 }
 
@@ -80,6 +89,13 @@ pub struct SweepOptions {
 /// its pipeline, so its per-repository [`Stage::Collect`] events land there
 /// too. `None` emits nothing at all.
 ///
+/// #5482: the lookback window is resolved once, here — `options.weeks` when the
+/// caller set it, else `config.audit.window_weeks`, else 52 weeks — and the
+/// collect, classify, and pr-metrics stages are all handed that one value. A
+/// caller that passes no window therefore gets a bounded sweep rather than the
+/// whole of history, which is what `trusty-audit` spawning `tga audit` with no
+/// `--weeks` needs.
+///
 /// A failed STAGE is reported inside `AuditSweepStats`, never as `Err` —
 /// `Err` means the run could not be started at all. Callers must therefore check
 /// [`AuditSweepStats::any_failed`] rather than treating `Ok` as a clean pass —
@@ -94,7 +110,9 @@ pub struct SweepOptions {
 ///
 /// Test: `super::tests::sweep_runs_every_stage_in_order_and_survives_failures`,
 /// `super::tests::failed_stage_is_recorded_and_does_not_stop_the_sweep`,
-/// `super::tests::sweep_emits_progress_for_non_collection_stages`.
+/// `super::tests::sweep_emits_progress_for_non_collection_stages`,
+/// `super::tests::the_sweep_window_falls_back_to_the_config_field`,
+/// `super::tests::an_explicit_sweep_window_beats_the_config_field`.
 ///
 /// `SPEC-TGAUDIT-05~draft` §5 "Executed stage order" lists the nine stages this
 /// body runs, in this order (#5306). Changing the sequence here means changing
@@ -118,6 +136,11 @@ pub async fn run_full_sweep(
         std::fs::create_dir_all(dir)?;
     }
 
+    // #5482: resolve the lookback window ONCE — CLI flag, else the
+    // `audit.window_weeks` config field, else 52 weeks. Both consumers below
+    // read this local, so neither can apply a different fallback.
+    let weeks = Some(options.weeks.unwrap_or_else(|| config.audit_window_weeks()));
+
     let mut stats = AuditSweepStats::default();
     // #6130: read the declarations BEFORE the stage they describe, so a sweep
     // that dies mid-collect still leaves the record of what it was never going
@@ -129,7 +152,7 @@ pub async fn run_full_sweep(
 
     let t = begin(progress, &stats, SweepStage::Collect);
     let args = CollectArgs {
-        weeks: options.weeks,
+        weeks,
         // #5217: DOC-67 §9 — a one-shot org sweep cannot inherit `tga
         // collect`'s abort-on-fetch-failure default; a stale repo is a named
         // gap, not a reason to halt the other 199.
@@ -154,7 +177,7 @@ pub async fn run_full_sweep(
 
     let t = begin(progress, &stats, SweepStage::Classify);
     let args = ClassifyArgs {
-        weeks: options.weeks,
+        weeks,
         ..ClassifyArgs::default()
     };
     let result = classify::run(config.clone(), db, args).await;
@@ -185,7 +208,7 @@ pub async fn run_full_sweep(
     // directory itself — passing the directory makes it write a regular file
     // there and the report stage then cannot create the directory.
     let args = PrMetricsArgs {
-        weeks: options.weeks,
+        weeks,
         csv: true,
         output: options.output.as_ref().map(|d| d.join("pr-metrics.csv")),
     };

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -2,11 +2,12 @@
 
 use std::time::Instant;
 
+use chrono::{Duration, Utc};
 use clap::{Args as _, FromArgMatches, Parser};
 
 use crate::audit::{run_full_sweep, AuditSweepStats, StageStatus, SweepOptions, SweepStage};
 use crate::commands::audit::AuditArgs;
-use crate::core::config::Config;
+use crate::core::config::{AuditConfig, Config, DEFAULT_AUDIT_WINDOW_WEEKS};
 use crate::core::db::Database;
 use crate::core::progress::{ProgressBus, Stage};
 
@@ -257,6 +258,122 @@ async fn sweep_writes_reports_into_the_requested_directory() {
             out.join(expected).is_file(),
             "expected artifact {expected} missing from {}: {written:?}",
             out.display()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The audit window: CLI flag > config field > 52 weeks (#5482)
+// ---------------------------------------------------------------------------
+
+/// A config carrying only an audit window.
+fn config_with_window(window_weeks: Option<u32>) -> Config {
+    Config {
+        audit: Some(AuditConfig { window_weeks }),
+        ..Config::default()
+    }
+}
+
+/// Run a sweep over an empty database and return the pr-metrics stage's
+/// failure message.
+///
+/// Why: the message is where the resolved window becomes observable without a
+/// network or a populated repository. #6796 made an empty pr-metrics result an
+/// error, and its text branches on whether a cutoff was applied: with one it
+/// quotes the cutoff timestamp, without one it reports the table as empty. So
+/// the message says both THAT a window reached the stage and WHICH one.
+async fn pr_metrics_failure(config: &Config, options: &SweepOptions) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut db = Database::open(&dir.path().join("tga.db")).expect("open db");
+    let mut options = options.clone();
+    options.output = Some(dir.path().join("out"));
+
+    let stats = run_full_sweep(config, &mut db, &options, None)
+        .await
+        .expect("sweep");
+
+    let outcome = stats
+        .outcomes
+        .iter()
+        .find(|o| o.stage == SweepStage::PrMetrics)
+        .expect("pr-metrics stage ran");
+    match &outcome.status {
+        StageStatus::Failed(message) => message.clone(),
+        StageStatus::Succeeded => panic!("an empty database must fail pr-metrics (#6796)"),
+    }
+}
+
+/// The two UTC dates a cutoff `weeks` back can legitimately carry.
+///
+/// Why: the cutoff is `Utc::now() - weeks`, evaluated inside the sweep, so a run
+/// that straddles midnight UTC lands on the day after the one the test computed.
+/// Accepting both is what makes the assertion deterministic rather than a
+/// once-a-day flake.
+fn plausible_cutoff_dates(weeks: u32) -> [String; 2] {
+    let cutoff = Utc::now() - Duration::weeks(i64::from(weeks));
+    [
+        (cutoff - Duration::days(1)).format("%Y-%m-%d").to_string(),
+        cutoff.format("%Y-%m-%d").to_string(),
+    ]
+}
+
+/// Assert `message` quotes a cutoff `weeks` back — and therefore that the sweep
+/// handed pr-metrics exactly that window.
+fn assert_window_reached_pr_metrics(message: &str, weeks: u32) {
+    let dates = plausible_cutoff_dates(weeks);
+    assert!(
+        dates.iter().any(|d| message.contains(d.as_str())),
+        "expected a cutoff {weeks} week(s) back (one of {dates:?}) in: {message}"
+    );
+}
+
+/// #5482's first closure condition: the config field reaches the sweep with no
+/// CLI flag involved. Before this change `SweepOptions::weeks` was the only
+/// source, so `None` collected unbounded history and pr-metrics reported the
+/// table as empty rather than naming a window.
+#[tokio::test]
+async fn the_sweep_window_falls_back_to_the_config_field() {
+    let message = pr_metrics_failure(
+        &config_with_window(Some(3)),
+        &SweepOptions {
+            weeks: None,
+            ..SweepOptions::default()
+        },
+    )
+    .await;
+
+    assert_window_reached_pr_metrics(&message, 3);
+}
+
+/// #5482's second closure condition: no `audit:` section at all resolves to 52
+/// weeks, not to unbounded. This is the case `trusty-audit` actually runs — it
+/// spawns `tga audit` with no `--weeks`.
+#[tokio::test]
+async fn the_sweep_window_defaults_to_a_year_when_nothing_declares_one() {
+    let message = pr_metrics_failure(&Config::default(), &SweepOptions::default()).await;
+
+    assert_window_reached_pr_metrics(&message, DEFAULT_AUDIT_WINDOW_WEEKS);
+    assert_eq!(DEFAULT_AUDIT_WINDOW_WEEKS, 52);
+}
+
+/// The CLI flag outranks the config field — same precedence `--database`
+/// already has over `database:` in `main.rs`.
+#[tokio::test]
+async fn an_explicit_sweep_window_beats_the_config_field() {
+    let message = pr_metrics_failure(
+        &config_with_window(Some(40)),
+        &SweepOptions {
+            weeks: Some(2),
+            ..SweepOptions::default()
+        },
+    )
+    .await;
+
+    assert_window_reached_pr_metrics(&message, 2);
+    for stale in plausible_cutoff_dates(40) {
+        assert!(
+            !message.contains(stale.as_str()),
+            "the config's 40-week window should have been overridden: {message}"
         );
     }
 }

--- a/crates/trusty-git-analytics/src/core/config/mod.rs
+++ b/crates/trusty-git-analytics/src/core/config/mod.rs
@@ -292,12 +292,50 @@ pub struct Config {
     #[serde(default)]
     pub llm: Option<LlmConfig>,
 
+    /// `tga audit` settings (`audit:` in YAML).
+    ///
+    /// Why (#5482): the audit window was reachable only through `tga audit
+    /// --weeks`, and `trusty-audit` spawns `tga audit` with no such flag — so
+    /// an engagement could not state its own lookback and every run collected
+    /// unbounded history. A config section is what a generated engagement
+    /// config can carry.
+    /// What: holds [`AuditConfig`]. Absent means "take every default".
+    /// Test: `tests::audit_window_weeks_*`.
+    #[serde(default)]
+    pub audit: Option<AuditConfig>,
+
     /// Filesystem path to the loaded config file, if any.
     ///
     /// Populated by [`Config::load`] and used to resolve relative paths
     /// (notably [`Config::aliases_file`]). Not serialized to YAML.
     #[serde(skip)]
     pub source_path: Option<PathBuf>,
+}
+
+/// The lookback window `tga audit` uses when nothing else names one.
+///
+/// Why (#5482): one year, per the owner's stated default. It lives here rather
+/// than at the sweep's call site so the config accessor and the docs quote the
+/// same number.
+/// What: `52` ISO weeks.
+/// Test: `tests::audit_window_weeks_defaults_when_the_section_is_absent`.
+pub const DEFAULT_AUDIT_WINDOW_WEEKS: u32 = 52;
+
+/// `tga audit` configuration (`audit:` in YAML).
+///
+/// Why (#5482): see [`Config::audit`].
+/// What: the audit-specific settings an engagement config declares. Today that
+/// is the collection window alone.
+/// Test: `tests::audit_window_weeks_reads_the_config_value`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AuditConfig {
+    /// Limit the audit's collection and PR metrics to the last N ISO weeks.
+    ///
+    /// Absent means [`DEFAULT_AUDIT_WINDOW_WEEKS`]. `tga audit --weeks` still
+    /// overrides whatever is set here.
+    #[serde(default)]
+    pub window_weeks: Option<u32>,
 }
 
 /// Analysis pipeline configuration (forward-compat with Python schema).
@@ -1641,6 +1679,25 @@ impl Config {
         database_path::resolve(self.database.as_deref(), self.config_dir())
     }
 
+    /// The audit lookback window in ISO weeks, with the default folded in.
+    ///
+    /// Why (#5482): `audit.window_weeks` had no reader, so the only way to bound
+    /// an audit was `tga audit --weeks` — and `trusty-audit` spawns `tga audit`
+    /// without it. Resolving the default here rather than at the call site is
+    /// what keeps the sweep's two consumers (the collect stage and PR metrics)
+    /// reading one number instead of each applying its own fallback.
+    /// What: `audit.window_weeks` when set, else [`DEFAULT_AUDIT_WINDOW_WEEKS`].
+    /// The CLI flag outranks both, and applies that precedence in
+    /// [`crate::audit::run_full_sweep`].
+    /// Test: `tests::audit_window_weeks_reads_the_config_value`,
+    /// `tests::audit_window_weeks_defaults_when_the_section_is_absent`.
+    pub fn audit_window_weeks(&self) -> u32 {
+        self.audit
+            .as_ref()
+            .and_then(|a| a.window_weeks)
+            .unwrap_or(DEFAULT_AUDIT_WINDOW_WEEKS)
+    }
+
     /// Validate cross-field invariants of the config.
     ///
     /// # Errors
@@ -2032,5 +2089,30 @@ mod tests {
             alice_email, bob_email,
             "distinct members must not collide on the same canonical_email"
         );
+    }
+
+    /// #5482: an `audit:` section states the window, and the accessor reads it
+    /// from YAML rather than from a field a caller happened to set.
+    #[test]
+    fn audit_window_weeks_reads_the_config_value() {
+        let yaml = "repositories: []\naudit:\n  window_weeks: 13\n";
+        let cfg: Config = serde_yaml::from_str(yaml).expect("parse audit section");
+
+        assert_eq!(cfg.audit_window_weeks(), 13);
+    }
+
+    /// An absent section, and a present section that names no window, both mean
+    /// one year — never "unbounded". Every config written before `audit:`
+    /// existed takes this path.
+    #[test]
+    fn audit_window_weeks_defaults_when_the_section_is_absent() {
+        assert_eq!(
+            Config::default().audit_window_weeks(),
+            DEFAULT_AUDIT_WINDOW_WEEKS
+        );
+        assert_eq!(DEFAULT_AUDIT_WINDOW_WEEKS, 52);
+
+        let cfg: Config = serde_yaml::from_str("repositories: []\naudit: {}\n").expect("parse");
+        assert_eq!(cfg.audit_window_weeks(), DEFAULT_AUDIT_WINDOW_WEEKS);
     }
 }

--- a/docs/trusty-git-analytics/requirements/configuration.md
+++ b/docs/trusty-git-analytics/requirements/configuration.md
@@ -16,6 +16,7 @@ developer_aliases: {}     # dict[str, list[str]] — inline identity alias map
 aliases_file: ~           # path — external YAML alias file
 fuzzy_identity_fallback: ~ # bool — Tier-3/4 fuzzy identity fallback (issue #4251)
 analysis: {}              # AnalysisConfig
+audit: {}                 # AuditConfig — `tga audit` settings (issue #5482)
 output: {}                # OutputConfig
 cache: {}                 # CacheConfig
 jira: {}                  # JIRAConfig
@@ -331,6 +332,30 @@ downstream with no signal that it happened.
 | `directory` | path | `~/.tga-cache` |
 | `ttl_hours` | u32 | 168 (7 days) |
 | `max_size_mb` | u32 | 1024 |
+
+### `audit` — AuditConfig (added issue #5482)
+
+Settings for `tga audit`, the one-shot due-diligence sweep.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `window_weeks` | u32 | 52 (1 year) | Lookback window in ISO weeks, applied to the sweep's collect, classify, and pr-metrics stages |
+
+**Precedence** (highest first):
+
+1. `tga audit --weeks` — always wins.
+2. `audit.window_weeks:` in this config file.
+3. The 52-week default.
+
+```yaml
+# Example: a two-year engagement
+audit:
+  window_weeks: 104
+```
+
+The window is a real collection bound, not a report filter — a narrower window
+collects less. `trusty-audit` spawns `tga audit` with no `--weeks`, so this field
+is the only way an engagement states its own window.
 
 ### `jira` — JIRAConfig
 


### PR DESCRIPTION
Refs #5482

The audit lookback window was reachable only through `tga audit --weeks`.
`trusty-audit` spawns `tga audit` with no such flag (`crates/trusty-audit/src/run.rs`
passes `--output` only), so every engagement run collected unbounded history and no
config could say otherwise.

## What changed

`Config` gains an `audit:` section — `AuditConfig { window_weeks: Option<u32> }` —
plus `DEFAULT_AUDIT_WINDOW_WEEKS = 52` and `Config::audit_window_weeks()`, which folds
the default in. The real key is `audit.window_weeks`; tga's config is YAML, not the TOML
the issue body's `[audit]` implies.

`run_full_sweep` resolves the window once, before stage 1, and hands that one local to
every consumer:

```rust
let weeks = Some(options.weeks.unwrap_or_else(|| config.audit_window_weeks()));
```

The issue names two consumers. `ClassifyArgs` reads the same field, and leaving it on the
raw `options.weeks` would have produced exactly the drift closure condition 3 forbids —
an unbounded classify beside a 52-week collect. All three now read one value.

Precedence — flag, then config, then default — follows the `--database` / `database:` /
`tga.db` chain already in `main.rs:369-372`.

`SweepOptions::weeks` changes meaning: `None` was "unbounded", it is now "the caller
stated nothing". Documented on the field and in the function contract.

## Coordination with #5478

#5478's generator emits the window value, and its shipped `EngagementConfig` lives in
`crates/trusty-audit/src/config.rs` — a separate TOML file from tga's `config.yaml`.
Whether that generator writes tga's `config.yaml` directly or needs a second hop from
`EngagementConfig` is #5478's decision. This PR makes tga honor `audit.window_weeks` in
its own config either way, and forecloses neither route.

## Test ladder — rung 3 (localized behavior inside one crate)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p tga --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p tga --no-fail-fast` | EXIT=0 — 11 targets; lib `1589 passed; 0 failed; 7 ignored`, doc-tests `10 passed`, 9 integration targets ok |
| five new tests by name | `5 passed; 0 failed; 1591 filtered out` |
| `check_line_cap.sh` | `4565 tracked .rs file(s); 0 violations` |
| `check_test_pointers.sh` | `31608 Test: citation(s) — 0 dangling` |
| `check_sld.sh` | `0 error(s), 0 warning(s)` |
| `check_changelog_fragment.sh` | `OK trusty-git-analytics: fragment present and valid` |
| `check-pr-version-bump.sh` | `clear (0 warning(s))` |
| `check_rustdoc_links.sh` | `26 crate(s), 0 broken link(s)` |

No test deleted or ignored; the 7 lib ignores are the pre-existing ONNX/corpus set.

### Regression proof

Reverting only `sweep.rs` — the plumbing — and keeping the config field, which on its own
is inert:

```
test audit::tests::an_explicit_sweep_window_beats_the_config_field ... ok
test audit::tests::the_sweep_window_falls_back_to_the_config_field ... FAILED
test audit::tests::the_sweep_window_defaults_to_a_year_when_nothing_declares_one ... FAILED

panicked at crates/trusty-git-analytics/src/audit/tests.rs:324:5:
expected a cutoff 52 week(s) back (one of ["2025-09-07", "2025-09-08"]) in: pr-metrics
produced no rows: the pull_requests table is empty, so no review-quality data was
collected for this repository. […] (issue #6796)

test result: FAILED. 1 passed; 2 failed; 0 ignored; 1593 filtered out
```

The message shows no cutoff was applied at all. The precedence test passes pre-fix
because `--weeks` already worked — it guards against a regression rather than proving the
new path.

The tests read the window through a real sweep rather than at the call site: #6796 made
an empty pr-metrics result an error whose text branches on whether a cutoff was applied
and quotes it, so the message proves both that a window reached the stage and which one.
The midnight-UTC straddle is handled by accepting the cutoff date and the day before it.

## Docs

`docs/trusty-git-analytics/requirements/configuration.md` gains an `audit` section with
the precedence list and a top-level-structure row. The crate README documents no config
keys, so it needed no edit.
