### PR TITLE
feat(trusty-code): agents.describe reports effective config, provenance, and warnings (#2074)

### DIFF
--- a/crates/trusty-code/README.md
+++ b/crates/trusty-code/README.md
@@ -209,6 +209,76 @@ stored under an unrelated key (`"endpoint": "https://user:pw@host"`) is not
 detected, and this check is not a substitute for a secret scanner on the
 repository itself.
 
+## Agent inspection — `agents.describe`
+
+`agents.list` answers "what could I dispatch": one row per agent with its name,
+tier, description, model, and a `has_warnings` flag. `agents.describe` answers
+the question after it — which definition actually runs under a name, and whether
+anything about it needs attention.
+
+```json
+{"method": "agents.describe", "params": {"name": "engineer"}}
+```
+
+```json
+{
+  "name": "engineer",
+  "tier": "project",
+  "path": "/w/.trusty-code/agents/engineer.md",
+  "role": "engineer",
+  "description": "General-purpose software engineer.",
+  "model": "sonnet",
+  "tools": {"allowed": null},
+  "skills": ["toolchains-rust-core"],
+  "instructions": {"length_bytes": 18422},
+  "provenance": {
+    "manifest": "present",
+    "origin": "bundled",
+    "framework_owned": true,
+    "checksum": "match",
+    "deployed_at": "2026-09-07T11:04:19Z",
+    "source_chain": ["base-agent", "base-engineer", "engineer"]
+  },
+  "warnings": []
+}
+```
+
+- **`tier`** — `embedded`, `project`, `user`, `plugin`, or `broken`. The name is
+  resolved through the same disk-wins/embedded-fallback chain dispatch uses, so
+  inspection and dispatch can never disagree about which definition wins.
+- **`tools.allowed`** — the agent's tool allowlist. `null` means every
+  registered tool is permitted, matching how the runtime reads it.
+- **`instructions`** — the resolved prompt's length in bytes. Pass
+  `"include_instructions": true` to get the text itself in
+  `instructions.text`; a composed roster prompt runs to tens of kilobytes, so it
+  is opt-in.
+- **`provenance`** — read back from the deployed-agent manifest beside the file.
+  `manifest` is `present`, `absent`, `corrupt`, or `not-applicable` (the agent
+  has no file on disk). `origin` and `framework_owned` say whether Trusty Code
+  wrote the file; `checksum` says whether it still matches what was written.
+- **`warnings`** — everything an operator would otherwise have to diff for: a
+  disk copy that diverges from the bundled roster, a file the manifest does not
+  track, a missing ledger in `.trusty-code/agents/`, an unreadable one, or a
+  parse failure. `agents.list`'s `has_warnings` is `true` for exactly the rows
+  that would return a non-empty list here.
+
+**A broken file is described, not raised.** An agent whose `.md` exists but
+fails to parse or compose comes back with `tier: "broken"` and the parse error
+in `warnings`, because the reason a name fell back to the embedded roster is
+what the operator is looking for. A name that resolves nowhere is a `not_found`
+error listing the agents that do exist.
+
+**Capability grants are not reported, because they do not exist yet.** An
+agent's declared authority in Trusty Code today is the flat `tools.allowed`
+allowlist and nothing else. The write, shell, network, credential, and
+delegation grants #2074 calls for are a later slice; until they are enforced,
+this payload carries no `grants` key rather than a field that would imply the
+runtime checks something it does not.
+
+There is no `tcode agents` CLI family — this surface is JSON-RPC only. Use
+`tcode paths show` for the directory-level view of which root won and what the
+ledger tracks.
+
 ## Build
 
 ```bash

--- a/crates/trusty-code/changelog.d/2074-s3-agents-describe.md
+++ b/crates/trusty-code/changelog.d/2074-s3-agents-describe.md
@@ -1,0 +1,32 @@
+Added
+
+- **`agents.describe` reports one agent's effective configuration, source
+  provenance, and warnings (#2074).** `agents.list` answers "what could I
+  dispatch"; the new method answers the question after it — which file on disk
+  this name resolves from, whether Trusty Code wrote that file, when, from which
+  compose chain, and whether anyone has edited it since. It resolves through
+  `agents::resolve_agent`, the same disk-wins/embedded-fallback/plugin chain
+  dispatch uses, so inspection and dispatch cannot disagree about which
+  definition wins, and it reads the provenance back out of the deployed-agent
+  ledger slice 1 writes. The payload carries the tier (`embedded`, `project`,
+  `user`, `plugin`, or `broken`), the source path, model, role, description,
+  the `tools.allowed` allowlist, the declared skills, the resolved instruction
+  text's length — and the text itself only when `include_instructions: true`,
+  because a composed roster prompt runs to tens of kilobytes. Provenance reports
+  the manifest state, the recorded origin and whether it is framework-owned, the
+  deploy timestamp, the resolved compose chain, and whether the file still
+  matches its recorded checksum. Warnings name what an operator would otherwise
+  have to diff for: a disk copy that diverges from the bundled roster, a file
+  the manifest does not track, a missing ledger in Trusty Code's own agents
+  directory, and an unreadable one. An agent whose file exists but fails to
+  parse is reported with `tier: "broken"` and the parse error in `warnings`
+  rather than raised as an RPC error, so the reason a name fell back to the
+  embedded roster is visible; a name that resolves nowhere is a typed
+  `not_found`. Capability grants are deliberately absent from the payload:
+  Trusty Code has no grant model yet, so the flat allowlist that exists is
+  reported and no `grants` key is invented.
+- **`agents.list` rows carry `has_warnings` (#2074).** An additive boolean
+  computed by the same module `agents.describe` uses, so a client can badge the
+  rows worth opening without describing every one. The ledger is read once per
+  listing rather than once per row. The four original keys are unchanged, so a
+  client written against the previous shape deserializes an entry as before.

--- a/crates/trusty-code/changelog.d/2074-s3-skills-projection.md
+++ b/crates/trusty-code/changelog.d/2074-s3-skills-projection.md
@@ -1,0 +1,8 @@
+Changed
+
+- **An agent's frontmatter `skills:` list is no longer dropped when a `.md`
+  agent is projected onto `AgentConfig` (#2074).** It now populates
+  `SystemPrompt::append_skills`, which `agents.describe` reports as the agent's
+  declared skills. The field was previously left empty because nothing consumed
+  it; `agents.describe` is that consumer. Nothing injects those skills into a
+  prompt yet — this is a reporting surface, not a runtime one.

--- a/crates/trusty-code/src/agents/describe.rs
+++ b/crates/trusty-code/src/agents/describe.rs
@@ -1,0 +1,409 @@
+//! `agents.describe` — the effective configuration, provenance, and warnings
+//! for ONE agent (#2074, epic #2892).
+//!
+//! Why: `agents.list` answers "what could I dispatch?" with four fields per row
+//! — name, tier, description, model. An operator debugging drift needs the next
+//! question answered: which file on disk is this, did Trusty Code write it, has
+//! anyone edited it since, and what is actually in the prompt. Slice 1 put a
+//! file, a checksum, and an [`Origin`] on disk for every shipped role
+//! (`crate::agents::deploy`); this module is what reads them back out.
+//!
+//! What: [`describe_agent`] resolves one name through
+//! [`crate::agents::resolve_agent`] — the SAME disk-wins/embedded-fallback/
+//! plugin chain dispatch uses, never a second copy of it — and pairs the
+//! resolved config with the deployed-agent ledger sitting beside the file.
+//! [`load_ledger`] reads that ledger once per request, and
+//! [`disk_entry_has_warnings`] lets `agents.list` reuse the same judgement for
+//! its per-row `has_warnings` flag without a second ledger parse.
+//!
+//! ## What this surface deliberately does NOT report
+//!
+//! Trusty Code has no capability-grant model yet: an agent's declared authority
+//! is the flat `tools.allowed` allowlist
+//! ([`crate::agents::config::ToolsConfig`]) and nothing else. #2074's
+//! write/shell/network/credential/delegation grants are a later slice, so this
+//! payload reports the allowlist that exists and carries NO `grants` key.
+//! An absent field is the honest answer; a fabricated one would tell an
+//! operator the runtime enforces something it does not.
+//!
+//! Test: `crate::agents::describe::tests::*`.
+//!
+//! [`Origin`]: trusty_agents_common::agents::manifest::Origin
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+use trusty_agents_common::agents::manifest::{AgentManifest, MANIFEST_FILE, ManifestLoad, Origin};
+
+use crate::jsonrpc::RpcError;
+use crate::paths::TRUSTY_CODE_DIRNAME;
+
+use super::deploy::AGENTS_DIRNAME;
+use super::{ResolveAgentError, resolve_agent};
+
+/// The deployed-agent ledger's state for one agents directory.
+///
+/// Why: `AgentManifest::load_checked` reports a MISSING ledger and an EMPTY one
+/// identically (`Ok`), and the two mean different things here — a missing
+/// ledger in Trusty Code's own roster directory is an anomaly worth a warning,
+/// while an empty one is a deploy that tracked nothing. Testing the file itself
+/// is what separates them, exactly as `crate::agents::deploy::
+/// roster_manifest_status` already does for `tcode paths show`.
+/// What: absent, parsed, or unreadable-with-detail.
+/// Test: `absent_ledger_in_the_native_roster_dir_warns`,
+/// `corrupt_ledger_is_reported_as_a_warning`.
+pub(crate) enum LedgerState {
+    /// No ledger file exists in this directory.
+    Absent,
+    /// The ledger parsed.
+    Ok(AgentManifest),
+    /// The ledger exists but could not be read; carries the underlying detail.
+    Corrupt(String),
+}
+
+/// Read the deployed-agent ledger in `dir` once.
+///
+/// Why: `agents.list` describes up to a whole roster in one call. Loading the
+/// ledger per row would re-parse the same JSON once per agent; hoisting it to
+/// the caller keeps the listing one parse regardless of roster size.
+/// What: distinguishes an absent file from an empty ledger by testing the file,
+/// then defers to `AgentManifest::load_checked` for the parse.
+/// Test: `absent_ledger_in_the_native_roster_dir_warns`,
+/// `deployed_pristine_agent_reports_framework_origin_and_no_warnings`.
+pub(crate) fn load_ledger(dir: &Path) -> LedgerState {
+    if !dir.join(MANIFEST_FILE).exists() {
+        return LedgerState::Absent;
+    }
+    match AgentManifest::load_checked(dir) {
+        ManifestLoad::Ok(manifest) => LedgerState::Ok(manifest),
+        ManifestLoad::Corrupt(detail) => LedgerState::Corrupt(detail),
+    }
+}
+
+/// What the ledger records about one agent file, plus anything wrong with it.
+///
+/// Why: the JSON shape and the warning list are derived from the same three
+/// facts (is the ledger readable, does it track this file, does the file still
+/// match its recorded checksum), so they are computed together rather than by
+/// two passes that could disagree.
+/// What: a stable `manifest` token plus the ledger entry's fields when there is
+/// one, and the human-readable warnings those facts imply.
+/// Test: `deployed_pristine_agent_reports_framework_origin_and_no_warnings`,
+/// `hand_edited_agent_reports_a_checksum_mismatch_and_warns`,
+/// `untracked_disk_file_warns_that_trusty_code_did_not_write_it`.
+struct DiskProvenance {
+    /// `"absent"`, `"present"`, or `"corrupt"`.
+    manifest: &'static str,
+    /// The ledger's recorded origin, when it tracks this file.
+    origin: Option<Origin>,
+    /// `Origin::is_framework_owned` for that origin.
+    framework_owned: Option<bool>,
+    /// `"match"` or `"mismatch"`, when a checksum comparison was possible.
+    checksum: Option<&'static str>,
+    /// The ledger's RFC3339 deploy timestamp, when recorded.
+    deployed_at: Option<String>,
+    /// The resolved `extends:` chain the deploy composed, base-first.
+    source_chain: Vec<String>,
+    /// Everything an operator should know that is not simply "this is fine".
+    warnings: Vec<String>,
+}
+
+impl DiskProvenance {
+    /// The wire shape, with every absent fact rendered as an explicit `null`.
+    ///
+    /// Why: a client reading `provenance.origin` must be able to tell "not
+    /// recorded" from "key missing because the server is older" — so the keys
+    /// are always present and it is the VALUES that go null.
+    /// What: a fixed six-key object. `warnings` is not included here; the
+    /// caller merges them into the response's single top-level `warnings` list
+    /// so a client has one place to look.
+    fn to_json(&self) -> Value {
+        json!({
+            "manifest": self.manifest,
+            "origin": self.origin.map(origin_token),
+            "framework_owned": self.framework_owned,
+            "checksum": self.checksum,
+            "deployed_at": self.deployed_at,
+            "source_chain": self.source_chain,
+        })
+    }
+}
+
+/// The stable lowercase token for an [`Origin`].
+///
+/// Why: the manifest's own serde rendering is lowercase; matching it by hand
+/// here keeps the JSON-RPC payload identical to the on-disk ledger's spelling
+/// without depending on a `Serialize` round-trip through a `Value`.
+/// What: `"bundled"`, `"registry"`, `"user"`.
+/// Test: `deployed_pristine_agent_reports_framework_origin_and_no_warnings`.
+fn origin_token(origin: Origin) -> &'static str {
+    match origin {
+        Origin::Bundled => "bundled",
+        Origin::Registry => "registry",
+        Origin::User => "user",
+    }
+}
+
+/// The provenance placeholder for an agent with no file on disk.
+///
+/// Why: an embedded or plugin agent has no ledger entry and never will, which
+/// is not the same condition as a missing ledger. Naming it keeps a client from
+/// reading `"absent"` as "something is wrong".
+/// What: the same six keys [`DiskProvenance::to_json`] emits, with
+/// `manifest: "not-applicable"`.
+/// Test: `embedded_agent_has_no_disk_path_and_no_warnings`.
+fn not_applicable_provenance() -> Value {
+    json!({
+        "manifest": "not-applicable",
+        "origin": Value::Null,
+        "framework_owned": Value::Null,
+        "checksum": Value::Null,
+        "deployed_at": Value::Null,
+        "source_chain": [],
+    })
+}
+
+/// Whether `dir` is Trusty Code's OWN `<project>/.trusty-code/agents`.
+///
+/// Why: a missing ledger means different things in different roots. In the
+/// native root it means the roster deploy has not run (or its ledger was
+/// deleted) — worth saying. In a `.claude/agents` compatibility root, no ledger
+/// is expected at all, and warning there would flag every hand-authored project
+/// agent as suspect.
+/// What: the last two path components, compared against
+/// [`crate::paths::TRUSTY_CODE_DIRNAME`] and
+/// [`crate::agents::deploy::AGENTS_DIRNAME`] — the same two names the deploy
+/// target is built from, never a re-spelled literal.
+/// Test: `absent_ledger_in_the_native_roster_dir_warns`,
+/// `absent_ledger_in_a_compat_root_does_not_warn`.
+fn is_native_roster_dir(dir: &Path) -> bool {
+    dir.file_name().is_some_and(|n| n == AGENTS_DIRNAME)
+        && dir
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|n| n == TRUSTY_CODE_DIRNAME)
+}
+
+/// Read the ledger's record of `<name>.md` in `dir`, and what is wrong with it.
+///
+/// Why: this is the whole of #2074's "source provenance" requirement for a
+/// disk-backed agent — did Trusty Code write this file, when, from which
+/// compose chain, and does its content still match what was written.
+/// What: four terminal cases, in order — an unreadable ledger, no ledger, a
+/// ledger that does not track this file, and a tracked file whose on-disk bytes
+/// either match its recorded checksum or no longer do. Checksum comparison
+/// reuses `AgentManifest::checksum_matches`, the same call
+/// `crate::agents::deploy::ensure_roster_deployed` selects against, so
+/// "diverges" means exactly what the deployer means by it.
+/// Test: `deployed_pristine_agent_reports_framework_origin_and_no_warnings`,
+/// `hand_edited_agent_reports_a_checksum_mismatch_and_warns`,
+/// `untracked_disk_file_warns_that_trusty_code_did_not_write_it`,
+/// `corrupt_ledger_is_reported_as_a_warning`.
+fn provenance_for(dir: &Path, ledger: &LedgerState, name: &str) -> DiskProvenance {
+    let filename = format!("{name}.md");
+    let mut provenance = DiskProvenance {
+        manifest: "absent",
+        origin: None,
+        framework_owned: None,
+        checksum: None,
+        deployed_at: None,
+        source_chain: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    let manifest = match ledger {
+        LedgerState::Corrupt(detail) => {
+            provenance.manifest = "corrupt";
+            provenance.warnings.push(format!(
+                "the deployed-agent manifest in {} could not be read ({detail}); the provenance \
+                 of '{name}' is unavailable until that file is repaired or deleted",
+                dir.display()
+            ));
+            return provenance;
+        }
+        LedgerState::Absent => {
+            if is_native_roster_dir(dir) {
+                provenance.warnings.push(format!(
+                    "manifest missing: no deployed-agent manifest in {}, so '{name}' has no \
+                     recorded origin or checksum. Start Trusty Code against this project to \
+                     materialize the roster.",
+                    dir.display()
+                ));
+            }
+            return provenance;
+        }
+        LedgerState::Ok(manifest) => manifest,
+    };
+
+    provenance.manifest = "present";
+    let Some(entry) = manifest.managed.get(&filename) else {
+        provenance.warnings.push(format!(
+            "'{filename}' is not tracked by the deployed-agent manifest in {}; Trusty Code did \
+             not write this file, so it has no recorded origin or checksum",
+            dir.display()
+        ));
+        return provenance;
+    };
+
+    provenance.origin = Some(entry.origin);
+    provenance.framework_owned = Some(entry.origin.is_framework_owned());
+    provenance.deployed_at = Some(entry.deployed_at.clone());
+    provenance.source_chain = entry.source_chain.clone();
+
+    match std::fs::read_to_string(dir.join(&filename)) {
+        Ok(current) if manifest.checksum_matches(&filename, &current) => {
+            provenance.checksum = Some("match");
+        }
+        Ok(_) => {
+            provenance.checksum = Some("mismatch");
+            provenance.warnings.push(format!(
+                "the disk copy of '{name}' diverges from the bundled roster: its content no \
+                 longer matches the checksum the manifest recorded. That file is what runs, and \
+                 Trusty Code will not overwrite it."
+            ));
+        }
+        Err(e) => provenance.warnings.push(format!(
+            "'{filename}' is tracked by the deployed-agent manifest but could not be read ({e}); \
+             its checksum could not be verified"
+        )),
+    }
+
+    provenance
+}
+
+/// Whether `agents.list` should flag this disk row for an operator's attention.
+///
+/// Why: the listing's `has_warnings` flag and `agents.describe`'s `warnings`
+/// array must never disagree — a row flagged clean that describes with three
+/// warnings is worse than no flag at all. Both read this one function.
+/// What: `true` when [`provenance_for`] produced any warning. A row whose file
+/// failed to PARSE is flagged by its caller instead, which is where the parse
+/// error is known.
+/// Test: `list_flags_a_hand_edited_row_and_leaves_pristine_rows_clean`.
+pub(crate) fn disk_entry_has_warnings(dir: &Path, ledger: &LedgerState, name: &str) -> bool {
+    !provenance_for(dir, ledger, name).warnings.is_empty()
+}
+
+/// The `<dir>/<name>.md` this agent resolves from, when there is one.
+///
+/// Why: the tier, the reported path, and whether provenance applies all hinge
+/// on this single question, so it is asked once.
+/// What: `None` for a namespaced `<plugin>:<name>` (plugin agents live under
+/// `.claude/plugins/`, not in `dir`) and `None` when no such file exists. The
+/// separator rejection is defense in depth — every caller validates the name
+/// through `crate::agents::protocol::validate_agent_name` first, which already
+/// makes a traversing name unreachable.
+/// Test: `embedded_agent_has_no_disk_path_and_no_warnings`,
+/// `deployed_pristine_agent_reports_framework_origin_and_no_warnings`.
+fn disk_file(dir: &Path, name: &str) -> Option<PathBuf> {
+    if name.contains(':') || name.contains('/') || name.contains('\\') || name.contains("..") {
+        return None;
+    }
+    let path = dir.join(format!("{name}.md"));
+    path.is_file().then_some(path)
+}
+
+/// Describe one agent: effective config, provenance, and warnings.
+///
+/// Why: #2074's "expose effective instructions, model routing, tools, skills,
+/// source provenance, and warnings through agent inspection".
+///
+/// What, in order:
+/// 1. Resolve `name` through [`crate::agents::resolve_agent`], so describe and
+///    dispatch can never disagree about which definition wins.
+/// 2. Label the tier from where it resolved: `disk_tier` (`"project"` or
+///    `"user"`) when a file in `dir` backs it, `"plugin"` for a namespaced
+///    name, `"embedded"` otherwise, and `"broken"` when a file exists but
+///    failed to parse or compose.
+/// 3. Attach the ledger's provenance for a disk-backed agent, or the
+///    `"not-applicable"` placeholder for one that has no file.
+/// 4. Report the resolved instruction text's length; include the text itself
+///    only when `include_instructions` is set, because a composed roster prompt
+///    runs to tens of kilobytes and a catalog client does not want it by
+///    default.
+///
+/// A name that resolves nowhere is a typed `-32002 not_found` carrying
+/// `resolve_agent`'s own available-agents list — never a panic. A name whose
+/// FILE is broken is NOT an error: it returns a normal payload with
+/// `tier: "broken"` and the parse failure in `warnings`, because an operator
+/// debugging why a name fell back needs to see the reason, not a bare RPC
+/// error (the same rule `agents.list` already applies to a broken row).
+///
+/// Test: `deployed_pristine_agent_reports_framework_origin_and_no_warnings`,
+/// `hand_edited_agent_reports_a_checksum_mismatch_and_warns`,
+/// `unknown_name_is_a_typed_not_found`,
+/// `unparseable_disk_agent_is_broken_with_the_parse_error`,
+/// `embedded_agent_has_no_disk_path_and_no_warnings`,
+/// `instructions_text_is_omitted_by_default_and_returned_on_request`,
+/// `describe_reports_the_tools_allowlist_and_declared_skills`.
+pub(crate) fn describe_agent(
+    dir: &Path,
+    disk_tier: &str,
+    name: &str,
+    include_instructions: bool,
+) -> Result<Value, RpcError> {
+    let disk_path = disk_file(dir, name);
+    let mut warnings: Vec<String> = Vec::new();
+
+    let (tier, cfg) = match resolve_agent(dir, name) {
+        Ok(cfg) => {
+            let tier = if disk_path.is_some() {
+                disk_tier
+            } else if name.contains(':') {
+                "plugin"
+            } else {
+                "embedded"
+            };
+            (tier, Some(cfg))
+        }
+        // #2074: a file that exists but will not load is reported, not raised —
+        // this is the "why did my override fall back?" case.
+        Err(ResolveAgentError::Load { source, .. }) => {
+            warnings.push(format!("parse error: {source:#}"));
+            ("broken", None)
+        }
+        Err(e @ ResolveAgentError::NotFound { .. }) => {
+            return Err(RpcError::not_found(e.to_string()));
+        }
+    };
+
+    let provenance = if disk_path.is_some() {
+        let mut p = provenance_for(dir, &load_ledger(dir), name);
+        warnings.append(&mut p.warnings);
+        p.to_json()
+    } else {
+        not_applicable_provenance()
+    };
+
+    let instructions = cfg.as_ref().map(|c| {
+        let text = &c.system_prompt.content;
+        let mut value = json!({ "length_bytes": text.len() });
+        if include_instructions {
+            value["text"] = json!(text);
+        }
+        value
+    });
+
+    Ok(json!({
+        "name": cfg.as_ref().map_or_else(|| name.to_string(), |c| c.agent.name.clone()),
+        "tier": tier,
+        "path": disk_path.as_ref().map(|p| p.display().to_string()),
+        "role": cfg.as_ref().and_then(|c| c.agent.role.clone()),
+        "description": cfg.as_ref().and_then(|c| c.agent.description.clone()),
+        "model": cfg.as_ref().and_then(|c| c.agent.model.clone()),
+        "tools": cfg.as_ref().map(|c| {
+            json!({ "allowed": c.tools.as_ref().and_then(|t| t.allowed.clone()) })
+        }),
+        "skills": cfg
+            .as_ref()
+            .map(|c| c.system_prompt.append_skills.clone())
+            .unwrap_or_default(),
+        "instructions": instructions,
+        "provenance": provenance,
+        "warnings": warnings,
+    }))
+}
+
+#[cfg(test)]
+#[path = "describe_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/agents/describe_tests.rs
+++ b/crates/trusty-code/src/agents/describe_tests.rs
@@ -1,0 +1,353 @@
+//! Tests for `crate::agents::describe` (#2074, epic #2892).
+//!
+//! Why: split out of `describe.rs` so the production file stays well under the
+//! 500-SLOC cap `scripts/check_line_cap.sh` enforces, mirroring the
+//! `protocol.rs` + `protocol_tests.rs` split already established beside it.
+//! What: the provenance ladder end to end — a pristine deployed agent, a
+//! hand-edited one, an untracked file, an absent ledger in each root, a corrupt
+//! ledger — plus the tier labelling and the payload's own field contract.
+//! Test: this file — self-describing.
+
+use super::*;
+
+use crate::agents::deploy::{ensure_roster_deployed, roster_target};
+
+/// A project whose whole roster has been materialized, and its agents dir.
+///
+/// Why: three tests need a real deployed roster with a real ledger, and
+/// re-deriving the target path at each call site would be a second copy of the
+/// layout rule.
+/// What: a `TempDir` kept alive by the caller plus
+/// `<project>/.trusty-code/agents`.
+fn deployed_project() -> (tempfile::TempDir, PathBuf) {
+    let project = tempfile::tempdir().expect("project tempdir");
+    ensure_roster_deployed(project.path()).expect("deploy the roster");
+    let target = roster_target(project.path());
+    (project, target)
+}
+
+/// The `warnings` array of a describe payload, as owned strings.
+fn warnings_of(payload: &Value) -> Vec<String> {
+    payload["warnings"]
+        .as_array()
+        .expect("warnings must always be an array")
+        .iter()
+        .map(|w| w.as_str().expect("warning must be a string").to_string())
+        .collect()
+}
+
+#[test]
+fn deployed_pristine_agent_reports_framework_origin_and_no_warnings() {
+    let (_project, target) = deployed_project();
+
+    let payload = describe_agent(&target, "project", "engineer", false).expect("describe");
+
+    assert_eq!(payload["tier"], "project");
+    assert_eq!(
+        payload["path"],
+        target.join("engineer.md").display().to_string()
+    );
+    assert_eq!(payload["provenance"]["manifest"], "present");
+    assert_eq!(payload["provenance"]["origin"], "bundled");
+    assert_eq!(payload["provenance"]["framework_owned"], true);
+    assert_eq!(payload["provenance"]["checksum"], "match");
+    assert!(
+        payload["provenance"]["deployed_at"].is_string(),
+        "a tracked file records when it was deployed: {payload:?}"
+    );
+    assert!(
+        !payload["provenance"]["source_chain"]
+            .as_array()
+            .expect("source_chain")
+            .is_empty(),
+        "the deploy records the compose chain it resolved: {payload:?}"
+    );
+    assert_eq!(
+        warnings_of(&payload),
+        Vec::<String>::new(),
+        "a pristine deployed agent has nothing wrong with it"
+    );
+}
+
+#[test]
+fn hand_edited_agent_reports_a_checksum_mismatch_and_warns() {
+    let (_project, target) = deployed_project();
+    std::fs::write(
+        target.join("engineer.md"),
+        "---\nname: engineer\nmodel: marker/hand-edited\n---\n\nMine now.\n",
+    )
+    .expect("hand-edit the deployed agent");
+
+    let payload = describe_agent(&target, "project", "engineer", false).expect("describe");
+
+    assert_eq!(payload["provenance"]["checksum"], "mismatch");
+    assert_eq!(
+        payload["provenance"]["origin"], "bundled",
+        "the ledger still records who wrote it originally"
+    );
+    assert_eq!(
+        payload["model"], "marker/hand-edited",
+        "the edited file is what resolves, so it is what is reported"
+    );
+    let warnings = warnings_of(&payload);
+    assert_eq!(
+        warnings.len(),
+        1,
+        "exactly one divergence warning: {warnings:?}"
+    );
+    assert!(
+        warnings[0].contains("diverges from the bundled roster"),
+        "the warning must name the divergence: {warnings:?}"
+    );
+
+    // Its untouched neighbour stays clean — the warning is per-file, not
+    // per-directory.
+    let neighbour = describe_agent(&target, "project", "rust-engineer", false).expect("describe");
+    assert_eq!(neighbour["provenance"]["checksum"], "match");
+    assert_eq!(warnings_of(&neighbour), Vec::<String>::new());
+}
+
+#[test]
+fn unknown_name_is_a_typed_not_found() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let err = describe_agent(tmp.path(), "project", "no-such-agent", false)
+        .expect_err("an unresolvable name must be an error, never a panic");
+
+    assert_eq!(
+        err.code,
+        RpcError::not_found("x").code,
+        "an unknown agent is a not_found, not an internal error"
+    );
+    assert!(
+        err.message.contains("no-such-agent"),
+        "the error must name what was asked for: {err:?}"
+    );
+}
+
+#[test]
+fn unparseable_disk_agent_is_broken_with_the_parse_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // `extends:` naming a nonexistent parent is the same compose failure
+    // `resolve_agent` refuses to dispatch through.
+    std::fs::write(
+        tmp.path().join("engineer.md"),
+        "---\nname: engineer\nextends: nonexistent-parent\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let payload = describe_agent(tmp.path(), "project", "engineer", false)
+        .expect("a broken file is reported, not raised");
+
+    assert_eq!(payload["tier"], "broken");
+    assert_eq!(payload["name"], "engineer");
+    assert!(payload["instructions"].is_null());
+    assert!(payload["tools"].is_null());
+    let warnings = warnings_of(&payload);
+    assert!(
+        warnings.iter().any(|w| w.starts_with("parse error:")),
+        "the parse failure must be a warning an operator can read: {warnings:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.contains("nonexistent-parent") || w.contains("compose")),
+        "the warning must carry the underlying reason: {warnings:?}"
+    );
+}
+
+#[test]
+fn embedded_agent_has_no_disk_path_and_no_warnings() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let payload = describe_agent(tmp.path(), "project", "engineer", false).expect("describe");
+
+    assert_eq!(payload["tier"], "embedded");
+    assert!(payload["path"].is_null());
+    assert_eq!(payload["provenance"]["manifest"], "not-applicable");
+    assert!(payload["provenance"]["origin"].is_null());
+    assert_eq!(
+        warnings_of(&payload),
+        Vec::<String>::new(),
+        "an agent with no file cannot have a stale one"
+    );
+}
+
+#[test]
+fn instructions_text_is_omitted_by_default_and_returned_on_request() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("solo.md"),
+        "---\nname: solo\n---\n\nYou are a solo agent.\n",
+    )
+    .expect("write");
+
+    let terse = describe_agent(tmp.path(), "project", "solo", false).expect("describe");
+    assert_eq!(terse["instructions"]["length_bytes"], 21);
+    assert!(
+        terse["instructions"]["text"].is_null(),
+        "the text is opt-in: {terse:?}"
+    );
+
+    let full = describe_agent(tmp.path(), "project", "solo", true).expect("describe");
+    assert_eq!(full["instructions"]["text"], "You are a solo agent.");
+    assert_eq!(
+        full["instructions"]["length_bytes"], 21,
+        "the length must describe the same text either way"
+    );
+}
+
+#[test]
+fn describe_reports_the_tools_allowlist_and_declared_skills() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("locked-down.md"),
+        "---\nname: locked-down\ntools: [read_file, grep]\nskills: [systematic-debugging]\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let payload = describe_agent(tmp.path(), "project", "locked-down", false).expect("describe");
+
+    assert_eq!(payload["tools"]["allowed"], json!(["read_file", "grep"]));
+    assert_eq!(payload["skills"], json!(["systematic-debugging"]));
+    assert!(
+        payload.get("grants").is_none(),
+        "capability grants are not modelled yet — the key must be absent, never invented: {payload:?}"
+    );
+}
+
+#[test]
+fn unrestricted_agent_reports_a_null_allowlist() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("open.md"),
+        "---\nname: open\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let payload = describe_agent(tmp.path(), "project", "open", false).expect("describe");
+
+    assert!(
+        payload["tools"]["allowed"].is_null(),
+        "null means every registered tool, matching ToolsConfig's own semantics: {payload:?}"
+    );
+}
+
+#[test]
+fn untracked_disk_file_warns_that_trusty_code_did_not_write_it() {
+    let (_project, target) = deployed_project();
+    std::fs::write(
+        target.join("my-custom.md"),
+        "---\nname: my-custom\n---\n\nProject-owned.\n",
+    )
+    .expect("write");
+
+    let payload = describe_agent(&target, "project", "my-custom", false).expect("describe");
+
+    assert_eq!(payload["provenance"]["manifest"], "present");
+    assert!(payload["provenance"]["origin"].is_null());
+    let warnings = warnings_of(&payload);
+    assert!(
+        warnings.iter().any(|w| w.contains("not tracked")),
+        "an untracked file must say so rather than claim an origin: {warnings:?}"
+    );
+}
+
+#[test]
+fn absent_ledger_in_the_native_roster_dir_warns() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let target = roster_target(project.path());
+    std::fs::create_dir_all(&target).expect("mkdir the native agents dir");
+    std::fs::write(
+        target.join("engineer.md"),
+        "---\nname: engineer\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let payload = describe_agent(&target, "project", "engineer", false).expect("describe");
+
+    assert_eq!(payload["provenance"]["manifest"], "absent");
+    let warnings = warnings_of(&payload);
+    assert!(
+        warnings.iter().any(|w| w.contains("manifest missing")),
+        "a missing ledger in Trusty Code's own root is an anomaly: {warnings:?}"
+    );
+}
+
+#[test]
+fn absent_ledger_in_a_compat_root_does_not_warn() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let target = project.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&target).expect("mkdir the compat agents dir");
+    std::fs::write(
+        target.join("engineer.md"),
+        "---\nname: engineer\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let payload = describe_agent(&target, "project", "engineer", false).expect("describe");
+
+    assert_eq!(payload["provenance"]["manifest"], "absent");
+    assert_eq!(
+        warnings_of(&payload),
+        Vec::<String>::new(),
+        "a `.claude/agents` catalog never had a ledger and is not expected to"
+    );
+}
+
+#[test]
+fn corrupt_ledger_is_reported_as_a_warning() {
+    let (_project, target) = deployed_project();
+    std::fs::write(target.join(MANIFEST_FILE), "{ not json").expect("corrupt the ledger");
+
+    let payload = describe_agent(&target, "project", "engineer", false).expect("describe");
+
+    assert_eq!(payload["provenance"]["manifest"], "corrupt");
+    assert!(
+        payload["provenance"]["checksum"].is_null(),
+        "nothing can be verified against an unreadable ledger: {payload:?}"
+    );
+    let warnings = warnings_of(&payload);
+    assert!(
+        warnings.iter().any(|w| w.contains("could not be read")),
+        "the corruption must be surfaced, never treated as an empty ledger: {warnings:?}"
+    );
+}
+
+#[test]
+fn disk_entry_has_warnings_agrees_with_the_describe_payload() {
+    let (_project, target) = deployed_project();
+    std::fs::write(
+        target.join("engineer.md"),
+        "---\nname: engineer\n---\n\nEdited.\n",
+    )
+    .expect("hand-edit");
+
+    let ledger = load_ledger(&target);
+    assert!(
+        disk_entry_has_warnings(&target, &ledger, "engineer"),
+        "the edited row must be flagged"
+    );
+    assert!(
+        !disk_entry_has_warnings(&target, &ledger, "rust-engineer"),
+        "an untouched row must not be"
+    );
+    assert!(
+        !warnings_of(&describe_agent(&target, "project", "engineer", false).expect("describe"))
+            .is_empty()
+    );
+}
+
+#[test]
+fn native_roster_dir_is_recognised_only_by_both_path_components() {
+    let root = Path::new("/tmp/project");
+    assert!(is_native_roster_dir(
+        &root.join(TRUSTY_CODE_DIRNAME).join(AGENTS_DIRNAME)
+    ));
+    assert!(!is_native_roster_dir(
+        &root.join(".claude").join(AGENTS_DIRNAME)
+    ));
+    assert!(!is_native_roster_dir(
+        &root.join(TRUSTY_CODE_DIRNAME).join("skills")
+    ));
+}

--- a/crates/trusty-code/src/agents/md_loader.rs
+++ b/crates/trusty-code/src/agents/md_loader.rs
@@ -219,14 +219,13 @@ pub(crate) fn extract_body(composed: &str) -> String {
 ///   wrapping in `Some(ToolsConfig { allowed })` is safe and matches the
 ///   instructed direct-map).
 /// - composed prose body -> `system_prompt.content`.
-/// - `skills:` -> intentionally DROPPED. `SystemPrompt::append_skills` exists
-///   in tcode's schema but has no consumer anywhere in the codebase (verified:
-///   `grep -rn append_skills crates/trusty-code/src` only shows the field
-///   declaration and TOML asset literals that set it — nothing reads it). The
-///   shared frontmatter's `skills:` list is real and populated
-///   (DOC-42/#2889), but mapping it into a dead field would fabricate a
-///   consumer that doesn't exist. Left as a gap for a future slice that adds
-///   an actual skills consumer to tcode.
+/// - `skills:` -> `system_prompt.append_skills` (direct map, #2074). This was
+///   deliberately DROPPED until `crate::agents::describe` gave it a consumer:
+///   an agent's declared skills are part of the effective configuration
+///   `agents.describe` reports. Nothing INJECTS them into the prompt yet, so
+///   the field is a reporting surface rather than a runtime one — a
+///   distinction the describe payload's own docs state, so no caller can read
+///   a reported skill as an enforced one.
 ///
 /// `pub(crate)`: also reused by `plugins::agents::load_plugin_agent` (#3539),
 /// which calls this with the plugin's LOCAL agent name (not yet namespaced)
@@ -252,10 +251,10 @@ pub(crate) fn project_to_agent_config(
         },
         system_prompt: SystemPrompt {
             content: body,
-            // Gap: no tcode consumer for agent-declared skills yet — see the
-            // doc comment above. Left empty rather than mapping into a dead
-            // field.
-            append_skills: Vec::new(),
+            // #2074: `agents.describe` reports an agent's declared skills, so
+            // this is no longer a dead field. Nothing INJECTS them into the
+            // prompt yet — see the doc comment above.
+            append_skills: meta.skills,
         },
         tools: Some(ToolsConfig {
             allowed: meta.tools,

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -35,6 +35,9 @@ pub mod config;
 // with a manifest and recorded provenance, reusing trusty-agents-common's
 // deployer unchanged.
 pub mod deploy;
+// #2074: read that provenance back out — the `agents.describe` inspection
+// surface pairing one resolved agent with the ledger beside its file.
+pub mod describe;
 pub mod md_loader;
 pub mod protocol;
 

--- a/crates/trusty-code/src/agents/protocol.rs
+++ b/crates/trusty-code/src/agents/protocol.rs
@@ -39,6 +39,12 @@
 //!     permission_denied` (403); an already-existing disk file of the same
 //!     name with a `-32009 already_exists` conflict (409, use
 //!     delete-then-create to replace).
+//!   - `agents.describe{name, include_instructions?}` -> the effective
+//!     configuration, source provenance, and warnings for ONE agent (#2074).
+//!     Every field and every rule lives in [`super::describe`]; this module
+//!     only parses the params and forwards. `agents.list` gained nothing but a
+//!     per-row `has_warnings` flag computed from that same module, so a client
+//!     can badge the rows worth opening without describing all of them.
 //!   - `agents.delete{name}` -> removes `<dir>/<name>.md`. `-32002 not_found`
 //!     (404) if no disk file exists under that name; `-32001
 //!     permission_denied` (403) if `name` names an EMBEDDED agent (nothing
@@ -53,7 +59,7 @@ use serde_json::{Value, json};
 
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 
-use super::{AgentConfig, discover_agents, load_embedded_default_agents, md_loader};
+use super::{AgentConfig, describe, discover_agents, load_embedded_default_agents, md_loader};
 
 /// Maximum length for a caller-supplied agent `name` in [`agents_create`].
 ///
@@ -95,14 +101,16 @@ impl AgentsCatalogState {
     }
 }
 
-/// Register `agents.list`, `agents.create`, `agents.delete` onto `router`.
+/// Register `agents.list`, `agents.describe`, `agents.create`, `agents.delete`
+/// onto `router`.
 ///
 /// Why: the one place listing this namespace's full surface, mirroring
 /// every other `*::protocol::register` in this crate.
 /// What: clones `state` once per method (cheap — `PathBuf` + `&'static
 /// str`) into a small adapter closure that forwards to the corresponding
 /// free function below.
-/// Test: `tests::register_wires_all_three_methods`.
+/// Test: `tests::register_wires_all_three_methods`,
+/// `tests::register_wires_describe`.
 pub fn register(router: &mut Router, state: AgentsCatalogState) {
     let s = state.clone();
     router.register(
@@ -110,6 +118,16 @@ pub fn register(router: &mut Router, state: AgentsCatalogState) {
         move |params: Value, ctx: ConnectionContext| {
             let s = s.clone();
             async move { agents_list(&s, params, ctx).await }
+        },
+    );
+
+    // #2074: the per-agent inspection surface beside the catalog listing.
+    let s = state.clone();
+    router.register(
+        "agents.describe",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { agents_describe(&s, params, ctx).await }
         },
     );
 
@@ -164,12 +182,22 @@ pub(crate) fn is_base_agent(name: &str) -> bool {
 
 /// Wire shape for one catalog entry — shared by `agents.list`'s embedded and
 /// disk halves so the two are indistinguishable to a client beyond `tier`.
-fn entry_json(cfg: &AgentConfig, tier: &str) -> Value {
+///
+/// `has_warnings` (#2074) is ADDITIVE: the four original keys keep their names,
+/// types, and meanings, so a client written against the pre-#2074 shape
+/// deserializes an entry unchanged. It answers only "would `agents.describe`
+/// have something to say about this row" — the reasons themselves live there,
+/// and both are computed by [`super::describe`] so the flag and the list can
+/// never disagree.
+/// Test: `tests::list_entries_still_parse_into_the_pre_2074_wire_shape`,
+/// `tests::list_flags_a_hand_edited_row_and_leaves_pristine_rows_clean`.
+fn entry_json(cfg: &AgentConfig, tier: &str, has_warnings: bool) -> Value {
     json!({
         "name": cfg.agent.name,
         "tier": tier,
         "description": cfg.agent.description,
         "model": cfg.agent.model,
+        "has_warnings": has_warnings,
     })
 }
 
@@ -225,15 +253,25 @@ async fn agents_list(
     let mut by_name: Vec<(String, Value)> = load_embedded_default_agents()
         .iter()
         .filter(|cfg| !is_base_agent(&cfg.agent.name))
-        .map(|cfg| (cfg.agent.name.clone(), entry_json(cfg, "embedded")))
+        // An embedded agent has no file and no ledger entry, so there is
+        // nothing about it that could be stale or diverged.
+        .map(|cfg| (cfg.agent.name.clone(), entry_json(cfg, "embedded", false)))
         .collect();
+
+    // #2074: read the deployed-agent ledger ONCE for the whole listing rather
+    // than once per row.
+    let ledger = describe::load_ledger(&state.dir);
 
     for (name, path) in discover_agents(&state.dir) {
         if is_base_agent(&name) {
             continue;
         }
         let entry = match md_loader::load_md_agent(&path) {
-            Ok(cfg) => entry_json(&cfg, state.tier),
+            Ok(cfg) => entry_json(
+                &cfg,
+                state.tier,
+                describe::disk_entry_has_warnings(&state.dir, &ledger, &name),
+            ),
             Err(e) => {
                 tracing::warn!("agents.list: disk agent '{name}' is unparseable: {e}");
                 json!({
@@ -241,6 +279,7 @@ async fn agents_list(
                     "tier": "broken",
                     "description": format!("unparseable agent file — dispatch of this name will fail until it is fixed or deleted: {e}"),
                     "model": Value::Null,
+                    "has_warnings": true,
                 })
             }
         };
@@ -260,7 +299,9 @@ async fn agents_list(
             // defense-in-depth so "additive only" holds even if two plugins
             // resolved to the same namespaced name (first one found wins).
             if !by_name.iter().any(|(n, _)| *n == name) {
-                by_name.push((name, entry_json(&cfg, "plugin")));
+                // A plugin agent lives outside `state.dir` and is never tracked
+                // by the deployed-agent ledger, so provenance cannot flag it.
+                by_name.push((name, entry_json(&cfg, "plugin", false)));
             }
         }
     }
@@ -268,6 +309,52 @@ async fn agents_list(
     by_name.sort_by(|a, b| a.0.cmp(&b.0));
     let agents: Vec<Value> = by_name.into_iter().map(|(_, v)| v).collect();
     Ok(json!({ "agents": agents }))
+}
+
+/// `params` shape for `agents.describe` (#2074).
+#[derive(Deserialize)]
+struct DescribeParams {
+    /// The agent to describe, bare or `<plugin>:<local-name>`.
+    name: String,
+    /// Return the resolved instruction TEXT, not only its length. Defaults to
+    /// `false`: a composed roster prompt runs to tens of kilobytes, and a
+    /// catalog client asking "is this agent healthy" does not want it.
+    #[serde(default)]
+    include_instructions: bool,
+}
+
+/// `agents.describe` -> one agent's effective config, provenance, and warnings.
+///
+/// Why: the operator-facing half of #2074 — slice 1 recorded which files
+/// Trusty Code wrote and what they hashed to; this reads that back beside the
+/// resolved configuration, so "which definition is actually running, and has
+/// anyone changed it" is one call rather than a manual diff.
+/// What: validates `name` (each half, for a namespaced plugin name) through the
+/// same [`validate_agent_name`] guard `create`/`delete` use, then forwards to
+/// [`super::describe::describe_agent`], which owns every field and rule. Errors:
+/// malformed params (`-32602`), an invalid name (`-32003`), or a name that
+/// resolves nowhere (`-32002 not_found`). A name whose disk file exists but
+/// fails to parse is NOT an error — see that function's docs.
+/// Test: `tests::register_wires_describe`,
+/// `tests::describe_unknown_name_is_not_found`,
+/// `tests::describe_rejects_invalid_name`.
+async fn agents_describe(
+    state: &AgentsCatalogState,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: DescribeParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::invalid_params(format!("agents.describe: {e}")))?;
+
+    match p.name.split_once(':') {
+        Some((plugin, agent)) => {
+            validate_agent_name(plugin)?;
+            validate_agent_name(agent)?;
+        }
+        None => validate_agent_name(&p.name)?,
+    }
+
+    describe::describe_agent(&state.dir, state.tier, &p.name, p.include_instructions)
 }
 
 /// `params` shape for `agents.create`.

--- a/crates/trusty-code/src/agents/protocol_tests.rs
+++ b/crates/trusty-code/src/agents/protocol_tests.rs
@@ -535,3 +535,157 @@ async fn list_excludes_symlinked_plugin_agent_leak_file() {
         "the secret content must never appear anywhere in the response"
     );
 }
+
+/// `agents.describe` is reachable through the router like its three siblings
+/// (#2074).
+#[tokio::test]
+async fn register_wires_describe() {
+    use trusty_mcp::Request;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut router = Router::new();
+    register(&mut router, state(tmp.path(), true));
+
+    let req = Request {
+        jsonrpc: Some("2.0".to_string()),
+        id: Some(Value::from(1)),
+        method: "agents.describe".to_string(),
+        params: Some(json!({ "name": "engineer" })),
+    };
+    let resp = router.dispatch(req, &ctx()).await;
+    let result = resp.result.expect("agents.describe must be wired");
+    assert_eq!(result["name"], "engineer");
+    assert_eq!(result["tier"], "embedded");
+}
+
+/// A `name` that resolves nowhere is a typed `-32002 not_found`, not a panic
+/// and not an internal error (#2074).
+#[tokio::test]
+async fn describe_unknown_name_is_not_found() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let s = state(tmp.path(), true);
+
+    let err = agents_describe(&s, json!({ "name": "no-such-agent" }), ctx())
+        .await
+        .expect_err("an unknown agent must be an error");
+
+    assert_eq!(err.code, RpcError::not_found("x").code);
+}
+
+/// `agents.describe` applies the same name guard `create`/`delete` do, so a
+/// traversing name never reaches a path join (#2074).
+#[tokio::test]
+async fn describe_rejects_invalid_name() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let s = state(tmp.path(), true);
+
+    for bad in ["../../etc/passwd", "Engineer", ""] {
+        assert!(
+            agents_describe(&s, json!({ "name": bad }), ctx())
+                .await
+                .is_err(),
+            "'{bad}' must be rejected"
+        );
+    }
+}
+
+/// One unparseable disk file does not stop `agents.list` reporting the rest of
+/// the catalog, and the broken row is flagged (#2074).
+///
+/// Why: the operator repair path is "list, spot the bad one, delete it" — a
+/// listing that failed wholesale because of one file would remove the only
+/// affordance for finding which file it was.
+#[tokio::test]
+async fn list_still_lists_other_agents_when_one_disk_file_is_unparseable() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("engineer.md"),
+        "---\nname: engineer\nextends: nonexistent-parent\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let s = state(tmp.path(), true);
+    let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+    let agents = result["agents"].as_array().expect("array");
+
+    assert_eq!(
+        agents.len(),
+        crate::assets::DEFAULT_AGENTS.len(),
+        "the broken file overrides one name; every other agent still lists"
+    );
+    let broken: Vec<_> = agents.iter().filter(|a| a["tier"] == "broken").collect();
+    assert_eq!(broken.len(), 1);
+    assert_eq!(broken[0]["has_warnings"], true);
+    assert!(
+        agents
+            .iter()
+            .filter(|a| a["name"] != "engineer")
+            .all(|a| a["has_warnings"] == false),
+        "one bad file must not taint its neighbours: {agents:?}"
+    );
+}
+
+/// `has_warnings` tracks the same divergence `agents.describe` reports (#2074).
+#[tokio::test]
+async fn list_flags_a_hand_edited_row_and_leaves_pristine_rows_clean() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    crate::agents::deploy::ensure_roster_deployed(project.path()).expect("deploy");
+    let target = crate::agents::deploy::roster_target(project.path());
+    std::fs::write(
+        target.join("engineer.md"),
+        "---\nname: engineer\n---\n\nEdited.\n",
+    )
+    .expect("hand-edit");
+
+    let s = state(&target, true);
+    let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+    let agents = result["agents"].as_array().expect("array");
+
+    let flagged: Vec<_> = agents
+        .iter()
+        .filter(|a| a["has_warnings"] == true)
+        .map(|a| a["name"].as_str().expect("name"))
+        .collect();
+    assert_eq!(
+        flagged,
+        vec!["engineer"],
+        "only the edited row carries a warning: {agents:?}"
+    );
+}
+
+/// The pre-#2074 `agents.list` wire shape still deserializes (#2074).
+///
+/// Why: `has_warnings` was added to every row. A client compiled against the
+/// four-field shape must keep working, so this deserializes each entry into a
+/// struct that knows nothing about the new key.
+#[tokio::test]
+async fn list_entries_still_parse_into_the_pre_2074_wire_shape() {
+    /// Exactly the fields `agents.list` returned before #2074.
+    #[derive(Deserialize)]
+    struct PreSliceEntry {
+        name: String,
+        tier: String,
+        description: Option<String>,
+        model: Option<String>,
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("my-custom.md"),
+        "---\nname: my-custom\ndescription: Custom\nmodel: sonnet\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let s = state(tmp.path(), true);
+    let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+
+    let entries: Vec<PreSliceEntry> =
+        serde_json::from_value(result["agents"].clone()).expect("the old shape must still parse");
+    let custom = entries
+        .iter()
+        .find(|e| e.name == "my-custom")
+        .expect("the disk agent must be present");
+    assert_eq!(custom.tier, "project");
+    assert_eq!(custom.description.as_deref(), Some("Custom"));
+    assert_eq!(custom.model.as_deref(), Some("sonnet"));
+}


### PR DESCRIPTION
Slice 3 of #2074 (slice 1 landed as #7017, squash `f99071cce`). `agents.list`
says what could be dispatched; `agents.describe{name, include_instructions?}`
says which definition actually runs under a name and whether anything about it
needs attention.

It resolves through `agents::resolve_agent` — the same disk-wins /
embedded-fallback / plugin chain dispatch uses, not a second copy — and pairs
the resolved config with the deployed-agent ledger slice 1 writes beside the
file. Provenance reuses `AgentManifest::load_checked` and `checksum_matches`
unchanged; `deploy::AGENTS_DIRNAME` and `paths::TRUSTY_CODE_DIRNAME` are reused
rather than re-spelled.

## Payload

`name`, `tier` (`embedded` / `project` / `user` / `plugin` / `broken`), `path`,
`role`, `description`, `model`, `tools.allowed`, `skills`,
`instructions.length_bytes` (plus `.text` only on `include_instructions: true`,
because a composed roster prompt runs to tens of kilobytes), `provenance`
(`manifest`, `origin`, `framework_owned`, `checksum`, `deployed_at`,
`source_chain`), and `warnings[]`.

A broken file is described with `tier: "broken"` and the parse error in
`warnings`, not raised — an operator debugging why a name fell back needs the
reason. A name that resolves nowhere is a typed `not_found` carrying
`resolve_agent`'s own available-agents list.

`agents.list` gained one additive `has_warnings` boolean per row, computed by
the same module so the flag and the describe payload cannot disagree. The ledger
is read once per listing, not once per row. The four original keys are
unchanged.

## `grants` is deliberately absent

Slice 2 (capability grants) is not landed and waits on two owner decisions. An
agent's declared authority in Trusty Code today is the flat `tools.allowed`
allowlist and nothing else, so the payload reports that allowlist and carries no
`grants` key. A fabricated field would tell an operator the runtime enforces
something it does not. `describe.rs`'s module docs, the README section, and the
changelog fragment all state this. A test asserts the key is absent.

## Behaviour change outside describe

`md_loader::project_to_agent_config` no longer drops the frontmatter `skills:`
list — it populates `SystemPrompt::append_skills`, which describe reports. That
field was deliberately left empty because nothing consumed it; describe is that
consumer. Nothing injects those skills into a prompt yet, and the docs say so.

## The manifest-missing warning rule

"Manifest missing" fires only when the agents directory is Trusty Code's own
`<project>/.trusty-code/agents`, where a missing ledger means the roster deploy
never ran or its ledger was deleted. In a `.claude/agents` compatibility root no
ledger was ever expected, so provenance reports `manifest: "absent"` with no
warning — otherwise every hand-authored project agent would light up as suspect.
Both halves are pinned by tests
(`absent_ledger_in_the_native_roster_dir_warns`,
`absent_ledger_in_a_compat_root_does_not_warn`).

## No CLI verb

`crates/trusty-code/src/cli/` has no agents family, so this surface is JSON-RPC
only. Adding `tcode agents describe` would mean a new `main.rs` `Command`
variant plus a new `cli/agents.rs` — scope this slice did not take. Noted in the
README.

## Rung 3 — evidence

Localized behaviour inside one crate. No shared-crate signature changed; the
`trusty-agents-common` reuse is read-only against an existing API.

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-code --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-code --no-fail-fast` | EXIT=0 — 20 targets, 1890 passed, 0 failed, 4 ignored |
| `scripts/check_line_cap.sh` | 4569 tracked files, 0 violations |
| `scripts/check_test_pointers.sh` | 31652 citations, 0 dangling, 0 stale allowlist rows |
| `scripts/check_sld.sh` | 63 specs + 3700 code files, 0 errors, 0 warnings |
| `scripts/check_agent_assets.sh` | 8 files accounted, 4 pinned deviations match |
| `scripts/check_changelog_fragment.sh` | all crates with source changes recorded |
| `scripts/check-pr-version-bump.sh` | clear, 0 warnings |
| `scripts/check_rustdoc_links.sh` | 26 crates, 0 broken links, baseline 0 |

New coverage: 14 tests in `describe_tests.rs`, 6 in `protocol_tests.rs`.

### Regression evidence — reverting only the fix

**Skills reporting.** `git show HEAD~1:.../md_loader.rs > .../md_loader.rs`:

```
test agents::describe::tests::describe_reports_the_tools_allowlist_and_declared_skills ... FAILED
assertion `left == right` failed
  left: Array []
 right: Array [String("systematic-debugging")]
test result: FAILED. 0 passed; 1 failed; 0 ignored; 1791 filtered out
```

**The describe surface.** Reverting `protocol.rs` and `mod.rs` to `HEAD~1`:

```
error[E0425]: cannot find function `agents_describe` in this scope
error[E0282]: type annotations needed
error[E0425]: cannot find function `agents_describe` in this scope
error[E0282]: type annotations needed
error: could not compile `trusty-code` (lib test) due to 4 previous errors
```

**Wire-shape compatibility.** This one is a regression guard, so it passes on
`origin/main` by construction and a revert proves nothing. Mutating `"name"` to
`"agent_name"` in `entry_json` shows it has teeth:

```
test agents::protocol::tests::list_entries_still_parse_into_the_pre_2074_wire_shape ... FAILED
the old shape must still parse: Error("missing field `name`", line: 0, column: 0)
```

All three files were restored; the committed tree is clean.

## Left for slice 4

Two spec files now trail the code by one method and one field, left alone
rather than edited inside an implementation slice:

- `docs/specs/trusty-code-harness-ui.md:929` — documents the four-field
  `agents.list` shape and three `agents.*` methods.
- `docs/specs/DOC-51-tcode-plugin-support-phase1.md:234` — same method list.

Refs #2074

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
