### PR TITLE
fix(tga): fallback narrative counts distinct recurring issues (#5490)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5490-narrative-distinct-clusters.md
+++ b/crates/trusty-git-analytics/changelog.d/5490-narrative-distinct-clusters.md
@@ -1,0 +1,3 @@
+Changed
+
+- The fallback contributor-profile narrative now counts distinct recurring issues rather than tagged occurrences, so one issue seen in three periods reads as 1 recurring issue instead of 3 (#5490).

--- a/crates/trusty-git-analytics/src/profile/synthesizer.rs
+++ b/crates/trusty-git-analytics/src/profile/synthesizer.rs
@@ -118,30 +118,13 @@ pub fn assign_trend_tags(findings: Vec<LongitudinalFinding>) -> Vec<Longitudinal
     let latest_period = period_order.last().cloned().unwrap_or_default();
 
     // Cluster by description similarity; `clusters` holds indices into `findings`.
-    let mut clusters: Vec<Vec<usize>> = Vec::new();
-    let mut assigned = vec![false; findings.len()];
-
-    for i in 0..findings.len() {
-        if assigned[i] {
-            continue;
-        }
-        let mut cluster = vec![i];
-        assigned[i] = true;
-        for j in (i + 1)..findings.len() {
-            if assigned[j] {
-                continue;
-            }
-            if jaccard_similarity(
-                &findings[i].finding.description,
-                &findings[j].finding.description,
-            ) >= JACCARD_THRESHOLD
-            {
-                cluster.push(j);
-                assigned[j] = true;
-            }
-        }
-        clusters.push(cluster);
-    }
+    let clusters = {
+        let descriptions: Vec<&str> = findings
+            .iter()
+            .map(|f| f.finding.description.as_str())
+            .collect();
+        cluster_by_similarity(&descriptions)
+    };
 
     let mut tagged = findings;
     for cluster in &clusters {
@@ -179,6 +162,42 @@ pub fn assign_trend_tags(findings: Vec<LongitudinalFinding>) -> Vec<Longitudinal
     }
 
     tagged
+}
+
+/// Group descriptions that name the same underlying issue.
+///
+/// Why: the trend tagger and the fallback narrative both have to agree on what
+/// counts as one issue; two independent clusterings would let the narrative
+/// report a different number of issues than the tags imply.
+/// What: greedy single-seed clustering — each still-unassigned description
+/// opens a cluster and absorbs every later unassigned description scoring at or
+/// above [`JACCARD_THRESHOLD`] against it. Returns index groups into
+/// `descriptions`, in seed order; an empty input yields no clusters.
+/// Test: `synthesizer_dedup_assigns_recurring`,
+/// `synthesizer_fail_safe_narrative_counts_distinct_clusters`.
+fn cluster_by_similarity(descriptions: &[&str]) -> Vec<Vec<usize>> {
+    let mut clusters: Vec<Vec<usize>> = Vec::new();
+    let mut assigned = vec![false; descriptions.len()];
+
+    for i in 0..descriptions.len() {
+        if assigned[i] {
+            continue;
+        }
+        let mut cluster = vec![i];
+        assigned[i] = true;
+        for j in (i + 1)..descriptions.len() {
+            if assigned[j] {
+                continue;
+            }
+            if jaccard_similarity(descriptions[i], descriptions[j]) >= JACCARD_THRESHOLD {
+                cluster.push(j);
+                assigned[j] = true;
+            }
+        }
+        clusters.push(cluster);
+    }
+
+    clusters
 }
 
 /// Token-set Jaccard similarity between two descriptions.
@@ -610,19 +629,25 @@ pub fn apply_synthesis_json(profile: &mut ContributorProfile, body: &str) {
 /// "the narrative pass did not run", so the fallback states both the findings
 /// and the fact that it is a fallback.
 /// What: sets `narrative` to a template naming the contributor, the window, the
-/// trajectory, and the recurring-finding count.
-/// Test: `synthesizer_fail_safe_narrative`.
+/// trajectory, and the number of DISTINCT recurring issues — one issue seen in
+/// three periods is one issue, not three (#5490).
+/// Test: `synthesizer_fail_safe_narrative`,
+/// `synthesizer_fail_safe_narrative_counts_distinct_clusters`.
 pub fn apply_fallback_narrative(profile: &mut ContributorProfile) {
     let traj_str = match profile.improvement_trajectory {
         Trajectory::Improving => "improving",
         Trajectory::Stable => "stable",
         Trajectory::Declining => "declining",
     };
-    let n_recurring = profile
+    // #5490: the sentence says "recurring issue(s)", so count clusters, not the
+    // per-period occurrences that carry the tag.
+    let recurring: Vec<&str> = profile
         .all_findings
         .iter()
         .filter(|f| f.trend_tag == Some(TrendTag::Recurring))
-        .count();
+        .map(|f| f.finding.description.as_str())
+        .collect();
+    let n_recurring = cluster_by_similarity(&recurring).len();
     profile.narrative = format!(
         "Longitudinal profile for {} ({} to {}). \
          Quality trajectory: {}. \

--- a/crates/trusty-git-analytics/src/profile/synthesizer_tests.rs
+++ b/crates/trusty-git-analytics/src/profile/synthesizer_tests.rs
@@ -369,6 +369,9 @@ fn synthesizer_ignores_unknown_trajectory() {
 /// about, which way they are trending, and that the prose is a fallback.
 /// What: applies the fallback directly, asserts the name, the failure notice,
 /// and the recurring count all appear.
+///
+/// The count assertion moved from 2 to 1 with #5490: the two findings here are
+/// one issue seen in two periods, and the sentence claims issues, not sightings.
 /// Test: this test itself.
 #[test]
 fn synthesizer_fail_safe_narrative() {
@@ -393,8 +396,48 @@ fn synthesizer_fail_safe_narrative() {
         profile.narrative
     );
     assert!(
+        profile.narrative.contains("1 recurring issue(s)"),
+        "one issue seen in two periods is one recurring issue: {}",
+        profile.narrative
+    );
+}
+
+/// Why: #5490 — counting tagged occurrences reported one issue spanning three
+/// periods as three, overstating how many distinct problems keep coming back.
+/// What: builds five `Recurring` occurrences that cluster into two issues and
+/// asserts the narrative says 2, not 5.
+/// Test: this test itself.
+#[test]
+fn synthesizer_fail_safe_narrative_counts_distinct_clusters() {
+    let mut profile = make_profile();
+    profile.all_findings = assign_trend_tags(vec![
+        make_finding("2026-Q1", "missing error propagation in async"),
+        make_finding(
+            "2026-Q1",
+            "unbounded channel growth starves the worker pool",
+        ),
+        make_finding("2026-Q2", "missing error propagation in async"),
+        make_finding("2026-Q3", "missing error propagation in async"),
+        make_finding(
+            "2026-Q3",
+            "unbounded channel growth starves the worker pool",
+        ),
+    ]);
+    assert_eq!(
+        profile
+            .all_findings
+            .iter()
+            .filter(|f| f.trend_tag == Some(TrendTag::Recurring))
+            .count(),
+        5,
+        "fixture must tag every occurrence Recurring for the count to mean anything"
+    );
+
+    apply_fallback_narrative(&mut profile);
+
+    assert!(
         profile.narrative.contains("2 recurring issue(s)"),
-        "fail-safe narrative must count the recurring findings: {}",
+        "five occurrences of two issues are two recurring issues: {}",
         profile.narrative
     );
 }


### PR DESCRIPTION
Refs #5490

## Decision: distinct clusters

The narrative sentence reads "N recurring issue(s) identified across periods." That claims a count of problems, not of sightings. `assign_trend_tags` clusters findings and tags every member of a cluster identically, so one issue appearing in three periods produced three `Recurring`-tagged findings and the sentence said "3 recurring issue(s)".

The issue left the choice open — occurrence count reflects total review burden, cluster count reflects unresolved-issue burden — and nobody had answered it (no comments). Decided from the report text: the wording promises issues, so the number counts issues. Occurrence count would need different wording to be honest, and the trend tags are already per-cluster, so cluster count is the reading the rest of the pipeline already takes.

The wording is unchanged; under distinct-cluster counting it is already accurate.

## Corrected premises from the issue

- The function is `apply_fallback_narrative` (`crates/trusty-git-analytics/src/profile/synthesizer.rs:607`), not `deterministic_narrative` — that symbol lives in `crates/trusty-mpm/src/daemon/manager/digest.rs` and is unrelated.
- PR #5486 is CLOSED, not merged. The port landed as #5558.
- The wording fix #5486 is credited with never reached tga: the string on `main` is still `"{} recurring issue(s) identified across periods"`, the overstating form.

## Out of scope

A cluster whose confidence climbs is tagged `Worsening`, not `Recurring`, so it stays outside this count. Whether the narrative should include worsening issues is a separate semantics question from occurrences-vs-clusters.

## Change

`synthesizer.rs`
- Extracted the greedy clustering out of `assign_trend_tags` into `cluster_by_similarity(&[&str]) -> Vec<Vec<usize>>`, and gave `apply_fallback_narrative` the same helper. Sharing it means the tagger and the count cannot disagree about what one issue is. Re-clustering the `Recurring` subset reproduces the original groups exactly: tags are assigned per cluster, so the retained set is always whole clusters, and the seed comparisons among them are unchanged.
- `// #5490:` at the counting site.

`synthesizer_tests.rs`
- `synthesizer_fail_safe_narrative`: assertion moved 2 → 1. Its fixture is one description in two periods, so it was pinning the defect. Reason stated in the test's doc comment.
- Added `synthesizer_fail_safe_narrative_counts_distinct_clusters`: 5 occurrences across 2 clusters over 3 periods, with a pre-assertion that all 5 carry `Recurring` so the count means something, then asserts the narrative says 2.
- No test deleted or ignored.

Changelog fragment: `crates/trusty-git-analytics/changelog.d/5490-narrative-distinct-clusters.md`.

## Pre-fix failure

Reverted only `synthesizer.rs` to the parent commit, kept the tests, `cargo test -p tga --lib --no-fail-fast synthesizer_fail_safe`:

```
test profile::synthesizer::tests::synthesizer_fail_safe_narrative ... FAILED
test profile::synthesizer::tests::synthesizer_fail_safe_narrative_counts_distinct_clusters ... FAILED

---- profile::synthesizer::tests::synthesizer_fail_safe_narrative stdout ----
panicked at crates/trusty-git-analytics/src/profile/synthesizer_tests.rs:398:5:
one issue seen in two periods is one recurring issue: Longitudinal profile for Alice
(2026-01-01 to 2026-12-31). Quality trajectory: stable. 2 recurring issue(s) identified
across periods. (Narrative generation unavailable — the LLM call failed or returned
invalid output.)

---- profile::synthesizer::tests::synthesizer_fail_safe_narrative_counts_distinct_clusters stdout ----
panicked at crates/trusty-git-analytics/src/profile/synthesizer_tests.rs:438:5:
five occurrences of two issues are two recurring issues: Longitudinal profile for Alice
(2026-01-01 to 2026-12-31). Quality trajectory: stable. 5 recurring issue(s) identified
across periods. (Narrative generation unavailable — the LLM call failed or returned
invalid output.)

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 1590 filtered out
```

Restored with `git show HEAD:… > …`; `git status --porcelain` empty; filtered re-run `test result: ok. 23 passed; 0 failed`.

## Gates — rung 3 (localized behavior inside one crate)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p tga --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p tga --no-fail-fast` | EXIT=0 — lib `1585 passed; 0 failed; 7 ignored`, plus 10 integration targets all ok |
| `cargo test -p tga --lib synthesizer_fail_safe` | `2 passed; 0 failed; 1590 filtered out` |
| `scripts/check_line_cap.sh` | 4567 files, 0 violations |
| `scripts/check_test_pointers.sh` | 31624 citations, 0 dangling |
| `scripts/check_sld.sh` | 0 errors, 0 warnings |
| `scripts/check_changelog_fragment.sh` | fragment present and valid |
| `scripts/check-pr-version-bump.sh` | `[ OK ] tga 8.0.0 — src changed, version not yet published`; 0 warnings, no bump owed |
| `scripts/check_rustdoc_links.sh` | 26 crates, 0 broken links |

`synthesizer.rs` goes 403 → 420 SLOC, under the 500 cap.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
