### PR TITLE
feat(tga): aliases suggest writes near-miss pairs to a review file (#6993)

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/6993-identity-near-miss-review.md
+++ b/crates/trusty-git-analytics/changelog.d/6993-identity-near-miss-review.md
@@ -1,0 +1,8 @@
+Added
+
+- `tga aliases suggest --review-file <PATH>` writes the near-miss identity pairs —
+  the ones scoring below `--confidence` but at or above 0.50, which the normal
+  output never shows — to a tab-separated file with both addresses, the reason, the
+  confidence, and a `confirmed` column the operator sets to `yes`. Stdout still
+  carries only the at-or-above-threshold suggestions, and no file is written unless
+  the flag is given (#6993).

--- a/crates/trusty-git-analytics/src/commands/aliases/mod.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases/mod.rs
@@ -7,6 +7,7 @@
 //! consolidated identity.
 
 use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 use rusqlite::params;
@@ -36,6 +37,8 @@ Use these subcommands for manual corrections and audits.",
   tga aliases merge old@contractor.com alice@company.com\n\n\
   # Auto-detect probable alias pairs from commit history\n\
   tga aliases suggest\n\n\
+  # Also park the pairs that scored just under the threshold in a review file\n\
+  tga aliases suggest --review-file ./identity-review.tsv\n\n\
   # Detach a previously-merged alias back to its own identity\n\
   tga aliases unmerge old@contractor.com\n\n\
 TIPS:\n\
@@ -119,6 +122,13 @@ pub enum AliasesSubcommand {
         /// Automatically merge HIGH-confidence pairs above `--confidence`.
         #[arg(long, default_value_t = false)]
         auto_accept: bool,
+        // #6993: near misses are invisible in the normal output; this routes
+        // them to a file an operator confirms against.
+        /// Write near-miss pairs — scoring below `--confidence` but at or above
+        /// 0.50 — to this TSV for a human to confirm. Nothing is written unless
+        /// the flag is given.
+        #[arg(long, value_name = "PATH")]
+        review_file: Option<PathBuf>,
     },
 }
 
@@ -158,7 +168,8 @@ pub fn run(config: Config, db: &mut Database, args: AliasesArgs) -> anyhow::Resu
         AliasesSubcommand::Suggest {
             confidence,
             auto_accept,
-        } => suggest::run(&config, db, confidence, auto_accept),
+            review_file,
+        } => suggest::run(&config, db, confidence, auto_accept, review_file.as_deref()),
     }
 }
 

--- a/crates/trusty-git-analytics/src/commands/aliases/suggest.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases/suggest.rs
@@ -2,25 +2,46 @@
 //!
 //! Why: detection itself moved to [`tga::collect::identity::suggest`] under
 //! #6142, because the authorship report needs the same answer and cannot call
-//! a CLI handler. What remains here is presentation and the `--auto-accept`
-//! merge, both of which are CLI-only concerns.
+//! a CLI handler. What remains here is presentation, the `--auto-accept`
+//! merge, and the `--review-file` near-miss artifact (#6993) — all three are
+//! CLI-only concerns.
 //! What: [`run`] resolves the configured canonical domain, calls
-//! [`tga::collect::identity::suggest::detect_all`], prints the ranked pairs,
-//! and optionally applies the HIGH-confidence ones.
+//! [`tga::collect::identity::suggest::detect_all`], prints the ranked pairs at
+//! or above `--confidence`, optionally applies the HIGH-confidence ones, and
+//! optionally writes the pairs BELOW `--confidence` to a review TSV.
 //! Test: `tests` in `suggest_tests.rs`.
+
+use std::io::{self, Write};
+use std::path::Path;
 
 use rusqlite::params;
 use tga::collect::identity::resolver::configured_canonical_domain;
-use tga::collect::identity::suggest::{detect_all, HIGH_CONFIDENCE_CUTOFF};
+use tga::collect::identity::suggest::{detect_all, Suggestion, HIGH_CONFIDENCE_CUTOFF};
 use tga::core::config::Config;
 use tga::core::db::Database;
+
+/// The lowest confidence a pair may score and still reach the `--review-file`
+/// artifact.
+///
+/// Why (#6993): a near miss is the band between "not worth a human's time" and
+/// "printed as a suggestion". 0.50 is the wide-net figure the no-suggestions
+/// message already points operators at, so the review file covers exactly the
+/// pairs a `--confidence 0.5` run would have printed.
+/// Test: `tests::the_review_file_lists_only_near_miss_pairs`.
+const NEAR_MISS_FLOOR: f64 = 0.50;
+
+/// Header row of the `--review-file` TSV, naming the columns issue #6993 asks
+/// for: both identities, the reason, the confidence, and the column an
+/// operator edits to confirm the pair.
+const REVIEW_HEADER: &str = "src\tdst\treason\tconfidence\tconfirmed";
 
 /// Public entry point invoked by the CLI dispatcher.
 ///
 /// Why: the dispatcher only knows about config + DB + flag values; the
 /// detection algorithm lives in the library so the report layer shares it.
-/// What: collects ranked suggestions above `confidence_floor`, prints them,
-/// and (with `auto_accept`) merges the HIGH-confidence pairs.
+/// What: collects ranked suggestions above `confidence_floor`, prints them to
+/// stdout, writes the near misses to `review_file` when one is given, and
+/// (with `auto_accept`) merges the HIGH-confidence pairs.
 /// Test: `tests::auto_accept_only_merges_high`,
 /// `tests::config_canonical_domain_threads_through`.
 pub(super) fn run(
@@ -28,38 +49,89 @@ pub(super) fn run(
     db: &mut Database,
     confidence_floor: f64,
     auto_accept: bool,
+    review_file: Option<&Path>,
+) -> anyhow::Result<()> {
+    let mut out = io::stdout().lock();
+    run_to(
+        config,
+        db,
+        confidence_floor,
+        auto_accept,
+        review_file,
+        &mut out,
+    )
+}
+
+/// [`run`] with the destination for its report lines injected.
+///
+/// Why (#6993): the review file's contract is that stdout keeps showing only
+/// the at-or-above-threshold pairs, which is only assertable when a test can
+/// read what was printed.
+/// What: identical to [`run`], writing every report line to `out` instead of
+/// stdout. Merge warnings still go to stderr.
+/// Test: `tests::{the_review_file_lists_only_near_miss_pairs,
+/// no_review_file_is_written_without_the_flag}`.
+fn run_to<W: Write>(
+    config: &Config,
+    db: &mut Database,
+    confidence_floor: f64,
+    auto_accept: bool,
+    review_file: Option<&Path>,
+    out: &mut W,
 ) -> anyhow::Result<()> {
     let canonical_domain = configured_canonical_domain(config);
 
-    let suggestions = detect_all(
-        db.connection(),
-        canonical_domain.as_deref(),
-        confidence_floor,
-    )?;
+    // #6993: a review file needs the pairs BELOW `--confidence`, so detection
+    // runs down to the near-miss floor and the partition below restores the
+    // printed set to exactly what an unflagged run would show.
+    let detect_floor = match review_file {
+        Some(_) => NEAR_MISS_FLOOR.min(confidence_floor),
+        None => confidence_floor,
+    };
+    let (suggestions, near_misses): (Vec<Suggestion>, Vec<Suggestion>) =
+        detect_all(db.connection(), canonical_domain.as_deref(), detect_floor)?
+            .into_iter()
+            .partition(|s| s.confidence >= confidence_floor);
+
+    if let Some(path) = review_file {
+        write_review_file(path, &near_misses)?;
+        writeln!(
+            out,
+            "Wrote {count} near-miss candidate(s) (confidence {NEAR_MISS_FLOOR:.2} up to \
+             {confidence_floor:.2}) to {path} — set `confirmed` to `yes` on a row to accept it.",
+            count = near_misses.len(),
+            path = path.display()
+        )?;
+    }
 
     if suggestions.is_empty() {
-        println!(
+        writeln!(
+            out,
             "No alias suggestions found above confidence {confidence_floor:.2}. \
              (Try `--confidence 0.5` for a wider net.)"
-        );
+        )?;
         return Ok(());
     }
 
-    println!("Suggested aliases (confidence ≥ {confidence_floor:.2}):");
+    writeln!(
+        out,
+        "Suggested aliases (confidence ≥ {confidence_floor:.2}):"
+    )?;
     for s in &suggestions {
         let label = if s.confidence >= HIGH_CONFIDENCE_CUTOFF {
             "HIGH"
         } else {
             "MED "
         };
-        println!(
+        writeln!(
+            out,
             "  {label}  {src} → {dst}  [{reason}]",
             src = s.src,
             dst = s.dst,
             reason = s.reason
-        );
+        )?;
     }
-    println!();
+    writeln!(out)?;
 
     if auto_accept {
         let mut accepted = 0usize;
@@ -76,22 +148,70 @@ pub(super) fn run(
             match apply_merge(db, &s.src, &s.dst) {
                 Ok(n) => {
                     accepted += 1;
-                    println!("Merged {} → {} ({} commits reassigned)", s.src, s.dst, n);
+                    writeln!(
+                        out,
+                        "Merged {} → {} ({} commits reassigned)",
+                        s.src, s.dst, n
+                    )?;
                 }
                 Err(e) => {
                     eprintln!("WARN: skip merge {} → {}: {e}", s.src, s.dst);
                 }
             }
         }
-        println!("Auto-accepted {accepted} HIGH-confidence merge(s).");
+        writeln!(out, "Auto-accepted {accepted} HIGH-confidence merge(s).")?;
     } else {
-        println!(
+        writeln!(
+            out,
             "Run `tga aliases merge <source> <dest>` to accept individual pairs, \
              or `tga aliases suggest --auto-accept --confidence {HIGH_CONFIDENCE_CUTOFF:.2}` \
              to accept all HIGH-confidence pairs at once."
-        );
+        )?;
     }
     Ok(())
+}
+
+/// Write the near-miss candidates to `path` as a TSV an operator edits.
+///
+/// Why (#6993): a pair scoring just under `--confidence` never appears in the
+/// normal output, so the split it represents stays invisible until someone
+/// re-runs with a lower threshold and remembers what they saw. The artifact
+/// carries the same four facts the suggestion line prints, plus the
+/// `confirmed` column that makes a human's answer durable.
+/// What: writes `REVIEW_HEADER` followed by one row per candidate, in the
+/// detector's own confidence-descending order, with `confirmed` seeded to
+/// `no`. The file is truncated on every run, and an empty candidate list still
+/// produces the header so the operator sees the answer rather than a missing
+/// file. Nothing beyond the printed suggestion's own fields is written.
+/// Test: `tests::the_review_file_lists_only_near_miss_pairs`.
+fn write_review_file(path: &Path, near_misses: &[Suggestion]) -> anyhow::Result<()> {
+    let mut body = String::from(REVIEW_HEADER);
+    body.push('\n');
+    for s in near_misses {
+        body.push_str(&format!(
+            "{src}\t{dst}\t{reason}\t{confidence:.2}\tno\n",
+            src = tsv_field(&s.src),
+            dst = tsv_field(&s.dst),
+            reason = tsv_field(&s.reason),
+            confidence = s.confidence
+        ));
+    }
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, body)?;
+    Ok(())
+}
+
+/// One TSV cell with the delimiters neutralised.
+///
+/// Why: `src` and `dst` come from the database, so a tab or newline inside an
+/// address would silently shift every later column.
+/// Test: covered by `tests::the_review_file_lists_only_near_miss_pairs`.
+fn tsv_field(value: &str) -> String {
+    value.replace(['\t', '\n', '\r'], " ")
 }
 
 /// Apply a merge between two existing identities, returning the number of

--- a/crates/trusty-git-analytics/src/commands/aliases/suggest_tests.rs
+++ b/crates/trusty-git-analytics/src/commands/aliases/suggest_tests.rs
@@ -3,7 +3,8 @@
 //! Detection-algorithm coverage lives with the algorithm, in
 //! `tga::collect::identity::suggest::tests` (#6142). What remains here is the
 //! handler's own behaviour: threading the configured canonical domain through,
-//! and the `--auto-accept` merge.
+//! the `--auto-accept` merge, and the `--review-file` near-miss artifact
+//! (#6993).
 
 use super::*;
 use rusqlite::params;
@@ -22,6 +23,18 @@ fn config_with_domain(domain: &str) -> Config {
     }
 }
 
+/// Two identities that score 0.95 (same canonical_name) plus two that score
+/// 0.78 (edit-distance 2 on the local-part), so a 0.85 threshold splits them
+/// one to stdout and one to the review file.
+fn db_with_one_hit_and_one_near_miss() -> Database {
+    let db = Database::open_in_memory().expect("open");
+    insert_author(&db, "Bob", "alt@example.com");
+    insert_author(&db, "Bob", "bob@example.com");
+    insert_author(&db, "Carol", "carol@example.com");
+    insert_author(&db, "Carolyn", "carolyn@example.com");
+    db
+}
+
 #[test]
 fn auto_accept_only_merges_high() {
     let mut db = Database::open_in_memory().expect("open");
@@ -36,7 +49,7 @@ fn auto_accept_only_merges_high() {
     insert_commit(&db, "sha-alt", alt);
 
     let cfg = Config::default();
-    run(&cfg, &mut db, 0.85, true).expect("run");
+    run(&cfg, &mut db, 0.85, true, None).expect("run");
 
     // After auto-accept the src (bob@) row should be gone.
     let bob_exists: i64 = db
@@ -72,7 +85,7 @@ fn suggest_without_auto_accept_never_merges() {
     insert_author(&db, "Bob", "bob@example.com");
 
     let cfg = Config::default();
-    run(&cfg, &mut db, 0.85, false).expect("run");
+    run(&cfg, &mut db, 0.85, false, None).expect("run");
 
     let rows: i64 = db
         .connection()
@@ -90,5 +103,101 @@ fn config_canonical_domain_threads_through() {
     insert_author(&db, "Z", "z@duettoresearch.com");
     let cfg = config_with_domain("duettoresearch.com");
     // Run with auto_accept=false so we don't mutate; just ensure no panic.
-    run(&cfg, &mut db, 0.5, false).expect("run");
+    run(&cfg, &mut db, 0.5, false, None).expect("run");
+}
+
+#[test]
+fn the_review_file_lists_only_near_miss_pairs() {
+    // #6993: the pair below `--confidence` reaches the file and nothing else
+    // does, and the pair above it still reaches stdout and only stdout.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("nested").join("identity-review.tsv");
+    let mut db = db_with_one_hit_and_one_near_miss();
+
+    let mut stdout: Vec<u8> = Vec::new();
+    run_to(
+        &Config::default(),
+        &mut db,
+        0.85,
+        false,
+        Some(&path),
+        &mut stdout,
+    )
+    .expect("run");
+
+    let written = std::fs::read_to_string(&path).expect("review file");
+    let lines: Vec<&str> = written.lines().collect();
+    assert_eq!(
+        lines[0], "src\tdst\treason\tconfidence\tconfirmed",
+        "header names the columns #6993 asks for"
+    );
+    assert_eq!(
+        lines.len(),
+        2,
+        "exactly one near-miss row belongs in the file, got: {written}"
+    );
+    assert_eq!(
+        lines[1], "carolyn@example.com\tcarol@example.com\tedit-distance 2 on local-part\t0.78\tno",
+        "the near-miss row carries both identities, the reason, the score, and confirmed=no"
+    );
+    assert!(
+        !written.contains("bob@example.com"),
+        "the above-threshold pair must not leak into the review file: {written}"
+    );
+
+    let printed = String::from_utf8(stdout).expect("utf8");
+    assert!(
+        printed.contains("bob@example.com → alt@example.com"),
+        "the above-threshold pair is still printed: {printed}"
+    );
+    assert!(
+        !printed.contains("carolyn@example.com → carol@example.com"),
+        "a near miss must not be printed as a suggestion: {printed}"
+    );
+}
+
+#[test]
+fn no_review_file_is_written_without_the_flag() {
+    // #6993: the artifact is opt-in — an unflagged run leaves no file behind.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("identity-review.tsv");
+    let mut db = db_with_one_hit_and_one_near_miss();
+
+    let mut stdout: Vec<u8> = Vec::new();
+    run_to(&Config::default(), &mut db, 0.85, false, None, &mut stdout).expect("run");
+
+    assert!(
+        !path.exists(),
+        "no review file may be written without --review-file"
+    );
+    let printed = String::from_utf8(stdout).expect("utf8");
+    assert!(
+        !printed.contains("near-miss"),
+        "an unflagged run says nothing about a review file: {printed}"
+    );
+}
+
+#[test]
+fn an_empty_near_miss_set_still_writes_the_header() {
+    // #6993: "no near misses" is an answer the operator asked for, so the
+    // flagged run leaves a header-only file rather than no file at all.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("identity-review.tsv");
+    let mut db = Database::open_in_memory().expect("open");
+    insert_author(&db, "Bob", "alt@example.com");
+    insert_author(&db, "Bob", "bob@example.com");
+
+    let mut stdout: Vec<u8> = Vec::new();
+    run_to(
+        &Config::default(),
+        &mut db,
+        0.85,
+        false,
+        Some(&path),
+        &mut stdout,
+    )
+    .expect("run");
+
+    let written = std::fs::read_to_string(&path).expect("review file");
+    assert_eq!(written, format!("{REVIEW_HEADER}\n"));
 }

--- a/docs/trusty-git-analytics/user/user-guide.md
+++ b/docs/trusty-git-analytics/user/user-guide.md
@@ -341,6 +341,46 @@ tga aliases merge "jdoe-github" "John Doe"
 tga aliases merge "jdoe-github" "John Doe" --yes
 ```
 
+### Let tga suggest the pairs
+
+`tga aliases suggest` scores every identity pair the database holds and prints the
+ones at or above `--confidence`. It never merges on its own unless you ask it to.
+
+```bash
+# Print probable pairs (default threshold 0.85)
+tga aliases suggest
+
+# Merge the HIGH-confidence pairs without prompting
+tga aliases suggest --auto-accept
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--confidence <N>` | `0.85` | Minimum confidence to print a pair |
+| `--auto-accept` | false | Merge the HIGH-confidence pairs |
+| `--review-file <PATH>` | none | Write the near misses to a TSV |
+
+#### Review the near misses
+
+A pair scoring just under `--confidence` is the split most likely to go unnoticed:
+too weak to print, too strong to be a coincidence. `--review-file` writes those
+pairs — everything below `--confidence` and at or above 0.50 — to a tab-separated
+file instead, so a human can decide.
+
+```bash
+tga aliases suggest --review-file ./identity-review.tsv
+```
+
+```
+src	dst	reason	confidence	confirmed
+carolyn@company.com	carol@company.com	edit-distance 2 on local-part	0.78	no
+```
+
+Set `confirmed` to `yes` on the rows you accept, then merge them with
+`tga aliases merge <src> <dst>`. The file is rewritten on every run and carries
+nothing the printed suggestions would not — both addresses, the reason, and the
+score. Without the flag no file is written at all.
+
 ### Define aliases in config.yaml
 
 For deterministic identity resolution, declare aliases explicitly in `config.yaml`:


### PR DESCRIPTION
A pair scoring just under `--confidence` is the identity split most likely to go
unnoticed: too weak to print, too strong to be a coincidence. `tga aliases
suggest --review-file <PATH>` now writes those pairs to a TSV an operator
confirms against.

```
src	dst	reason	confidence	confirmed
carolyn@company.com	carol@company.com	edit-distance 2 on local-part	0.78	no
```

Detection runs down to a 0.50 near-miss floor only when the flag is given, then
partitions at `--confidence`: at or above goes to stdout exactly as before,
below goes to the file. Without the flag the detection floor is `--confidence`,
so the unflagged path is unchanged and no file is written. `--auto-accept` still
sees only the above-threshold set.

The file carries the same four fields the suggestion line already prints, so
nothing reaches it that a `--confidence 0.5` run would not already put on the
terminal. It is truncated each run, and an empty candidate list writes the
header alone rather than no file.

`run` gained a `run_to` sibling taking the report destination, which is what
makes the stdout half of the contract assertable.

## Scope — the issue stays open

This is the artifact half of #6993 only. **Not in this PR:** reading `confirmed:
yes` rows back into `authors.aliases`, and unconfirmed rows persisting across
runs (the file is rewritten every run). Two of the issue's four closure
conditions therefore remain unmet, so `Refs`, not `Closes`.

## Gates — test ladder rung 3

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy -p tga --all-targets -- -D warnings` | clean |
| `cargo test -p tga --no-fail-fast` | `1593 passed; 0 failed; 7 ignored` (lib) plus 10 further targets, 0 failed each |
| `check_line_cap.sh` | 4567 tracked `.rs`, 0 violations |
| `check_test_pointers.sh` | 31625 citations, 0 dangling |
| `check_sld.sh` | 0 errors, 0 warnings |
| `check_changelog_fragment.sh` | fragment present and valid |
| `check-pr-version-bump.sh` | clear |
| `check_rustdoc_links.sh` | 26 crates, 0 broken links |

All three gate runs repeated after rebasing onto the two sibling tga PRs.

Reverting `suggest.rs` and `mod.rs` to the parent commit fails the build — `run`
has no `review_file` parameter there, and `run_to` and `REVIEW_HEADER` do not
exist — so neither new assertion is reachable on `main`.

Refs #6993.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
