### PR TITLE
feat(trusty-review): resolve dependency versions from lockfiles and name the source (#6794)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11493,7 +11493,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12012,7 +12012,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 #      this line existed. Both consumers name what they need: trusty-analyze's
 #      `review` feature pulls `trusty-review/mcp`; trusty-mpm's dev-dependency
 #      only touches `integrations`, which is unconditional.
-trusty-review = { path = "crates/trusty-review", version = "0.35", default-features = false }
+trusty-review = { path = "crates/trusty-review", version = "0.36", default-features = false }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -22,7 +22,11 @@ name = "trusty-audit"
 # `grounding::coverage_rollup::Sampling` enum plus `RepoCoverage::sampling` and
 # `Rollup::sampling` — so no existing signature or struct shape changed and
 # `cargo-semver-checks` has nothing to report against 0.14.2.
-version = "0.14.3"
+# 0.14.3 -> 0.14.4 (#6794): PATCH. 0.14.3 is already on crates.io and this PR
+# changes `src/**`. The change is confined to the body of the private
+# `grounding::osv::absorb`, which now honours the producer's `resolved` flag;
+# no public item is added, removed, or reshaped.
+version = "0.14.4"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"

--- a/crates/trusty-audit/changelog.d/6794-lockfile-resolved-deps.md
+++ b/crates/trusty-audit/changelog.d/6794-lockfile-resolved-deps.md
@@ -1,0 +1,9 @@
+Fixed
+
+- The OSV scan no longer sends an unresolved locked cell to OSV.dev as if it
+  were a version. `trusty-review` writes `0.13.1, 0.22.1 (none satisfies ^0.30)`
+  into `locked` when no locked version satisfies the declared requirement, and
+  that string was queried verbatim, asking about a package that does not exist.
+  The row is now named in the scan's unpinned gap line instead, using the
+  `resolved` flag the producer records (issue #6794). A snapshot written before
+  that flag existed carries no such key and behaves exactly as before.

--- a/crates/trusty-audit/src/grounding/osv.rs
+++ b/crates/trusty-audit/src/grounding/osv.rs
@@ -357,8 +357,10 @@ pub struct Inventory {
 /// What: `repos[].deps.{deps,total}` from the snapshot, folded across every
 /// repository entry the file carries — on the sweep path that is the one
 /// repository the directory belongs to. A row contributes a coordinate when it
-/// has a `locked` version AND a mappable ecosystem, and is named in `unpinned`
-/// or `unmapped` otherwise.
+/// has a `locked` version that the producer marks `resolved` (#6794) AND a
+/// mappable ecosystem, and is named in `unpinned` or `unmapped` otherwise. A
+/// snapshot written before `resolved` existed carries no such key, and there
+/// the presence of `locked` remains the only signal.
 ///
 /// # Errors
 /// One line, safe to show the recipient, when the snapshot is absent,
@@ -429,7 +431,16 @@ fn absorb(inventory: &mut Inventory, row: &serde_json::Value) {
         inventory.unmapped.push(format!("{name} ({label})"));
         return;
     };
-    match string("locked") {
+    // #6794: the producer now states whether `locked` is an exact resolution.
+    // A row it marks unresolved carries prose — `0.13.1, 0.22.1 (none satisfies
+    // ^0.30)` — and sending that as a version asks OSV a question about a
+    // package that does not exist. An older snapshot has no `resolved` key at
+    // all, and for those the presence of `locked` is still the only signal.
+    let resolved = row
+        .get("resolved")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
+    match string("locked").filter(|_| resolved) {
         Some(version) => inventory
             .coordinates
             .push(Coordinate::new(ecosystem, name, version)),

--- a/crates/trusty-audit/src/grounding/osv_tests.rs
+++ b/crates/trusty-audit/src/grounding/osv_tests.rs
@@ -186,6 +186,43 @@ fn the_inventory_becomes_osv_coordinates() {
     assert_eq!(inventory.declared, 3);
 }
 
+/// #6794: the producer now states whether a `locked` cell is an exact
+/// resolution. A row it marks unresolved carries prose rather than a version —
+/// `0.13.1, 0.22.1 (none satisfies ^0.30)` — and asking OSV about that invents
+/// a package. It must be named as unpinned instead. A snapshot written before
+/// `resolved` existed has no such key, and there `locked` alone still decides.
+#[test]
+fn an_unresolved_locked_cell_is_unpinned_not_a_coordinate() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let snapshot = snapshot_at(
+        tmp.path(),
+        r#"{"name":"acme-parser","ecosystem":"cargo","spec":"1","locked":"1.2.3","resolved":true},
+           {"name":"base64","ecosystem":"cargo","spec":"^0.30",
+            "locked":"0.13.1, 0.22.1 (none satisfies ^0.30)","resolved":false}"#,
+        2,
+    );
+
+    let current = inventory(&snapshot).expect("the snapshot parses");
+    assert_eq!(
+        current.coordinates,
+        vec![Coordinate::new("crates.io", "acme-parser", "1.2.3")]
+    );
+    assert_eq!(current.unpinned, vec!["base64 (cargo)".to_string()]);
+
+    // A pre-#6794 snapshot omits the key entirely; `locked` alone still decides.
+    let legacy = snapshot_at(
+        tmp.path(),
+        r#"{"name":"acme-parser","ecosystem":"cargo","spec":"1","locked":"1.2.3"}"#,
+        1,
+    );
+    let legacy = inventory(&legacy).expect("the snapshot parses");
+    assert_eq!(
+        legacy.coordinates,
+        vec![Coordinate::new("crates.io", "acme-parser", "1.2.3")]
+    );
+    assert!(legacy.unpinned.is_empty());
+}
+
 /// 🔴 The producer caps its inventory at 30 rows, so a large workspace offers
 /// a fraction of itself to OSV. The report must say how much it left out — a
 /// scan over 30 of 134 packages that reads as a scan of the repository is the

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -106,7 +106,15 @@ name        = "trusty-review"
 # report. A MINOR bump would also have to widen the root
 # `[workspace.dependencies]` row (`trusty-review = { …, version = "0.35" }`),
 # which this change gives no reason to touch.
-version     = "0.35.1"
+#
+# 0.36.0 (#6794): MINOR — `Dependency` gains `resolved` and `source`,
+# `DependencyInventory` gains `lockfile_warnings`, and both become
+# `#[non_exhaustive]`. Each of those is a `cargo-semver-checks` major lint
+# (`constructible_struct_adds_field`, `struct_marked_non_exhaustive`), and for a
+# `0.y.z` crate the breaking bump is the MINOR position. `#[non_exhaustive]` is
+# the same choice made at 0.18.0 for the three report types: field additions
+# stay non-breaking from here on, so the next one costs no bump.
+version     = "0.36.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-review/changelog.d/6794-lockfile-resolved-deps.md
+++ b/crates/trusty-review/changelog.d/6794-lockfile-resolved-deps.md
@@ -1,0 +1,17 @@
+Changed
+
+- The dependency inventory now resolves a declared range against the checkout's
+  lockfile and records which file answered. `poetry.lock`, `uv.lock` and the
+  `==` pins of `requirements.txt` are read for the first time, so a
+  `pyproject.toml` project no longer reaches the report as ranges only —
+  previously every python row was unresolved, the largest share of the 515 of
+  1230 unscannable rows a 59-repository run produced. `Dependency` gains
+  `resolved` (true only when the locked cell is one exact version) and `source`
+  (the filename it came from); the Dependency Inventory table gains a
+  `Resolved from` column that reads `not resolved` when no lockfile answered.
+  A lockfile that is present and fails to parse no longer degrades silently: it
+  is named in `DependencyInventory::lockfile_warnings` and rendered under the
+  section, and the pass carries on with that ecosystem's declared ranges. Only
+  the resolved name/version pairs are kept, so the inventory does not grow by
+  the size of the lockfile it read. `Dependency` and `DependencyInventory` are
+  now `#[non_exhaustive]` (issue #6794).

--- a/crates/trusty-review/src/report/investigate/deps.rs
+++ b/crates/trusty-review/src/report/investigate/deps.rs
@@ -8,13 +8,17 @@
 //! What: [`build_inventory`] probes a checkout root for the supported ecosystems,
 //! parses each manifest's direct dependencies and (best-effort) its lockfile's
 //! resolved versions, and returns a capped [`DependencyInventory`].  All parsing
-//! is lenient: a malformed lockfile degrades to declared-only, never an error.
-//! Test: `deps_tests.rs` covers npm (+lock), Cargo (+lock), pyproject, and go.mod.
+//! is lenient: a malformed lockfile degrades to declared-only and names itself in
+//! [`DependencyInventory::lockfile_warnings`] (#6794), never an error.
+//! Test: `deps_tests.rs` covers npm (+lock), Cargo (+lock), pyproject
+//! (+poetry.lock / uv.lock / requirements.txt), and go.mod.
 
-use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::Serialize;
+
+#[path = "deps_lock.rs"]
+mod lock;
 
 /// The maximum number of dependency rows rendered before an "and N more" line.
 ///
@@ -26,12 +30,18 @@ pub const MAX_ROWS: usize = 30;
 ///
 /// Why: an acquirer wants both the declared constraint (what the project asks
 /// for) and the pinned reality (what a fresh install gets); carrying both makes
-/// drift and loose pinning visible.
+/// drift and loose pinning visible. #6794 adds the two facts a consumer needs
+/// to tell those apart mechanically — whether the version is a resolution and
+/// which file resolved it — because `serde = "1"` and `serde 1.0.210` reached
+/// trusty-audit's OSV stage indistinguishable, and a range is unscannable.
 /// What: `name` is the package; `ecosystem` names the manifest family; `spec` is
-/// the declared version constraint (empty when the manifest states none); `locked`
-/// is the resolved version from the lockfile, or `None` when unlocked/unparsed.
-/// Test: `deps_tests::npm_manifest_and_lock`.
+/// the declared version constraint (empty when the manifest states none);
+/// `locked` is the resolved version from the lockfile, or `None` when
+/// unlocked/unparsed; `resolved` is true only when `locked` is a single exact
+/// version; `source` names the file `locked` came from.
+/// Test: `deps_tests::{npm_manifest_and_lock, cargo_lock_records_its_source}`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
 pub struct Dependency {
     /// Package/crate/module name.
     pub name: String,
@@ -41,6 +51,49 @@ pub struct Dependency {
     pub spec: String,
     /// Resolved version from the lockfile, if available.
     pub locked: Option<String>,
+    /// True when `locked` is one exact version, not a range or a no-match note.
+    ///
+    /// #6794: a consumer matching this row against an advisory database needs a
+    /// version, and `^1.2` is not one. False is the safe default — an
+    /// unresolved row is unassessed, never clean.
+    pub resolved: bool,
+    /// The file `locked` was read from, e.g. `Cargo.lock` (#6794).
+    ///
+    /// `None` exactly when `locked` is `None`. Only the filename is kept: the
+    /// inventory must not grow by the size of the lockfile it read.
+    pub source: Option<String>,
+}
+
+impl Dependency {
+    /// A declared-only row: no lockfile answered for this package (#6794).
+    fn declared(name: String, ecosystem: &str, spec: String) -> Self {
+        Self {
+            name,
+            ecosystem: ecosystem.to_owned(),
+            spec,
+            locked: None,
+            resolved: false,
+            source: None,
+        }
+    }
+
+    /// Apply `index`'s resolution for this row, if it has one (#6794).
+    fn resolve_from(mut self, index: &lock::LockIndex) -> Self {
+        let key = if self.ecosystem == "pypi" {
+            lock::normalize(&self.name)
+        } else {
+            self.name.clone()
+        };
+        let Some(versions) = index.versions.get(&key) else {
+            return self;
+        };
+        if let Some(resolution) = lock::resolve(&self.spec, versions) {
+            self.resolved = resolution.exact;
+            self.locked = Some(resolution.version);
+            self.source = index.sources.get(&key).cloned();
+        }
+        self
+    }
 }
 
 /// The deterministic dependency inventory for one repository.
@@ -52,10 +105,12 @@ pub struct Dependency {
 /// the cap was applied before serialisation). Keeping the full inventory here
 /// and capping at render time serves both.
 /// What: `deps` holds EVERY discovered row in stable order; `total` is that
-/// same count; [`Self::rendered`] is the capped view the table draws.
+/// same count; [`Self::rendered`] is the capped view the table draws;
+/// `lockfile_warnings` names each lockfile that existed and did not parse.
 /// Test: `deps_tests::{inventory_keeps_every_row_past_the_render_cap,
-/// rendered_caps_at_max_rows}`.
+/// rendered_caps_at_max_rows, a_malformed_lockfile_warns_and_falls_back}`.
 #[derive(Debug, Clone, Default, Serialize)]
+#[non_exhaustive]
 pub struct DependencyInventory {
     /// Every dependency row discovered, stable-sorted and uncapped (#6788).
     pub deps: Vec<Dependency>,
@@ -71,6 +126,14 @@ pub struct DependencyInventory {
     /// gap instead of a false clean claim.
     /// Test: `deps_tests::records_the_manifests_it_examined`.
     pub manifests_examined: Vec<String>,
+    /// One line per lockfile that was present but could not be parsed (#6794).
+    ///
+    /// Why: a lockfile that fails to parse silently degrades every row in its
+    /// ecosystem to a declared range, and the page then shows those ranges with
+    /// nothing saying why. The sweep must not abort for it either — one bad
+    /// lockfile in one repository cannot cost the run.
+    /// Test: `deps_tests::a_malformed_lockfile_warns_and_falls_back`.
+    pub lockfile_warnings: Vec<String>,
 }
 
 impl DependencyInventory {
@@ -96,6 +159,16 @@ impl DependencyInventory {
     pub fn overflow(&self) -> usize {
         self.total.saturating_sub(self.rendered().len())
     }
+
+    /// How many rows carry an exact lockfile-resolved version (#6794).
+    ///
+    /// Why: "how much of this inventory is scannable" is the question the OSV
+    /// stage's coverage line answers, and it is a property of the inventory
+    /// rather than of any one consumer.
+    /// Test: `deps_tests::poetry_lock_resolves_pyproject_ranges`.
+    pub fn resolved_count(&self) -> usize {
+        self.deps.iter().filter(|d| d.resolved).count()
+    }
 }
 
 /// Build the dependency inventory by probing every supported ecosystem at `root`.
@@ -105,19 +178,21 @@ impl DependencyInventory {
 /// for a local checkout.
 /// What: collects direct dependencies from package.json, Cargo.toml, pyproject.toml,
 /// and go.mod, enriches each with a locked version from the matching lockfile when
-/// one parses, and sorts by (ecosystem, name). Every row is kept (#6788); the
-/// [`MAX_ROWS`] cap is applied by [`DependencyInventory::rendered`] at table-build
-/// time. Records which of those manifests existed in `manifests_examined` (#6137),
-/// so a zero total can be told apart from a root where nothing was read.
+/// one parses ([`lock`]), and sorts by (ecosystem, name). Every row is kept
+/// (#6788); the [`MAX_ROWS`] cap is applied by [`DependencyInventory::rendered`]
+/// at table-build time. Records which of those manifests existed in
+/// `manifests_examined` (#6137), so a zero total can be told apart from a root
+/// where nothing was read, and which lockfiles failed to parse in
+/// `lockfile_warnings` (#6794).
 /// Test: `deps_tests::{multi_ecosystem_inventory, records_the_manifests_it_examined,
-/// inventory_keeps_every_row_past_the_render_cap}`.
+/// inventory_keeps_every_row_past_the_render_cap, a_malformed_lockfile_warns_and_falls_back}`.
 pub fn build_inventory(root: &Path) -> DependencyInventory {
+    let mut warnings = Vec::new();
     let mut all: Vec<Dependency> = Vec::new();
-    all.extend(npm_deps(root));
-    all.extend(cargo_deps(root));
-    all.extend(pypi_deps(root));
+    all.extend(npm_deps(root, &mut warnings));
+    all.extend(cargo_deps(root, &mut warnings));
+    all.extend(pypi_deps(root, &mut warnings));
     all.extend(go_deps(root));
-
     all.sort_by(|a, b| {
         a.ecosystem
             .cmp(&b.ecosystem)
@@ -133,6 +208,7 @@ pub fn build_inventory(root: &Path) -> DependencyInventory {
             .filter(|name| root.join(name).is_file())
             .map(|name| (*name).to_string())
             .collect(),
+        lockfile_warnings: warnings,
     }
 }
 
@@ -151,56 +227,27 @@ fn read(root: &Path, name: &str) -> Option<String> {
 // ─── npm ─────────────────────────────────────────────────────────────────────
 
 /// Parse `package.json` direct deps and enrich with `package-lock.json` versions.
-fn npm_deps(root: &Path) -> Vec<Dependency> {
+fn npm_deps(root: &Path, warnings: &mut Vec<String>) -> Vec<Dependency> {
     let Some(text) = read(root, "package.json") else {
         return Vec::new();
     };
     let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
         return Vec::new();
     };
-    let locked = npm_lock_versions(root);
+    let index = lock::npm(root);
+    warnings.extend(index.warnings.iter().cloned());
     let mut out = Vec::new();
     for key in ["dependencies", "devDependencies"] {
         if let Some(map) = value.get(key).and_then(|v| v.as_object()) {
             for (name, spec) in map {
-                out.push(Dependency {
-                    name: name.clone(),
-                    ecosystem: "npm".to_string(),
-                    spec: spec.as_str().unwrap_or_default().to_string(),
-                    locked: locked.get(name).cloned(),
-                });
-            }
-        }
-    }
-    out
-}
-
-/// Best-effort resolved versions from `package-lock.json` (v2/v3 `packages`, or
-/// v1 `dependencies`).  Returns an empty map when absent/unparseable.
-fn npm_lock_versions(root: &Path) -> BTreeMap<String, String> {
-    let mut out = BTreeMap::new();
-    let Some(text) = read(root, "package-lock.json") else {
-        return out;
-    };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
-        return out;
-    };
-    // v2/v3: `packages` keyed by "node_modules/<name>" (root key is "").
-    if let Some(pkgs) = value.get("packages").and_then(|v| v.as_object()) {
-        for (path, meta) in pkgs {
-            if let Some(name) = path.strip_prefix("node_modules/")
-                && let Some(ver) = meta.get("version").and_then(|v| v.as_str())
-                && !name.contains("/node_modules/")
-            {
-                out.insert(name.to_string(), ver.to_string());
-            }
-        }
-    }
-    // v1: `dependencies` keyed by name.
-    if let Some(deps) = value.get("dependencies").and_then(|v| v.as_object()) {
-        for (name, meta) in deps {
-            if let Some(ver) = meta.get("version").and_then(|v| v.as_str()) {
-                out.entry(name.clone()).or_insert_with(|| ver.to_string());
+                out.push(
+                    Dependency::declared(
+                        name.clone(),
+                        "npm",
+                        spec.as_str().unwrap_or_default().to_string(),
+                    )
+                    .resolve_from(&index),
+                );
             }
         }
     }
@@ -215,14 +262,15 @@ fn npm_lock_versions(root: &Path) -> BTreeMap<String, String> {
 /// WORKSPACE root declares its shared dependencies only in the latter table, so
 /// reading `[dependencies]` alone reported zero for a 134-dependency workspace
 /// and the section rendered that as a clean result.
-fn cargo_deps(root: &Path) -> Vec<Dependency> {
+fn cargo_deps(root: &Path, warnings: &mut Vec<String>) -> Vec<Dependency> {
     let Some(text) = read(root, "Cargo.toml") else {
         return Vec::new();
     };
     let Ok(value) = toml::from_str::<toml::Value>(&text) else {
         return Vec::new();
     };
-    let locked = cargo_lock_versions(root);
+    let index = lock::cargo(root);
+    warnings.extend(index.warnings.iter().cloned());
     let mut tables: Vec<&toml::map::Map<String, toml::Value>> = Vec::new();
     if let Some(t) = value.get("dependencies").and_then(|v| v.as_table()) {
         tables.push(t);
@@ -238,108 +286,40 @@ fn cargo_deps(root: &Path) -> Vec<Dependency> {
         .into_iter()
         .flatten()
         .map(|(name, spec)| {
-            let spec_str = match spec {
-                toml::Value::String(s) => s.clone(),
-                toml::Value::Table(t) => t
-                    .get("version")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default()
-                    .to_string(),
-                _ => String::new(),
-            };
-            let locked = locked.get(name).map_or_else(Vec::new, |v| v.clone());
-            Dependency {
-                locked: resolve_locked(&spec_str, &locked),
-                name: name.clone(),
-                ecosystem: "cargo".to_string(),
-                spec: spec_str,
-            }
+            Dependency::declared(name.clone(), "cargo", toml_spec(spec)).resolve_from(&index)
         })
         .collect()
 }
 
-/// Every resolved version in `Cargo.lock`, per package name.
+/// The declared version constraint a TOML dependency value states.
 ///
-/// Why: a workspace lockfile routinely carries several versions of one crate —
-/// `base64` 0.13.1 alongside 0.22.1, `dashmap` 5.5.3 alongside 6.1.0 — because
-/// transitive dependents pin older majors. Keeping only the first entry
-/// reported the LOWEST of them (cargo writes `[[package]]` blocks sorted by
-/// name then version), so a manifest declaring `base64 = "0.22"` had `0.13.1`
-/// printed against it. The list is what [`resolve_locked`] needs to pick the
-/// version the declared requirement actually resolves to.
-/// What: `name → versions`, in lockfile order, duplicates preserved.
-/// Test: `deps_tests::{cargo_locked_version_satisfies_the_declared_req,
-/// cargo_locked_prefers_the_highest_satisfying_version}`.
-fn cargo_lock_versions(root: &Path) -> BTreeMap<String, Vec<String>> {
-    let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    let Some(text) = read(root, "Cargo.lock") else {
-        return out;
-    };
-    let Ok(value) = toml::from_str::<toml::Value>(&text) else {
-        return out;
-    };
-    if let Some(pkgs) = value.get("package").and_then(|v| v.as_array()) {
-        for pkg in pkgs {
-            if let (Some(name), Some(ver)) = (
-                pkg.get("name").and_then(|v| v.as_str()),
-                pkg.get("version").and_then(|v| v.as_str()),
-            ) {
-                out.entry(name.to_string())
-                    .or_default()
-                    .push(ver.to_string());
-            }
-        }
+/// A bare string IS the constraint; a table states it under `version`; anything
+/// else (a bare path or git dependency) declares no version at all.
+fn toml_spec(spec: &toml::Value) -> String {
+    match spec {
+        toml::Value::String(s) => s.clone(),
+        toml::Value::Table(t) => t
+            .get("version")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        _ => String::new(),
     }
-    out
-}
-
-/// Pick the locked version a declared requirement resolves to.
-///
-/// Why: the Locked column answers "what is this build actually using for the
-/// version it asked for". With several versions in the lock, that is a semver
-/// question, not a first-wins one — and when NONE of them satisfies the
-/// declared requirement the honest answer is to say so rather than print an
-/// unrelated version as if it were the resolution.
-/// What: one locked version resolves to itself. With several, the highest that
-/// satisfies `spec` wins; with an empty or unparseable `spec` the highest
-/// overall wins; with none satisfying, the cell names every candidate and
-/// states that none matches. An unparseable version string is skipped for
-/// matching but still named in the no-match text.
-/// Test: `deps_tests::{cargo_locked_version_satisfies_the_declared_req,
-/// cargo_locked_prefers_the_highest_satisfying_version,
-/// cargo_locked_states_when_no_version_satisfies}`.
-fn resolve_locked(spec: &str, versions: &[String]) -> Option<String> {
-    match versions {
-        [] => return None,
-        [only] => return Some(only.clone()),
-        _ => {}
-    }
-    let parsed: Vec<(semver::Version, &String)> = versions
-        .iter()
-        .filter_map(|v| semver::Version::parse(v).ok().map(|p| (p, v)))
-        .collect();
-    let req = semver::VersionReq::parse(spec.trim()).ok();
-    let matching: Vec<&(semver::Version, &String)> = parsed
-        .iter()
-        .filter(|(v, _)| req.as_ref().is_none_or(|r| r.matches(v)))
-        .collect();
-    if let Some((_, raw)) = matching.iter().max_by(|a, b| a.0.cmp(&b.0)) {
-        return Some((*raw).clone());
-    }
-    Some(format!("{} (none satisfies {spec})", versions.join(", ")))
 }
 
 // ─── pypi ────────────────────────────────────────────────────────────────────
 
-/// Parse `pyproject.toml` project/poetry dependencies (declared-only; poetry.lock
-/// parsing is best-effort-skipped to avoid a heavy lock format dependency).
-fn pypi_deps(root: &Path) -> Vec<Dependency> {
+/// Parse `pyproject.toml` project/poetry dependencies and enrich them with the
+/// pins in `poetry.lock`, `uv.lock`, or `requirements.txt` (#6794).
+fn pypi_deps(root: &Path, warnings: &mut Vec<String>) -> Vec<Dependency> {
     let Some(text) = read(root, "pyproject.toml") else {
         return Vec::new();
     };
     let Ok(value) = toml::from_str::<toml::Value>(&text) else {
         return Vec::new();
     };
+    let index = lock::pypi(root);
+    warnings.extend(index.warnings.iter().cloned());
     let mut out = Vec::new();
     // PEP 621 `project.dependencies`: array of requirement strings.
     if let Some(arr) = value
@@ -349,12 +329,7 @@ fn pypi_deps(root: &Path) -> Vec<Dependency> {
     {
         for req in arr.iter().filter_map(|v| v.as_str()) {
             let (name, spec) = split_pep508(req);
-            out.push(Dependency {
-                name,
-                ecosystem: "pypi".to_string(),
-                spec,
-                locked: None,
-            });
+            out.push(Dependency::declared(name, "pypi", spec).resolve_from(&index));
         }
     }
     // Poetry `[tool.poetry.dependencies]`: table of name → constraint.
@@ -368,21 +343,9 @@ fn pypi_deps(root: &Path) -> Vec<Dependency> {
             if name.eq_ignore_ascii_case("python") {
                 continue;
             }
-            let spec_str = match spec {
-                toml::Value::String(s) => s.clone(),
-                toml::Value::Table(t) => t
-                    .get("version")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default()
-                    .to_string(),
-                _ => String::new(),
-            };
-            out.push(Dependency {
-                name: name.clone(),
-                ecosystem: "pypi".to_string(),
-                spec: spec_str,
-                locked: None,
-            });
+            out.push(
+                Dependency::declared(name.clone(), "pypi", toml_spec(spec)).resolve_from(&index),
+            );
         }
     }
     out
@@ -429,13 +392,15 @@ fn go_deps(root: &Path) -> Vec<Dependency> {
             let mut parts = d.split_whitespace();
             if let Some(name) = parts.next() {
                 let ver = parts.next().unwrap_or_default().to_string();
-                out.push(Dependency {
-                    name: name.to_string(),
-                    ecosystem: "go".to_string(),
-                    // go.mod pins exactly, so the declared spec IS the locked ver.
-                    spec: ver.clone(),
-                    locked: if ver.is_empty() { None } else { Some(ver) },
-                });
+                let mut dep = Dependency::declared(name.to_string(), "go", ver.clone());
+                // go.mod pins exactly, so the declared spec IS the locked ver
+                // and the manifest itself is the source (#6794).
+                if !ver.is_empty() {
+                    dep.locked = Some(ver);
+                    dep.resolved = true;
+                    dep.source = Some("go.mod".to_string());
+                }
+                out.push(dep);
             }
         }
     }

--- a/crates/trusty-review/src/report/investigate/deps_lock.rs
+++ b/crates/trusty-review/src/report/investigate/deps_lock.rs
@@ -1,0 +1,341 @@
+//! Lockfile-resolved dependency versions, per ecosystem (#6794).
+//!
+//! Why: the inventory used to record whatever the manifest declared, so a
+//! `serde = "1"` reached the report — and trusty-audit's OSV stage — as the
+//! range `1`, which no advisory database can answer. In a 59-repository run
+//! 515 of 1230 rows carried a range rather than a version. The lockfile beside
+//! the manifest already holds the answer; reading it is what turns an
+//! unscannable row into a coordinate.
+//! What: one reader per ecosystem, each returning a [`LockIndex`] — resolved
+//! versions per package, the lockfile each came from, and a named warning for
+//! any lockfile that existed but did not parse. Nothing here aborts: an
+//! unparseable lockfile degrades that ecosystem to declared ranges and says so.
+//! Only the resolved `name → version` pairs are kept, so the inventory never
+//! grows by the size of the lockfile it read.
+//! Test: `deps_tests::{cargo_lock_records_its_source, npm_lock_records_its_source,
+//! poetry_lock_resolves_pyproject_ranges, uv_lock_resolves_pyproject_ranges,
+//! requirements_pins_resolve_pyproject_ranges,
+//! a_malformed_lockfile_warns_and_falls_back}`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Resolved versions one ecosystem's lockfiles supplied.
+///
+/// Why: three facts travel together — what a package resolved to, which file
+/// said so, and which lockfiles could not be read at all. Splitting them across
+/// three return values loses the pairing.
+/// What: `versions` keeps every resolved version per package in lockfile order
+/// (Cargo.lock routinely carries several majors of one crate); `sources` names
+/// the file each package's versions came from; `warnings` is one line per
+/// lockfile that existed and failed to parse.
+/// Test: `deps_tests::cargo_lock_records_its_source`.
+#[derive(Debug, Default)]
+pub(super) struct LockIndex {
+    /// Package name → resolved versions, in lockfile order, duplicates kept.
+    pub versions: BTreeMap<String, Vec<String>>,
+    /// Package name → the lockfile that supplied its versions.
+    pub sources: BTreeMap<String, String>,
+    /// One line per lockfile that existed but could not be parsed.
+    pub warnings: Vec<String>,
+}
+
+impl LockIndex {
+    /// Record `name` as resolving to `version`, credited to `source`.
+    fn insert(&mut self, name: &str, version: &str, source: &str) {
+        self.versions
+            .entry(name.to_owned())
+            .or_default()
+            .push(version.to_owned());
+        self.sources
+            .entry(name.to_owned())
+            .or_insert_with(|| source.to_owned());
+    }
+
+    /// The warning line an existing-but-unparseable lockfile earns.
+    fn unparseable(&mut self, file: &str, ecosystem: &str, cause: &str) {
+        self.warnings.push(format!(
+            "{file} was found but could not be parsed ({cause}); {ecosystem} dependencies fall \
+             back to their declared ranges"
+        ));
+    }
+}
+
+/// One lockfile's text, or `None` when it is not present at `root`.
+///
+/// An unreadable-but-present file returns its io error so the caller can warn:
+/// a lockfile the sweep could not open is exactly the case #6794 forbids
+/// swallowing.
+fn slurp(root: &Path, name: &str) -> Option<Result<String, String>> {
+    let path = root.join(name);
+    if !path.is_file() {
+        return None;
+    }
+    Some(std::fs::read_to_string(path).map_err(|e| e.to_string()))
+}
+
+// ─── npm ─────────────────────────────────────────────────────────────────────
+
+/// The npm lockfile this reader understands.
+pub(super) const NPM_LOCK: &str = "package-lock.json";
+
+/// Resolved npm versions from `package-lock.json` (v2/v3 `packages`, or v1
+/// `dependencies`).
+///
+/// Test: `deps_tests::npm_lock_records_its_source`.
+pub(super) fn npm(root: &Path) -> LockIndex {
+    let mut index = LockIndex::default();
+    let Some(text) = slurp(root, NPM_LOCK) else {
+        return index;
+    };
+    let text = match text {
+        Ok(text) => text,
+        Err(e) => {
+            index.unparseable(NPM_LOCK, "npm", &e);
+            return index;
+        }
+    };
+    let value = match serde_json::from_str::<serde_json::Value>(&text) {
+        Ok(value) => value,
+        Err(e) => {
+            index.unparseable(NPM_LOCK, "npm", &e.to_string());
+            return index;
+        }
+    };
+    // v2/v3: `packages` keyed by "node_modules/<name>" (root key is "").
+    if let Some(pkgs) = value.get("packages").and_then(|v| v.as_object()) {
+        for (path, meta) in pkgs {
+            if let Some(name) = path.strip_prefix("node_modules/")
+                && let Some(ver) = meta.get("version").and_then(|v| v.as_str())
+                && !name.contains("/node_modules/")
+            {
+                index.insert(name, ver, NPM_LOCK);
+            }
+        }
+    }
+    // v1: `dependencies` keyed by name.
+    if let Some(deps) = value.get("dependencies").and_then(|v| v.as_object()) {
+        for (name, meta) in deps {
+            if let Some(ver) = meta.get("version").and_then(|v| v.as_str())
+                && !index.versions.contains_key(name)
+            {
+                index.insert(name, ver, NPM_LOCK);
+            }
+        }
+    }
+    index
+}
+
+// ─── cargo ───────────────────────────────────────────────────────────────────
+
+/// The cargo lockfile this reader understands.
+pub(super) const CARGO_LOCK: &str = "Cargo.lock";
+
+/// Every resolved version in `Cargo.lock`, per package name.
+///
+/// Why: a workspace lockfile routinely carries several versions of one crate —
+/// `base64` 0.13.1 alongside 0.22.1 — because transitive dependents pin older
+/// majors. Keeping only the first entry reported the LOWEST of them, so a
+/// manifest declaring `base64 = "0.22"` had `0.13.1` printed against it.
+/// What: `name → versions`, in lockfile order, duplicates preserved, for
+/// [`resolve`] to pick from.
+/// Test: `deps_tests::{cargo_locked_version_satisfies_the_declared_req,
+/// cargo_locked_prefers_the_highest_satisfying_version}`.
+pub(super) fn cargo(root: &Path) -> LockIndex {
+    let mut index = LockIndex::default();
+    let Some(text) = slurp(root, CARGO_LOCK) else {
+        return index;
+    };
+    let text = match text {
+        Ok(text) => text,
+        Err(e) => {
+            index.unparseable(CARGO_LOCK, "cargo", &e);
+            return index;
+        }
+    };
+    let value = match toml::from_str::<toml::Value>(&text) {
+        Ok(value) => value,
+        Err(e) => {
+            index.unparseable(CARGO_LOCK, "cargo", &e.to_string());
+            return index;
+        }
+    };
+    for pkg in value
+        .get("package")
+        .and_then(|v| v.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        if let (Some(name), Some(ver)) = (
+            pkg.get("name").and_then(|v| v.as_str()),
+            pkg.get("version").and_then(|v| v.as_str()),
+        ) {
+            index.insert(name, ver, CARGO_LOCK);
+        }
+    }
+    index
+}
+
+// ─── pypi ────────────────────────────────────────────────────────────────────
+
+/// The pypi pin sources this reader understands, in precedence order.
+///
+/// Why: a project pins in exactly one of these in practice, and when it has
+/// more than one the lockfile proper is the stronger claim — `requirements.txt`
+/// is often a partial export. First hit per package wins ([`LockIndex::insert`]
+/// keeps the first `source`), so the order here is the precedence.
+pub(super) const PYPI_LOCKS: &[&str] = &["poetry.lock", "uv.lock", "requirements.txt"];
+
+/// Resolved pypi versions from `poetry.lock`, `uv.lock`, or `requirements.txt`.
+///
+/// Why: `pyproject.toml` states ranges and nothing else, so before #6794 every
+/// python row in the inventory was unresolved — the single largest share of the
+/// 515 unscannable rows the issue counts.
+/// What: the two lock formats are TOML `[[package]] name/version` arrays;
+/// `requirements.txt` contributes only its `==` pins, since a `>=` line is a
+/// range and not a resolution. Names are normalised ([`normalize`]) because
+/// PyPI treats `-`, `_` and case as equivalent while the files do not.
+/// Test: `deps_tests::{poetry_lock_resolves_pyproject_ranges,
+/// uv_lock_resolves_pyproject_ranges, requirements_pins_resolve_pyproject_ranges}`.
+pub(super) fn pypi(root: &Path) -> LockIndex {
+    let mut index = LockIndex::default();
+    for file in PYPI_LOCKS {
+        let Some(text) = slurp(root, file) else {
+            continue;
+        };
+        let text = match text {
+            Ok(text) => text,
+            Err(e) => {
+                index.unparseable(file, "pypi", &e);
+                continue;
+            }
+        };
+        if *file == "requirements.txt" {
+            absorb_requirements(&mut index, &text, file);
+            continue;
+        }
+        match toml::from_str::<toml::Value>(&text) {
+            Ok(value) => absorb_toml_lock(&mut index, &value, file),
+            Err(e) => index.unparseable(file, "pypi", &e.to_string()),
+        }
+    }
+    index
+}
+
+/// Absorb a `[[package]] name/version` TOML lock (poetry.lock, uv.lock).
+fn absorb_toml_lock(index: &mut LockIndex, value: &toml::Value, source: &str) {
+    for pkg in value
+        .get("package")
+        .and_then(|v| v.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        if let (Some(name), Some(ver)) = (
+            pkg.get("name").and_then(|v| v.as_str()),
+            pkg.get("version").and_then(|v| v.as_str()),
+        ) {
+            index.insert(&normalize(name), ver, source);
+        }
+    }
+}
+
+/// Absorb the `==` pins of a `requirements.txt`, ignoring every other line.
+///
+/// A `>=`, `~=` or bare name is a range or no constraint at all, and recording
+/// it as a resolution would invent the fact this module exists to measure.
+fn absorb_requirements(index: &mut LockIndex, text: &str, source: &str) {
+    for line in text.lines() {
+        let line = line.split('#').next().unwrap_or("").trim();
+        if line.is_empty() || line.starts_with('-') {
+            continue;
+        }
+        // Strip an environment marker or extras hash tail before the split.
+        let line = line.split(';').next().unwrap_or("").trim();
+        let Some((name, version)) = line.split_once("==") else {
+            continue;
+        };
+        let name = name.split('[').next().unwrap_or("").trim();
+        let version = version.split_whitespace().next().unwrap_or("").trim();
+        if name.is_empty() || version.is_empty() {
+            continue;
+        }
+        index.insert(&normalize(name), version, source);
+    }
+}
+
+/// PyPI's own name equivalence: case-insensitive, `_` and `.` fold to `-`.
+///
+/// Test: `deps_tests::poetry_lock_resolves_pyproject_ranges`.
+pub(super) fn normalize(name: &str) -> String {
+    name.trim()
+        .to_ascii_lowercase()
+        .replace(['_', '.'], "-")
+        .trim_matches('-')
+        .to_owned()
+}
+
+// ─── resolution ──────────────────────────────────────────────────────────────
+
+/// One dependency's resolved version, and whether it is an exact pin.
+///
+/// Why: #6794 asks the report to distinguish a resolved version from a declared
+/// range, so the boolean travels with the string rather than being re-derived
+/// by every reader of it.
+/// What: `version` is what the Locked cell shows; `exact` is false when no
+/// lockfile answered, or when several locked versions exist and none satisfies
+/// the declared requirement.
+/// Test: `deps_tests::cargo_locked_states_when_no_version_satisfies`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Resolution {
+    /// The text the Locked column renders.
+    pub version: String,
+    /// True when `version` is a single exact version a lockfile resolved.
+    pub exact: bool,
+}
+
+/// Pick the locked version a declared requirement resolves to.
+///
+/// Why: the Locked column answers "what is this build actually using for the
+/// version it asked for". With several versions in the lock that is a semver
+/// question, not a first-wins one — and when NONE of them satisfies the
+/// declared requirement the honest answer is to say so rather than print an
+/// unrelated version as if it were the resolution.
+/// What: one locked version resolves to itself. With several, the highest that
+/// satisfies `spec` wins; with an empty or unparseable `spec` the highest
+/// overall wins; with none satisfying, the cell names every candidate, states
+/// that none matches, and reports `exact: false` so the row is not offered to a
+/// vulnerability database as a coordinate (#6794).
+/// Test: `deps_tests::{cargo_locked_version_satisfies_the_declared_req,
+/// cargo_locked_prefers_the_highest_satisfying_version,
+/// cargo_locked_states_when_no_version_satisfies}`.
+pub(super) fn resolve(spec: &str, versions: &[String]) -> Option<Resolution> {
+    match versions {
+        [] => return None,
+        [only] => {
+            return Some(Resolution {
+                version: only.clone(),
+                exact: true,
+            });
+        }
+        _ => {}
+    }
+    let parsed: Vec<(semver::Version, &String)> = versions
+        .iter()
+        .filter_map(|v| semver::Version::parse(v).ok().map(|p| (p, v)))
+        .collect();
+    let req = semver::VersionReq::parse(spec.trim()).ok();
+    let matching: Vec<&(semver::Version, &String)> = parsed
+        .iter()
+        .filter(|(v, _)| req.as_ref().is_none_or(|r| r.matches(v)))
+        .collect();
+    if let Some((_, raw)) = matching.iter().max_by(|a, b| a.0.cmp(&b.0)) {
+        return Some(Resolution {
+            version: (*raw).clone(),
+            exact: true,
+        });
+    }
+    Some(Resolution {
+        version: format!("{} (none satisfies {spec})", versions.join(", ")),
+        exact: false,
+    })
+}

--- a/crates/trusty-review/src/report/investigate/deps_tests.rs
+++ b/crates/trusty-review/src/report/investigate/deps_tests.rs
@@ -300,4 +300,211 @@ fn cargo_locked_states_when_no_version_satisfies() {
     assert!(locked.contains("none satisfies 3"), "locked: {locked}");
     assert!(locked.contains("1.0.0"), "locked: {locked}");
     assert!(locked.contains("2.0.0"), "locked: {locked}");
+    // #6794: the cell holds prose, not a version, so the row is not resolved.
+    let foo = inv.deps.iter().find(|d| d.name == "foo").unwrap();
+    assert!(
+        !foo.resolved,
+        "a no-match note is not a resolution: {foo:?}"
+    );
+}
+
+/// One dependency row by name, for the #6794 assertions below.
+fn row<'a>(inv: &'a DependencyInventory, name: &str) -> &'a Dependency {
+    inv.deps
+        .iter()
+        .find(|d| d.name == name)
+        .unwrap_or_else(|| panic!("no `{name}` row in {:?}", inv.deps))
+}
+
+/// #6794: the graded case. A declared range plus a lockfile must record the
+/// resolved version and the file it came from; the same manifest with no
+/// lockfile must record the range and say it is unresolved.
+///
+/// Why: `serde = "1"` and `serde 1.0.210` reached trusty-audit's OSV stage
+/// indistinguishable, and a range is unscannable — 515 of 1230 rows in a
+/// 59-repository run.
+#[test]
+fn cargo_lock_records_its_source() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"x\"\n[dependencies]\nserde = \"1\"\n",
+    );
+    write(
+        tmp.path(),
+        "Cargo.lock",
+        "[[package]]\nname = \"serde\"\nversion = \"1.0.210\"\n",
+    );
+    let serde = row(&build_inventory(tmp.path()), "serde").clone();
+    assert_eq!(serde.spec, "1");
+    assert_eq!(serde.locked.as_deref(), Some("1.0.210"));
+    assert!(serde.resolved, "{serde:?}");
+    assert_eq!(serde.source.as_deref(), Some("Cargo.lock"));
+
+    std::fs::remove_file(tmp.path().join("Cargo.lock")).unwrap();
+    let inv = build_inventory(tmp.path());
+    let serde = row(&inv, "serde");
+    assert_eq!(serde.spec, "1", "the declared range is still recorded");
+    assert_eq!(serde.locked, None);
+    assert!(!serde.resolved, "{serde:?}");
+    assert_eq!(serde.source, None);
+    assert_eq!(inv.resolved_count(), 0);
+}
+
+/// #6794: the same contract for the JS ecosystem — `package-lock.json` names
+/// itself as the source, and removing it drops the row back to its range.
+#[test]
+fn npm_lock_records_its_source() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    write(
+        tmp.path(),
+        "package.json",
+        r#"{"dependencies": {"react": "^18.0.0"}}"#,
+    );
+    write(
+        tmp.path(),
+        "package-lock.json",
+        r#"{"lockfileVersion": 3, "packages": {"": {}, "node_modules/react": {"version": "18.2.0"}}}"#,
+    );
+    let react = row(&build_inventory(tmp.path()), "react").clone();
+    assert_eq!(react.locked.as_deref(), Some("18.2.0"));
+    assert!(react.resolved, "{react:?}");
+    assert_eq!(react.source.as_deref(), Some("package-lock.json"));
+
+    std::fs::remove_file(tmp.path().join("package-lock.json")).unwrap();
+    let react = row(&build_inventory(tmp.path()), "react").clone();
+    assert_eq!(react.spec, "^18.0.0");
+    assert_eq!(react.locked, None);
+    assert!(!react.resolved, "{react:?}");
+}
+
+/// A pyproject declaring PEP 621 ranges, for the three pypi pin sources below.
+fn pyproject_with_ranges(root: &Path) {
+    write(
+        root,
+        "pyproject.toml",
+        "[project]\nname = \"x\"\ndependencies = [\"requests>=2\", \"PyYAML>=6\"]\n",
+    );
+}
+
+/// #6794: `pyproject.toml` states ranges only, so before this every python row
+/// was unresolved — the single largest share of the unscannable rows.
+#[test]
+fn poetry_lock_resolves_pyproject_ranges() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    pyproject_with_ranges(tmp.path());
+    write(
+        tmp.path(),
+        "poetry.lock",
+        "[[package]]\nname = \"requests\"\nversion = \"2.32.3\"\n\n\
+         [[package]]\nname = \"pyyaml\"\nversion = \"6.0.2\"\n",
+    );
+    let inv = build_inventory(tmp.path());
+    let requests = row(&inv, "requests");
+    assert_eq!(requests.locked.as_deref(), Some("2.32.3"));
+    assert!(requests.resolved, "{requests:?}");
+    assert_eq!(requests.source.as_deref(), Some("poetry.lock"));
+    // PyPI folds case and `-`/`_`/`.`, so `PyYAML` matches the lock's `pyyaml`.
+    assert_eq!(row(&inv, "PyYAML").locked.as_deref(), Some("6.0.2"));
+    assert_eq!(inv.resolved_count(), 2);
+}
+
+/// #6794: uv writes the same `[[package]]` shape under a different filename,
+/// and the source column must name the file actually read.
+#[test]
+fn uv_lock_resolves_pyproject_ranges() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    pyproject_with_ranges(tmp.path());
+    write(
+        tmp.path(),
+        "uv.lock",
+        "[[package]]\nname = \"requests\"\nversion = \"2.31.0\"\n",
+    );
+    let requests = row(&build_inventory(tmp.path()), "requests").clone();
+    assert_eq!(requests.locked.as_deref(), Some("2.31.0"));
+    assert_eq!(requests.source.as_deref(), Some("uv.lock"));
+}
+
+/// #6794: a `requirements.txt` `==` pin is a resolution; every other line shape
+/// in it is a range or a flag and contributes nothing.
+#[test]
+fn requirements_pins_resolve_pyproject_ranges() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    pyproject_with_ranges(tmp.path());
+    write(
+        tmp.path(),
+        "requirements.txt",
+        "# comment\n-r other.txt\nrequests==2.32.3  # pinned\nPyYAML>=6\n",
+    );
+    let inv = build_inventory(tmp.path());
+    let requests = row(&inv, "requests");
+    assert_eq!(requests.locked.as_deref(), Some("2.32.3"));
+    assert_eq!(requests.source.as_deref(), Some("requirements.txt"));
+    let pyyaml = row(&inv, "PyYAML");
+    assert_eq!(pyyaml.locked, None, "a `>=` line is not a pin: {pyyaml:?}");
+    assert!(!pyyaml.resolved);
+}
+
+/// #6794: a lockfile that fails to parse must be NAMED and must not stop the
+/// pass — the rows fall back to their declared ranges and the run report says
+/// which file could not be read.
+#[test]
+fn a_malformed_lockfile_warns_and_falls_back() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    write(
+        tmp.path(),
+        "Cargo.toml",
+        "[package]\nname = \"x\"\n[dependencies]\nserde = \"1\"\n",
+    );
+    write(tmp.path(), "Cargo.lock", "[[package\nname = broken\n");
+    write(
+        tmp.path(),
+        "package.json",
+        r#"{"dependencies": {"react": "^18"}}"#,
+    );
+    write(tmp.path(), "package-lock.json", "{not json");
+
+    let inv = build_inventory(tmp.path());
+    assert_eq!(inv.total, 2, "the sweep completed: {:?}", inv.deps);
+    assert_eq!(row(&inv, "serde").spec, "1");
+    assert!(!row(&inv, "serde").resolved);
+    assert!(!row(&inv, "react").resolved);
+    assert_eq!(inv.resolved_count(), 0);
+
+    assert_eq!(
+        inv.lockfile_warnings.len(),
+        2,
+        "{:?}",
+        inv.lockfile_warnings
+    );
+    let joined = inv.lockfile_warnings.join("\n");
+    assert!(
+        joined.contains("Cargo.lock was found but could not be parsed"),
+        "{joined}"
+    );
+    assert!(
+        joined.contains("package-lock.json was found but could not be parsed"),
+        "{joined}"
+    );
+    assert!(
+        joined.contains("fall back to their declared ranges"),
+        "{joined}"
+    );
+}
+
+/// #6794: go.mod pins exactly, so its rows are resolved and name the manifest
+/// itself as the source — there is no separate lockfile to read.
+#[test]
+fn go_mod_rows_are_resolved_from_the_manifest() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    write(
+        tmp.path(),
+        "go.mod",
+        "module x\n\nrequire github.com/pkg/errors v0.9.1\n",
+    );
+    let inv = build_inventory(tmp.path());
+    let errors = row(&inv, "github.com/pkg/errors");
+    assert!(errors.resolved, "{errors:?}");
+    assert_eq!(errors.source.as_deref(), Some("go.mod"));
 }

--- a/crates/trusty-review/src/report/investigate/render.rs
+++ b/crates/trusty-review/src/report/investigate/render.rs
@@ -48,10 +48,12 @@ fn dependency_section(inv: &Investigation) -> String {
     let mut out = String::from("\n\n## Dependency Inventory\n\n");
     if !any {
         out.push_str(&empty_inventory_line(inv));
+        // #6794: an unreadable lockfile is why a root can look dependency-free.
+        out.push_str(&lockfile_warning_block(inv));
         return out;
     }
     out.push_str(&format!(
-        "_Parsed deterministically from manifests + lockfiles{MEASURED_TAG}; staleness judgements, where present, are inferred{INFERRED_TAG}._\n\n",
+        "_Parsed deterministically from manifests + lockfiles{MEASURED_TAG}; staleness judgements, where present, are inferred{INFERRED_TAG}. The Resolved from column names the lockfile a version came from; `not resolved` means no lockfile answered and the Declared range is all this pass knows._\n\n",
     ));
     for repo in &inv.repos {
         if repo.deps.is_empty() {
@@ -61,6 +63,7 @@ fn dependency_section(inv: &Investigation) -> String {
         out.push_str(&dependency_table(&repo.deps));
         out.push('\n');
     }
+    out.push_str(&lockfile_warning_block(inv));
     out
 }
 
@@ -105,18 +108,58 @@ fn empty_inventory_line(inv: &Investigation) -> String {
 /// Test: `render_tests::{dependency_table_caps_and_overflows,
 /// dependency_table_draws_only_max_rows_of_a_full_inventory}`.
 fn dependency_table(inv: &DependencyInventory) -> String {
-    let mut out = String::from("| Package | Ecosystem | Declared | Locked |\n|---|---|---|---|\n");
+    let mut out = String::from(
+        "| Package | Ecosystem | Declared | Locked | Resolved from |\n|---|---|---|---|---|\n",
+    );
     for d in inv.rendered() {
         let spec = if d.spec.is_empty() { "—" } else { &d.spec };
         let locked = d.locked.as_deref().unwrap_or("—");
+        // #6794: an unresolved row shows the declared range in the Locked cell
+        // and says so, rather than reading as a pin the reader can act on.
+        let source = match (&d.source, d.resolved) {
+            (Some(file), true) => file.as_str(),
+            _ => "not resolved",
+        };
         out.push_str(&format!(
-            "| {} | {} | {} | {} |\n",
-            d.name, d.ecosystem, spec, locked
+            "| {} | {} | {} | {} | {} |\n",
+            d.name, d.ecosystem, spec, locked, source
         ));
     }
     let overflow = inv.overflow();
     if overflow > 0 {
-        out.push_str(&format!("| … and {overflow} more | | | |\n"));
+        out.push_str(&format!("| … and {overflow} more | | | | |\n"));
+    }
+    out
+}
+
+/// The warning block naming every lockfile that was present and did not parse.
+///
+/// Why: #6794 — a lockfile that fails to parse degrades its whole ecosystem to
+/// declared ranges. Without this the page shows those ranges with nothing
+/// saying why, which reads as "this project pins loosely" rather than "this
+/// pass could not read the pins".
+/// What: an empty string when every lockfile parsed; otherwise one bullet per
+/// warning, de-duplicated across repositories.
+/// Test: `render_tests::dependency_section_names_unparseable_lockfiles`.
+fn lockfile_warning_block(inv: &Investigation) -> String {
+    let mut seen: Vec<&str> = Vec::new();
+    for warning in inv
+        .repos
+        .iter()
+        .flat_map(|r| r.deps.lockfile_warnings.iter())
+    {
+        if !seen.contains(&warning.as_str()) {
+            seen.push(warning);
+        }
+    }
+    if seen.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from(
+        "\n**Lockfiles that could not be read**, so the rows above fall back to declared ranges:\n\n",
+    );
+    for warning in seen {
+        out.push_str(&format!("- {warning}\n"));
     }
     out
 }

--- a/crates/trusty-review/src/report/investigate/render_tests.rs
+++ b/crates/trusty-review/src/report/investigate/render_tests.rs
@@ -47,6 +47,9 @@ fn dep(name: &str, locked: Option<&str>) -> Dependency {
         ecosystem: "cargo".to_string(),
         spec: "1.0".to_string(),
         locked: locked.map(str::to_string),
+        // #6794: a row with a locked version was resolved from Cargo.lock.
+        resolved: locked.is_some(),
+        source: locked.map(|_| "Cargo.lock".to_string()),
     }
 }
 
@@ -238,11 +241,7 @@ fn coverage_section_omits_the_verdict_line_without_verdicts() {
 
 /// An empty inventory, for fixtures that care about coverage only.
 fn deps_none() -> DependencyInventory {
-    DependencyInventory {
-        deps: vec![],
-        total: 0,
-        manifests_examined: vec![],
-    }
+    DependencyInventory::default()
 }
 
 /// Why: the dependency table must render declared + locked and an honest overflow.
@@ -254,12 +253,13 @@ fn dependency_table_caps_and_overflows() {
         deps: vec![dep("serde", Some("1.0.203")), dep("tokio", None)],
         total: 5,
         manifests_examined: vec!["Cargo.toml".to_string()],
+        lockfile_warnings: Vec::new(),
     };
     let out = dependency_table(&inv);
-    assert!(out.contains("| serde | cargo | 1.0 | 1.0.203 |"));
+    assert!(out.contains("| serde | cargo | 1.0 | 1.0.203 | Cargo.lock |"));
     assert!(
-        out.contains("| tokio | cargo | 1.0 | — |"),
-        "missing lock → em dash"
+        out.contains("| tokio | cargo | 1.0 | — | not resolved |"),
+        "missing lock → em dash + not resolved: {out}"
     );
     assert!(out.contains("and 3 more"));
 }
@@ -279,6 +279,7 @@ fn dependency_table_draws_only_max_rows_of_a_full_inventory() {
         total: deps.len(),
         deps,
         manifests_examined: vec!["Cargo.toml".to_string()],
+        lockfile_warnings: Vec::new(),
     };
     let out = dependency_table(&inv);
 
@@ -530,6 +531,54 @@ fn empty_inventory_names_the_manifests_it_read() {
         out.contains("no directly declared dependencies"),
         "out: {out}"
     );
+}
+
+/// #6794: a lockfile that was present and failed to parse leaves every row in
+/// its ecosystem showing a declared range. The section must say which file
+/// could not be read, so those ranges read as unassessed rather than as loose
+/// pinning — and it must say it whether or not any dependency row survived.
+#[test]
+fn dependency_section_names_unparseable_lockfiles() {
+    let warning = "Cargo.lock was found but could not be parsed (expected an equals, found a \
+                   newline); cargo dependencies fall back to their declared ranges"
+        .to_string();
+    let with_rows = Investigation {
+        repos: vec![repo(
+            InvestigationStatus::Available,
+            vec![],
+            DependencyInventory {
+                deps: vec![dep("serde", None)],
+                total: 1,
+                manifests_examined: vec!["Cargo.toml".to_string()],
+                lockfile_warnings: vec![warning.clone()],
+            },
+        )],
+    };
+    let out = dependency_section(&with_rows);
+    assert!(
+        out.contains("Lockfiles that could not be read"),
+        "out: {out}"
+    );
+    assert!(out.contains(&warning), "out: {out}");
+    assert!(
+        out.contains("| serde | cargo | 1.0 | — | not resolved |"),
+        "the row still renders from the manifest: {out}"
+    );
+
+    // The same warning must survive the empty-inventory early return.
+    let no_rows = Investigation {
+        repos: vec![repo(
+            InvestigationStatus::Available,
+            vec![],
+            DependencyInventory {
+                manifests_examined: vec!["Cargo.toml".to_string()],
+                lockfile_warnings: vec![warning.clone()],
+                ..Default::default()
+            },
+        )],
+    };
+    let out = dependency_section(&no_rows);
+    assert!(out.contains(&warning), "out: {out}");
 }
 
 /// Why: a truncated/failed batch must be NAMED — which files, which position,


### PR DESCRIPTION
## Where the capture actually lives

Not in trusty-audit. `crates/trusty-audit/src/grounding/osv.rs:352` reads the
inventory from `investigation.json` and its doc comment refuses to re-derive it
under CLAUDE.md's common-entry-point rule. The producer is
`crates/trusty-review/src/report/investigate/deps.rs`, which already resolved
`Cargo.lock` and `package-lock.json`. The 515-of-1230 gap #6794 counts is
python: `pyproject.toml` states ranges only, and `pypi_deps` hard-coded
`locked: None` because no python lockfile was read at all.

## What changed

- **`deps_lock.rs`** (new) holds every lockfile reader. `poetry.lock`,
  `uv.lock` and the `==` pins of `requirements.txt` are read for the first
  time; `Cargo.lock` and `package-lock.json` move here unchanged. Only resolved
  name/version pairs are kept, so the package does not grow by the lockfile.
- `Dependency` gains `resolved` (true only when `locked` is one exact version)
  and `source` (the filename that answered). `DependencyInventory` gains
  `lockfile_warnings`. Both structs become `#[non_exhaustive]`.
- The Dependency Inventory table gains a `Resolved from` column reading
  `not resolved` when nothing answered, and a lockfile that is present and
  fails to parse is named under the section instead of degrading silently. The
  pass carries on with that ecosystem's declared ranges.
- trusty-audit's OSV scan stops sending an unresolved locked cell to OSV.dev as
  a version — `0.13.1, 0.22.1 (none satisfies ^0.30)` was queried verbatim. It
  is named in the unpinned gap line instead. A snapshot written before
  `resolved` existed carries no such key and behaves exactly as before.
- Lockfile parsing moved out of `deps.rs` to keep it under the 500-SLOC cap.

## Version bumps

| Crate | Bump | Why |
|---|---|---|
| trusty-review | 0.35.1 -> **0.36.0** (MINOR) | `Dependency` and `DependencyInventory` gain fields and `#[non_exhaustive]` — `cargo-semver-checks` majors, MINOR position for a `0.y.z` crate. Root `[workspace.dependencies]` row widened to `"0.36"`. |
| trusty-audit | 0.14.3 -> **0.14.4** (PATCH) | Confined to the body of the private `grounding::osv::absorb`; no public item added, removed, or reshaped. |

## Proof each criterion fails on origin/main

Reverting only the production files and keeping the new tests:

```
error[E0609]: no field `source` on type `&Dependency`
    = note: available fields are: `name`, `ecosystem`, `spec`, `locked`
error[E0609]: no field `resolved` on type `&Dependency`
error[E0609]: no field `lockfile_warnings` on type `DependencyInventory`
    = note: available fields are: `deps`, `total`, `manifests_examined`
```

A behavioural probe using only the `locked` field that exists on both sides,
run against main's `deps.rs`:

```
test probe_cargo_lock_resolution ... ok
test probe_uv_lock_resolution ... FAILED
test probe_requirements_pin_resolution ... FAILED
test probe_poetry_lock_resolution ... FAILED

---- probe_poetry_lock_resolution stdout ----
assertion `left == right` failed: poetry.lock must resolve the declared range
  left: None
 right: Some("2.32.3")
test result: FAILED. 27 passed; 3 failed; 0 ignored; 0 measured; 2167 filtered out
```

## Test ladder — rung 4

`trusty-review` is a shared library, so rung 3 on it plus `check --workspace`
and each direct dependent's suite. All counts below are from the rebased head.

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-review -p trusty-audit --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-review --no-fail-fast` | `ok. 2209 passed; 0 failed; 5 ignored` + 14 further targets, all ok |
| `cargo test -p trusty-audit --no-fail-fast` | `ok. 957 passed; 0 failed; 5 ignored` + 9 further targets, all ok |
| `cargo check --workspace` | EXIT=0 |
| `cargo test -p trusty-analyze --no-fail-fast` | `ok. 517 passed; 0 failed` + 9 further targets, all ok |
| `check_line_cap.sh` | 4568 files, 0 violations |
| `check_test_pointers.sh` | 31640 citations, 0 dangling |
| `check_sld.sh` | 0 errors, 0 warnings |
| `check_changelog_fragment.sh` | both crates recorded |
| `check-pr-version-bump.sh` | clear, 0 warnings |
| `check_rustdoc_links.sh` | 0 broken links |

### Dependent crates

| Dependent | Edge | Covered by |
|---|---|---|
| trusty-analyze | `trusty-review = { workspace = true, optional }`, plus a path dev-dependency | `cargo test -p trusty-analyze --no-fail-fast` |
| trusty-mpm | dev-dependency only, for the conformance BACK gate | `cargo check --workspace` |

No crate outside trusty-review references `Dependency` or `DependencyInventory`
(`git grep` empty), so the two changed structs reach no other compilation unit.

## Follow-ups, not in this PR

- **pnpm and yarn lockfiles stay unread.** `pnpm-lock.yaml` needs `serde_yaml`,
  which trusty-review does not depend on, and yarn v1 is not YAML at all.
  #6794 names neither.
- **A repo with `requirements.txt` and no `pyproject.toml` still declares zero
  dependencies.** `requirements.txt` is read here as a pin source only;
  `pypi_deps` keys off the manifest, so there is nothing for it to enrich.
- **These rows reach an engagement only after trusty-review 0.36.0 publishes.**
  trusty-audit consumes a pinned, published trusty-review, so the pin has to be
  bumped before a sweep sees the new fields.

Refs #6794

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
