### PR TITLE
feat(trusty-audit): operator override for any pinned tool binary

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -237,6 +237,37 @@ a Unix socket derived from the data directory (overridable with
 `TRUSTY_ANALYZE_SOCKET`, #6287), so whatever is serving that path is what
 answers.
 
+**Running a locally built tool (#6132).** Four variables replace a pinned binary
+for one run, one per tool:
+
+| Variable | Replaces |
+| --- | --- |
+| `TRUSTY_AUDIT_TGA_BIN` | the pinned `tga` |
+| `TRUSTY_AUDIT_SEARCH_BIN` | the pinned `trusty-search` |
+| `TRUSTY_AUDIT_ANALYZE_BIN` | the pinned `trusty-analyze` |
+| `TRUSTY_AUDIT_REVIEW_BIN` | the pinned `trusty-review` |
+
+Each takes an absolute path to an executable file. Precedence is the override,
+then the pin — and there is no third branch: a variable naming a path that does
+not exist, is relative, or is not executable **refuses the run** naming the
+variable, rather than quietly falling back to the pinned copy. An operator who
+believes they tested their build while the published one ran is worse off than
+one with no override at all.
+
+An overridden tool is also excused from install, which is the case this exists
+for: a version that is merged but not yet published cannot be downloaded at all,
+so demanding it would refuse the very run the override enables.
+
+The override is stamped into the `index.md` **Versions** table of both the sweep
+and the return package, in that tool's row, led by the word `OVERRIDDEN` and
+naming the variable and the path. No version is claimed for it — this client
+neither installed nor verified that binary — so an audit run driven by a local
+build can never be mistaken for a pinned one.
+
+These are not `TRUSTY_REVIEW_BIN` / `TRUSTY_SEARCH_BIN` / `TRUSTY_ANALYZE_BIN`,
+which are internal plumbing: the sweep SETS those on every child from the pinned
+paths, so a value you export is clobbered before any child reads it.
+
 **The code-analysis leg (#6081, #6082).** After each repository is audited, this
 client indexes its checkout in `trusty-search` and measures it with
 `trusty-analyze`, starting either daemon if it is not already answering, and

--- a/crates/trusty-audit/changelog.d/6132-pinned-tool-override.md
+++ b/crates/trusty-audit/changelog.d/6132-pinned-tool-override.md
@@ -1,0 +1,21 @@
+Added
+
+- An operator can now point the audit chain at a locally built binary for any of
+  the four pinned tools, with one documented variable each:
+  `TRUSTY_AUDIT_TGA_BIN`, `TRUSTY_AUDIT_SEARCH_BIN`, `TRUSTY_AUDIT_ANALYZE_BIN`
+  and `TRUSTY_AUDIT_REVIEW_BIN`. Each takes an absolute path to an executable
+  file; precedence is the override, then the pin, with no third branch. A
+  variable naming a path that does not exist, is relative, or is not executable
+  refuses the run naming the variable, rather than falling back to the pinned
+  copy. An overridden tool is also excused from install, which is the case this
+  exists for: a version that is merged but not yet published cannot be downloaded
+  at all, so a merged fix previously could not be exercised through the chain
+  without publishing it. The override is recorded in
+  `state/tool-overrides.toml` and stamped into that tool's row of the `index.md`
+  Versions table — led by `OVERRIDDEN`, naming the variable and the path, and
+  claiming no version — in both the sweep's index and the return package's, so a
+  run driven by a local build cannot be mistaken for a pinned one. New public
+  module `tool_overrides`, new `tools::RequiredTool::override_env` and
+  `tools::unsatisfied_with`, new `AuditError::ToolOverride` variant; the existing
+  `TRUSTY_REVIEW_BIN` / `TRUSTY_SEARCH_BIN` / `TRUSTY_ANALYZE_BIN` plumbing onto
+  sweep children is unchanged (issue #6132).

--- a/crates/trusty-audit/changelog.d/6789-secrets-report-dir-prefix.md
+++ b/crates/trusty-audit/changelog.d/6789-secrets-report-dir-prefix.md
@@ -1,0 +1,14 @@
+Fixed
+
+- The secrets collector now names each raw-report directory under a prefix
+  scoped to the scanning process AND thread — `trusty-audit-secrets-<pid>-<thread>-`
+  rather than one stem shared by every scanner. The private-directory test proves
+  nothing survives a scan by differencing the shared `std::env::temp_dir()`
+  listing around its own, and with one prefix for everybody that difference
+  picked up directories written by sibling tests whose sweeps scan for real, so
+  it failed intermittently under the parallel test harness. The `#[file_serial]`
+  lock added earlier could not close it: it excludes only a second copy of that
+  same test, and the collisions observed were sibling threads inside one test
+  binary, which also share a pid. Filtering the listing on the scanner's own
+  prefix makes the difference exact against any other scanner, in this process or
+  another (issue #6789).

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -384,6 +384,32 @@ pub enum AuditError {
         missing: Vec<&'static str>,
     },
 
+    /// An operator's tool override names a path that cannot be run.
+    ///
+    /// Why: #6132 gives an operator one documented way to point the chain at a
+    /// locally built binary, and the whole value of that is being able to trust
+    /// which binary ran. So a variable naming a path that cannot be executed
+    /// refuses the run rather than falling back to the pinned copy — an override
+    /// that quietly did not take is the #5454 skew class wearing the operator's
+    /// own intent, and it is worse than no override, because they believe they
+    /// tested their build.
+    /// What: names the variable, the path it carried, and what is wrong with
+    /// that path, so the operator knows which of the four to fix.
+    /// Test: `crate::tool_overrides::override_tests::an_override_naming_a_missing_path_is_refused`.
+    #[error(
+        "{variable} names {}, which {reason}; set it to an absolute path to an executable \
+         file, or unset it — it will not fall back to the pinned copy",
+        path.display()
+    )]
+    ToolOverride {
+        /// The environment variable the operator set.
+        variable: &'static str,
+        /// The path it carried.
+        path: PathBuf,
+        /// What is wrong with that path.
+        reason: &'static str,
+    },
+
     /// Listing the repositories a credential can reach failed.
     ///
     /// Why: #5487 routes discovery through `gh`, and every way that can fail —

--- a/crates/trusty-audit/src/grounding/secrets.rs
+++ b/crates/trusty-audit/src/grounding/secrets.rs
@@ -441,7 +441,7 @@ fn run_gitleaks(checkout: &Path) -> Result<Run, String> {
 /// descriptor, files created in it after the mode changed. So the report goes in
 /// a SUBDIRECTORY made by `mkdir(2)` with an explicit 0700 — a umask can only
 /// clear bits, so that one is private from birth and there is no window at all.
-/// What: a `TempDir` named [`REPORT_DIR_PREFIX`]`<random>` holding a 0700
+/// What: a `TempDir` named [`report_dir_prefix`]`<random>` holding a 0700
 /// [`REPORT_SUBDIR`]. The caller keeps it alive for exactly as long as it needs
 /// the report, and reads the path from [`report_path_in`].
 ///
@@ -459,7 +459,9 @@ fn private_report_dir() -> Result<TempDir, String> {
         )
     };
     let dir = tempfile::Builder::new()
-        .prefix(REPORT_DIR_PREFIX)
+        // #6789: per-process, per-thread prefix so the private-dir test's TMPDIR
+        // difference is exact under parallel scans
+        .prefix(&report_dir_prefix())
         .tempdir()
         .map_err(|e| refuse("directory", e))?;
 
@@ -480,8 +482,39 @@ fn report_path_in(dir: &TempDir) -> PathBuf {
     dir.path().join(REPORT_SUBDIR).join(REPORT_FILE)
 }
 
-/// Prefix of the private directory [`private_report_dir`] creates.
+/// Stem shared by every private directory [`private_report_dir`] creates.
 const REPORT_DIR_PREFIX: &str = "trusty-audit-secrets-";
+
+/// The prefix THIS scanner's report directories carry (#6789).
+///
+/// Why: every report directory lands in `std::env::temp_dir()`, one real path
+/// the whole host shares, and the private-directory test proves nothing survives
+/// a scan by differencing that listing around its own. With one prefix for
+/// everybody the difference caught other people's directories, and the test
+/// failed intermittently — `#[file_serial]` excludes only a second copy of that
+/// same test, never the other tests whose sweeps scan for real.
+///
+/// A pid alone does not fix it: the collisions observed were sibling THREADS in
+/// one test binary, which share a pid. So the thread is in the prefix too, and
+/// the difference a scanner takes over its own prefix cannot hold anyone else's
+/// directory — in this process or another.
+/// What: `trusty-audit-secrets-<pid>-<thread>-`, where `<thread>` is this
+/// thread's [`std::thread::ThreadId`] hashed to a value stable for as long as
+/// the thread lives. Hashed rather than printed because `ThreadId`'s only
+/// portable rendering is a `Debug` string with punctuation in it.
+/// Test: `secrets_tests::two_threads_get_different_report_dir_prefixes`,
+/// `secrets_tests::the_raw_report_lives_in_a_private_directory_and_does_not_outlive_the_run`.
+fn report_dir_prefix() -> String {
+    use std::hash::{Hash as _, Hasher as _};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::thread::current().id().hash(&mut hasher);
+    format!(
+        "{REPORT_DIR_PREFIX}{}-{:x}-",
+        std::process::id(),
+        hasher.finish()
+    )
+}
 
 /// The 0700 subdirectory the raw report actually lives in.
 const REPORT_SUBDIR: &str = "private";

--- a/crates/trusty-audit/src/grounding/secrets_tests.rs
+++ b/crates/trusty-audit/src/grounding/secrets_tests.rs
@@ -216,8 +216,9 @@ fn an_empty_report_parses_to_no_leaks() {
 #[cfg(unix)]
 #[test]
 // #6789: the sweep at the end reads `std::env::temp_dir()`, one real path every
-// process on the host shares, so a file lock is the only thing that can keep a
-// concurrent copy of THIS test out of the listing.
+// process on the host shares. `report_dir_prefix` is what narrows the listing to
+// this thread's own directories; the file lock stays because a second copy of
+// THIS test in another process runs the same assertions over the same TMPDIR.
 #[serial_test::file_serial(trusty_audit_secrets_report_dirs)]
 fn the_raw_report_lives_in_a_private_directory_and_does_not_outlive_the_run() {
     use std::os::unix::fs::PermissionsExt;
@@ -267,10 +268,16 @@ fn the_raw_report_lives_in_a_private_directory_and_does_not_outlive_the_run() {
     );
 }
 
-/// Every [`REPORT_DIR_PREFIX`] directory the shared temp directory holds right
+/// Every report directory THIS THREAD owns in the shared temp directory right
 /// now, as a set two readings can be differenced across (#6789).
+///
+/// Filtering on [`report_dir_prefix`] rather than the shared
+/// [`REPORT_DIR_PREFIX`] stem is what makes the difference exact: a sibling
+/// test whose sweep scans for real writes under its own prefix, so it cannot
+/// appear here however the two runs interleave.
 #[cfg(unix)]
 fn report_dirs_in_temp() -> BTreeSet<PathBuf> {
+    let mine = report_dir_prefix();
     std::fs::read_dir(std::env::temp_dir())
         .expect("read the temp dir")
         .filter_map(Result::ok)
@@ -279,9 +286,34 @@ fn report_dirs_in_temp() -> BTreeSet<PathBuf> {
             entry
                 .file_name()
                 .and_then(std::ffi::OsStr::to_str)
-                .is_some_and(|name| name.starts_with(REPORT_DIR_PREFIX))
+                .is_some_and(|name| name.starts_with(&mine))
         })
         .collect()
+}
+
+/// 🔴 #6789: two scanners must never name the same directory family, or the
+/// difference above is not a difference of one scanner's work.
+///
+/// Sibling THREADS share a pid, so this is the assertion a pid-only prefix
+/// fails — and sibling threads are what the observed flake actually was.
+#[test]
+fn two_threads_get_different_report_dir_prefixes() {
+    let mine = report_dir_prefix();
+    let theirs = std::thread::spawn(report_dir_prefix)
+        .join()
+        .expect("the sibling thread ran");
+
+    assert_ne!(
+        mine, theirs,
+        "two threads sharing a prefix put each other's directories in the other's difference set"
+    );
+    for prefix in [&mine, &theirs] {
+        assert!(prefix.starts_with(REPORT_DIR_PREFIX), "{prefix}");
+        assert!(
+            prefix.contains(&format!("{}-", std::process::id())),
+            "the prefix must still separate processes: {prefix}"
+        );
+    }
 }
 
 /// `Run` holds gitleaks' `Secret` and `Match` verbatim, so its `Debug` is

--- a/crates/trusty-audit/src/index_report.rs
+++ b/crates/trusty-audit/src/index_report.rs
@@ -812,18 +812,32 @@ fn human(d: Duration) -> String {
 /// Why: shared by the sweep's index and the return package's, which state the
 /// same fact from the same record — a second lookup would be a second place for
 /// "not recorded" to be worded differently.
+/// #6132: an override REPLACES the pin for a run, so an overridden tool's row
+/// states that instead of the version the install record still names. Without
+/// this the table would report the pinned version of a binary that did not run,
+/// which is the one reading of it nobody could catch.
+///
 /// What: one row per [`crate::tools::RequiredTool`], in that type's own order,
 /// so a tool missing from the record is a stated row rather than an absent one.
-/// The record is read fail-open: an unreadable one yields four stated gaps, not
+/// Both records are read fail-open: an unreadable one yields stated gaps, not
 /// a failed sweep.
 /// Test: `crate::run::run_tests::a_sweep_writes_an_index_beside_its_reports`,
+/// `crate::run::run_tests::an_overridden_tool_is_stamped_into_the_index`,
 /// `crate::package::package_tests::the_package_carries_an_index_of_its_reports`.
 pub fn recorded_tools(work: &crate::workdir::WorkDir) -> Vec<ToolVersion> {
     let recorded = crate::tools::read_record(work).unwrap_or_default();
+    let overrides = crate::tool_overrides::ToolOverrides::read(work).unwrap_or_default();
     crate::tools::RequiredTool::ALL
         .iter()
         .map(|tool| {
             let name = tool.crate_name();
+            // #6132: no version is claimed for an overridden tool. This client
+            // neither installed nor verified that binary, and inventing a
+            // version by asking the binary itself would state as fact something
+            // no record backs.
+            if let Some(why) = overrides.provenance_of(name) {
+                return ToolVersion::unknown(name, why);
+            }
             match recorded.iter().find(|t| t.crate_name == name) {
                 Some(installed) => {
                     ToolVersion::known(name, installed.version.clone(), "recorded at install")

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -25,6 +25,7 @@
 //! | [`config`] | the engagement config that ships TO the recipient — and the key it carries |
 //! | [`manifest`] | reading tga's `manifest.toml` rather than duplicating it |
 //! | [`tools`] | which pinned tools are needed, and the call that installs them |
+//! | [`tool_overrides`] | the operator's explicit replacement for a pinned binary (#6132) |
 //! | [`discover`] | which repositories the recipient's `gh` credential can reach (#5487) |
 //! | [`registry`] | the repositories and boards this engagement targets (#5822) |
 //! | [`validate`] | proving a target can be read, before it is registered (#5822) |
@@ -122,6 +123,10 @@ pub mod run;
 // the same binary and both were masked by the same update-availability notice.
 pub(crate) mod search_stderr;
 pub mod session;
+// #6132: the operator's one documented way to run the chain on a locally built
+// binary, kept beside `tools` rather than inside it — `tools` owns the pinned
+// set and its installation, this owns the explicit escape hatch from it.
+pub mod tool_overrides;
 pub mod tools;
 pub mod validate;
 pub mod workdir;

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -372,7 +372,18 @@ where
     // #6080: the sweep's own wall clock, for the index it writes at the end.
     let sweep_started = std::time::Instant::now();
     work.create()?;
-    let binaries = pinned_binaries(work, &config.tools)?;
+    // #6132: the operator's explicit overrides, resolved before anything is
+    // checked against a pin — this is the one thing that can replace a pinned
+    // binary, and a variable naming a path that cannot run refuses right here
+    // rather than as a spawn failure per repository.
+    let overrides = crate::tool_overrides::ToolOverrides::resolve(&operator)?;
+    let binaries = pinned_binaries(work, &config.tools, &overrides)?;
+    // #6132: written down before the first child, because the deliverable is
+    // read on a machine whose shell never exported these variables. This is what
+    // stops a run driven by a local binary reading as a pinned one — see
+    // `crate::index_report::recorded_tools`. Recording an EMPTY set deletes an
+    // earlier run's claim, so a clean pinned run never inherits one.
+    overrides.record(work)?;
     // Resolved once, before any child: a half-named selection is identical for
     // every repository, so failing per-repo would just repeat one misconfiguration.
     // #6135: both halves at once — the pairs the child inherits, and the
@@ -877,6 +888,7 @@ pub const PER_REPO_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 mod run_tests {
     use super::*;
     use crate::progress::{ProgressUpdate, Recorder, StageEvent, StageState};
+    use crate::tool_overrides::ToolOverrides;
     use crate::tools::{self, RequiredTool};
     // The selection document itself, so a test can write a torn one by hand.
     use crate::run::selection::Selection;
@@ -1545,14 +1557,26 @@ exit 0
         let work = work_in(tmp.path());
         let pins = config().tools;
 
+        // #6132: both sides read the same overrides, so the agreement asserted
+        // here is about the pins rather than about what a shell exported.
+        let none = ToolOverrides::default();
+
         // Unsatisfied and refused.
-        assert!(!tools::unsatisfied(&work, &pins).expect("reads").is_empty());
-        assert!(pinned_binaries(&work, &pins).is_err());
+        assert!(
+            !tools::unsatisfied_with(&work, &pins, &none)
+                .expect("reads")
+                .is_empty()
+        );
+        assert!(pinned_binaries(&work, &pins, &none).is_err());
 
         // Satisfied and accepted.
         install_stubs(&work, "#!/bin/sh\nexit 0\n");
-        assert!(tools::unsatisfied(&work, &pins).expect("reads").is_empty());
-        assert!(pinned_binaries(&work, &pins).is_ok());
+        assert!(
+            tools::unsatisfied_with(&work, &pins, &none)
+                .expect("reads")
+                .is_empty()
+        );
+        assert!(pinned_binaries(&work, &pins, &none).is_ok());
     }
 
     /// A binary this client did not install and verify is not a usable binary.
@@ -1563,7 +1587,7 @@ exit 0
         for tool in RequiredTool::ALL {
             std::fs::write(tool.path_in(&work), b"stub").expect("stub");
         }
-        let err = pinned_binaries(&work, &config().tools)
+        let err = pinned_binaries(&work, &config().tools, &ToolOverrides::default())
             .expect_err("no version record means unverified");
         let AuditError::ToolsNotInstalled { missing } = err else {
             panic!("expected ToolsNotInstalled, got {err:?}");
@@ -1585,7 +1609,8 @@ exit 0
         )
         .expect("parses");
 
-        let err = pinned_binaries(&work, &bumped.tools).expect_err("2.9.4 is not 2.10.0");
+        let err = pinned_binaries(&work, &bumped.tools, &ToolOverrides::default())
+            .expect_err("2.9.4 is not 2.10.0");
         let AuditError::VersionMismatch {
             tool,
             pinned,
@@ -1598,6 +1623,171 @@ exit 0
             (tool, pinned.as_str(), installed.as_str()),
             ("tga", "2.10.0", "2.9.4")
         );
+    }
+
+    /// A stub `tga` that names ITSELF in the output, so a test can prove which
+    /// binary ran rather than that one did (#6132).
+    fn writes_a_manifest_naming(marker: &str) -> String {
+        let mut script = writes_a_manifest(None)
+            .trim_end_matches("exit 0\n")
+            .to_owned();
+        script.push_str(&format!(
+            "echo \"{marker}\" > \"$out/which-tga.txt\"\nexit 0\n"
+        ));
+        script
+    }
+
+    /// Write `script` at `path` and make it runnable.
+    fn write_executable(path: &Path, script: &str) {
+        std::fs::write(path, script).expect("write stub");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        }
+    }
+
+    /// The three tools this client installed, and no tga at all — the state of
+    /// an engagement whose tga pin is merged but not yet published (#6132).
+    fn install_stubs_without_tga(work: &WorkDir) {
+        install_stubs(work, SEARCH_APPROVES);
+        std::fs::remove_file(RequiredTool::Tga.path_in(work)).expect("remove the pinned tga");
+        let record = format!(
+            "[[tools]]\ncrate_name = \"trusty-search\"\nversion = \"0.47.0\"\nbinary = \"{s}\"\n\
+             [[tools]]\ncrate_name = \"trusty-analyze\"\nversion = \"0.9.2\"\nbinary = \"{a}\"\n\
+             [[tools]]\ncrate_name = \"trusty-review\"\nversion = \"0.15.1\"\nbinary = \"{r}\"\n",
+            s = RequiredTool::TrustySearch.path_in(work).display(),
+            a = RequiredTool::TrustyAnalyze.path_in(work).display(),
+            r = RequiredTool::TrustyReview.path_in(work).display(),
+        );
+        std::fs::write(tools::record_path(work), record).expect("write record");
+    }
+
+    /// An environment naming `path` as the tga override, and nothing else.
+    fn tga_override(path: &Path) -> impl Fn(&str) -> Option<String> + use<'_> {
+        let value = path.display().to_string();
+        move |name: &str| (name == RequiredTool::Tga.override_env()).then(|| value.clone())
+    }
+
+    /// 🔴 #6132: the whole feature. An operator points `TRUSTY_AUDIT_TGA_BIN` at
+    /// a locally built binary and the sweep runs THAT — with no tga in `tools/`
+    /// and no install record naming one, which is the state of a pin that is
+    /// merged but unpublished. The #6131 verification ran published tga 3.2.0
+    /// while 3.3.0 sat merged, because there was nowhere to say this.
+    ///
+    /// Against `origin/main` this fails at the `pinned_binaries` preflight:
+    /// nothing could replace a pin, so a tga the client had not installed
+    /// refused the run with `ToolsNotInstalled`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_override_replaces_a_pin_the_client_never_installed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs_without_tga(&work);
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let local = tmp.path().join("locally-built-tga");
+        write_executable(&local, &writes_a_manifest_naming("built-from-source"));
+
+        let report = sweep_with_operator(&work, tga_override(&local))
+            .await
+            .expect("the override supplies what the pin cannot");
+        assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
+        assert_eq!(
+            std::fs::read_to_string(report.repos[0].output.join("which-tga.txt"))
+                .expect("the local binary ran")
+                .trim(),
+            "built-from-source"
+        );
+    }
+
+    /// 🔴 #6132: an audit run driven by a local binary must never read as a
+    /// pinned one. The index's Versions table is where a reader looks, so the
+    /// override is stamped into that tool's row — and the three tools nobody
+    /// overrode still state the versions this client installed and verified.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_overridden_tool_is_stamped_into_the_index() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs_without_tga(&work);
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let local = tmp.path().join("locally-built-tga");
+        write_executable(&local, &writes_a_manifest_naming("built-from-source"));
+
+        sweep_with_operator(&work, tga_override(&local))
+            .await
+            .expect("the sweep completes");
+
+        let index = index_of(&work);
+        assert!(index.contains(crate::tool_overrides::MARKER), "{index}");
+        assert!(index.contains("TRUSTY_AUDIT_TGA_BIN"), "{index}");
+        assert!(index.contains(&local.display().to_string()), "{index}");
+        assert!(index.contains("| `trusty-review` | 0.15.1 |"), "{index}");
+    }
+
+    /// 🔴 #6132: no silent fallback. A variable naming a path that cannot be run
+    /// refuses the sweep, even though the pinned copy is right there and would
+    /// have worked — an operator who believes they tested their build while the
+    /// published one ran is worse off than one with no override at all.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_override_naming_nothing_refuses_rather_than_using_the_pin() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest_naming("the-pinned-copy"));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let absent = tmp.path().join("never-built-tga");
+        let err = sweep_with_operator(&work, tga_override(&absent))
+            .await
+            .expect_err("an override that cannot run must not fall back");
+        let AuditError::ToolOverride {
+            variable, reason, ..
+        } = err
+        else {
+            panic!("expected ToolOverride, got {err:?}");
+        };
+        assert_eq!(variable, "TRUSTY_AUDIT_TGA_BIN");
+        assert_eq!(reason, "does not exist");
+        assert!(
+            !work
+                .path(Area::Output)
+                .join(crate::index_report::INDEX_FILE)
+                .exists(),
+            "the refusal must land before any child runs"
+        );
+    }
+
+    /// 🔴 #6132: a run that overrides nothing must not inherit an earlier run's
+    /// confession — a stale record would have every later report claiming a
+    /// local binary that no longer runs.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_later_pinned_run_clears_an_earlier_override() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_stubs(&work, &writes_a_manifest_naming("the-pinned-copy"));
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+
+        let local = tmp.path().join("locally-built-tga");
+        write_executable(&local, &writes_a_manifest_naming("built-from-source"));
+        sweep_with_operator(&work, tga_override(&local))
+            .await
+            .expect("the overridden sweep completes");
+        assert!(index_of(&work).contains(crate::tool_overrides::MARKER));
+
+        sweep_with_operator(&work, |_| None)
+            .await
+            .expect("the pinned sweep completes");
+        let index = index_of(&work);
+        assert!(!index.contains(crate::tool_overrides::MARKER), "{index}");
+        assert!(index.contains("| `tga` | 2.9.4 |"), "{index}");
     }
 
     #[test]
@@ -2655,6 +2845,10 @@ exit 0
     /// none of the four onto the child, so nothing of ours can contradict
     /// theirs. The injected lookup reports all four set without exporting them,
     /// so an emitted default would show up here as a non-empty value.
+    ///
+    /// #6132: the lookup answers for those four BY NAME rather than for
+    /// everything. A blanket answer now also claims `TRUSTY_AUDIT_TGA_BIN` is
+    /// set to `operator`, which the override resolution correctly refuses.
     #[cfg(unix)]
     #[tokio::test]
     async fn a_fully_set_operator_environment_is_left_alone() {
@@ -2662,9 +2856,17 @@ exit 0
         let work = work_in(tmp.path());
         one_repo_ready(&work);
 
-        let report = sweep_with_operator(&work, |_| Some("operator".to_owned()))
-            .await
-            .expect("a whole operator selection resolves");
+        let selection = [
+            inference::ENV_PROVIDER,
+            inference::ENV_REVIEWER_MODEL,
+            inference::ENV_VERIFIER_MODEL,
+            inference::ENV_SUMMARIZER_MODEL,
+        ];
+        let report = sweep_with_operator(&work, |name| {
+            selection.contains(&name).then(|| "operator".to_owned())
+        })
+        .await
+        .expect("a whole operator selection resolves");
         assert_eq!(report.status, RunStatus::AllSucceeded, "{report:?}");
 
         let dumped = child_env(&report);

--- a/crates/trusty-audit/src/run/pins.rs
+++ b/crates/trusty-audit/src/run/pins.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 
 use crate::config::ToolPins;
 use crate::error::AuditError;
+use crate::tool_overrides::ToolOverrides;
 use crate::tools::{self, RequiredTool};
 use crate::workdir::WorkDir;
 
@@ -46,25 +47,39 @@ pub(super) struct PinnedBinaries {
 /// hand reads as `installed` with no version — unverified is not a weaker kind
 /// of installed. The third matters because install and run are separate steps,
 /// so the config can change between them.
-/// What: reads [`tools::status`], checks all three conditions, and returns the
-/// paths by name.
+/// #6132 adds ONE branch ahead of those three, and only one: an explicit
+/// operator override REPLACES the pin for that tool. It is not a fallback —
+/// [`ToolOverrides::resolve`] has already proven the path executable and refused
+/// the run if it could not, so nothing here can silently return to the pin. A
+/// tool nobody overrode is unaffected, which is every tool on an ordinary run.
+///
+/// What: reads [`tools::status`], applies the override where there is one,
+/// checks all three conditions where there is not, and returns the paths by
+/// name.
 /// Test: `crate::run::run_tests::a_run_without_the_pinned_tools_is_refused`,
 /// `crate::run::run_tests::an_unverified_binary_does_not_count_as_installed`,
-/// `crate::run::run_tests::a_binary_installed_at_a_different_pin_is_refused`.
+/// `crate::run::run_tests::a_binary_installed_at_a_different_pin_is_refused`,
+/// `crate::run::run_tests::an_override_replaces_a_pin_the_client_never_installed`.
 ///
 /// # Errors
 ///
-/// [`AuditError::ToolsNotInstalled`] naming every tool that is missing or
-/// unverified, [`AuditError::VersionMismatch`] for the first tool whose recorded
-/// version is not the engagement's pin, and whatever [`tools::status`] fails
-/// with.
+/// [`AuditError::ToolsNotInstalled`] naming every non-overridden tool that is
+/// missing or unverified, [`AuditError::VersionMismatch`] for the first such
+/// tool whose recorded version is not the engagement's pin, and whatever
+/// [`tools::status`] fails with.
 pub(super) fn pinned_binaries(
     work: &WorkDir,
     pins: &ToolPins,
+    overrides: &ToolOverrides,
 ) -> Result<PinnedBinaries, AuditError> {
     let statuses = tools::status(work)?;
     let missing: Vec<&'static str> = statuses
         .iter()
+        // #6132: an overridden tool is not required to be installed at all. The
+        // case this exists for is a pin that cannot be downloaded because it is
+        // merged and unpublished, so demanding the install would refuse the run
+        // the override enables.
+        .filter(|s| overrides.path_of(s.tool).is_none())
         .filter(|s| !s.installed || s.version.is_none())
         .map(|s| s.tool.binary_name())
         .collect();
@@ -73,6 +88,10 @@ pub(super) fn pinned_binaries(
     }
 
     let path_of = |tool: RequiredTool| -> Result<PathBuf, AuditError> {
+        // #6132: explicit override, then the pin. There is no third branch.
+        if let Some(local) = overrides.path_of(tool) {
+            return Ok(local.to_path_buf());
+        }
         let pinned = tool.pin_in(pins).version();
         let status = statuses.iter().find(|s| s.tool == tool).ok_or_else(|| {
             AuditError::ToolsNotInstalled {

--- a/crates/trusty-audit/src/tool_overrides.rs
+++ b/crates/trusty-audit/src/tool_overrides.rs
@@ -1,0 +1,455 @@
+//! The one documented way to run the chain on a locally built binary (#6132).
+//!
+//! Why: every tool this client drives is resolved from the working directory's
+//! own `tools/` area, at the version `engagement.toml` pins and the version
+//! record vouches for. That is the whole point of [`crate::tools`], and it is
+//! also why a merged-but-unpublished fix could not be exercised through the
+//! chain at all — the #6131 verification ran published tga 3.2.0 while 3.3.0 sat
+//! merged, because there was nowhere to say "use this build instead".
+//!
+//! `TRUSTY_REVIEW_BIN` / `TRUSTY_SEARCH_BIN` / `TRUSTY_ANALYZE_BIN` looked like
+//! that override and are not: `crate::run`'s child spawn SETS them from the pinned
+//! paths on every child, so an inherited value is clobbered before any child
+//! reads it. They are internal plumbing between this process and its children.
+//!
+//! What: four `TRUSTY_AUDIT_*_BIN` variables, one per [`RequiredTool`], each
+//! naming an absolute path to an executable file. Precedence is explicit
+//! override, then the pinned copy — and only those two. There is no third
+//! branch: a variable naming a path that cannot run REFUSES the run rather than
+//! falling back to the pin, because an override that quietly did not take is the
+//! #5454 version-skew class wearing the operator's own intent.
+//!
+//! An override also excuses its tool from install ([`crate::tools::unsatisfied`])
+//! — an unpublished pin is exactly the case this exists for, and demanding a
+//! download of the version being replaced would refuse the run it enables.
+//!
+//! ## Provenance is not optional
+//!
+//! A run driven by a local binary must never read as a pinned one. [`ToolOverrides::record`]
+//! writes what this run resolved into `state/`[`RECORD_FILE`], and
+//! [`crate::index_report::recorded_tools`] stamps [`MARKER`] into that tool's row
+//! of every `index.md` Versions table — the sweep's and the return package's.
+//!
+//! Test: `override_tests`.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AuditError;
+use crate::tools::RequiredTool;
+use crate::workdir::{Area, WorkDir};
+
+/// The word an overridden tool's provenance is stamped with, everywhere.
+///
+/// Why: a reader skimming a Versions table needs one token that cannot be
+/// mistaken for a version, and a test needs one string to assert on rather than
+/// a sentence that may be reworded.
+pub const MARKER: &str = "OVERRIDDEN";
+
+/// File under `state/` recording the overrides a run resolved.
+pub const RECORD_FILE: &str = "tool-overrides.toml";
+
+/// One tool an operator pointed somewhere other than the pinned copy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ToolOverride {
+    /// The crate whose pinned binary was replaced.
+    pub crate_name: String,
+    /// The environment variable that replaced it.
+    pub variable: String,
+    /// The binary that ran instead.
+    pub binary: PathBuf,
+}
+
+/// The `state/tool-overrides.toml` document.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct OverrideRecord {
+    #[serde(default)]
+    overrides: Vec<ToolOverride>,
+}
+
+/// Every override in force, each proven runnable before it was accepted.
+///
+/// Why: resolved ONCE per invocation and handed down, the same shape the
+/// inference selection and the investigation budget have (`crate::run`). A
+/// second read could disagree with the first, and the thing that would disagree
+/// is which binary produced the report.
+/// What: zero to four entries, in [`RequiredTool::ALL`] order. Empty is the
+/// ordinary case and means every tool comes from its pin.
+/// Test: `override_tests::an_unset_environment_overrides_nothing`,
+/// `override_tests::an_executable_override_is_resolved`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolOverrides {
+    entries: Vec<ToolOverride>,
+}
+
+impl ToolOverrides {
+    /// Resolve every override the given environment declares, or refuse.
+    ///
+    /// Why: takes the lookup rather than reading the process environment, so
+    /// every rule below is provable without `std::env::set_var` — `unsafe` in
+    /// edition 2024 and racy in a parallel test binary. Same shape as
+    /// `crate::run::sweep_with_env`.
+    ///
+    /// # Postconditions
+    /// On `Ok`, every entry's `binary` is an absolute path to an executable
+    /// file that existed when this ran. On `Err`, no override is in force and
+    /// the caller must not run: there is no partial acceptance, because a set
+    /// where one variable took and another did not is the state an operator
+    /// cannot reason about.
+    ///
+    /// What: one pass over [`RequiredTool::ALL`], reading each tool's
+    /// [`RequiredTool::override_env`]. An unset or empty value is not an
+    /// override; anything else must pass [`validated`].
+    /// Test: `override_tests::an_unset_environment_overrides_nothing`,
+    /// `override_tests::an_executable_override_is_resolved`,
+    /// `override_tests::an_override_naming_a_missing_path_is_refused`.
+    ///
+    /// # Errors
+    ///
+    /// [`AuditError::ToolOverride`] naming the first variable whose path cannot
+    /// be run.
+    pub fn resolve<F>(lookup: F) -> Result<Self, AuditError>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let mut entries = Vec::new();
+        for tool in RequiredTool::ALL {
+            let variable = tool.override_env();
+            // Empty is unset: an exported-but-blank variable is far more often a
+            // shell accident than a deliberate path, and the rule matches
+            // `grounding::daemons::socket_from_override`.
+            let Some(value) = lookup(variable).filter(|v| !v.is_empty()) else {
+                continue;
+            };
+            entries.push(ToolOverride {
+                crate_name: tool.crate_name().to_owned(),
+                variable: variable.to_owned(),
+                binary: validated(variable, PathBuf::from(value))?,
+            });
+        }
+        Ok(Self { entries })
+    }
+
+    /// [`Self::resolve`], against this process's own environment.
+    ///
+    /// # Errors
+    ///
+    /// Exactly [`Self::resolve`]'s.
+    pub fn from_environment() -> Result<Self, AuditError> {
+        Self::resolve(|name| std::env::var(name).ok())
+    }
+
+    /// The binary this run uses for `tool`, or `None` when its pin stands.
+    #[must_use]
+    pub fn path_of(&self, tool: RequiredTool) -> Option<&Path> {
+        self.entries
+            .iter()
+            .find(|e| e.crate_name == tool.crate_name())
+            .map(|e| e.binary.as_path())
+    }
+
+    /// What a report says in place of a version for this crate, if it is overridden.
+    ///
+    /// Why: the source string is built HERE rather than at each index producer,
+    /// so the sweep's table and the return package's cannot word the same fact
+    /// differently — the reason [`crate::index_report::recorded_tools`] exists
+    /// at all.
+    /// What: `None` for a tool running from its pin. Otherwise a line leading
+    /// with [`MARKER`] and naming both the variable and the path.
+    /// Test: `override_tests::an_overridden_tool_states_its_provenance`.
+    #[must_use]
+    pub fn provenance_of(&self, crate_name: &str) -> Option<String> {
+        self.entries
+            .iter()
+            .find(|e| e.crate_name == crate_name)
+            .map(|e| {
+                format!(
+                    "{MARKER} — {} named {}, a local binary this client did not install or verify",
+                    e.variable,
+                    e.binary.display()
+                )
+            })
+    }
+
+    /// Whether nothing is overridden, i.e. every tool runs from its pin.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Read what the last run recorded, or nothing when it recorded none.
+    ///
+    /// # Errors
+    ///
+    /// [`AuditError::Read`] when the file exists but cannot be read, and
+    /// [`AuditError::Parse`] when it is not a valid record. A malformed record
+    /// is an error rather than a shrug, for [`crate::tools::read_record`]'s
+    /// reason: it would otherwise read as "nothing was overridden", which is the
+    /// state a tampered-with record wants to look like.
+    pub fn read(work: &WorkDir) -> Result<Self, AuditError> {
+        let path = record_path(work);
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(source) => return Err(AuditError::Read { path, source }),
+        };
+        let record: OverrideRecord = toml::from_str(&text).map_err(|source| AuditError::Parse {
+            path,
+            what: "tool override record",
+            source: Box::new(source),
+        })?;
+        Ok(Self {
+            entries: record.overrides,
+        })
+    }
+
+    /// Record what this run resolved, so its reports can state it.
+    ///
+    /// Why: the deliverable is read on a different machine, in a different
+    /// process, from a shell that never exported these variables. A report that
+    /// asked the environment at render time would describe THAT shell rather
+    /// than the run — so the fact is written down where every index producer
+    /// already reads its tool versions from.
+    /// What: overwrites `state/`[`RECORD_FILE`] with the whole set, and DELETES
+    /// it when nothing is overridden — a stale file would have a clean pinned
+    /// run confessing to an override it did not use.
+    /// Test: `override_tests::a_recorded_set_round_trips`,
+    /// `override_tests::recording_nothing_clears_an_earlier_claim`.
+    ///
+    /// # Errors
+    ///
+    /// [`AuditError::WorkDir`] when the record cannot be written or removed.
+    pub fn record(&self, work: &WorkDir) -> Result<(), AuditError> {
+        let path = record_path(work);
+        if self.entries.is_empty() {
+            return match std::fs::remove_file(&path) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(source) => Err(AuditError::WorkDir { path, source }),
+            };
+        }
+        let record = OverrideRecord {
+            overrides: self.entries.clone(),
+        };
+        // Infallible in practice: owned strings and paths, no map keys.
+        let text = toml::to_string_pretty(&record).map_err(|e| AuditError::WorkDir {
+            path: path.clone(),
+            source: std::io::Error::other(e),
+        })?;
+        std::fs::write(&path, text).map_err(|source| AuditError::WorkDir { path, source })
+    }
+}
+
+/// Where the override record lives.
+#[must_use]
+pub fn record_path(work: &WorkDir) -> PathBuf {
+    work.path(Area::State).join(RECORD_FILE)
+}
+
+/// Prove a path can actually be run, or say exactly what is wrong with it.
+///
+/// Why: fail closed. Every reason below would otherwise surface hours later as
+/// a child that could not be started, or — worse — as a silent fall back to the
+/// pin, which is the one outcome this feature must never produce.
+///
+/// Absoluteness is checked because `crate::run`'s child spawn runs the
+/// child with `current_dir` set to the repository checkout, so a relative path
+/// would resolve against a directory the operator never typed it in.
+///
+/// What: absolute, present, a regular file, and — on unix — carrying an execute
+/// bit. Each failure names the variable so the operator knows which of the four
+/// to fix.
+/// Test: `override_tests::an_override_naming_a_missing_path_is_refused`,
+/// `override_tests::a_relative_override_is_refused`,
+/// `override_tests::a_non_executable_override_is_refused`.
+///
+/// # Errors
+///
+/// [`AuditError::ToolOverride`] naming `variable`, the path, and the reason.
+fn validated(variable: &'static str, path: PathBuf) -> Result<PathBuf, AuditError> {
+    let refuse = |reason: &'static str| AuditError::ToolOverride {
+        variable,
+        path: path.clone(),
+        reason,
+    };
+    if !path.is_absolute() {
+        return Err(refuse("is not an absolute path"));
+    }
+    let meta = match std::fs::metadata(&path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(refuse("does not exist")),
+        Err(_) => return Err(refuse("cannot be read")),
+    };
+    if !meta.is_file() {
+        return Err(refuse("is not a regular file"));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if meta.permissions().mode() & 0o111 == 0 {
+            return Err(refuse("is not executable"));
+        }
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod override_tests {
+    use super::*;
+
+    /// An environment that names one override for `tool`, and nothing else.
+    fn only(tool: RequiredTool, value: &str) -> impl Fn(&str) -> Option<String> + use<'_> {
+        let wanted = tool.override_env();
+        move |name: &str| (name == wanted).then(|| value.to_owned())
+    }
+
+    /// An executable stub at `path`, so `validated` has something to accept.
+    fn executable(path: &Path) {
+        std::fs::write(path, b"#!/bin/sh\nexit 0\n").expect("write stub");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        }
+    }
+
+    /// The ordinary case: nothing exported, so every tool runs from its pin.
+    #[test]
+    fn an_unset_environment_overrides_nothing() {
+        let resolved = ToolOverrides::resolve(|_| None).expect("nothing to refuse");
+        assert!(resolved.is_empty());
+        assert_eq!(resolved.path_of(RequiredTool::Tga), None);
+        // An exported-but-blank variable is the same as unset, not a refusal.
+        let blank = ToolOverrides::resolve(|_| Some(String::new())).expect("blank is unset");
+        assert!(blank.is_empty());
+    }
+
+    /// #6132: the feature itself — a locally built binary the chain will run.
+    #[cfg(unix)]
+    #[test]
+    fn an_executable_override_is_resolved() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let local = tmp.path().join("tga");
+        executable(&local);
+
+        let resolved =
+            ToolOverrides::resolve(only(RequiredTool::Tga, &local.display().to_string()))
+                .expect("an executable file is accepted");
+        assert_eq!(resolved.path_of(RequiredTool::Tga), Some(local.as_path()));
+        // Only the tool that was named: the other three still come from the pin.
+        assert_eq!(resolved.path_of(RequiredTool::TrustyReview), None);
+    }
+
+    /// 🔴 The fail-closed rule. A variable naming nothing must refuse the run,
+    /// never fall back to the pinned copy — a run the operator believes is
+    /// testing their build while it tests the published one is worse than no
+    /// override at all.
+    #[test]
+    fn an_override_naming_a_missing_path_is_refused() {
+        let err = ToolOverrides::resolve(only(RequiredTool::TrustyReview, "/nonexistent/tr"))
+            .expect_err("a missing path cannot be run");
+        let AuditError::ToolOverride {
+            variable, reason, ..
+        } = err
+        else {
+            panic!("expected ToolOverride, got {err:?}");
+        };
+        assert_eq!(variable, "TRUSTY_AUDIT_REVIEW_BIN");
+        assert_eq!(reason, "does not exist");
+    }
+
+    /// The child runs with `current_dir` set to a checkout, so a relative path
+    /// would resolve somewhere the operator never typed it.
+    #[test]
+    fn a_relative_override_is_refused() {
+        let err = ToolOverrides::resolve(only(RequiredTool::TrustySearch, "target/debug/ts"))
+            .expect_err("a relative path cannot be trusted");
+        let AuditError::ToolOverride {
+            variable, reason, ..
+        } = err
+        else {
+            panic!("expected ToolOverride, got {err:?}");
+        };
+        assert_eq!(variable, "TRUSTY_AUDIT_SEARCH_BIN");
+        assert_eq!(reason, "is not an absolute path");
+    }
+
+    /// A path that exists but cannot be executed fails HERE, not as an
+    /// unexplained spawn failure per repository an hour later.
+    #[cfg(unix)]
+    #[test]
+    fn a_non_executable_override_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let plain = tmp.path().join("trusty-analyze");
+        std::fs::write(&plain, b"not a program").expect("write");
+
+        let err = ToolOverrides::resolve(only(
+            RequiredTool::TrustyAnalyze,
+            &plain.display().to_string(),
+        ))
+        .expect_err("a non-executable file cannot be run");
+        let AuditError::ToolOverride { reason, .. } = err else {
+            panic!("expected ToolOverride, got {err:?}");
+        };
+        assert_eq!(reason, "is not executable");
+    }
+
+    /// The provenance a report states, and the marker it can be found by.
+    #[cfg(unix)]
+    #[test]
+    fn an_overridden_tool_states_its_provenance() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let local = tmp.path().join("tga");
+        executable(&local);
+
+        let resolved =
+            ToolOverrides::resolve(only(RequiredTool::Tga, &local.display().to_string()))
+                .expect("resolves");
+        let stated = resolved.provenance_of("tga").expect("tga is overridden");
+        assert!(stated.starts_with(MARKER), "{stated}");
+        assert!(stated.contains("TRUSTY_AUDIT_TGA_BIN"), "{stated}");
+        assert!(stated.contains(&local.display().to_string()), "{stated}");
+        assert_eq!(resolved.provenance_of("trusty-review"), None);
+    }
+
+    /// The record is read on a machine that never exported the variable, so it
+    /// must carry everything a report needs to state.
+    #[cfg(unix)]
+    #[test]
+    fn a_recorded_set_round_trips() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = WorkDir::new(tmp.path().join("work"));
+        work.create().expect("create");
+        let local = tmp.path().join("tga");
+        executable(&local);
+
+        let resolved =
+            ToolOverrides::resolve(only(RequiredTool::Tga, &local.display().to_string()))
+                .expect("resolves");
+        resolved.record(&work).expect("records");
+
+        assert_eq!(ToolOverrides::read(&work).expect("reads back"), resolved);
+    }
+
+    /// 🔴 A clean pinned run must not inherit an earlier run's confession.
+    #[cfg(unix)]
+    #[test]
+    fn recording_nothing_clears_an_earlier_claim() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = WorkDir::new(tmp.path().join("work"));
+        work.create().expect("create");
+        let local = tmp.path().join("tga");
+        executable(&local);
+
+        ToolOverrides::resolve(only(RequiredTool::Tga, &local.display().to_string()))
+            .expect("resolves")
+            .record(&work)
+            .expect("records");
+        ToolOverrides::default().record(&work).expect("clears");
+
+        assert!(!record_path(&work).exists());
+        assert!(ToolOverrides::read(&work).expect("reads").is_empty());
+    }
+}

--- a/crates/trusty-audit/src/tools.rs
+++ b/crates/trusty-audit/src/tools.rs
@@ -52,6 +52,7 @@ use trusty_installer::download::pinned::{PinnedInstall, PinnedTool};
 use crate::config::{ToolPin, ToolPins};
 use crate::error::AuditError;
 use crate::progress::{Operation, Progress, UnitOutcome};
+use crate::tool_overrides::ToolOverrides;
 use crate::workdir::{Area, WorkDir};
 
 /// File under `state/` recording the exact versions that were installed.
@@ -112,6 +113,27 @@ impl RequiredTool {
     /// Where this tool's binary belongs under the working directory.
     pub fn path_in(self, work: &WorkDir) -> PathBuf {
         work.path(Area::Tools).join(self.binary_name())
+    }
+
+    /// The variable an operator names a locally built binary with (#6132).
+    ///
+    /// Why: an exhaustive match, for [`Self::pin_in`]'s reason — a fifth tool
+    /// must fail to compile here rather than resolve to "no override" at
+    /// runtime, which is how a tool silently loses its escape hatch.
+    ///
+    /// These are NOT `TRUSTY_SEARCH_BIN` and friends. Those are internal
+    /// plumbing that `crate::run::child` sets from the pinned paths on every
+    /// child, clobbering whatever the operator exported; see
+    /// [`crate::tool_overrides`] for the distinction and the precedence rule.
+    /// What: `TRUSTY_AUDIT_<TOOL>_BIN`, one per tool.
+    /// Test: `crate::tool_overrides::override_tests::an_override_naming_a_missing_path_is_refused`.
+    pub fn override_env(self) -> &'static str {
+        match self {
+            RequiredTool::Tga => "TRUSTY_AUDIT_TGA_BIN",
+            RequiredTool::TrustySearch => "TRUSTY_AUDIT_SEARCH_BIN",
+            RequiredTool::TrustyAnalyze => "TRUSTY_AUDIT_ANALYZE_BIN",
+            RequiredTool::TrustyReview => "TRUSTY_AUDIT_REVIEW_BIN",
+        }
     }
 
     /// This tool's pin, from the engagement config.
@@ -441,10 +463,39 @@ pub async fn install(
 ///
 /// # Errors
 ///
-/// Whatever [`status`] fails with — an unreadable or malformed version record.
+/// Whatever [`status`] fails with — an unreadable or malformed version record —
+/// plus [`AuditError::ToolOverride`] when this environment declares an override
+/// that cannot be run.
 pub fn unsatisfied(work: &WorkDir, pins: &ToolPins) -> Result<Vec<RequiredTool>, AuditError> {
+    unsatisfied_with(work, pins, &ToolOverrides::from_environment()?)
+}
+
+/// [`unsatisfied`], with the operator's overrides as an argument.
+///
+/// Why: #6132. An overridden tool is satisfied by definition — the operator has
+/// named the binary that will run, and this client will neither download nor
+/// check a pin for it. Demanding the download anyway would refuse the exact case
+/// the override exists for: a pin that is merged but not published, so
+/// `install_pinned_set` cannot resolve it at all.
+///
+/// Taking the set as an argument rather than reading the process environment is
+/// what lets `crate::run::run_tests::nothing_unsatisfied_is_exactly_what_the_preflight_accepts`
+/// keep asserting that this predicate and `pinned_binaries` agree, against the
+/// same overrides both are given.
+/// What: [`unsatisfied`]'s three conditions, over the tools no override covers.
+/// Test: `super::tool_tests::an_overridden_tool_needs_no_install`.
+///
+/// # Errors
+///
+/// Whatever [`status`] fails with.
+pub fn unsatisfied_with(
+    work: &WorkDir,
+    pins: &ToolPins,
+    overrides: &ToolOverrides,
+) -> Result<Vec<RequiredTool>, AuditError> {
     Ok(status(work)?
         .into_iter()
+        .filter(|s| overrides.path_of(s.tool).is_none())
         .filter(|s| {
             let pinned = s.tool.pin_in(pins).version();
             !(s.installed && s.version.as_deref() == Some(pinned))
@@ -1039,6 +1090,35 @@ trusty-review = "0.0.0-never-published"
             unsatisfied(&work, &pins).expect("reads").is_empty(),
             "a set installed at the pin needs nothing"
         );
+    }
+
+    /// 🔴 #6132: an overridden tool is satisfied by definition. The case the
+    /// override exists for is a pin that is merged but unpublished, so a
+    /// predicate that still demanded the download would send `install` at a
+    /// version `install_pinned_set` cannot resolve — refusing the exact run the
+    /// override enables.
+    #[cfg(unix)]
+    #[test]
+    fn an_overridden_tool_needs_no_install() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let local = tmp.path().join("locally-built-tga");
+        std::fs::write(&local, b"#!/bin/sh\nexit 0\n").expect("write stub");
+        std::fs::set_permissions(&local, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+        let value = local.display().to_string();
+        let overrides = ToolOverrides::resolve(|name| {
+            (name == RequiredTool::Tga.override_env()).then(|| value.clone())
+        })
+        .expect("the stub is executable");
+
+        let pending = unsatisfied_with(&work, &pins(), &overrides).expect("reads");
+        assert!(!pending.contains(&RequiredTool::Tga), "{pending:?}");
+        // The three nobody overrode are still unsatisfied: nothing here widened
+        // the escape hatch beyond the tool it was asked for.
+        assert_eq!(pending.len(), RequiredTool::ALL.len() - 1, "{pending:?}");
     }
 
     /// The `UNVERIFIED` state: a binary is there, nothing recorded it, so its


### PR DESCRIPTION
## What

trusty-audit resolved all four of its pinned tools only from the working
directory's own `tools/` area, so an operator could not point the chain at a
locally built binary. `TRUSTY_REVIEW_BIN` / `TRUSTY_SEARCH_BIN` /
`TRUSTY_ANALYZE_BIN` looked like that escape hatch and are not — `run::child`
sets them from the pinned paths on every child, clobbering whatever was
exported.

Four `TRUSTY_AUDIT_*_BIN` variables, one per tool, documented in the crate
README. Precedence is override, then pin, with no third branch. A variable
naming a path that does not exist, is relative, or is not executable refuses the
run naming the variable rather than falling back to the pin. An overridden tool
is excused from install, which is the case this exists for: a merged-but-
unpublished version cannot be downloaded at all.

Provenance is recorded in `state/tool-overrides.toml` before the first child and
stamped into that tool's `index.md` Versions row, led by `OVERRIDDEN`, naming
the variable and the path, claiming no version. Both index producers read the
record, so the return package states it on a machine whose shell never exported
the variable.

Also fixes the flake this work surfaced. See `Refs #6789` below.

## Why it matters

The #6131 verification ran published tga 3.2.0 while 3.3.0 sat merged, because
there was nowhere to say "use this build instead".

## Testing

Rung 3.

- `cargo fmt --check` — clean
- `cargo clippy -p trusty-audit --all-targets -- -D warnings` — clean
- `cargo test -p trusty-audit --no-fail-fast` — 10 targets, `971 passed; 0
  failed; 5 ignored` (lib) plus 3 / 5 / 4 / 4 / 8 / 9 integration, 0 failed.
  Run three times before the rebase and once after, all green.
- `check_line_cap.sh`, `check_test_pointers.sh`, `check_sld.sh`,
  `check_changelog_fragment.sh`, `check-pr-version-bump.sh`,
  `check_rustdoc_links.sh` — all clean

Each new test was proven to fail without the fix. Reverting `index_report.rs` to
`origin/main` fails `an_overridden_tool_is_stamped_into_the_index` and
`a_later_pinned_run_clears_an_earlier_override`; reverting `pins.rs`'s two
behavior hunks fails `an_override_replaces_a_pin_the_client_never_installed`
with `ToolsNotInstalled { missing: ["tga"] }`, the issue's symptom verbatim.

## Version

`trusty-audit` stays at 0.14.4, which #7023 introduced and which is not yet
published — `check-pr-version-bump.sh` reports `src changed, version not yet
published`. Bumps belong to `local-ops`.

Refs #6132
Refs #6789

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
