### PR TITLE
docs(trusty-analyze): retire stale POST /review/github-pr prose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11428,7 +11428,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.12.6"
+version = "0.12.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -16,7 +16,12 @@ name        = "trusty-analyze"
 # `src/**`: `mcp::rpc_client` dials the daemon through the shared
 # `trusty_mcp::DaemonBridgeJsonRpc` instead of its own framed client. Nothing
 # public changed shape — `call` is `pub(super)`.
-version     = "0.12.6"
+#
+# 0.12.7 (#5176): PATCH — 0.12.6 is live on crates.io and this PR edits a doc
+# comment in `src/core/github.rs` under it (retired-route prose cleanup); no
+# public signature changed. Bumped so the `PR version bump vs crates.io` gate
+# clears.
+version     = "0.12.7"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-analyze/changelog.d/5176-retired-route-prose.md
+++ b/crates/trusty-analyze/changelog.d/5176-retired-route-prose.md
@@ -1,0 +1,3 @@
+Documentation
+
+- Retired stale `POST /review/github-pr` mentions in the `GithubPrRequest` doc comment and the PRD/COMPONENTS specs; they now name the `analyze.review_github_pr` JSON-RPC method served over the Unix socket (#5176).

--- a/crates/trusty-analyze/src/core/github.rs
+++ b/crates/trusty-analyze/src/core/github.rs
@@ -48,10 +48,10 @@ pub enum GithubError {
     Api { status: u16, body: String },
 }
 
-/// Request body for `POST /review/github-pr` and the `review_github_pr` MCP
-/// tool.
+/// Request body for the `analyze.review_github_pr` JSON-RPC method and the
+/// `review_github_pr` MCP tool.
 ///
-/// Why: a single typed shape shared by the HTTP handler and the MCP dispatch
+/// Why: a single typed shape shared by the RPC handler and the MCP dispatch
 /// path so the two transports stay in lockstep.
 /// What: identifies a PR by `owner`/`repo`/`pr`, names the trusty-search index
 /// to cross-reference, and carries an opt-in `post_comment` flag.

--- a/docs/trusty-analyze/spec/COMPONENTS.md
+++ b/docs/trusty-analyze/spec/COMPONENTS.md
@@ -237,9 +237,11 @@ Per-subsystem specs. Each states **responsibility**, **key types/modules** (with
   `DEFAULT_PORT`; route handlers; `WebAssets` (rust-embed) + `ui_index_handler` /
   `ui_asset_handler`.
 - **Current (✅):** ~20 routes — health, index proxy, complexity/smells/quality,
-  diagnostics/graph/entities/clusters/ner, scip ingest, review/github-pr/deep,
-  github webhook, facts CRUD, `/ui` SPA (with index.html fallback for client-side
-  routing). Gated behind the `http-server` feature (#249); `serve` can also fork
+  diagnostics/graph/entities/clusters/ner, scip ingest, review/deep (GitHub PR
+  review is served via the `analyze.review_github_pr` JSON-RPC method over the
+  Unix socket, not this HTTP surface), github webhook, facts CRUD, `/ui` SPA
+  (with index.html fallback for client-side routing). Gated behind the
+  `http-server` feature (#249); `serve` can also fork
   an MCP stdio loop (`--mcp`) and/or an MCP HTTP/SSE server (`--mcp-port`).
   Graceful shutdown via `with_graceful_shutdown(trusty_common::shutdown_signal())`
   (#534/#535): drains in-flight requests on SIGTERM or SIGINT before process

--- a/docs/trusty-analyze/spec/PRD.md
+++ b/docs/trusty-analyze/spec/PRD.md
@@ -191,8 +191,9 @@ shipped code.
   *(`core/review.rs`, CLI `review`, `/review`, MCP `review_diff`)*
 - **FR-7.3 (✅)** GitHub PR review: fetch a PR diff via the REST API, run the
   review pipeline, optionally post the report back as a comment; HMAC webhook
-  signature verification. *(`core/github.rs`, CLI `review-pr`, `/review/github-pr`,
-  MCP `review_github_pr`; `/webhooks/github` retired in #5181)*
+  signature verification. *(`core/github.rs`, CLI `review-pr`, JSON-RPC
+  `analyze.review_github_pr` over the Unix socket, MCP `review_github_pr`;
+  `/webhooks/github` retired in #5181)*
 - **FR-7.4 (✅)** LLM-augmented deep analysis: a `DeepAnalysisReport`
   (narrative + frameworks + recommendations + model) layered on top of the
   deterministic `ReviewReport` via a `ChatProvider`. Two routing paths:


### PR DESCRIPTION
## Summary

Fixes three stale mentions of the retired `POST /review/github-pr` HTTP loopback route left over from ADR-0032 / #5176 (trusty-analyze now serves GitHub PR review via the `analyze.review_github_pr` JSON-RPC method over a Unix socket):

- `crates/trusty-analyze/src/core/github.rs` — `GithubPrRequest` doc comment
- `docs/trusty-analyze/spec/PRD.md` — FR-7.3 surface entry
- `docs/trusty-analyze/spec/COMPONENTS.md` — HTTP daemon route list entry

`crates/trusty-analyze/CHANGELOG.md` is untouched (historical record).

Refs #5176

## Test plan

Rung 1 (docs-only). Gates run from the worktree root, all EXIT=0:

- `cargo fmt --check`
- `cargo clippy -p trusty-analyze --all-targets -- -D warnings`
- `./scripts/check_sld.sh`
- `./scripts/check_test_pointers.sh`
- `./scripts/check_rustdoc_links.sh` — 26 crates examined, 0 broken links
- `./scripts/check_changelog_fragment.sh` — fragment present and valid

`git grep -n "review/github-pr"` confirms only `CHANGELOG.md` (historical) and an unrelated historical test comment in `setup.rs` remain.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
