### PR TITLE
feat(trusty-audit): verify finding citations at collection time (#6791)

### DIFF
--- a/crates/trusty-audit/changelog.d/6791-collection-time-citation-check.md
+++ b/crates/trusty-audit/changelog.d/6791-collection-time-citation-check.md
@@ -1,0 +1,14 @@
+Added
+
+- The grounding pass now checks every finding's cited path, line and traced
+  symbol against the checkout while that checkout is still on disk, and records
+  `confirmed` / `stale` / `unreachable` per citation on the manifest's
+  repository entry as `citation_verdicts`. Trace verdicts were produced only at
+  synthesis, which for a delivered bundle runs against manifests that ship with
+  no git checkouts — the 0.13.2 bundle reported 661 of 661 findings
+  unverifiable for that reason alone. A render now consumes the verdicts
+  collection recorded instead of producing verdicts it has no repository to
+  produce. A checkout that is absent yields `unreachable`, never `stale`, so
+  "nothing was checked" stays distinguishable from "the citation no longer
+  resolves"; a repository whose report has not been rendered yet writes nothing
+  and says nothing (issue #6791).

--- a/crates/trusty-audit/src/grounding.rs
+++ b/crates/trusty-audit/src/grounding.rs
@@ -29,6 +29,7 @@
 //! | [`cve`] | scanning the pinned dependency set for advisories (#6075) |
 //! | [`license`] | banding that same set by license obligation (#6076) |
 //! | [`churn`] | reading the checkout's own git history for change hotspots (#6079) |
+//! | [`citations`] | checking each finding's cited path and symbol while the checkout is still there (#6791) |
 //! | [`priority`] | writing that ranking, and the gaps, into the manifest |
 //!
 //! ## Fail-open, and never silently
@@ -59,6 +60,9 @@ use crate::tools::RequiredTool;
 use crate::workdir::WorkDir;
 
 pub mod churn;
+// #6791: the citation check, which must run here because here is where the
+// checkout still exists.
+pub mod citations;
 pub mod conflict;
 pub mod coverage_rollup;
 pub mod cve;
@@ -523,6 +527,13 @@ pub async fn ground_manifest(
     // they also feed the ranking. Only the write-back belongs here, on the same
     // `[report].findings` channel and the same gap list as the three legs above.
     manifest_leg_gaps.extend(churn::write_into(manifest, &grounding.churn, display));
+    // #6791: LAST of the manifest legs, and the only one whose value comes from
+    // WHEN it runs rather than from what it reads. The findings it checks were
+    // written by the `trusty-review report` that ran inside the `tga audit`
+    // child, and the checkout it checks them against is deleted once the sweep
+    // moves on — so a verdict this call does not record is a verdict no later
+    // render of the delivered bundle can produce.
+    manifest_leg_gaps.extend(citations::ground_into(manifest, checkout, display));
     // #6082: read BEFORE the write, which is what would otherwise make the two
     // states indistinguishable afterwards.
     let already_rendered = investigation_exists(manifest);
@@ -568,10 +579,11 @@ pub async fn ground_manifest(
 
 /// Name of the snapshot trusty-review writes beside a manifest it investigated.
 ///
-/// Spelled here rather than shared because it is read as EVIDENCE THAT A RENDER
-/// ALREADY HAPPENED, never as an interface — trusty-review owns the file and
-/// this only looks for it. Producer: `trusty_review::report::investigate`.
-const INVESTIGATION_SNAPSHOT: &str = "investigation.json";
+/// [`investigation_exists`] reads it as EVIDENCE THAT A RENDER ALREADY HAPPENED
+/// and looks no further; [`citations`] reads the findings out of it, so it is an
+/// interface to that caller (#6791). Producer:
+/// `trusty_review::report::investigate`.
+pub(crate) const INVESTIGATION_SNAPSHOT: &str = "investigation.json";
 
 /// True when a render has already investigated this manifest.
 ///

--- a/crates/trusty-audit/src/grounding/citations.rs
+++ b/crates/trusty-audit/src/grounding/citations.rs
@@ -1,0 +1,516 @@
+//! Checking a finding's citation while the checkout is still on disk (#6791).
+//!
+//! Why: the trace pass that decides whether a finding's citation still resolves
+//! runs at SYNTHESIS — `trusty-review`'s verify stage (#6166). This crate runs
+//! synthesis twice: once inside the `tga audit` child, and again whenever the
+//! delivered bundle is re-rendered (`crate::rerender`). The second run reads the
+//! manifests the package carries and nothing else, because a package
+//! deliberately ships no git checkouts (DOC-68 §13). Every citation therefore
+//! resolves against a repository that is not there, and the 0.13.2 bundle
+//! shipped 661 of 661 findings `unverifiable` for exactly that reason — a render
+//! whose every finding reads as unchecked, in a document whose value is that its
+//! findings were checked.
+//!
+//! Collection is the one moment the checkout exists. This leg spends it: it
+//! reads the findings `trusty-review` already wrote beside the manifest, checks
+//! each one's cited path, line and symbol against the files on disk, and records
+//! CONFIRMED / STALE / UNREACHABLE per citation IN THE MANIFEST — the interface
+//! that ships with the bundle (owner ruling 2026-08-19). A later render consumes
+//! those verdicts rather than producing verdicts it has no repository to produce
+//! them from.
+//!
+//! What: [`ground_into`], the leg [`super::ground_manifest`] calls, over
+//! [`read_citations`] → [`judge`] → [`write_into`].
+//!
+//! ## What a verdict claims, and what it does not
+//!
+//! It claims exactly what a filesystem read can settle: the cited file is in the
+//! checkout, the cited line is inside it, and the traced symbol is still on the
+//! line the trace anchored it to. It does NOT re-judge whether the code supports
+//! the finding — that is the verifier model's call and it stays where #6166 put
+//! it. A CONFIRMED citation is a citation a reader can follow, not a finding a
+//! second model agreed with.
+//!
+//! The evidence quote is deliberately not re-matched here. `trusty-review` owns
+//! that matcher (`investigate::verify::find_evidence_match`, whitespace-
+//! insensitive over the whole file) and this crate does not depend on that crate
+//! — reimplementing it would be the second implementation CLAUDE.md's
+//! common-entry-point rule makes a defect, and a divergent copy would report
+//! staleness the renderer disagrees with.
+//!
+//! Test: `super::citations_tests`.
+
+use std::path::{Component, Path};
+
+use toml_edit::{Array, DocumentMut, InlineTable, Item, Value};
+
+/// The collector's name, at the head of every gap line it writes.
+pub const COLLECTOR: &str = "citation-check";
+
+/// The per-repository manifest key these verdicts are written under.
+///
+/// Why: named on the repository entry rather than in `[report]` because a
+/// verdict is about one checkout — the same placement `crate_topology` takes,
+/// and for the same reason. Two repositories in one engagement each answer for
+/// their own citations.
+pub const MANIFEST_KEY: &str = "citation_verdicts";
+
+/// What a collection-time read of the checkout concluded about one citation.
+///
+/// Why: three outcomes, and the third is not a variety of the second. A citation
+/// nobody could check (no checkout) and a citation that was checked and no
+/// longer resolves (STALE) are opposite facts, and collapsing them is how a
+/// bundle ends up reporting that every finding failed verification when in truth
+/// none was ever verified.
+/// What: [`Verdict::as_str`] is the manifest spelling and the only one that
+/// travels — a renderer reads these strings, never this enum.
+/// Test: `super::citations_tests::a_present_citation_is_confirmed`,
+/// `…::a_missing_checkout_is_unreachable_not_stale`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Verdict {
+    /// The cited file, line and symbol are all still there.
+    Confirmed,
+    /// The checkout was read and does not support the citation.
+    Stale,
+    /// There was no checkout to read, so nothing was checked.
+    Unreachable,
+}
+
+impl Verdict {
+    /// The token written into the manifest.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Verdict::Confirmed => "confirmed",
+            Verdict::Stale => "stale",
+            Verdict::Unreachable => "unreachable",
+        }
+    }
+}
+
+/// One finding's citation, as `trusty-review` recorded it.
+///
+/// Why: the identity is `(file, title)` because that is the identity every other
+/// pass in that crate keys a finding on — `batch::merge_dedupe`,
+/// `merge_investigation_prose`, and #6166's own verdict fold all use it. A
+/// fourth notion of finding identity here would not join.
+/// What: the cited path and line, plus the symbol #6166's trace pass anchored
+/// and the line it anchored it at. Both symbol fields are `None` for a finding
+/// the trace pass never reached, which leaves the check to the path and line.
+/// Test: `super::citations_tests::the_snapshot_yields_one_citation_per_cited_finding`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Citation {
+    /// The finding's title.
+    pub title: String,
+    /// Repository-relative cited path.
+    pub file: String,
+    /// 1-based cited line, when the finding carried one.
+    pub line: Option<u64>,
+    /// The traced symbol, as the symbol graph spells it.
+    pub symbol: Option<String>,
+    /// The line the trace anchored [`Self::symbol`] at.
+    pub symbol_line: Option<u64>,
+}
+
+/// One citation, and what the checkout said about it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CitationVerdict {
+    /// The citation this verdict is about.
+    pub citation: Citation,
+    /// The verdict.
+    pub verdict: Verdict,
+    /// One line saying why, empty for [`Verdict::Confirmed`].
+    pub reason: String,
+}
+
+/// Every cited finding in one repository's investigation snapshot.
+///
+/// Why: the snapshot is the only record of what the findings CITE. The manifest
+/// carries the assurance-scan rows, which cite a package rather than a line, and
+/// the rendered Markdown is prose. Reading the snapshot is how this leg learns
+/// what to check, and it is already this crate's channel for that file
+/// (`super::osv::inventory` reads its dependency inventory the same way).
+/// What: one [`Citation`] per finding that cites a file, joined to its trace
+/// anchor by `(file, title)`. A GREEN topic with no citation contributes
+/// nothing — there is no path to check.
+///
+/// # Errors
+/// One line, safe to show the recipient, when the snapshot is absent, unreadable
+/// or not an investigation snapshot. The caller turns it into a gap.
+///
+/// # Postconditions
+/// On `Ok`, every returned citation has a non-empty `file`.
+///
+/// Test: `super::citations_tests::{the_snapshot_yields_one_citation_per_cited_finding,
+/// a_missing_snapshot_is_a_named_gap, an_anchor_supplies_the_symbol_and_its_line}`.
+pub fn read_citations(snapshot: &Path) -> Result<Vec<Citation>, String> {
+    let text = std::fs::read_to_string(snapshot).map_err(|e| {
+        format!(
+            "{COLLECTOR}: the investigation snapshot at {} could not be read ({e})",
+            snapshot.display()
+        )
+    })?;
+    let doc: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+        format!(
+            "{COLLECTOR}: {} is not readable as JSON ({e})",
+            snapshot.display()
+        )
+    })?;
+    let repos = doc
+        .get("repos")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| {
+            format!(
+                "{COLLECTOR}: {} declares no `repos` array, so it is not an investigation snapshot",
+                snapshot.display()
+            )
+        })?;
+
+    let mut citations = Vec::new();
+    for repo in repos {
+        let anchors = anchors_of(repo);
+        for finding in repo
+            .get("findings")
+            .and_then(serde_json::Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+        {
+            let file = str_at(finding, "file").unwrap_or_default();
+            if file.is_empty() {
+                continue;
+            }
+            let title = str_at(finding, "title").unwrap_or_default();
+            let (symbol, symbol_line) = anchors
+                .iter()
+                .find(|(f, t, _, _)| *f == file && *t == title)
+                .map_or((None, None), |(_, _, s, l)| (Some(s.clone()), Some(*l)));
+            citations.push(Citation {
+                title,
+                file,
+                line: finding.get("line").and_then(serde_json::Value::as_u64),
+                symbol,
+                symbol_line,
+            });
+        }
+    }
+    Ok(citations)
+}
+
+/// The `(file, title, symbol, line)` of every trace record that reached an
+/// anchor, for one repository's snapshot entry.
+///
+/// A record with no anchor — #6166's fail-closed `no trace:` case — contributes
+/// nothing, so the citation it belongs to is checked on its path and line alone
+/// rather than against a symbol nobody resolved.
+fn anchors_of(repo: &serde_json::Value) -> Vec<(String, String, String, u64)> {
+    repo.get("traces")
+        .and_then(|t| t.get("traces"))
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|trace| {
+            let anchor = trace.get("anchor")?;
+            Some((
+                str_at(trace, "file")?,
+                str_at(trace, "title")?,
+                str_at(anchor, "symbol")?,
+                anchor.get("line").and_then(serde_json::Value::as_u64)?,
+            ))
+        })
+        .collect()
+}
+
+/// A trimmed string field, `None` when the key is absent or not a string.
+fn str_at(value: &serde_json::Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(|s| s.trim().to_string())
+}
+
+/// Judge every citation against `checkout`.
+///
+/// Why: the whole point of the leg, and the one function that touches the
+/// repository. The checkout is tested ONCE rather than per citation, because
+/// "there is no checkout" is one fact about the run and reporting it 661 times
+/// as 661 independent failures is what this leg exists to stop.
+///
+/// # Postconditions
+/// Exactly one verdict per input citation, in input order. Never panics, never
+/// reads outside `checkout`, and returns [`Verdict::Unreachable`] for every
+/// citation when `checkout` is not a directory.
+///
+/// Test: `super::citations_tests` drives one test per arm.
+#[must_use]
+pub fn judge(checkout: &Path, citations: &[Citation]) -> Vec<CitationVerdict> {
+    let reachable = checkout.is_dir();
+    citations
+        .iter()
+        .map(|citation| {
+            if reachable {
+                judge_one(checkout, citation)
+            } else {
+                CitationVerdict {
+                    citation: citation.clone(),
+                    verdict: Verdict::Unreachable,
+                    reason: format!(
+                        "the checkout at {} is not present, so no citation could be checked",
+                        checkout.display()
+                    ),
+                }
+            }
+        })
+        .collect()
+}
+
+/// Judge one citation against a checkout known to be present.
+fn judge_one(checkout: &Path, citation: &Citation) -> CitationVerdict {
+    let stale = |reason: String| CitationVerdict {
+        citation: citation.clone(),
+        verdict: Verdict::Stale,
+        reason,
+    };
+    let Some(relative) = inside_checkout(&citation.file) else {
+        return stale(format!(
+            "the cited path `{}` is not inside the checkout",
+            citation.file
+        ));
+    };
+    let source = match std::fs::read_to_string(checkout.join(relative)) {
+        Ok(source) => source,
+        Err(e) => {
+            return stale(format!(
+                "the cited path `{}` is no longer readable in the checkout ({e})",
+                citation.file
+            ));
+        }
+    };
+    let lines: Vec<&str> = source.lines().collect();
+    if let Some(line) = citation.line
+        && line_text(&lines, line).is_none()
+    {
+        return stale(format!(
+            "the cited line {line} is past the end of `{}`, which now has {} line(s)",
+            citation.file,
+            lines.len()
+        ));
+    }
+    if let (Some(symbol), Some(line)) = (&citation.symbol, citation.symbol_line) {
+        let short = short_name(symbol);
+        match line_text(&lines, line) {
+            Some(text) if text.contains(short) => {}
+            _ => {
+                return stale(format!(
+                    "the traced symbol `{symbol}` is no longer declared at `{}`:{line}",
+                    citation.file
+                ));
+            }
+        }
+    }
+    CitationVerdict {
+        citation: citation.clone(),
+        verdict: Verdict::Confirmed,
+        reason: String::new(),
+    }
+}
+
+/// The 1-based line's text, `None` when the file has no such line.
+fn line_text<'a>(lines: &[&'a str], line: u64) -> Option<&'a str> {
+    let index = usize::try_from(line.checked_sub(1)?).ok()?;
+    lines.get(index).copied()
+}
+
+/// The symbol's own name, without the type or module path that qualifies it.
+///
+/// The trace pass spells a method `Type::method`, and only the last segment is
+/// on the declaration line.
+fn short_name(symbol: &str) -> &str {
+    symbol.rsplit("::").next().unwrap_or(symbol)
+}
+
+/// The citation's path as a checkout-relative path, or `None` when it escapes.
+///
+/// Why: a cited path reaches this leg from a model-authored finding, so it is
+/// untrusted input to a filesystem read. An absolute path or a `..` component
+/// would let a citation address a file outside the repository, and a CONFIRMED
+/// verdict on such a read would state that the checkout carries a file that is
+/// not in it.
+/// What: `None` for an absolute path, a root or prefix component, or any `..`;
+/// the path itself otherwise, with `.` components left for `join` to absorb.
+/// Test: `super::citations_tests::a_citation_escaping_the_checkout_is_never_confirmed`.
+fn inside_checkout(file: &str) -> Option<&Path> {
+    let path = Path::new(file);
+    let contained = path
+        .components()
+        .all(|component| matches!(component, Component::Normal(_) | Component::CurDir));
+    contained.then_some(path)
+}
+
+/// Write `verdicts` onto the manifest's repository entry for `checkout`.
+///
+/// Why: the manifest is the interface (owner ruling 2026-08-19). A verdict this
+/// process holds and does not write reaches no renderer — least of all
+/// `crate::rerender`, which is the render this leg exists for.
+/// What: replaces the entry's [`MANIFEST_KEY`] array wholesale, written
+/// format-preserving exactly as [`super::topology::write_into`] writes its
+/// graph. Replacing rather than appending is what makes a resumed sweep record
+/// one verdict per citation instead of two.
+///
+/// # Errors
+/// One line, safe to show the recipient, when the manifest cannot be read,
+/// parsed, matched or written back.
+///
+/// # Postconditions
+/// On `Ok`, the repository whose `path` is `checkout` declares exactly these
+/// verdicts and nothing else in the document changed. An empty `verdicts` writes
+/// nothing and cannot fail.
+///
+/// Test: `super::citations_tests::{the_verdicts_land_on_the_matching_repository,
+/// a_second_run_restates_rather_than_duplicates}`.
+pub fn write_into(
+    manifest: &Path,
+    checkout: &Path,
+    verdicts: &[CitationVerdict],
+) -> Result<(), String> {
+    if verdicts.is_empty() {
+        return Ok(());
+    }
+    let text = std::fs::read_to_string(manifest)
+        .map_err(|e| format!("{} could not be read ({e})", manifest.display()))?;
+    let mut doc: DocumentMut = text
+        .parse()
+        .map_err(|e| format!("{} is not readable as TOML ({e})", manifest.display()))?;
+
+    let repositories = doc
+        .get_mut("repositories")
+        .and_then(Item::as_array_of_tables_mut)
+        .ok_or_else(|| "the manifest declares no `[[repositories]]` entry".to_string())?;
+    let entry = repositories
+        .iter_mut()
+        .find(|table| super::priority::names_checkout(table, checkout))
+        .ok_or_else(|| {
+            format!(
+                "no `[[repositories]]` entry names the checkout at {}",
+                checkout.display()
+            )
+        })?;
+    entry.insert(MANIFEST_KEY, Item::Value(Value::Array(rows(verdicts))));
+
+    std::fs::write(manifest, doc.to_string())
+        .map_err(|e| format!("{} could not be written ({e})", manifest.display()))
+}
+
+/// The verdicts as a multi-line TOML array of inline tables.
+fn rows(verdicts: &[CitationVerdict]) -> Array {
+    let mut array = Array::new();
+    for verdict in verdicts {
+        let mut row = InlineTable::new();
+        row.insert("title", Value::from(verdict.citation.title.as_str()));
+        row.insert("file", Value::from(verdict.citation.file.as_str()));
+        if let Some(line) = verdict.citation.line {
+            row.insert("line", Value::from(i64::try_from(line).unwrap_or(i64::MAX)));
+        }
+        if let Some(symbol) = &verdict.citation.symbol {
+            row.insert("symbol", Value::from(symbol.as_str()));
+        }
+        row.insert("verdict", Value::from(verdict.verdict.as_str()));
+        if !verdict.reason.is_empty() {
+            row.insert("reason", Value::from(verdict.reason.as_str()));
+        }
+        let mut value = Value::InlineTable(row);
+        value.decor_mut().set_prefix("\n    ");
+        array.push_formatted(value);
+    }
+    array.set_trailing("\n");
+    array.set_trailing_comma(true);
+    array
+}
+
+/// Read this repository's citations, judge them against its checkout, and write
+/// the verdicts into its manifest.
+///
+/// Why/What: see the module docs. `snapshot` is the `investigation.json`
+/// `trusty-review` wrote beside the manifest ([`super::INVESTIGATION_SNAPSHOT`]).
+///
+/// # Postconditions
+/// Never panics and never returns an error. Every degradation is one line in the
+/// returned gap list, naming `display` — the shape [`super::ground_manifest`]
+/// gives every leg. A snapshot that does not exist yet is NOT a gap: on a run
+/// whose render happens later there is nothing to check and nothing has been
+/// lost, which is a different state from a snapshot that exists and cannot be
+/// read.
+///
+/// Test: `super::citations_tests::{a_render_that_has_not_happened_yet_is_silent,
+/// stale_citations_are_counted_in_a_gap_line}`.
+pub fn ground_into(manifest: &Path, checkout: &Path, display: &str) -> Vec<String> {
+    let Some(dir) = manifest.parent() else {
+        return vec![format!(
+            "{display}: {COLLECTOR}: {} has no parent directory, so this repository's findings \
+             could not be located",
+            manifest.display()
+        )];
+    };
+    let snapshot = dir.join(super::INVESTIGATION_SNAPSHOT);
+    if !snapshot.is_file() {
+        return Vec::new();
+    }
+    let citations = match read_citations(&snapshot) {
+        Ok(citations) => citations,
+        Err(cause) => {
+            return vec![format!(
+                "{display}: {cause} — no citation was checked against the checkout, so a later \
+                 render of this bundle cannot tell a live citation from one the code has moved \
+                 past"
+            )];
+        }
+    };
+    if citations.is_empty() {
+        return Vec::new();
+    }
+
+    let verdicts = judge(checkout, &citations);
+    let mut gaps = outcome_gaps(&verdicts, display);
+    if let Err(cause) = write_into(manifest, checkout, &verdicts) {
+        gaps.push(format!(
+            "{display}: {COLLECTOR}: {cause} — the delivered bundle records no citation verdict \
+             for this repository, so a later render reports every one of its {} finding(s) as \
+             unverified",
+            verdicts.len()
+        ));
+    }
+    gaps
+}
+
+/// The lines the judged set owes the report.
+///
+/// A clean pass says nothing: every verdict is in the manifest, which is where a
+/// reader checks them. Only the two degradations earn a line — citations that no
+/// longer resolve, and a checkout that was not there to ask.
+fn outcome_gaps(verdicts: &[CitationVerdict], display: &str) -> Vec<String> {
+    let count = |wanted: Verdict| verdicts.iter().filter(|v| v.verdict == wanted).count();
+    let mut gaps = Vec::new();
+    let unreachable = count(Verdict::Unreachable);
+    if unreachable > 0 {
+        gaps.push(format!(
+            "{display}: {COLLECTOR}: its checkout was not on disk when its {unreachable} \
+             citation(s) were checked, so they are recorded unreachable — unassessed, not clean"
+        ));
+    }
+    let stale = count(Verdict::Stale);
+    if stale > 0 {
+        gaps.push(format!(
+            "{display}: {COLLECTOR}: {stale} of {} finding citation(s) no longer resolve against \
+             the checkout they were collected from",
+            verdicts.len()
+        ));
+    }
+    gaps
+}
+
+#[cfg(test)]
+#[path = "citations_tests.rs"]
+mod citations_tests;

--- a/crates/trusty-audit/src/grounding/citations_tests.rs
+++ b/crates/trusty-audit/src/grounding/citations_tests.rs
@@ -1,0 +1,333 @@
+//! Tests for the collection-time citation check (#6791).
+//!
+//! Every arm is driven from a literal investigation snapshot and a real
+//! checkout on disk, because the whole claim under test is what a filesystem
+//! read says about a cited path. Nothing here spawns a process or touches a
+//! daemon.
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::{Citation, MANIFEST_KEY, Verdict, ground_into, judge, read_citations, write_into};
+
+/// A snapshot with one repository, its findings, and optional trace anchors.
+///
+/// `findings` is `(title, file, line)`; `anchors` is `(title, file, symbol,
+/// line)` and produces the `traces.traces[]` records #6166 writes.
+fn snapshot(findings: &[(&str, &str, u64)], anchors: &[(&str, &str, &str, u64)]) -> String {
+    let findings: Vec<String> = findings
+        .iter()
+        .map(|(title, file, line)| {
+            format!(r#"{{"title":"{title}","file":"{file}","line":{line}}}"#)
+        })
+        .collect();
+    let traces: Vec<String> = anchors
+        .iter()
+        .map(|(title, file, symbol, line)| {
+            format!(
+                r#"{{"title":"{title}","file":"{file}","anchor":{{"symbol":"{symbol}","file":"{file}","line":{line},"signature":""}}}}"#
+            )
+        })
+        .collect();
+    format!(
+        r#"{{"repos":[{{"slug":"demo","name":"demo","findings":[{}],"traces":{{"traces":[{}]}}}}]}}"#,
+        findings.join(","),
+        traces.join(",")
+    )
+}
+
+/// A manifest declaring one repository at `checkout`.
+fn manifest_text(checkout: &Path) -> String {
+    format!(
+        "[report]\ntitle = \"demo\"\n\n[[repositories]]\nname = \"demo\"\npath = \"{}\"\n",
+        checkout.display()
+    )
+}
+
+/// A checkout holding `files`, each `(relative path, contents)`.
+fn checkout_with(root: &Path, files: &[(&str, &str)]) {
+    for (path, contents) in files {
+        let full = root.join(path);
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent).expect("checkout directory");
+        }
+        fs::write(&full, contents).expect("checkout file");
+    }
+}
+
+fn cite(file: &str, line: u64) -> Citation {
+    Citation {
+        title: "a finding".to_string(),
+        file: file.to_string(),
+        line: Some(line),
+        symbol: None,
+        symbol_line: None,
+    }
+}
+
+/// The snapshot's cited findings become citations; an uncited GREEN topic does
+/// not, because there is no path to check.
+#[test]
+fn the_snapshot_yields_one_citation_per_cited_finding() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("investigation.json");
+    fs::write(
+        &path,
+        r#"{"repos":[{"findings":[
+             {"title":"cited","file":"src/a.rs","line":7},
+             {"title":"a strength","file":"","line":null}
+           ]}]}"#,
+    )
+    .expect("snapshot");
+
+    let citations = read_citations(&path).expect("reads");
+
+    assert_eq!(citations.len(), 1, "{citations:?}");
+    assert_eq!(citations[0].title, "cited");
+    assert_eq!(citations[0].file, "src/a.rs");
+    assert_eq!(citations[0].line, Some(7));
+    assert_eq!(citations[0].symbol, None);
+}
+
+/// A trace record that reached an anchor supplies the symbol and the line it
+/// was anchored at; one that did not supplies neither.
+#[test]
+fn an_anchor_supplies_the_symbol_and_its_line() {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().join("investigation.json");
+    fs::write(
+        &path,
+        snapshot(
+            &[("anchored", "src/a.rs", 7), ("refused", "src/b.rs", 3)],
+            &[("anchored", "src/a.rs", "Guard::check", 5)],
+        ),
+    )
+    .expect("snapshot");
+
+    let citations = read_citations(&path).expect("reads");
+
+    let anchored = &citations[0];
+    assert_eq!(anchored.symbol.as_deref(), Some("Guard::check"));
+    assert_eq!(anchored.symbol_line, Some(5));
+    let refused = &citations[1];
+    assert_eq!(refused.symbol, None, "{refused:?}");
+    assert_eq!(refused.symbol_line, None);
+}
+
+/// A snapshot that is not there at all is a read error the caller can report.
+#[test]
+fn a_missing_snapshot_is_a_named_gap() {
+    let tmp = TempDir::new().expect("tempdir");
+
+    let cause =
+        read_citations(&tmp.path().join("investigation.json")).expect_err("there is no snapshot");
+
+    assert!(cause.contains("citation-check"), "{cause}");
+    assert!(cause.contains("could not be read"), "{cause}");
+}
+
+/// The core claim: a citation whose file and line are still on disk is
+/// CONFIRMED, and it is confirmed by reading the checkout rather than by asking
+/// a model.
+#[test]
+fn a_present_citation_is_confirmed() {
+    let tmp = TempDir::new().expect("tempdir");
+    checkout_with(tmp.path(), &[("src/a.rs", "one\ntwo\nthree\n")]);
+
+    let verdicts = judge(tmp.path(), &[cite("src/a.rs", 2)]);
+
+    assert_eq!(verdicts[0].verdict, Verdict::Confirmed, "{verdicts:?}");
+    assert!(verdicts[0].reason.is_empty(), "{verdicts:?}");
+}
+
+/// A cited path the checkout no longer carries is STALE, and the reason names
+/// the path.
+#[test]
+fn a_deleted_file_is_stale() {
+    let tmp = TempDir::new().expect("tempdir");
+    checkout_with(tmp.path(), &[("src/a.rs", "one\n")]);
+
+    let verdicts = judge(tmp.path(), &[cite("src/gone.rs", 1)]);
+
+    assert_eq!(verdicts[0].verdict, Verdict::Stale, "{verdicts:?}");
+    assert!(verdicts[0].reason.contains("src/gone.rs"), "{verdicts:?}");
+}
+
+/// A file that shrank past the cited line is STALE, and the reason states the
+/// length it now has.
+#[test]
+fn a_line_past_the_end_of_the_file_is_stale() {
+    let tmp = TempDir::new().expect("tempdir");
+    checkout_with(tmp.path(), &[("src/a.rs", "one\ntwo\n")]);
+
+    let verdicts = judge(tmp.path(), &[cite("src/a.rs", 9)]);
+
+    assert_eq!(verdicts[0].verdict, Verdict::Stale, "{verdicts:?}");
+    assert!(verdicts[0].reason.contains("2 line(s)"), "{verdicts:?}");
+}
+
+/// A traced symbol still on its anchored line confirms; one that has moved off
+/// it is STALE naming the symbol.
+#[test]
+fn a_symbol_that_left_its_anchored_line_is_stale() {
+    let tmp = TempDir::new().expect("tempdir");
+    checkout_with(
+        tmp.path(),
+        &[("src/a.rs", "// header\nfn check() {}\nfn other() {}\n")],
+    );
+    let anchored = |line| Citation {
+        title: "a finding".to_string(),
+        file: "src/a.rs".to_string(),
+        line: Some(2),
+        symbol: Some("Guard::check".to_string()),
+        symbol_line: Some(line),
+    };
+
+    let verdicts = judge(tmp.path(), &[anchored(2), anchored(3)]);
+
+    assert_eq!(verdicts[0].verdict, Verdict::Confirmed, "{verdicts:?}");
+    assert_eq!(verdicts[1].verdict, Verdict::Stale, "{verdicts:?}");
+    assert!(verdicts[1].reason.contains("Guard::check"), "{verdicts:?}");
+}
+
+/// A missing checkout is UNREACHABLE for every citation, never STALE. This is
+/// the 0.13.2 outcome the issue names: a render with no repository must report
+/// unassessed rather than failed.
+#[test]
+fn a_missing_checkout_is_unreachable_not_stale() {
+    let tmp = TempDir::new().expect("tempdir");
+    let absent = tmp.path().join("no-such-checkout");
+
+    let verdicts = judge(&absent, &[cite("src/a.rs", 1), cite("src/b.rs", 2)]);
+
+    assert_eq!(verdicts.len(), 2, "{verdicts:?}");
+    assert!(
+        verdicts.iter().all(|v| v.verdict == Verdict::Unreachable),
+        "{verdicts:?}"
+    );
+    assert!(verdicts[0].reason.contains("not present"), "{verdicts:?}");
+}
+
+/// A cited path that climbs out of the checkout is never CONFIRMED, however
+/// readable the file it names is.
+#[test]
+fn a_citation_escaping_the_checkout_is_never_confirmed() {
+    let tmp = TempDir::new().expect("tempdir");
+    let checkout = tmp.path().join("repo");
+    checkout_with(&checkout, &[("src/a.rs", "one\n")]);
+    fs::write(tmp.path().join("outside.rs"), "one\n").expect("outside file");
+
+    let verdicts = judge(&checkout, &[cite("../outside.rs", 1)]);
+
+    assert_eq!(verdicts[0].verdict, Verdict::Stale, "{verdicts:?}");
+    assert!(
+        verdicts[0].reason.contains("not inside the checkout"),
+        "{verdicts:?}"
+    );
+}
+
+/// The verdicts reach the manifest — the artifact that ships in the bundle —
+/// on the repository entry that names this checkout.
+#[test]
+fn the_verdicts_land_on_the_matching_repository() {
+    let tmp = TempDir::new().expect("tempdir");
+    let checkout = tmp.path().join("repo");
+    checkout_with(&checkout, &[("src/a.rs", "one\ntwo\n")]);
+    let manifest = tmp.path().join("manifest.toml");
+    fs::write(&manifest, manifest_text(&checkout)).expect("manifest");
+
+    let verdicts = judge(&checkout, &[cite("src/a.rs", 1), cite("src/gone.rs", 1)]);
+    write_into(&manifest, &checkout, &verdicts).expect("writes");
+
+    let written = fs::read_to_string(&manifest).expect("reads back");
+    assert!(written.contains(MANIFEST_KEY), "{written}");
+    assert!(written.contains(r#"verdict = "confirmed""#), "{written}");
+    assert!(written.contains(r#"verdict = "stale""#), "{written}");
+    // The document's own keys survive the format-preserving write.
+    assert!(written.contains(r#"title = "demo""#), "{written}");
+}
+
+/// A resumed sweep restates the verdicts rather than appending a second copy.
+#[test]
+fn a_second_run_restates_rather_than_duplicates() {
+    let tmp = TempDir::new().expect("tempdir");
+    let checkout = tmp.path().join("repo");
+    checkout_with(&checkout, &[("src/a.rs", "one\n")]);
+    let manifest = tmp.path().join("manifest.toml");
+    fs::write(&manifest, manifest_text(&checkout)).expect("manifest");
+    let verdicts = judge(&checkout, &[cite("src/a.rs", 1)]);
+
+    write_into(&manifest, &checkout, &verdicts).expect("first write");
+    write_into(&manifest, &checkout, &verdicts).expect("second write");
+
+    let written = fs::read_to_string(&manifest).expect("reads back");
+    assert_eq!(
+        written.matches(r#"verdict = "confirmed""#).count(),
+        1,
+        "{written}"
+    );
+}
+
+/// The leg runs end to end at collection time: snapshot beside the manifest,
+/// checkout on disk, verdicts in the manifest, and the stale count stated as a
+/// gap.
+#[test]
+fn stale_citations_are_counted_in_a_gap_line() {
+    let tmp = TempDir::new().expect("tempdir");
+    let checkout = tmp.path().join("repo");
+    checkout_with(&checkout, &[("src/a.rs", "one\ntwo\n")]);
+    let out = tmp.path().join("out");
+    fs::create_dir_all(&out).expect("output directory");
+    let manifest = out.join("manifest.toml");
+    fs::write(&manifest, manifest_text(&checkout)).expect("manifest");
+    fs::write(
+        out.join("investigation.json"),
+        snapshot(&[("live", "src/a.rs", 1), ("moved", "src/gone.rs", 4)], &[]),
+    )
+    .expect("snapshot");
+
+    let gaps = ground_into(&manifest, &checkout, "demo");
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("1 of 2 finding citation(s)"), "{gaps:?}");
+    let written = fs::read_to_string(&manifest).expect("reads back");
+    assert!(written.contains(r#"verdict = "confirmed""#), "{written}");
+    assert!(written.contains(r#"verdict = "stale""#), "{written}");
+}
+
+/// No snapshot beside the manifest means the render has not happened yet.
+/// Nothing was lost, so the leg writes nothing and says nothing.
+#[test]
+fn a_render_that_has_not_happened_yet_is_silent() {
+    let tmp = TempDir::new().expect("tempdir");
+    let checkout = tmp.path().join("repo");
+    checkout_with(&checkout, &[("src/a.rs", "one\n")]);
+    let manifest = tmp.path().join("manifest.toml");
+    fs::write(&manifest, manifest_text(&checkout)).expect("manifest");
+
+    let gaps = ground_into(&manifest, &checkout, "demo");
+
+    assert!(gaps.is_empty(), "{gaps:?}");
+    let written = fs::read_to_string(&manifest).expect("reads back");
+    assert!(!written.contains(MANIFEST_KEY), "{written}");
+}
+
+/// A snapshot that exists and cannot be read IS a gap, and the line says what
+/// a later render loses by it.
+#[test]
+fn an_unreadable_snapshot_is_a_named_gap() {
+    let tmp = TempDir::new().expect("tempdir");
+    let checkout = tmp.path().join("repo");
+    checkout_with(&checkout, &[("src/a.rs", "one\n")]);
+    let manifest = tmp.path().join("manifest.toml");
+    fs::write(&manifest, manifest_text(&checkout)).expect("manifest");
+    fs::write(tmp.path().join("investigation.json"), "{not json").expect("snapshot");
+
+    let gaps = ground_into(&manifest, &checkout, "demo");
+
+    assert_eq!(gaps.len(), 1, "{gaps:?}");
+    assert!(gaps[0].contains("not readable as JSON"), "{gaps:?}");
+    assert!(gaps[0].contains("moved past"), "{gaps:?}");
+}


### PR DESCRIPTION
Refs #6791

## The defect

`trusty-review report` runs twice in an engagement: once inside the `tga audit`
child, and again at `taudit render`. The render reads the manifests the delivered
package carries and nothing else, because a package ships no git checkouts
(`rerender.rs:6-11`). #6166's trace pass resolves a finding's citation by reading
`repo_path.join(file)` off disk, so at render time every candidate fail-closes to
`no trace:` and `verdict.rs` folds that to `Unverifiable`. The 0.13.2 bundle
reported 661 of 661 findings unverifiable for that reason alone.

## The change

`grounding::citations` is a new leg in the grounding pass. Grounding is the one
pass that holds the checkout AND the manifest, and `investigation.json` already
sits beside that manifest by then — `grounding.rs`'s existing
`investigation_exists` documents exactly that ordering. The leg reads the findings
out of that snapshot, checks each one's cited path, line and traced symbol against
the files on disk, and writes the verdict into the manifest.

**Manifest key added:** `citation_verdicts`, an array of inline tables on each
`[[repositories]]` entry — the same per-repository placement `crate_topology`
takes. Each row carries `title`, `file`, optional `line` and `symbol`, a `verdict`
of `confirmed` / `stale` / `unreachable`, and a `reason` for the non-confirmed
cases. Neither this crate's nor `trusty-review`'s manifest reader sets
`deny_unknown_fields`, so an older renderer ignores the key and behaves exactly as
it does today.

Three decisions worth naming:

- An absent checkout is `unreachable`, never `stale`. Collapsing them is how a
  bundle reports that every finding failed verification when none was ever
  verified.
- A cited path that is absolute or carries `..` is never confirmed. The path comes
  from a model-authored finding and feeds a filesystem read; confirming one would
  state that the checkout holds a file outside it.
- The evidence quote is not re-matched. `trusty-review` owns `find_evidence_match`
  and `trusty-audit` does not depend on that crate, so a copy would be the second
  implementation CLAUDE.md's common-entry-point rule makes a defect — and a
  divergent copy would report staleness the renderer disagrees with.

`INVESTIGATION_SNAPSHOT` went from private to `pub(crate)` rather than adding a
third spelling of the filename to the crate.

## Not in this PR

The consuming half. `trusty-review`'s render does not yet read
`citation_verdicts` — it still produces its own trace verdicts and will still
report `unverifiable` when the checkout is gone. This PR makes the verdicts exist
in the bundle, which is the half that can only be done at collection time and the
half that is lost forever if it is not done then. The renderer change is a
separate `trusty-review` PR.

## Testing — ladder rung 3

Localized behaviour inside one crate: a new grounding leg plus its wiring.
`trusty-audit` is a leaf, so no dependent suites are owed.

```
cargo test -p trusty-audit --no-fail-fast
```

Every target ran (`--no-fail-fast`), all green on the rebased head:

| Target | Result |
|---|---|
| `unittests src/lib.rs` | ok. 985 passed; 0 failed; 5 ignored |
| `unittests src/main.rs` (taudit) | ok. 0 passed; 0 failed |
| `unittests src/main.rs` (trusty-audit) | ok. 0 passed; 0 failed |
| `tests/binary_names.rs` | ok. 3 passed; 0 failed |
| `tests/cli_end_to_end.rs` | ok. 5 passed; 0 failed |
| `tests/guided_launch.rs` | ok. 4 passed; 0 failed |
| `tests/install_fails_closed.rs` | ok. 4 passed; 0 failed; 2 ignored |
| `tests/render_zero_arg.rs` | ok. 8 passed; 0 failed |
| `tests/run_fails_closed.rs` | ok. 9 passed; 0 failed |
| Doc-tests | ok. 0 passed; 0 failed |

Also `cargo fmt --check`, `cargo clippy -p trusty-audit --all-targets -- -D
warnings`, `check_line_cap.sh`, `check_test_pointers.sh`, `check_sld.sh`,
`check_changelog_fragment.sh`, `check-pr-version-bump.sh` and
`check_rustdoc_links.sh` — all clean. 0.14.4 is not on crates.io, so no bump.

### Acceptance criteria, as tests

| Issue's ask | Test |
|---|---|
| verify the cited path during collection | `a_present_citation_is_confirmed`, `a_deleted_file_is_stale` |
| verify the cited line | `a_line_past_the_end_of_the_file_is_stale` |
| verify the cited symbol | `a_symbol_that_left_its_anchored_line_is_stale` |
| record CONFIRMED/STALE/UNREACHABLE per trace | `a_missing_checkout_is_unreachable_not_stale`, `stale_citations_are_counted_in_a_gap_line` |
| …in the bundle, for synthesis to consume | `the_verdicts_land_on_the_matching_repository`, `a_second_run_restates_rather_than_duplicates` |

Plus the input and fail-closed arms:
`the_snapshot_yields_one_citation_per_cited_finding`,
`an_anchor_supplies_the_symbol_and_its_line`, `a_missing_snapshot_is_a_named_gap`,
`an_unreadable_snapshot_is_a_named_gap`,
`a_render_that_has_not_happened_yet_is_silent`,
`a_citation_escaping_the_checkout_is_never_confirmed`.

### Proof the tests need this change

A compile failure, not a red assertion — the fix is a new module, so on
`origin/main` there is no function for the tests to call. Removing only
`crates/trusty-audit/src/grounding/citations.rs`:

```
error[E0583]: file not found for module `citations`
  --> crates/trusty-audit/src/grounding.rs:65:1
   |
65 | pub mod citations;
   | ^^^^^^^^^^^^^^^^^^
error: could not compile `trusty-audit` (lib) due to 1 previous error
error: could not compile `trusty-audit` (lib test) due to 1 previous error
```

Reverting the wiring file alone does not go red — it exits 0 with `running 962
tests` against the fix's `running 976 tests`. The 14 acceptance tests vanish
rather than fail, which is the #4901 shape; the count difference is the proof,
and it is why the module-removal form above was run as well.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
