### PR TITLE
feat(trusty-common): port the Ollama liveness probe to inference::providers::local (#4490)

### DIFF
--- a/crates/trusty-common/changelog.d/4490-local-liveness-probe.md
+++ b/crates/trusty-common/changelog.d/4490-local-liveness-probe.md
@@ -1,0 +1,3 @@
+Added
+
+- `inference::providers::local` probes the local model server before every request, so an unreachable or wedged Ollama fails inside a one-second budget with an `InferenceError::Transport` naming the endpoint instead of hanging on a client that carried no timeout. The probe itself is the new unconditional `local_probe` module, shared with `chat::auto_detect_local_provider` — one implementation and one `LOCAL_PROBE_TIMEOUT`, so the two callers cannot drift. This is the capability `ChatProvider`'s ecosystem had and `InferenceAdapter` lacked, and a prerequisite for migrating trusty-search and trusty-memory off `ChatProvider`

--- a/crates/trusty-common/src/chat/openai_compat/providers.rs
+++ b/crates/trusty-common/src/chat/openai_compat/providers.rs
@@ -21,7 +21,11 @@ use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
 
-const LOCAL_PROBE_TIMEOUT_SECS: u64 = 1;
+// #4490: the local-probe budget is `crate::local_probe::LOCAL_PROBE_TIMEOUT` —
+// one constant shared with `inference::providers::local`, not a literal per
+// call site.
+use crate::local_probe::LOCAL_PROBE_TIMEOUT;
+
 const LOCAL_REQUEST_TIMEOUT_SECS: u64 = 120;
 const OPENROUTER_URL: &str = "https://openrouter.ai/api/v1/chat/completions";
 const OPENROUTER_CONNECT_TIMEOUT_SECS: u64 = 10;
@@ -201,7 +205,7 @@ impl ChatProvider for OllamaProvider {
         tx: Sender<ChatEvent>,
     ) -> Result<()> {
         let client = reqwest::Client::builder()
-            .connect_timeout(std::time::Duration::from_secs(LOCAL_PROBE_TIMEOUT_SECS))
+            .connect_timeout(LOCAL_PROBE_TIMEOUT)
             .timeout(std::time::Duration::from_secs(LOCAL_REQUEST_TIMEOUT_SECS))
             .build()
             .context("build reqwest client for OllamaProvider::chat_stream")?;
@@ -250,22 +254,17 @@ impl ChatProvider for OllamaProvider {
 /// returns an error — the caller treats absence as "no local provider
 /// available" and is responsible for setting the model id afterwards (e.g.
 /// from [`super::LocalModelConfig::model`](crate::LocalModelConfig::model)).
+/// The probe itself is [`crate::local_probe::probe_local`] (#4490), shared with
+/// `inference::providers::local`; this wrapper only discards its typed error,
+/// which is what a caller choosing between providers wants.
 /// Test: `auto_detect_returns_none_on_unreachable` points at a closed port
 /// and asserts `None` within the 1-second budget;
 /// `auto_detect_returns_some_on_200` spins up an in-process server and
 /// asserts a provider is returned.
 pub async fn auto_detect_local_provider(base_url: &str) -> Option<OllamaProvider> {
-    let client = reqwest::Client::builder()
-        .connect_timeout(std::time::Duration::from_secs(LOCAL_PROBE_TIMEOUT_SECS))
-        .timeout(std::time::Duration::from_secs(LOCAL_PROBE_TIMEOUT_SECS))
-        .build()
-        .ok()?;
-
-    let url = format!("{}/v1/models", base_url.trim_end_matches('/'));
-    match client.get(&url).send().await {
-        Ok(resp) if resp.status().is_success() => {
-            Some(OllamaProvider::new(base_url.to_string(), String::new()))
-        }
-        _ => None,
-    }
+    // #4490: one probe implementation, shared with `inference::providers::local`.
+    crate::local_probe::probe_local(base_url)
+        .await
+        .ok()
+        .map(|()| OllamaProvider::new(base_url.to_string(), String::new()))
 }

--- a/crates/trusty-common/src/inference/providers/local.rs
+++ b/crates/trusty-common/src/inference/providers/local.rs
@@ -9,11 +9,22 @@
 //! provider does, so this is a thin config over the shared core — the only
 //! deltas are the base URL and the (normally absent) bearer credential.
 //! What: [`LocalConfig`] (base URL + optional auth override, sourced from
-//! [`LocalConfig::from_env`]), [`build`] (constructs an [`OpenAiCompatAdapter`]
-//! from a [`LocalConfig`]; never requires a resolved credential — unlike the
-//! keyed providers, a missing key is not an error), and [`factory`] (the
-//! production entry point [`super::register_default_factories`] registers
-//! under [`ProviderId::Local`]).
+//! [`LocalConfig::from_env`]), [`LocalAdapter`] (the liveness-probing wrapper
+//! around an [`OpenAiCompatAdapter`], #4490), [`build`] (constructs one from a
+//! [`LocalConfig`]; never requires a resolved credential — unlike the keyed
+//! providers, a missing key is not an error), and [`factory`] (the production
+//! entry point [`super::register_default_factories`] registers under
+//! [`ProviderId::Local`]).
+//!
+//! Liveness (#4490): a local server is a process that is usually NOT running,
+//! unlike a cloud endpoint that is usually up. Every request therefore probes
+//! `{base_url}/models` first, through the shared
+//! [`crate::local_probe`] entry point `chat::auto_detect_local_provider` also
+//! uses, and fails inside [`crate::local_probe::LOCAL_PROBE_TIMEOUT`] with an
+//! [`InferenceError::Transport`] naming the endpoint. Without it this adapter
+//! POSTed unconditionally against a client with no timeout at all, so a
+//! consumer migrating off `chat::ChatProvider` (#4427) lost local
+//! auto-detection silently.
 //!
 //! Override mechanism: set [`LOCAL_HOST_ENV`] (`OLLAMA_HOST`, matching the
 //! env var `trusty-agents`' legacy `OllamaAdapter` already reads — a bare
@@ -23,14 +34,24 @@
 //! server that enforces auth. Both are optional; Ollama needs neither.
 //! Test: inline `tests` — `factory_builds_named_adapter_with_defaults`,
 //! `host_env_override_appends_v1_suffix`, `api_key_env_override_is_used`,
-//! `placeholder_key_used_when_no_override`.
+//! `placeholder_key_used_when_no_override`,
+//! `probe_url_is_derived_from_the_base_url`,
+//! `chat_fails_inside_the_probe_budget_when_the_server_never_answers`;
+//! the live-endpoint half is
+//! `local_probe_passes_and_the_request_proceeds`
+//! (`crates/trusty-common/tests/inference_adapters.rs`).
+
+use async_trait::async_trait;
+use serde_json::Value;
 
 use super::openai_compat::{OpenAiCompatAdapter, OpenAiCompatConfig};
 use crate::inference::adapter::InferenceAdapter;
 use crate::inference::configurator::ResolvedProvider;
 use crate::inference::error::InferenceError;
-use crate::inference::registry::ProviderId;
-use crate::inference::types::SecretString;
+use crate::inference::registry::{ProviderCapabilities, ProviderId};
+use crate::inference::streaming::ChatStream;
+use crate::inference::types::{ChatRequest, ChatResponse, SecretString, ToolChoice};
+use crate::local_probe::{self, LocalProbeError};
 
 /// Default local OpenAI-compatible base URL — Ollama's native `/v1` shim.
 pub const LOCAL_BASE_URL: &str = "http://localhost:11434/v1";
@@ -101,6 +122,131 @@ impl LocalConfig {
     }
 }
 
+/// Translate a probe failure into the adapter's error surface.
+///
+/// Why: a dead local server is a transport condition, not a configuration one —
+/// [`InferenceError::Transport`] is the variant
+/// [`InferenceError::is_retryable`] already reports as worth retrying, which is
+/// right for a server the operator may be about to start. The probe's own
+/// `Display` already names the endpoint, so nothing is added here.
+/// What: wraps the [`LocalProbeError`] text in [`InferenceError::Transport`].
+/// Test: `chat_fails_inside_the_probe_budget_when_the_server_never_answers`.
+fn probe_failure(err: LocalProbeError) -> InferenceError {
+    InferenceError::Transport(err.to_string())
+}
+
+/// An [`OpenAiCompatAdapter`] that confirms the local server is live before it
+/// sends anything (#4490).
+///
+/// Why: a cloud endpoint is up unless something is wrong; a local model server
+/// is a process on the operator's machine that is usually NOT running. The
+/// underlying [`OpenAiCompatAdapter`] builds its `reqwest` client with no
+/// timeout at all, so against a host that accepts the connection and never
+/// answers — a wedged Ollama, a port claimed by something else — a caller waits
+/// indefinitely instead of falling back to a cloud provider. Probing first turns
+/// that into a bounded, typed failure the caller can route around, which is the
+/// capability `chat::auto_detect_local_provider` had and `inference::` did not.
+/// What: delegates every [`InferenceAdapter`] method to the wrapped adapter, and
+/// runs [`Self::probe`] ahead of [`InferenceAdapter::chat`] and
+/// [`InferenceAdapter::chat_stream`]. The probe is
+/// [`crate::local_probe::probe_models_endpoint`] against a URL derived once at
+/// construction.
+/// Test: `chat_fails_inside_the_probe_budget_when_the_server_never_answers`,
+/// `probe_url_is_derived_from_the_base_url`.
+pub struct LocalAdapter {
+    inner: OpenAiCompatAdapter,
+    probe_url: String,
+}
+
+impl LocalAdapter {
+    /// Wrap `inner`, probing the models endpoint derived from `base_url`.
+    ///
+    /// Why: the base URL is consumed by [`OpenAiCompatConfig`], so the probe URL
+    /// is derived once here rather than recomputed per request.
+    /// What: stores `inner` and [`crate::local_probe::models_url`]'s output.
+    /// Test: `probe_url_is_derived_from_the_base_url`.
+    pub fn new(inner: OpenAiCompatAdapter, base_url: &str) -> Self {
+        Self {
+            inner,
+            probe_url: local_probe::models_url(base_url),
+        }
+    }
+
+    /// The `/v1/models` URL this adapter probes before each request.
+    ///
+    /// Why: exposed for diagnostics and so a caller can report what was dialled.
+    /// What: the URL derived at construction.
+    /// Test: `probe_url_is_derived_from_the_base_url`.
+    pub fn probe_url(&self) -> &str {
+        &self.probe_url
+    }
+
+    /// Confirm the local server is reachable right now.
+    ///
+    /// Why: the public form of the ported probe — a caller deciding between a
+    /// local provider and a cloud one can ask without issuing a chat request.
+    /// What: [`crate::local_probe::probe_models_endpoint`] against
+    /// [`Self::probe_url`], with the failure mapped to
+    /// [`InferenceError::Transport`].
+    /// Test: `chat_fails_inside_the_probe_budget_when_the_server_never_answers`.
+    pub async fn probe(&self) -> Result<(), InferenceError> {
+        local_probe::probe_models_endpoint(&self.probe_url)
+            .await
+            .map_err(probe_failure)
+    }
+}
+
+#[async_trait]
+impl InferenceAdapter for LocalAdapter {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn capabilities(&self) -> &ProviderCapabilities {
+        self.inner.capabilities()
+    }
+
+    fn capabilities_for(&self, model: &str) -> &ProviderCapabilities {
+        self.inner.capabilities_for(model)
+    }
+
+    /// Probe, then delegate (#4490).
+    async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError> {
+        self.probe().await?;
+        self.inner.chat(request).await
+    }
+
+    /// Probe, then delegate (#4490).
+    async fn chat_stream(&self, request: &ChatRequest) -> Result<ChatStream, InferenceError> {
+        self.probe().await?;
+        self.inner.chat_stream(request).await
+    }
+
+    fn map_tool_choice(&self, choice: ToolChoice) -> Value {
+        self.inner.map_tool_choice(choice)
+    }
+
+    fn supports_native_tools(&self) -> bool {
+        self.inner.supports_native_tools()
+    }
+
+    fn supports_prompt_caching(&self) -> bool {
+        self.inner.supports_prompt_caching()
+    }
+
+    fn supports_structured_output(&self) -> bool {
+        self.inner.supports_structured_output()
+    }
+
+    fn wants_detailed_usage(&self) -> bool {
+        self.inner.wants_detailed_usage()
+    }
+
+    fn context_window(&self, model: &str) -> usize {
+        self.inner.context_window(model)
+    }
+}
+
 /// Build a Local adapter from `config`.
 ///
 /// Why: unlike every keyed provider ([`super::together::build`] etc.), Local
@@ -109,8 +255,11 @@ impl LocalConfig {
 /// so a missing key is the expected common case, not an alarm.
 /// What: uses `config.auth` when present, otherwise [`LOCAL_PLACEHOLDER_KEY`];
 /// constructs an [`OpenAiCompatAdapter`] against `config.base_url` with no
-/// attribution headers and [`ProviderId::Local`]'s registry capabilities.
-/// Test: `factory_builds_named_adapter_with_defaults`.
+/// attribution headers and [`ProviderId::Local`]'s registry capabilities, then
+/// wraps it in a [`LocalAdapter`] so every request is gated on the liveness
+/// probe (#4490).
+/// Test: `factory_builds_named_adapter_with_defaults`,
+/// `chat_fails_inside_the_probe_budget_when_the_server_never_answers`.
 pub fn build(
     _resolved: &ResolvedProvider,
     config: LocalConfig,
@@ -118,14 +267,16 @@ pub fn build(
     let api_key = config
         .auth
         .unwrap_or_else(|| SecretString::new(LOCAL_PLACEHOLDER_KEY));
+    let base_url = config.base_url;
     let cfg = OpenAiCompatConfig {
         name: ProviderId::Local.as_str().to_string(),
-        base_url: config.base_url,
+        base_url: base_url.clone(),
         api_key,
         extra_headers: Vec::new(),
         capabilities: *crate::inference::registry::capabilities(ProviderId::Local),
     };
-    Ok(Box::new(OpenAiCompatAdapter::new(cfg)?))
+    let inner = OpenAiCompatAdapter::new(cfg)?;
+    Ok(Box::new(LocalAdapter::new(inner, &base_url)))
 }
 
 /// Production factory: build a Local adapter from the live env overrides.
@@ -242,5 +393,87 @@ mod tests {
         // Local's `ResolvedProvider` always carries `key: None`.
         let adapter = build(&resolved(), config).expect("built without any credential");
         assert_eq!(adapter.name(), "local");
+    }
+
+    /// Why (#4490): the probe URL is derived once at construction from a base
+    /// URL that already carries `/v1`; getting that wrong dials `/v1/v1/models`
+    /// and reports every live server as dead.
+    /// Test: this test.
+    #[test]
+    fn probe_url_is_derived_from_the_base_url() {
+        let inner = OpenAiCompatAdapter::new(OpenAiCompatConfig {
+            name: ProviderId::Local.as_str().to_string(),
+            base_url: LOCAL_BASE_URL.to_string(),
+            api_key: SecretString::new(LOCAL_PLACEHOLDER_KEY),
+            extra_headers: Vec::new(),
+            capabilities: *crate::inference::registry::capabilities(ProviderId::Local),
+        })
+        .expect("inner adapter builds");
+        let adapter = LocalAdapter::new(inner, LOCAL_BASE_URL);
+        assert_eq!(adapter.probe_url(), "http://localhost:11434/v1/models");
+    }
+
+    /// A request against a local endpoint that accepts the connection and never
+    /// answers fails inside the probe budget, naming the endpoint (#4490).
+    ///
+    /// Why: this is the regression the ticket exists to prevent. Without the
+    /// probe, `chat` POSTs through [`OpenAiCompatAdapter`]'s client — which is
+    /// built with NO timeout — so a wedged local server hangs the caller
+    /// indefinitely instead of failing fast enough to fall back to a cloud
+    /// provider. The black-hole listener is what separates the two behaviours: a
+    /// merely CLOSED port refuses instantly either way and would prove nothing.
+    /// What: binds a listener that accepts and holds connections without
+    /// writing a byte, points a Local adapter at it, and asserts `chat` returns
+    /// a retryable [`InferenceError::Transport`] naming the address, well inside
+    /// the outer 5s guard. The guard is what fails (rather than hangs) if the
+    /// probe is removed.
+    /// Test: this test.
+    #[tokio::test]
+    async fn chat_fails_inside_the_probe_budget_when_the_server_never_answers() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind black-hole listener");
+        let addr = listener.local_addr().expect("listener addr");
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        let config = LocalConfig {
+            base_url: format!("http://{addr}/v1"),
+            auth: None,
+        };
+        let adapter = build(&resolved(), config).expect("built");
+        let request = ChatRequest::new(
+            "local/llama3.1",
+            vec![crate::inference::types::ChatMessage::user("ping")],
+        );
+
+        let started = std::time::Instant::now();
+        let outcome =
+            tokio::time::timeout(std::time::Duration::from_secs(5), adapter.chat(&request))
+                .await
+                .expect(
+                    "chat must return inside the probe budget, not hang on a dead local server",
+                );
+        let elapsed = started.elapsed();
+
+        let err = outcome.expect_err("a server that never answers must not yield a response");
+        assert!(
+            matches!(err, InferenceError::Transport(_)),
+            "expected Transport, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains(&addr.to_string()),
+            "the error must name the endpoint that was dialled: {err}"
+        );
+        assert!(err.is_retryable(), "a dead local server is worth retrying");
+        assert!(
+            elapsed < std::time::Duration::from_secs(3),
+            "probe budget is {:?}; took {elapsed:?}",
+            crate::local_probe::LOCAL_PROBE_TIMEOUT
+        );
     }
 }

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -1101,6 +1101,21 @@ pub mod daemon_addr;
 /// Test: covered via daemon_addr integration tests.
 pub mod health_probe;
 
+/// The single liveness probe for a local OpenAI-compatible model server
+/// (#4490).
+///
+/// Why: `chat::auto_detect_local_provider` and `inference::providers::local`
+/// both need "is a local model server reachable right now?", and a second
+/// independent copy of that probe is what the common-entry-point rule forbids.
+/// Sharing it also shares the timeout, so the two callers cannot drift.
+/// What: Exposes [`local_probe::LOCAL_PROBE_TIMEOUT`],
+/// [`local_probe::models_url`], [`local_probe::probe_models_endpoint`],
+/// [`local_probe::probe_local`], and the endpoint-naming
+/// [`local_probe::LocalProbeError`].
+/// Test: `cargo test -p trusty-common --features unconditional-only --
+/// local_probe::tests`.
+pub mod local_probe;
+
 /// The local-client credential a loopback daemon and its clients share
 /// through a `0600` file (#5439).
 ///

--- a/crates/trusty-common/src/local_probe.rs
+++ b/crates/trusty-common/src/local_probe.rs
@@ -1,0 +1,325 @@
+//! Liveness probe for a local OpenAI-compatible model server (#4490).
+//!
+//! Why: two call sites answer the same question — "is a local model server
+//! actually reachable right now?" — and a wrong answer costs money and latency
+//! silently instead of failing loudly. `chat::auto_detect_local_provider` has
+//! probed since the `ChatProvider` era, while `inference::providers::local`
+//! built an adapter for a fixed base URL unconditionally, so a consumer moving
+//! from `ChatProvider` to `InferenceAdapter` (#4427) would have fallen through
+//! to OpenRouter on every turn even with a local model running. Copying the
+//! probe across would leave two independent implementations of one capability,
+//! which CLAUDE.md's common-entry-point rule forbids, so the probe lives here
+//! and both callers route through it — the timeout included, as one named
+//! constant rather than a literal repeated per call site.
+//!
+//! What: [`LOCAL_PROBE_TIMEOUT`](crate::local_probe::LOCAL_PROBE_TIMEOUT) (the
+//! shared budget, applied to both connect and whole-request),
+//! [`models_url`](crate::local_probe::models_url) (the `{host}/v1/models`
+//! derivation),
+//! [`probe_models_endpoint`](crate::local_probe::probe_models_endpoint) (the GET
+//! plus status check), and [`probe_local`](crate::local_probe::probe_local) (the
+//! two composed). Failure is a typed
+//! [`LocalProbeError`](crate::local_probe::LocalProbeError) that always names the
+//! endpoint it dialled, so a caller can report which address was dead rather than
+//! surfacing a bare transport timeout.
+//!
+//! Paths here are crate-absolute on purpose: this module carries docs both here
+//! and on the `pub mod local_probe;` declaration in `lib.rs`, rustdoc merges the
+//! two, and link resolution takes its scope from the FIRST fragment — the
+//! `lib.rs` one — so a bare `LOCAL_PROBE_TIMEOUT` resolves against the crate root
+//! and is not found (#6027).
+//!
+//! Scope: this deliberately does NOT route through
+//! [`crate::http_client::loopback_client_builder`]. That entry point disables
+//! proxies for LOOPBACK daemon targets, and a local model server is pointable at
+//! a non-loopback host (`OLLAMA_HOST=http://192.168.1.50:11434`) where the
+//! operator's proxy must still apply — the same carve-out `http_client`'s own
+//! docs state for inference providers. [`crate::health_probe::probe_health`] is
+//! the loopback-daemon counterpart; it answers `bool`, which cannot carry the
+//! endpoint a caller has to report.
+//!
+//! Test: inline `tests` — `models_url_appends_v1_when_absent`,
+//! `models_url_does_not_double_an_existing_v1_suffix`,
+//! `probe_reports_unreachable_naming_the_endpoint`,
+//! `probe_reports_non_success_status`, `probe_accepts_a_live_endpoint`,
+//! `probe_timeout_is_one_second`.
+
+use std::time::Duration;
+
+/// The budget one liveness probe gets, for connect AND for the whole request.
+///
+/// Why: the probe runs on a startup path in front of a fallback decision, so it
+/// must never be the thing that makes a command feel hung — a local server that
+/// is not up has to be ruled out in about the time a human would wait. One
+/// second is what `chat::auto_detect_local_provider` has used since it shipped;
+/// naming it once here is what keeps the two callers from drifting apart.
+/// What: one second, passed to both `connect_timeout` and `timeout`.
+/// Test: `probe_timeout_is_one_second`.
+pub const LOCAL_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// The OpenAI-compatible path every local server implements for a cheap,
+/// side-effect-free liveness check.
+pub const LOCAL_MODELS_PATH: &str = "/v1/models";
+
+/// Why the local model server could not be confirmed live.
+///
+/// Why: the caller's job after a failed probe is to tell an operator WHICH
+/// address was dead — "connection refused" alone sends them looking at the wrong
+/// host when `OLLAMA_HOST` points somewhere unexpected. Every variant therefore
+/// carries the endpoint, and [`Self::endpoint`] reads it back without a match.
+/// What: `ClientBuild` (the HTTP client could not be constructed at all),
+/// `Unreachable` (no response inside [`LOCAL_PROBE_TIMEOUT`] — refused, timed
+/// out, DNS, TLS), and `Status` (the server answered, but not 2xx). No variant
+/// carries a credential: the probe sends no `Authorization` header.
+/// Test: `probe_reports_unreachable_naming_the_endpoint`,
+/// `probe_reports_non_success_status`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LocalProbeError {
+    /// The `reqwest` client could not be built (never observed in practice).
+    ClientBuild {
+        /// The endpoint the probe would have dialled.
+        endpoint: String,
+        /// The stringified builder error.
+        cause: String,
+    },
+    /// No response arrived within [`LOCAL_PROBE_TIMEOUT`].
+    Unreachable {
+        /// The endpoint that did not answer.
+        endpoint: String,
+        /// The stringified transport error.
+        cause: String,
+    },
+    /// The server answered with a non-2xx status.
+    Status {
+        /// The endpoint that answered.
+        endpoint: String,
+        /// The HTTP status it returned.
+        status: u16,
+    },
+}
+
+impl LocalProbeError {
+    /// The endpoint this probe dialled.
+    ///
+    /// Why: every caller reports it, and none of them should have to match on
+    /// the variant to get at it.
+    /// What: the `endpoint` field of whichever variant this is.
+    /// Test: `probe_reports_unreachable_naming_the_endpoint`.
+    pub fn endpoint(&self) -> &str {
+        match self {
+            Self::ClientBuild { endpoint, .. }
+            | Self::Unreachable { endpoint, .. }
+            | Self::Status { endpoint, .. } => endpoint,
+        }
+    }
+}
+
+impl std::fmt::Display for LocalProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClientBuild { endpoint, cause } => write!(
+                f,
+                "could not build a probe client for local model server {endpoint}: {cause}"
+            ),
+            Self::Unreachable { endpoint, cause } => write!(
+                f,
+                "local model server not reachable at {endpoint} within {}s: {cause}",
+                LOCAL_PROBE_TIMEOUT.as_secs()
+            ),
+            Self::Status { endpoint, status } => write!(
+                f,
+                "local model server at {endpoint} answered HTTP {status}, not a success status"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LocalProbeError {}
+
+/// Derive the `/v1/models` probe URL from a local server's base URL.
+///
+/// Why: the two callers spell their base URL differently and neither should have
+/// to know the other's convention. `chat::LocalModelConfig::base_url` is a bare
+/// host (`http://localhost:11434`); `inference::providers::local::LOCAL_BASE_URL`
+/// already carries the `/v1` suffix the OpenAI dialect needs. One derivation that
+/// accepts both is what lets a single probe serve both.
+/// What: trims trailing slashes, drops a trailing `/v1` if present, and appends
+/// [`LOCAL_MODELS_PATH`]. A bare host is therefore unchanged from what
+/// `chat::auto_detect_local_provider` has always produced.
+/// Test: `models_url_appends_v1_when_absent`,
+/// `models_url_does_not_double_an_existing_v1_suffix`.
+pub fn models_url(base_url: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    let host = base.strip_suffix("/v1").unwrap_or(base);
+    format!("{host}{LOCAL_MODELS_PATH}")
+}
+
+/// GET an already-derived models endpoint and report whether it is live.
+///
+/// Why: the single implementation of the probe itself, so the timeout, the
+/// success criterion, and the error text cannot drift between `chat::` and
+/// `inference::`.
+/// What: builds a client bounded by [`LOCAL_PROBE_TIMEOUT`] on connect and on
+/// the whole request, GETs `url`, and returns `Ok(())` for any 2xx. Anything
+/// else — a build failure, a transport failure, a timeout, a non-2xx status — is
+/// a [`LocalProbeError`] naming `url`. Sends no credential.
+/// Test: `probe_reports_unreachable_naming_the_endpoint`,
+/// `probe_reports_non_success_status`, `probe_accepts_a_live_endpoint`.
+pub async fn probe_models_endpoint(url: &str) -> Result<(), LocalProbeError> {
+    // #4490: proxies are deliberately left enabled — see the module's Scope note.
+    let client = reqwest::Client::builder()
+        .connect_timeout(LOCAL_PROBE_TIMEOUT)
+        .timeout(LOCAL_PROBE_TIMEOUT)
+        .build()
+        .map_err(|e| LocalProbeError::ClientBuild {
+            endpoint: url.to_string(),
+            cause: e.to_string(),
+        })?;
+
+    match client.get(url).send().await {
+        Ok(resp) if resp.status().is_success() => Ok(()),
+        Ok(resp) => Err(LocalProbeError::Status {
+            endpoint: url.to_string(),
+            status: resp.status().as_u16(),
+        }),
+        Err(e) => Err(LocalProbeError::Unreachable {
+            endpoint: url.to_string(),
+            cause: e.to_string(),
+        }),
+    }
+}
+
+/// Probe a local model server given its base URL.
+///
+/// Why: the form both callers actually want — they hold a base URL, not a models
+/// endpoint.
+/// What: [`models_url`] followed by [`probe_models_endpoint`].
+/// Test: `probe_accepts_a_live_endpoint`,
+/// `probe_reports_unreachable_naming_the_endpoint`.
+pub async fn probe_local(base_url: &str) -> Result<(), LocalProbeError> {
+    probe_models_endpoint(&models_url(base_url)).await
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A loopback stub answering one canned status per connection, forever.
+    ///
+    /// Modelled on `http_client::tests::stub_server` — a real listener, so the
+    /// probe under test drives the real transport.
+    async fn stub_server(response: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback stub");
+        let addr = listener.local_addr().expect("stub addr").to_string();
+        tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    use tokio::io::AsyncWriteExt;
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        addr
+    }
+
+    /// An address with nothing listening: bind port 0, read it, release it.
+    fn dead_addr() -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind to free a port");
+        let addr = listener.local_addr().expect("dead addr").to_string();
+        drop(listener);
+        addr
+    }
+
+    /// Why: a bare host is what `chat::LocalModelConfig::base_url` holds, and
+    /// the URL this produces for it must stay byte-identical to the one
+    /// `chat::auto_detect_local_provider` has always built.
+    /// Test: this test.
+    #[test]
+    fn models_url_appends_v1_when_absent() {
+        assert_eq!(
+            models_url("http://localhost:11434"),
+            "http://localhost:11434/v1/models"
+        );
+        assert_eq!(
+            models_url("http://localhost:11434/"),
+            "http://localhost:11434/v1/models"
+        );
+    }
+
+    /// Why: `inference::providers::local::LOCAL_BASE_URL` already ends in `/v1`,
+    /// so a naive append would dial `/v1/v1/models` and report every live server
+    /// as dead.
+    /// Test: this test.
+    #[test]
+    fn models_url_does_not_double_an_existing_v1_suffix() {
+        assert_eq!(
+            models_url("http://localhost:11434/v1"),
+            "http://localhost:11434/v1/models"
+        );
+        assert_eq!(
+            models_url("http://localhost:11434/v1/"),
+            "http://localhost:11434/v1/models"
+        );
+    }
+
+    /// Why: the whole point of the typed error is that a caller can name the
+    /// address that was dead; a bare "connection refused" sends an operator to
+    /// the wrong host.
+    /// Test: this test.
+    #[tokio::test]
+    async fn probe_reports_unreachable_naming_the_endpoint() {
+        let addr = dead_addr();
+        let base = format!("http://{addr}");
+        let err = probe_local(&base).await.expect_err("closed port must fail");
+        assert!(
+            matches!(err, LocalProbeError::Unreachable { .. }),
+            "expected Unreachable, got {err:?}"
+        );
+        assert_eq!(err.endpoint(), format!("{base}/v1/models"));
+        assert!(err.to_string().contains(&addr), "{err}");
+    }
+
+    /// Why: a server that answers but does not serve `/v1/models` is not a
+    /// usable local model server, and must be rejected rather than treated as
+    /// live because a socket accepted the connection.
+    /// Test: this test.
+    #[tokio::test]
+    async fn probe_reports_non_success_status() {
+        let addr = stub_server("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n").await;
+        let err = probe_local(&format!("http://{addr}"))
+            .await
+            .expect_err("404 must fail");
+        assert_eq!(
+            err,
+            LocalProbeError::Status {
+                endpoint: format!("http://{addr}/v1/models"),
+                status: 404,
+            }
+        );
+    }
+
+    /// Why: the positive half — a reachable server must pass, or the probe would
+    /// disable local inference entirely.
+    /// Test: this test.
+    #[tokio::test]
+    async fn probe_accepts_a_live_endpoint() {
+        let addr = stub_server("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+        probe_local(&format!("http://{addr}"))
+            .await
+            .expect("live endpoint must probe clean");
+    }
+
+    /// Why (#4490): the budget is a contract, not an implementation detail —
+    /// both callers depend on a failed probe costing about a second, and this is
+    /// the single definition they share.
+    /// Test: this test.
+    #[test]
+    fn probe_timeout_is_one_second() {
+        assert_eq!(LOCAL_PROBE_TIMEOUT, Duration::from_secs(1));
+    }
+}

--- a/crates/trusty-common/tests/inference_adapters.rs
+++ b/crates/trusty-common/tests/inference_adapters.rs
@@ -16,8 +16,9 @@
 use serde_json::{Value, json};
 use serial_test::serial;
 use trusty_common::credentials::{KeyStore, MemoryKeyStore};
+use trusty_common::inference::providers::local::LocalConfig;
 use trusty_common::inference::providers::{
-    anthropic, atlascloud, fireworks, openai, openrouter, together,
+    anthropic, atlascloud, fireworks, local, openai, openrouter, together,
 };
 use trusty_common::inference::test_support::MockInferenceServer;
 use trusty_common::inference::{
@@ -718,6 +719,70 @@ async fn http_429_maps_to_retryable_api_error() {
     assert!(matches!(err, InferenceError::Api { status: 429, .. }));
     assert!(err.is_retryable());
     assert!(!err.is_alarm());
+}
+
+// ── Local provider liveness probe (#4490) ────────────────────────────────────────
+
+/// A live local endpoint passes the probe and the request proceeds (#4490).
+///
+/// Why: the ported probe must gate the request without blocking it. The failure
+/// half is covered inline in `local.rs`; this is the half that proves the gate
+/// opens — a probe that rejected a healthy server would disable local inference
+/// entirely, which is the same silent cost regression #4490 exists to prevent,
+/// only inverted.
+/// What: points a Local adapter at [`MockInferenceServer`] (which answers every
+/// path), issues one `chat`, and asserts BOTH that the canned response came back
+/// AND that the mock recorded the probe's `GET /v1/models` ahead of the
+/// `POST /v1/chat/completions`. The recorded GET is what makes this a test of
+/// the probe rather than of the adapter it wraps.
+#[tokio::test]
+#[serial(dotenv_credential_env)]
+async fn local_probe_passes_and_the_request_proceeds() {
+    clear_provider_env();
+    let server = MockInferenceServer::spawn(200, text_response_body())
+        .await
+        .expect("spawn mock");
+
+    let base = format!("{}/v1", server.url());
+    let mut cfg = Configurator::new();
+    cfg.register(
+        ProviderId::Local,
+        Box::new(move |r: &ResolvedProvider| {
+            local::build(
+                r,
+                LocalConfig {
+                    base_url: base.clone(),
+                    auth: None,
+                },
+            )
+        }),
+    );
+
+    let store = MemoryKeyStore::new();
+    let adapter = cfg.build("local/llama3.1", &store).expect("build local");
+    assert_eq!(adapter.name(), "local");
+
+    let req = ChatRequest::new("local/llama3.1", vec![ChatMessage::user("ping")]);
+    let resp = adapter.chat(&req).await.expect("chat ok");
+    assert_eq!(resp.first_text().as_deref(), Some("pong"));
+
+    let requests = server.requests();
+    let probe_index = requests
+        .iter()
+        .position(|r| r.method == "GET" && r.path == "/v1/models")
+        .expect("the liveness probe must have been issued");
+    let post_index = requests
+        .iter()
+        .position(|r| r.method == "POST" && r.path == "/v1/chat/completions")
+        .expect("the chat request must have been sent");
+    assert!(
+        requests[probe_index].header("authorization").is_none(),
+        "the probe must not send a credential"
+    );
+    assert!(
+        probe_index < post_index,
+        "the probe must run BEFORE the chat POST, not after it"
+    );
 }
 
 // ── Default factory registration ─────────────────────────────────────────────────


### PR DESCRIPTION
`chat::auto_detect_local_provider` probed `{base_url}/v1/models` with a 1s timeout before preferring a local model server over OpenRouter. `inference::providers::local::build` had no equivalent — it constructed an adapter unconditionally, over an `OpenAiCompatAdapter` whose reqwest client carries no timeout at all (`openai_compat.rs:92-95`). A consumer migrating from `ChatProvider` to `InferenceAdapter` (#4427) therefore lost local auto-detection silently, and a wedged local server hung the caller instead of failing over.

## What changed

`crates/trusty-common/src/local_probe.rs` (new, unconditional) holds the probe once: `LOCAL_PROBE_TIMEOUT`, the `{host}/v1/models` derivation, the GET plus status check, and a typed `LocalProbeError` whose every variant carries the endpoint it dialled.

`inference::providers::local` gains `LocalAdapter`, which wraps the `OpenAiCompatAdapter`, runs the probe ahead of `chat` and `chat_stream`, and maps a failure to `InferenceError::Transport` — retryable, which is right for a server the operator may be about to start. Every other `InferenceAdapter` method delegates unchanged. `LocalConfig`'s public fields are untouched, so no struct-literal break.

`chat::auto_detect_local_provider` now calls the shared probe and discards its typed error. Its own `LOCAL_PROBE_TIMEOUT_SECS` const is gone; both callers read one named constant, which is what the common-entry-point rule asks for instead of the second independent copy a straight port would have left. `chat::`'s behaviour is unchanged for the base URL it documents: a bare host still yields `{host}/v1/models`, pinned by `models_url_appends_v1_when_absent` and by the pre-existing `auto_detect_returns_none_on_unreachable` / `auto_detect_returns_some_on_200`.

The probe deliberately does not route through `http_client::loopback_client_builder`. That entry point disables proxies for loopback daemon targets, and `OLLAMA_HOST` can point at a non-loopback host where the operator's proxy must still apply — the carve-out `http_client`'s own docs state for inference providers. `health_probe::probe_health` is the loopback counterpart and answers `bool`, which cannot carry the endpoint a caller has to report.

## Regression proof

With `local.rs`, `lib.rs` and `chat/openai_compat/providers.rs` reverted to `origin/main` and `local_probe.rs` deleted, keeping the new test:

```
test local_probe_passes_and_the_request_proceeds ... FAILED
panicked at crates/trusty-common/tests/inference_adapters.rs:773:10:
the liveness probe must have been issued
test result: FAILED. 17 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

The inline `chat_fails_inside_the_probe_budget_when_the_server_never_answers` cannot be shown failing the same way — it lives in `local.rs`, so reverting that file removes the test with the fix. On `origin/main` it is a compile-level absence: `LocalAdapter` and `probe` do not exist. Its behavioural basis is the no-timeout client above: against the test's black-hole listener (accepts the connection, never writes) the un-probed `chat` never returns, and the test's 5s `tokio::time::timeout` guard is what fails.

## Test ladder — rung 4

Cross-crate change to a shared library, so rung 3 on `trusty-common` plus `check --workspace` and each direct dependent.

```
cargo test -p trusty-common --no-fail-fast --features inference-client,axum-server
cargo test -p trusty-common --no-fail-fast --features unconditional-only
cargo fmt --check
cargo clippy -p trusty-common --all-targets --features inference-client,axum-server -- -D warnings
SKIP_UI_BUILD=1 cargo check --workspace
SKIP_UI_BUILD=1 cargo test -p trusty-search --no-fail-fast
SKIP_UI_BUILD=1 cargo test -p trusty-memory --no-fail-fast
```

`inference-client` gates `inference::providers::local` (`inference/mod.rs:69-70`); `axum-server` gates `test_support::MockInferenceServer`, which the live-endpoint test needs. `unconditional-only` covers `chat` and the new `local_probe`, both ungated. `--all-features` is unavailable here — the `embedder-*` ORT variants are mutually exclusive.

| Gate | Result |
|---|---|
| `trusty-common` `--features inference-client,axum-server` | `ok. 732 passed; 0 failed; 12 ignored` (lib), `ok. 18 passed; 0 failed` (`inference_adapters`), `ok. 12 passed` (`inference_foundation`), `ok. 4 passed` (`feature_coverage`) |
| `trusty-common` `--features unconditional-only` | `ok. 465 passed; 0 failed; 6 ignored` |
| `cargo fmt --check` | clean |
| `clippy -p trusty-common --all-targets --features inference-client,axum-server -- -D warnings` | clean (only the pre-existing duplicate-bin-target manifest warnings) |
| `cargo check --workspace` | clean |
| `cargo test -p trusty-search --no-fail-fast` | `ok. 2066 passed; 0 failed; 1 ignored` plus 34 further targets all ok |
| `cargo test -p trusty-memory --no-fail-fast` | `ok. 860 passed; 0 failed; 4 ignored` plus 30 further targets all ok |
| `check_line_cap.sh` | `4575 tracked .rs file(s); 4 allowlisted, 0 violations` |
| `check_test_pointers.sh` | `resolved 31762 Test: citation(s) — 0 dangling pointers` |
| `check_sld.sh` | `0 error(s), 0 warning(s)` |
| `check_changelog_fragment.sh` | `OK trusty-common: changelog.d fragment present and valid` |
| `check-pr-version-bump.sh` | `[ OK ] trusty-common 0.49.1 — src changed, version not yet published` — no bump owed |
| `check_rustdoc_links.sh` | `26 crate(s) examined, 0 broken link(s)` |

Counts above carry `--no-fail-fast`, so every target ran (#5354). Both trusty-common lanes and `cargo check --workspace` were re-run after rebasing onto `238cd33fa`.

## Doc-link note (#6027)

`check_rustdoc_links.sh` failed on the first run with 5 unresolved links. rustdoc merges a module's own `//!` header with the `///` block on its `pub mod` declaration in `lib.rs` and resolves both against the scope of the FIRST fragment — the `lib.rs` one — so the bare `[`LOCAL_PROBE_TIMEOUT`]` and friends in `local_probe.rs`'s header resolved against the crate root and were not found. The same trap `http_client.rs` documents. Fixed by making that header's paths crate-absolute; the `///` item docs inside the module are not merged and stay relative.

Refs #4490
