### PR TITLE
feat(tga): record which signal family produced each is_ai_assisted verdict

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/4418-ai-detection-method.md
+++ b/crates/trusty-git-analytics/changelog.d/4418-ai-detection-method.md
@@ -1,0 +1,16 @@
+Added
+
+- `commits.ai_detection_method` records which signal family produced each
+  `is_ai_assisted` verdict — `trailer`, `message`, or `email` — and is NULL for
+  a commit no marker claimed (#4418). Consumers can now cut the trailer-matched
+  subset, the one they can re-derive from commit messages themselves, out of
+  the AI-assisted total instead of reading the total as if it already were that
+  subset. The column is nullable and additive: `is_ai_assisted` and `ai_tool`
+  keep their existing semantics, and an older `tga` reading the database is
+  unaffected. Migration v29 adds the column; `DETECTOR_VERSION` moves to 2, so
+  the next `tga collect` repopulates every stored row, and
+  `tga backfill ai-detection-commits` writes it too.
+- The weekly report and `weekly_activity.csv` gain `ai_trailer_count`,
+  `ai_message_count` and `ai_email_count`, which partition `ai_assisted_count`
+  by that same signal family (#4418). Appended after the existing columns, so a
+  consumer reading by column index is unaffected.

--- a/crates/trusty-git-analytics/src/collect/ai_marker_config.rs
+++ b/crates/trusty-git-analytics/src/collect/ai_marker_config.rs
@@ -77,6 +77,46 @@ pub enum MarkerScope {
     Email,
 }
 
+impl MarkerScope {
+    /// Stable string for the `commits.ai_detection_method` TEXT column (#4418).
+    ///
+    /// Why: the signal family that produced a commit's AI verdict is the scope
+    /// of the marker that matched it, so the persisted discriminator and the
+    /// config-file vocabulary are the same three values. Giving the column its
+    /// own parallel enum would be a second spelling of one concept, free to
+    /// drift from this one on the next scope added.
+    /// What: the identity mapping onto this enum's own serde spellings, so a
+    /// `scope: trailer` line in a marker file and a `'trailer'` cell in the
+    /// database read as the same word.
+    /// Test: `tests::marker_scope_strings_round_trip`,
+    /// `tests::marker_scope_strings_match_the_yaml_spellings`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            MarkerScope::Trailer => "trailer",
+            MarkerScope::Message => "message",
+            MarkerScope::Email => "email",
+        }
+    }
+}
+
+impl std::str::FromStr for MarkerScope {
+    type Err = ();
+
+    /// Inverse of [`MarkerScope::as_str`]; an unrecognised value is `Err(())`.
+    ///
+    /// A stored value this build has no name for means a newer tga wrote the
+    /// row. Callers read that as "no method recorded" rather than guessing one.
+    /// Test: `tests::marker_scope_strings_round_trip`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "trailer" => Ok(MarkerScope::Trailer),
+            "message" => Ok(MarkerScope::Message),
+            "email" => Ok(MarkerScope::Email),
+            _ => Err(()),
+        }
+    }
+}
+
 /// The classification an operator marker asserts when it matches.
 ///
 /// Why: [`AgenticMode`] carries a `None` variant that means "nothing matched",
@@ -339,6 +379,39 @@ mod tests {
             ]
         );
         assert_eq!(cfg.markers[1].mode, MarkerMode::IdeAssisted);
+    }
+
+    /// #4418: the persisted `commits.ai_detection_method` value must survive a
+    /// write and a read, or a downstream consumer filtering on `'trailer'`
+    /// silently selects nothing.
+    #[test]
+    fn marker_scope_strings_round_trip() {
+        for scope in [
+            MarkerScope::Trailer,
+            MarkerScope::Message,
+            MarkerScope::Email,
+        ] {
+            assert_eq!(scope.as_str().parse::<MarkerScope>(), Ok(scope));
+        }
+        assert_eq!("subject".parse::<MarkerScope>(), Err(()));
+        assert_eq!("".parse::<MarkerScope>(), Err(()));
+    }
+
+    /// #4418: the column vocabulary and the marker-file vocabulary are one set
+    /// of words. If `as_str` drifted from the serde spelling, an operator
+    /// reading `scope: email` in their own marker file would find a different
+    /// word in the column that marker wrote.
+    #[test]
+    fn marker_scope_strings_match_the_yaml_spellings() {
+        let cfg = MarkerConfig::from_yaml_str(
+            "markers:\n\
+             \x20 - { tool: a, mode: full_agentic, scope: trailer, pattern: x }\n\
+             \x20 - { tool: b, mode: ide_assisted, scope: message, pattern: y }\n\
+             \x20 - { tool: c, mode: full_agentic, scope: email, pattern: z }\n",
+        )
+        .expect("parses");
+        let spelled: Vec<&str> = cfg.markers.iter().map(|m| m.scope.as_str()).collect();
+        assert_eq!(spelled, vec!["trailer", "message", "email"]);
     }
 
     #[test]

--- a/crates/trusty-git-analytics/src/collect/ai_markers.rs
+++ b/crates/trusty-git-analytics/src/collect/ai_markers.rs
@@ -8,8 +8,9 @@
 //! (DOC-67 §8), so a confidently wrong number is worse than an absent one.
 //! What: an ordered list of markers, each a tool label, an [`AgenticMode`], a
 //! scope naming which text it is matched against, and a compiled regex. One
-//! pass yields both `commits.ai_tool` and `commits.agentic_mode`, so they can
-//! never disagree. Callers use [`detect`]. Since #5414 the list is
+//! pass yields `commits.ai_tool`, `commits.agentic_mode` and — since #4418 —
+//! `commits.ai_detection_method`, so they can never disagree. Callers use
+//! [`detect`]. Since #5414 the list is
 //! [`BUILTIN`] plus whatever [`crate::collect::ai_marker_config`] loads from
 //! disk, so a house footer is addable without a code change or a release. The
 //! two halves are scanned in sequence, not merged: [`BUILTIN`] decides first,
@@ -59,18 +60,52 @@ impl<'a> CommitSignals<'a> {
 
 /// Outcome of one detection pass.
 ///
-/// Why: `ai_tool`, `is_ai_assisted` and `agentic_mode` are written from the
-/// same scan so they cannot disagree about whether a commit was AI-assisted.
+/// Why: `ai_tool`, `is_ai_assisted`, `agentic_mode` and `ai_detection_method`
+/// are written from the same scan so they cannot disagree about whether a
+/// commit was AI-assisted, or about what said so.
 /// What: `tool` is the winning marker's label; when nothing matched, `mode` is
 /// [`AgenticMode::None`], or [`AgenticMode::Unknown`] if the message shows a
-/// rewrite fingerprint (#5250).
-/// Test: `tests::detects_trusty_mpm_footer`.
+/// rewrite fingerprint (#5250). `method` is the winning marker's
+/// [`MarkerScope`] — which text family carried the evidence (#4418).
+///
+/// `tool` and `method` are always both `Some` or both `None`: a marker
+/// contributes its label and its scope together, and nothing else sets either.
+/// That equivalence is what lets `is_ai_assisted` and `ai_detection_method` be
+/// derived from one struct without a second decision.
+/// Test: `tests::detects_trusty_mpm_footer`,
+/// `tests::method_is_present_exactly_when_a_tool_is`.
+///
+/// `#[non_exhaustive]` since #4418 added `method`: the next signal recorded
+/// beside a verdict should not have to be a breaking change to name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Detection {
     /// Label of the highest-priority matching marker.
     pub tool: Option<&'static str>,
     /// Classification implied by the matching markers.
     pub mode: AgenticMode,
+    /// Signal family of the marker that matched — `Trailer`, `Message`, or
+    /// `Email` — persisted as `commits.ai_detection_method` (#4418). `None`
+    /// when no marker matched, which is exactly when `tool` is `None`.
+    pub method: Option<MarkerScope>,
+}
+
+impl Detection {
+    /// The verdict for a commit no marker claimed.
+    ///
+    /// Why: `Detection` is `#[non_exhaustive]`, and three call sites in this
+    /// module spell the same no-match result. One constructor keeps the
+    /// `tool`/`method` equivalence in a single place.
+    /// What: `tool` and `method` `None`, with the caller's `mode` — the two
+    /// unmatched modes are [`AgenticMode::None`] and [`AgenticMode::Unknown`].
+    /// Test: `tests::method_is_present_exactly_when_a_tool_is`.
+    fn unmatched(mode: AgenticMode) -> Self {
+        Detection {
+            tool: None,
+            mode,
+            method: None,
+        }
+    }
 }
 
 /// Generation number of the shipped detector, stamped onto every row it
@@ -100,7 +135,11 @@ pub struct Detection {
 /// they classified is not re-visited by a version bump alone — run
 /// `tga backfill ai-detection-commits` after editing the marker file.
 /// Test: `crate::collect::reclassify::tests::stale_rows_are_reclassified_and_current_rows_are_not`.
-pub const DETECTOR_VERSION: i64 = 1;
+///
+/// Generation 2 is #4418: [`detect`] now also returns the matching marker's
+/// [`MarkerScope`], and every row stored by generation 1 has a NULL
+/// `ai_detection_method` that only a re-classification pass can fill.
+pub const DETECTOR_VERSION: i64 = 2;
 
 /// Classify one commit against the marker set.
 ///
@@ -115,11 +154,14 @@ pub const DETECTOR_VERSION: i64 = 1;
 /// `IdeAssisted` match found earlier in that slice; among `IdeAssisted` matches
 /// the earliest supplies the label. When neither scan matches, the verdict
 /// splits on [`provenance_possibly_stripped`] (#5250) — that predicate reads the
-/// message only, never the identities the backfill lacks.
+/// message only, never the identities the backfill lacks. Whichever marker
+/// supplies the label also supplies [`Detection::method`], the signal family
+/// the label came from (#4418).
 /// Test: `tests::detects_trusty_mpm_footer`,
 /// `tests::full_agentic_wins_over_ide_assisted`,
 /// `tests::operator_full_agentic_cannot_upgrade_a_builtin_ide_match`,
-/// `tests::merge_summary_is_unknown_not_none`.
+/// `tests::merge_summary_is_unknown_not_none`,
+/// `tests::method_names_the_signal_family_that_matched`.
 pub fn detect(signals: &CommitSignals<'_>) -> Detection {
     detect_in(marker_set(), signals)
 }
@@ -161,20 +203,18 @@ fn detect_in(set: &MarkerSet, signals: &CommitSignals<'_>) -> Detection {
     // `scan` that returned `Unknown` itself would satisfy the `!= None` test
     // above and skip the operator markers #5414 added.
     if provenance_possibly_stripped(signals.message) {
-        return Detection {
-            tool: None,
-            mode: AgenticMode::Unknown,
-        };
+        return Detection::unmatched(AgenticMode::Unknown);
     }
-    Detection {
-        tool: None,
-        mode: AgenticMode::None,
-    }
+    Detection::unmatched(AgenticMode::None)
 }
 
 /// One ordered pass over a marker slice.
 fn scan(markers: &[AiMarker], signals: &CommitSignals<'_>, trailers: &[&str]) -> Detection {
-    let mut ide: Option<&'static str> = None;
+    // #4418: the label and the scope travel together, so the recorded method is
+    // always the scope of the marker that supplied the label — including on the
+    // IDE path, where an earlier match wins and a later one must not overwrite
+    // half the verdict.
+    let mut ide: Option<(&'static str, MarkerScope)> = None;
     for marker in markers {
         if !marker.matches(signals, trailers) {
             continue;
@@ -184,11 +224,12 @@ fn scan(markers: &[AiMarker], signals: &CommitSignals<'_>, trailers: &[&str]) ->
                 return Detection {
                     tool: Some(marker.tool),
                     mode: AgenticMode::FullAgentic,
+                    method: Some(marker.scope),
                 };
             }
             AgenticMode::IdeAssisted => {
                 if ide.is_none() {
-                    ide = Some(marker.tool);
+                    ide = Some((marker.tool, marker.scope));
                 }
             }
             AgenticMode::None | AgenticMode::Unknown => {}
@@ -196,16 +237,14 @@ fn scan(markers: &[AiMarker], signals: &CommitSignals<'_>, trailers: &[&str]) ->
     }
 
     match ide {
-        Some(tool) => Detection {
+        Some((tool, scope)) => Detection {
             tool: Some(tool),
             mode: AgenticMode::IdeAssisted,
+            method: Some(scope),
         },
         // "No marker in this slice" only. The #5250 Unknown split belongs to
         // `detect_in`, which alone knows both slices came up empty.
-        None => Detection {
-            tool: None,
-            mode: AgenticMode::None,
-        },
+        None => Detection::unmatched(AgenticMode::None),
     }
 }
 
@@ -640,6 +679,96 @@ mod tests {
             committer_email: "devin-ai-integration[bot]@users.noreply.github.com",
         };
         assert_eq!(detect(&by_committer).mode, AgenticMode::FullAgentic);
+    }
+
+    /// #4418: a commit classified by each detection path records the matching
+    /// method.
+    ///
+    /// Why: `is_ai_assisted` fuses three signal families, and a consumer can
+    /// independently re-derive only the first — regexing the message for a
+    /// literal trailer. Without the discriminator, "flagged by a trailer" and
+    /// "flagged by a bot address" are the same row, so no defensible floor can
+    /// be cut out of the flag. cto-reports published a bracket on that reading
+    /// and had to retract it.
+    /// What: one commit per builtin scope — a `Co-Authored-By:` trailer, a body
+    /// footer, and a bot committer address — asserting the recorded method
+    /// names the family that actually matched, not merely that something did.
+    #[test]
+    fn method_names_the_signal_family_that_matched() {
+        let trailer = detect(&CommitSignals::from_message(
+            "feat: auth\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+        ));
+        assert_eq!(trailer.method, Some(MarkerScope::Trailer));
+        assert_eq!(trailer.tool, Some("claude"));
+
+        let footer = detect(&CommitSignals::from_message(
+            "feat: add thing\n\n🤖🤖🤖 Generated with trusty-mpm — \
+             https://github.com/bobmatnyc/trusty-tools",
+        ));
+        assert_eq!(
+            footer.method,
+            Some(MarkerScope::Message),
+            "the house footer is a body match, not a trailer — this is exactly \
+             the row a consumer's own trailer regex cannot see"
+        );
+        assert_eq!(footer.tool, Some("trusty-mpm"));
+
+        let email = detect(&CommitSignals {
+            message: "fix: something",
+            author_email: "human@example.com",
+            committer_email: "devin-ai-integration[bot]@users.noreply.github.com",
+        });
+        assert_eq!(email.method, Some(MarkerScope::Email));
+        assert_eq!(email.tool, Some("devin"));
+
+        // The persisted strings, since the column is what a consumer reads.
+        assert_eq!(trailer.method.map(MarkerScope::as_str), Some("trailer"));
+        assert_eq!(footer.method.map(MarkerScope::as_str), Some("message"));
+        assert_eq!(email.method.map(MarkerScope::as_str), Some("email"));
+    }
+
+    /// #4418: a commit not classified as AI records no method.
+    ///
+    /// Why: `is_ai_assisted = 0` with a method set would be a row asserting
+    /// both "no AI" and "here is how we found the AI". The two columns are
+    /// written from one struct precisely so that cannot happen, and this
+    /// pins the equivalence rather than trusting the writer.
+    /// What: covers both unmatched verdicts — a plain human commit
+    /// ([`AgenticMode::None`]) and a merge summary whose provenance was
+    /// stripped ([`AgenticMode::Unknown`], #5250), which is not a positive
+    /// classification either.
+    #[test]
+    fn method_is_present_exactly_when_a_tool_is() {
+        let human = detect(&CommitSignals::from_message("chore: bump dep"));
+        assert_eq!(human.mode, AgenticMode::None);
+        assert_eq!(human.tool, None);
+        assert_eq!(human.method, None);
+
+        let stripped = detect(&CommitSignals::from_message(
+            "Merge branch 'main' into topic",
+        ));
+        assert_eq!(stripped.mode, AgenticMode::Unknown);
+        assert_eq!(stripped.tool, None);
+        assert_eq!(
+            stripped.method, None,
+            "Unknown means the evidence may have been discarded, so there is \
+             no family to name"
+        );
+
+        for msg in [
+            "chore: bump dep",
+            "Merge branch 'main' into topic",
+            "feat: auth\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+            "fix: npe\n\nCo-Authored-By: Cursor <noreply@cursor.sh>",
+            "docs: x\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)",
+        ] {
+            let d = detect(&CommitSignals::from_message(msg));
+            assert_eq!(
+                d.tool.is_some(),
+                d.method.is_some(),
+                "tool and method must agree on {msg:?}"
+            );
+        }
     }
 
     /// Why: an All Hands employee's own commits are human work; a vendor

--- a/crates/trusty-git-analytics/src/collect/git/extractor.rs
+++ b/crates/trusty-git-analytics/src/collect/git/extractor.rs
@@ -12,6 +12,7 @@ use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rusqlite::params;
 use tracing::{debug, info, warn};
 
+use crate::collect::ai_marker_config::MarkerScope;
 use crate::collect::ai_markers::{detect, CommitSignals, DETECTOR_VERSION};
 use crate::collect::collector::{FetchOutcome, PerRepoFetch};
 use crate::collect::errors::{CollectError, Result};
@@ -607,12 +608,18 @@ impl GitCollector {
             let ai_tool = detection.tool;
             let is_ai_assisted = ai_tool.is_some();
             let agentic_mode = detection.mode;
+            // #4418: which signal family carried the evidence, so a consumer
+            // can separate the trailer-matched subset it can re-derive itself
+            // from the footer- and address-matched rows it cannot.
+            let ai_detection_method = detection.method.map(MarkerScope::as_str);
             let inserted = tx.execute(
                 "INSERT OR IGNORE INTO commits \
                  (sha, author_name, author_email, timestamp, message, repository, \
                   files_changed, insertions, deletions, is_merge, ticketed, ticket_id, \
-                  is_ai_assisted, ai_tool, agentic_mode, ai_detector_version) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                  is_ai_assisted, ai_tool, agentic_mode, ai_detector_version, \
+                  ai_detection_method) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, \
+                         ?16, ?17)",
                 params![
                     sha_str,
                     author_name,
@@ -632,6 +639,7 @@ impl GitCollector {
                     // #6748: record which detector generation produced this
                     // verdict, so a later marker-set change can find the row.
                     DETECTOR_VERSION,
+                    ai_detection_method,
                 ],
             )?;
 
@@ -1058,6 +1066,86 @@ mod tests {
         let (mode, tool, is_ai) = stored_detection(&db, &human.to_string());
         assert_eq!(mode, "none", "a plain commit must stay unclassified");
         assert!(tool.is_none());
+        assert_eq!(is_ai, 0);
+    }
+
+    fn stored_method(db: &Database, sha_prefix: &str) -> Option<String> {
+        db.connection()
+            .query_row(
+                "SELECT ai_detection_method FROM commits WHERE sha LIKE ?1 || '%'",
+                params![sha_prefix],
+                |r| r.get(0),
+            )
+            .expect("read ai_detection_method")
+    }
+
+    /// #4418: the walk records which signal family produced each AI verdict.
+    ///
+    /// Why: this is the column a downstream consumer reads. Proving the
+    /// detector returns a method proves nothing about whether the INSERT
+    /// carries it, and the INSERT is where a forgotten placeholder would
+    /// silently leave every row NULL while every detector test stayed green.
+    /// What: walks one commit per builtin scope — a `Co-Authored-By:` trailer,
+    /// the house footer, and a bot committer address — plus a plain human
+    /// commit, then reads the stored strings back out of `commits`.
+    /// Test: this test itself.
+    #[test]
+    fn walk_records_the_ai_detection_method() {
+        let (repo_dir, repo) = init_repo("detection-method");
+        let ts = utc_seconds(2026, 8, 3, 12, 0, 0);
+        let trailer = commit_at(
+            &repo,
+            &repo_dir.path,
+            ts,
+            0,
+            "feat: add auth\n\nCo-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>\n",
+        );
+        let footer = commit_at(
+            &repo,
+            &repo_dir.path,
+            ts + 60,
+            0,
+            "docs: link the website (#5330)\n\n\
+             🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools\n",
+        );
+        let human = commit_at(&repo, &repo_dir.path, ts + 120, 0, "chore: bump dep\n");
+        let by_email = commit_with_identities(
+            &repo,
+            &repo_dir.path,
+            "Fix flaky integration test\n",
+            "human@example.com",
+            "openhands@all-hands.dev",
+        );
+
+        let mut db = open_in_memory_db();
+        make_collector(&repo_dir.path, None, None)
+            .collect_window(&mut db, None, None)
+            .expect("collect");
+
+        assert_eq!(
+            stored_method(&db, &trailer.to_string()).as_deref(),
+            Some("trailer")
+        );
+        assert_eq!(
+            stored_method(&db, &footer.to_string()).as_deref(),
+            Some("message"),
+            "the house footer is the family a consumer's own trailer regex \
+             cannot re-derive — the whole point of the column"
+        );
+        assert_eq!(
+            stored_method(&db, &by_email.to_string()).as_deref(),
+            Some("email")
+        );
+        assert_eq!(
+            stored_method(&db, &human.to_string()),
+            None,
+            "a commit with no AI verdict records no method"
+        );
+
+        // The method never contradicts the flag it explains.
+        let (_, _, is_ai) = stored_detection(&db, &footer.to_string());
+        assert_eq!(is_ai, 1);
+        let (_, _, is_ai) = stored_detection(&db, &human.to_string());
         assert_eq!(is_ai, 0);
     }
 

--- a/crates/trusty-git-analytics/src/collect/reclassify.rs
+++ b/crates/trusty-git-analytics/src/collect/reclassify.rs
@@ -22,6 +22,7 @@
 
 use rusqlite::params;
 
+use crate::collect::ai_marker_config::MarkerScope;
 use crate::collect::ai_markers::{detect, CommitSignals, Detection, DETECTOR_VERSION};
 use crate::collect::errors::Result;
 use crate::core::db::Database;
@@ -40,7 +41,23 @@ pub const RECLASSIFY_BATCH: usize = 1_000;
 /// alone would need one. See [`reclassify_batch_with`] for why `INDEXED BY` is
 /// there.
 /// Test: `tests::the_scan_uses_the_index_on_a_populated_database`.
-const SCAN_SQL: &str = "SELECT id, message, ai_tool, agentic_mode, author_email FROM commits \
+/// One row of [`SCAN_SQL`], in its column order: id, message, stored `ai_tool`,
+/// stored `agentic_mode`, `author_email`, stored `ai_detection_method`.
+type ScannedRow = (i64, String, Option<String>, String, String, Option<String>);
+
+/// One re-classified row awaiting its UPDATE: id, `is_ai_assisted`, `ai_tool`,
+/// `agentic_mode`, `ai_detection_method`, and whether the verdict moved.
+type PendingWrite = (
+    i64,
+    i64,
+    Option<String>,
+    &'static str,
+    Option<&'static str>,
+    bool,
+);
+
+const SCAN_SQL: &str =
+    "SELECT id, message, ai_tool, agentic_mode, author_email, ai_detection_method FROM commits \
      INDEXED BY idx_commits_ai_detector_version \
      WHERE ai_detector_version < ?1 \
      ORDER BY ai_detector_version, id LIMIT ?2";
@@ -50,7 +67,8 @@ const SCAN_SQL: &str = "SELECT id, message, ai_tool, agentic_mode, author_email 
 /// Why: the operator notice needs both numbers — how much was stale, and how
 /// much of it the current detector actually reads differently.
 /// What: `stamped` counts rows advanced to [`DETECTOR_VERSION`]; `changed`
-/// counts the subset whose `ai_tool` or `agentic_mode` moved.
+/// counts the subset whose `ai_tool`, `agentic_mode`, or (since #4418)
+/// `ai_detection_method` moved.
 /// Test: `tests::stale_rows_are_reclassified_and_current_rows_are_not`.
 ///
 /// `#[non_exhaustive]` because a later counter — rows skipped, batches
@@ -146,12 +164,11 @@ pub fn reclassify_batch_with<F>(
 where
     F: FnMut(&CommitSignals<'_>) -> Detection,
 {
-    // (id, is_ai_assisted, ai_tool, agentic_mode, verdict_changed)
-    let mut pending: Vec<(i64, i64, Option<String>, &'static str, bool)> = Vec::new();
+    let mut pending: Vec<PendingWrite> = Vec::new();
     {
         let conn = db.connection();
         let mut stmt = conn.prepare(SCAN_SQL)?;
-        let rows: Vec<(i64, String, Option<String>, String, String)> = stmt
+        let rows: Vec<ScannedRow> = stmt
             .query_map(params![DETECTOR_VERSION, batch as i64], |row| {
                 Ok((
                     row.get::<_, i64>(0)?,
@@ -161,11 +178,14 @@ where
                     row.get::<_, Option<String>>(3)?
                         .unwrap_or_else(|| "none".to_string()),
                     row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+                    // #4418: NULL on every row written before v29, which is
+                    // what makes the generation bump repopulate them.
+                    row.get::<_, Option<String>>(5)?,
                 ))
             })?
             .collect::<std::result::Result<_, _>>()?;
 
-        for (id, message, stored_tool, stored_mode, author_email) in rows {
+        for (id, message, stored_tool, stored_mode, author_email, stored_method) in rows {
             // #6748: `commits` has no committer_email column, so the email
             // family sees the author address only on this path — the same
             // limitation `tga backfill ai-detection-commits` carries.
@@ -176,9 +196,12 @@ where
             });
             let tool = detection.tool;
             let mode = detection.mode.as_str();
-            let changed = tool != stored_tool.as_deref() || mode != stored_mode;
+            let method = detection.method.map(MarkerScope::as_str);
+            let changed = tool != stored_tool.as_deref()
+                || mode != stored_mode
+                || method != stored_method.as_deref();
             let is_ai = i64::from(tool.is_some());
-            pending.push((id, is_ai, tool.map(str::to_string), mode, changed));
+            pending.push((id, is_ai, tool.map(str::to_string), mode, method, changed));
         }
     }
 
@@ -195,10 +218,10 @@ where
     {
         let mut up = tx.prepare(
             "UPDATE commits SET is_ai_assisted = ?1, ai_tool = ?2, agentic_mode = ?3, \
-             ai_detector_version = ?4 WHERE id = ?5",
+             ai_detector_version = ?4, ai_detection_method = ?5 WHERE id = ?6",
         )?;
-        for (id, is_ai, tool, mode, _) in &pending {
-            up.execute(params![is_ai, tool, mode, DETECTOR_VERSION, id])?;
+        for (id, is_ai, tool, mode, method, _) in &pending {
+            up.execute(params![is_ai, tool, mode, DETECTOR_VERSION, method, id])?;
         }
     }
     tx.commit()?;
@@ -258,6 +281,67 @@ mod tests {
         assert_eq!(tool.as_deref(), Some("claude"));
         assert_eq!(mode, "full_agentic");
         assert_eq!(version, DETECTOR_VERSION);
+    }
+
+    /// #4418: a row stored by generation 1 has a NULL `ai_detection_method`,
+    /// and the generation bump is the only thing that fills it in.
+    ///
+    /// Why: the column ships empty on every deployed database. If the
+    /// re-classification pass wrote the other three verdict columns and left
+    /// this one alone, the corpus would carry a permanently NULL method that
+    /// no `tga collect` ever repairs — the column would exist and answer
+    /// nothing, which is the state #4418 was filed against.
+    /// What: stores a house-footer commit at generation 1 with a correct
+    /// tool and mode and a NULL method — the shape a pre-#4418 collector left
+    /// behind — and asserts the pass fills the method in and counts the row as
+    /// changed even though nothing else about the verdict moved.
+    /// Test: this test itself.
+    #[test]
+    fn a_generation_1_row_gains_its_detection_method() {
+        let mut db = Database::open_in_memory().expect("open db");
+        let footer = "docs: link the website (#5330)\n\n\
+                      🤖🤖🤖 Generated with trusty-mpm — \
+                      https://github.com/bobmatnyc/trusty-tools\n";
+        db.connection()
+            .execute(
+                "INSERT INTO commits \
+                 (sha, author_name, author_email, timestamp, message, repository, \
+                  is_ai_assisted, ai_tool, agentic_mode, ai_detector_version, \
+                  ai_detection_method) \
+                 VALUES ('gen1', 'Ada', 'ada@example.com', '2026-01-01T00:00:00Z', ?1, \
+                         'testrepo', 1, 'trusty-mpm', 'full_agentic', 1, NULL)",
+                params![footer],
+            )
+            .expect("seed a generation-1 row");
+
+        let stats = reclassify_stale(&mut db).expect("reclassify");
+
+        assert_eq!(stats.stamped, 1);
+        assert_eq!(
+            stats.changed, 1,
+            "the method moved from NULL, so the row changed even though the \
+             tool and mode did not"
+        );
+        let method: Option<String> = db
+            .connection()
+            .query_row(
+                "SELECT ai_detection_method FROM commits WHERE sha = 'gen1'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read method");
+        assert_eq!(method.as_deref(), Some("message"));
+        let (is_ai, tool, mode, version) = verdict(&db, "gen1");
+        assert_eq!(
+            (is_ai, tool.as_deref(), mode.as_str()),
+            (1, Some("trusty-mpm"), "full_agentic"),
+            "the rest of the verdict is unchanged"
+        );
+        assert_eq!(version, DETECTOR_VERSION);
+
+        // A second pass has nothing left to claim.
+        let again = reclassify_stale(&mut db).expect("reclassify twice");
+        assert_eq!(again.stamped, 0);
     }
 
     /// Why: the settled-corpus claim is about a query PLAN, and a plan is not

--- a/crates/trusty-git-analytics/src/commands/backfill/flags.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill/flags.rs
@@ -6,6 +6,7 @@
 //! makes the shared `build_commits_filter_sql` helper easy to find.
 
 use rusqlite::params;
+use tga::collect::ai_marker_config::MarkerScope;
 use tga::collect::ai_markers::{detect, CommitSignals, DETECTOR_VERSION};
 use tga::collect::ticket::{extract_ticket_id, is_ticketed};
 use tga::core::db::Database;
@@ -347,13 +348,15 @@ pub(super) fn backfill_ai_detection(db: &mut Database, dry_run: bool) -> anyhow:
 /// detects Claude, GitHub Copilot, and Cursor via `Co-Authored-By:` trailers AND
 /// recomputes `agentic_mode`, exactly as the forward `tga collect` path does.
 /// What: loads every commit (filtered by repos/since/until), runs detection
-/// over the stored message and author email, and updates rows where `ai_tool`
-/// OR `agentic_mode` differs from the stored value. No LLM required — pure
-/// string matching, identical to the extractor's INSERT path. The committer
-/// email is unavailable here because `commits` never stored it.
+/// over the stored message and author email, and updates rows where `ai_tool`,
+/// `agentic_mode`, or `ai_detection_method` differs from the stored value. No
+/// LLM required — pure string matching, identical to the extractor's INSERT
+/// path. The committer email is unavailable here because `commits` never
+/// stored it.
 /// Test: `tests::backfill_ai_detection_commits_detects_claude` (ai_tool),
-/// `tests::backfill_ai_detection_commits_repairs_agentic_mode` (agentic_mode)
-/// and `tests::backfill_ai_detection_commits_repairs_house_footer_and_openhands` (#5249).
+/// `tests::backfill_ai_detection_commits_repairs_agentic_mode` (agentic_mode),
+/// `tests::backfill_ai_detection_commits_repairs_house_footer_and_openhands` (#5249)
+/// and `tests::backfill_ai_detection_commits_records_the_detection_method` (#4418).
 ///
 /// # Errors
 ///
@@ -365,19 +368,27 @@ pub(super) fn backfill_ai_detection_commits(
     since: Option<&str>,
     until: Option<&str>,
 ) -> anyhow::Result<()> {
-    // (id, is_ai, ai_tool, agentic_mode) — agentic_mode is the forward-path
-    // string ("none" | "ide_assisted" | "full_agentic") via `AgenticMode::as_str`.
-    let mut to_update: Vec<(i64, i64, Option<String>, &'static str)> = Vec::new();
+    // (id, is_ai, ai_tool, agentic_mode, ai_detection_method) — agentic_mode is
+    // the forward-path string ("none" | "unknown" | "ide_assisted" |
+    // "full_agentic") via `AgenticMode::as_str`; the method is the matching
+    // marker's scope via `MarkerScope::as_str` (#4418), NULL when none matched.
+    type Repair = (i64, i64, Option<String>, &'static str, Option<&'static str>);
+    // One scanned row, in the SELECT's column order: id, message, stored
+    // `ai_tool`, stored `agentic_mode`, `author_email`, stored
+    // `ai_detection_method`.
+    type ScannedRow = (i64, String, Option<String>, String, String, Option<String>);
+    let mut to_update: Vec<Repair> = Vec::new();
     {
         let conn = db.connection();
         let (sql, params) = build_commits_filter_sql(
-            "SELECT id, message, ai_tool, agentic_mode, author_email FROM commits",
+            "SELECT id, message, ai_tool, agentic_mode, author_email, ai_detection_method \
+             FROM commits",
             repos_filter,
             since,
             until,
         );
         let mut stmt = conn.prepare(&sql)?;
-        let rows: Vec<(i64, String, Option<String>, String, String)> = stmt
+        let rows: Vec<ScannedRow> = stmt
             .query_map(rusqlite::params_from_iter(params.iter()), |row| {
                 Ok((
                     row.get::<_, i64>(0)?,
@@ -387,11 +398,13 @@ pub(super) fn backfill_ai_detection_commits(
                     row.get::<_, Option<String>>(3)?
                         .unwrap_or_else(|| "none".to_string()),
                     row.get::<_, Option<String>>(4)?.unwrap_or_default(),
+                    // #4418: NULL on every row written before migration v29.
+                    row.get::<_, Option<String>>(5)?,
                 ))
             })?
             .collect::<Result<_, _>>()?;
 
-        for (id, message, current_tool, current_mode, author_email) in rows {
+        for (id, message, current_tool, current_mode, author_email, current_method) in rows {
             // #5249: `commits` has no committer_email column, so the email
             // family sees the author address only on this path.
             let detection = detect(&CommitSignals {
@@ -401,16 +414,21 @@ pub(super) fn backfill_ai_detection_commits(
             });
             let detected = detection.tool;
             let mode = detection.mode.as_str();
+            let method = detection.method.map(MarkerScope::as_str);
             let tool_changed = detected != current_tool.as_deref();
             let mode_changed = mode != current_mode;
-            if tool_changed || mode_changed {
+            // #4418: a row whose tool and mode already agree can still hold a
+            // NULL method — every row written before v29 does — so the method
+            // has to be its own reason to rewrite, or the repair skips them.
+            let method_changed = method != current_method.as_deref();
+            if tool_changed || mode_changed || method_changed {
                 let is_ai = if detected.is_some() { 1_i64 } else { 0_i64 };
-                to_update.push((id, is_ai, detected.map(str::to_string), mode));
+                to_update.push((id, is_ai, detected.map(str::to_string), mode, method));
             }
         }
     }
 
-    let with_tool = to_update.iter().filter(|(_, _, t, _)| t.is_some()).count();
+    let with_tool = to_update.iter().filter(|(_, _, t, ..)| t.is_some()).count();
 
     if dry_run {
         println!(
@@ -425,11 +443,11 @@ pub(super) fn backfill_ai_detection_commits(
     let tx = conn.transaction()?;
     {
         let mut up = tx.prepare(
-            "UPDATE commits SET is_ai_assisted = ?1, ai_tool = ?2, agentic_mode = ?3 \
-             WHERE id = ?4",
+            "UPDATE commits SET is_ai_assisted = ?1, ai_tool = ?2, agentic_mode = ?3, \
+             ai_detection_method = ?4 WHERE id = ?5",
         )?;
-        for (id, is_ai, tool, mode) in &to_update {
-            up.execute(params![is_ai, tool, mode, id])?;
+        for (id, is_ai, tool, mode, method) in &to_update {
+            up.execute(params![is_ai, tool, mode, method, id])?;
         }
     }
     // #6748: every row this pass looked at now holds the current detector's

--- a/crates/trusty-git-analytics/src/commands/backfill/tests.rs
+++ b/crates/trusty-git-analytics/src/commands/backfill/tests.rs
@@ -911,6 +911,74 @@ fn backfill_ai_detection_commits_repairs_house_footer_and_openhands() {
     }
 }
 
+/// Why: #4418 — the repair command is the path an operator runs to fix a
+/// database without a full walk, so it has to write the new column too. It
+/// carries a second hazard the collect path does not: it rewrites a row only
+/// when the verdict differs, and on a real corpus the tool and mode already
+/// agree while the method is NULL. Diffing on tool and mode alone would skip
+/// exactly the rows the repair exists for, and report "0 updated" while every
+/// method stayed empty.
+/// What: seeds one commit per builtin scope plus a human commit, runs the
+/// repair, and asserts each recorded method names the family that matched and
+/// the human commit records none. The email row is seeded with a bot AUTHOR
+/// address because `commits` has no committer column on this path.
+/// Test: this test itself.
+#[test]
+fn backfill_ai_detection_commits_records_the_detection_method() {
+    let mut db = Database::open_in_memory().expect("open");
+
+    seed(
+        &db,
+        "trailer1",
+        "feat: add auth\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+    );
+    seed(
+        &db,
+        "footer1",
+        "docs: add website link to README (#5330)\n\n\
+         🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools",
+    );
+    seed(&db, "human2", "chore: bump dep");
+    db.connection()
+        .execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository) \
+             VALUES ('email1', 'n', 'openhands@all-hands.dev', '2024-01-01T00:00:00Z', \
+                     'Fix flaky test', 'r')",
+            [],
+        )
+        .expect("insert bot-authored commit");
+
+    // A row a pre-#4418 collector left behind: the tool and mode are already
+    // right, only the method is missing. Nothing but the method can mark it.
+    db.connection()
+        .execute(
+            "UPDATE commits SET is_ai_assisted = 1, ai_tool = 'claude', \
+             agentic_mode = 'full_agentic' WHERE sha = 'trailer1'",
+            [],
+        )
+        .expect("pre-set the trailer row's verdict");
+
+    backfill_ai_detection_commits(&mut db, false, &[], None, None).expect("backfill ai-detection");
+
+    let method = |sha: &str| -> Option<String> {
+        db.connection()
+            .query_row(
+                "SELECT ai_detection_method FROM commits WHERE sha = ?1",
+                params![sha],
+                |r| r.get(0),
+            )
+            .expect("read method")
+    };
+    assert_eq!(
+        method("trailer1").as_deref(),
+        Some("trailer"),
+        "a row whose tool and mode already agreed must still be repaired"
+    );
+    assert_eq!(method("footer1").as_deref(), Some("message"));
+    assert_eq!(method("email1").as_deref(), Some("email"));
+    assert_eq!(method("human2"), None, "no verdict, no method");
+}
+
 /// Why: `backfill_top_level` must fill `top_level_category` for existing
 /// classifications where it is NULL, using the built-in taxonomy.
 /// What: seeds a classification with subcategory='bugfix' and

--- a/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
+++ b/crates/trusty-git-analytics/src/core/db/migrations/mod.rs
@@ -182,6 +182,15 @@ pub const MIGRATIONS: &[Migration] = &[
         name: "commit_detector_version",
         sql: include_str!("../sql/0028_commit_detector_version.sql"),
     },
+    // #4418: which signal family produced each stored AI verdict — the trailer,
+    // the message body, or an author address. Nullable, never backfilled here:
+    // DETECTOR_VERSION moves in the same change, so the v28 re-classification
+    // pass fills it in on the next collect.
+    Migration {
+        version: 29,
+        name: "commit_ai_detection_method",
+        sql: include_str!("../sql/0029_commit_ai_detection_method.sql"),
+    },
 ];
 
 /// Ensure the `schema_migrations` bookkeeping table exists.
@@ -1090,5 +1099,125 @@ mod tests {
             )
             .expect("count v28 rows");
         assert_eq!(applied, 1, "v28 is recorded exactly once");
+    }
+
+    /// Why: #4418 adds a column to `commits`, the table every deployed `tga.db`
+    /// has its whole corpus in. Two failures would be silent. A migration that
+    /// rewrote or dropped verdicts would move a published AI-adoption figure
+    /// with no command having asked for it — the exact class of error that
+    /// forced cto-reports to retract a bracket. And a column added NOT NULL
+    /// would break an older tga's `INSERT`, which names its columns and cannot
+    /// know about this one, turning "additive only" into a downgrade break.
+    /// What: builds a real v28 database, writes an AI-assisted commit through
+    /// the v28 column set, then upgrades to head and asserts every stored
+    /// verdict survives unchanged with the new column reading NULL. Then
+    /// asserts the two downgrade-safety properties directly against
+    /// `PRAGMA table_info` — nullable, no default — and that an older binary's
+    /// column-naming INSERT still succeeds. Re-running the migrations is a
+    /// no-op.
+    /// Test: this test itself.
+    #[test]
+    fn migration_v29_preserves_an_existing_v28_database() {
+        let mut conn = rusqlite::Connection::open_in_memory().expect("open");
+        super::run_through(&mut conn, 28).expect("migrate to v28");
+
+        let version: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_migrations", [], |r| {
+                r.get(0)
+            })
+            .expect("read version");
+        assert_eq!(version, 28, "the fixture must be a real pre-#4418 database");
+
+        // A row written the way the v28 collector wrote it — no
+        // ai_detection_method, because the column did not exist.
+        conn.execute(
+            "INSERT INTO commits \
+             (sha, author_name, author_email, timestamp, message, repository, \
+              is_ai_assisted, ai_tool, agentic_mode, ai_detector_version) \
+             VALUES ('v28sha', 'Ada', 'ada@example.com', '2026-01-01T00:00:00Z', \
+                     ?1, 'testrepo', 1, 'claude', 'full_agentic', 1)",
+            params!["feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>"],
+        )
+        .expect("insert v28-era commit");
+
+        // The upgrade every existing database performs on next open.
+        super::run(&mut conn).expect("migrate to head");
+
+        let (is_ai, tool, mode, method): (i64, String, String, Option<String>) = conn
+            .query_row(
+                "SELECT is_ai_assisted, ai_tool, agentic_mode, ai_detection_method \
+                 FROM commits WHERE sha = 'v28sha'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .expect("the pre-migration row must still be readable");
+        assert_eq!(is_ai, 1, "the existing verdict must survive untouched");
+        assert_eq!(tool, "claude");
+        assert_eq!(mode, "full_agentic");
+        assert_eq!(
+            method, None,
+            "the migration records no method it did not observe; the \
+             DETECTOR_VERSION bump is what fills it in"
+        );
+
+        // Downgrade safety, read off the live schema rather than asserted of
+        // the SQL text: an older tga must be able to write this table.
+        let (notnull, dflt): (i64, Option<String>) = conn
+            .query_row(
+                "SELECT \"notnull\", dflt_value FROM pragma_table_info('commits') \
+                 WHERE name = 'ai_detection_method'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("the column exists");
+        assert_eq!(notnull, 0, "the column must be nullable, never NOT NULL");
+        assert_eq!(dflt, None, "and carry no default");
+
+        conn.execute(
+            "INSERT INTO commits \
+             (sha, author_name, author_email, timestamp, message, repository, \
+              is_ai_assisted, ai_tool, agentic_mode) \
+             VALUES ('oldbin', 'Ada', 'ada@example.com', '2026-01-02T00:00:00Z', \
+                     'chore: y', 'testrepo', 0, NULL, 'none')",
+            [],
+        )
+        .expect("an older binary's INSERT, which never names the new column");
+
+        // And the new column is writable on the upgraded database.
+        conn.execute(
+            "UPDATE commits SET ai_detection_method = 'trailer' WHERE sha = 'v28sha'",
+            [],
+        )
+        .expect("write the new column");
+        let round_trip: Option<String> = conn
+            .query_row(
+                "SELECT ai_detection_method FROM commits WHERE sha = 'v28sha'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read back");
+        assert_eq!(round_trip.as_deref(), Some("trailer"));
+
+        super::run(&mut conn).expect("re-run is idempotent");
+        let applied: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM schema_migrations WHERE version = 29",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count v29 rows");
+        assert_eq!(applied, 1, "v29 is recorded exactly once");
+        let after: Option<String> = conn
+            .query_row(
+                "SELECT ai_detection_method FROM commits WHERE sha = 'v28sha'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("read after re-run");
+        assert_eq!(
+            after.as_deref(),
+            Some("trailer"),
+            "a second run must not reset a written value"
+        );
     }
 }

--- a/crates/trusty-git-analytics/src/core/db/sql/0029_commit_ai_detection_method.sql
+++ b/crates/trusty-git-analytics/src/core/db/sql/0029_commit_ai_detection_method.sql
@@ -1,0 +1,37 @@
+-- Migration v29: ai_detection_method column for issue #4418.
+--
+-- `commits.is_ai_assisted` is written by a multi-signal detector: a
+-- `Co-Authored-By:` trailer, a body footer such as `Generated with trusty-mpm`,
+-- and an agent-identifying author/committer address all set it to 1. The stored
+-- row says the verdict but not which of those fired, so a downstream consumer
+-- cannot separate the subset it can independently re-derive (the literal
+-- trailer) from the subset it cannot. cto-reports anchored a published estimate
+-- on `is_ai_assisted` read as a trailer-only floor and had to retract the
+-- bracket when that reading turned out to be an assumption rather than a
+-- property of the column.
+--
+-- This column records the signal family of the marker that produced the
+-- verdict: 'trailer', 'message', or 'email' — the three values of
+-- `collect::ai_marker_config::MarkerScope`, which is what a marker is matched
+-- against. NULL means no marker matched, so it is NULL for exactly the rows
+-- where `is_ai_assisted = 0`.
+--
+-- NULLABLE ON PURPOSE, and never NOT NULL. Two reasons:
+--   1. NULL is the honest value for a commit no marker claimed, and for a row
+--      written before this column existed.
+--   2. An older tga reading this database names its columns in every SELECT
+--      and INSERT, so a nullable column it never mentions is invisible to it.
+--      A NOT NULL column with no default would instead break that binary's
+--      INSERT, which is what "additive only" has to rule out.
+--
+-- Existing rows are NOT backfilled by this file. `collect::ai_markers::
+-- DETECTOR_VERSION` moves 1 -> 2 in the same change, so the #6748
+-- re-classification pass claims every stored row as stale and repopulates the
+-- column on the next `tga collect`. `tga backfill ai-detection-commits` writes
+-- it too, for an operator who wants the repair without a walk.
+--
+-- No index: the column is a per-row attribute read alongside the row, never a
+-- selective filter — `is_ai_assisted` and `ai_detector_version` are what the
+-- scans key on, and both already have theirs.
+
+ALTER TABLE commits ADD COLUMN ai_detection_method TEXT;

--- a/crates/trusty-git-analytics/src/core/inspect/text_columns.rs
+++ b/crates/trusty-git-analytics/src/core/inspect/text_columns.rs
@@ -109,6 +109,9 @@ pub const CONSTRAINED: &[&str] = &[
     "commits.ticket_id",
     "commits.ai_tool",
     "commits.agentic_mode",
+    // #4418: one of 'trailer' / 'message' / 'email', or NULL. The writer is
+    // `MarkerScope::as_str`, so the value set is closed in code.
+    "commits.ai_detection_method",
     "deployment_failures.deploy_id",
     "deployment_failures.failure_commit_sha",
     "deployment_failures.recovery_commit_sha",

--- a/crates/trusty-git-analytics/src/report/aggregator/accumulate.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/accumulate.rs
@@ -14,6 +14,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use chrono::{DateTime, Datelike, Utc};
 
 use crate::collect::ai_attribution::AgenticMode;
+use crate::collect::ai_marker_config::MarkerScope;
 use crate::report::models::{
     AuthorSummary, RepositorySummary, UntrackedCommit, WeeklyActivity, WeeklyCategorization,
     WeeklyMetrics,
@@ -111,6 +112,13 @@ pub(super) struct WeekAcc {
     pub(super) agentic_count: usize,
     /// IDE-assisted commits (issue #1113: `agentic_mode = 'ide_assisted'`).
     pub(super) ide_assisted_count: usize,
+    /// AI-assisted commits whose evidence was a `Co-Authored-By:` trailer
+    /// (#4418).
+    pub(super) ai_by_trailer: usize,
+    /// AI-assisted commits whose evidence was a message-body footer (#4418).
+    pub(super) ai_by_message: usize,
+    /// AI-assisted commits whose evidence was an author address (#4418).
+    pub(super) ai_by_email: usize,
 }
 
 /// Cross-developer per-week running totals during accumulation.
@@ -239,6 +247,9 @@ pub(super) fn accumulate_rows(rows: &[CommitRow], flags: &RowFlags) -> Accumulat
             complexity_count: 0,
             agentic_count: 0,
             ide_assisted_count: 0,
+            ai_by_trailer: 0,
+            ai_by_message: 0,
+            ai_by_email: 0,
         });
         w.commits += 1;
         w.insertions += row.insertions;
@@ -263,6 +274,22 @@ pub(super) fn accumulate_rows(rows: &[CommitRow], flags: &RowFlags) -> Accumulat
         // so the weekly activity report can surface AI-adoption rates.
         if row.is_ai_assisted {
             w.ai_assisted += 1;
+        }
+        // #4418: break that count down by the signal family that produced it,
+        // so a consumer can cut the trailer-only subset — the one it could
+        // re-derive from commit messages alone — out of the AI-assisted total
+        // instead of assuming the total already is that subset.
+        //
+        // The three sum to `ai_assisted` on a corpus the current detector
+        // wrote. They fall short of it on a database whose rows still predate
+        // migration v29, where the method is NULL and the family is genuinely
+        // unrecorded — which is why the shortfall is left visible rather than
+        // being assigned to a family.
+        match row.ai_detection_method {
+            Some(MarkerScope::Trailer) => w.ai_by_trailer += 1,
+            Some(MarkerScope::Message) => w.ai_by_message += 1,
+            Some(MarkerScope::Email) => w.ai_by_email += 1,
+            None => {}
         }
         // Issue #1113: count agentic/IDE-assisted commits per bucket.
         match row.agentic_mode {
@@ -457,6 +484,10 @@ pub(super) fn materialize_weekly_activity(
                 // Issue #1113: agentic-mode commit counts.
                 agentic_count: w.agentic_count,
                 ide_assisted_count: w.ide_assisted_count,
+                // #4418: the AI-assisted count split by signal family.
+                ai_trailer_count: w.ai_by_trailer,
+                ai_message_count: w.ai_by_message,
+                ai_email_count: w.ai_by_email,
                 // Issue #660: net-new commits excluding reverts. `commit_count`
                 // is left untouched above so downstream consumers relying on
                 // the gross total keep working unmodified.

--- a/crates/trusty-git-analytics/src/report/aggregator/mod.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/mod.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 use tracing::{debug, warn};
 
 use crate::collect::ai_attribution::AgenticMode;
+use crate::collect::ai_marker_config::MarkerScope;
 use crate::core::config::Config;
 use crate::core::db::Database;
 use crate::report::errors::{ReportError, Result};
@@ -50,6 +51,11 @@ pub(super) struct CommitRow {
     pub(super) complexity: Option<i64>,
     /// Canonical agentic mode (issue #1113): full_agentic / ide_assisted / none.
     pub(super) agentic_mode: AgenticMode,
+    /// Signal family that produced the AI verdict (#4418): the trailer, the
+    /// message body, or an author address. `None` for a commit no marker
+    /// claimed, and for any row written before migration v29 that has not yet
+    /// been re-classified.
+    pub(super) ai_detection_method: Option<MarkerScope>,
 }
 
 /// Minimal PR row used by velocity / DORA computations and (issue #377)
@@ -387,13 +393,16 @@ impl Aggregator {
         // Issue #445 batch B (request #6): include cl.complexity so the weekly
         // aggregator can surface avg_complexity without a second DB scan.
         // Issue #1113: include c.agentic_mode for per-week agentic-% aggregation.
+        // #4418: include c.ai_detection_method so the weekly row can break the
+        // AI-assisted count down by which signal family produced it.
         let sql_base = "SELECT c.sha, \
                         COALESCE(a.canonical_name,  c.author_name)  AS author_name, \
                         COALESCE(NULLIF(a.canonical_email, ''), c.author_email) AS author_email, \
                         c.timestamp, c.repository, \
                         c.insertions, c.deletions, c.files_changed, cl.category, \
                         c.message, c.ticketed, c.is_ai_assisted, cl.complexity, \
-                        COALESCE(c.agentic_mode, 'none') AS agentic_mode \
+                        COALESCE(c.agentic_mode, 'none') AS agentic_mode, \
+                        c.ai_detection_method \
                  FROM commits c \
                  LEFT JOIN authors a ON a.id = c.author_id \
                  LEFT JOIN classifications cl ON cl.id = c.classification_id";
@@ -419,6 +428,14 @@ impl Aggregator {
             let agentic_mode = agentic_mode_str
                 .parse::<AgenticMode>()
                 .unwrap_or(AgenticMode::Unknown);
+            // #4418: NULL until migration v29's row is re-classified, and an
+            // unparseable value means a newer tga recorded a family this build
+            // has no name for. Both read as "no method recorded" rather than
+            // being folded into one of the three this build does know.
+            let ai_detection_method: Option<MarkerScope> = row
+                .get::<_, Option<String>>(14)
+                .unwrap_or(None)
+                .and_then(|s| s.parse::<MarkerScope>().ok());
             Ok(CommitRow {
                 sha: row.get(0)?,
                 author_name: row.get(1)?,
@@ -434,6 +451,7 @@ impl Aggregator {
                 is_ai_assisted: is_ai_assisted != 0,
                 complexity,
                 agentic_mode,
+                ai_detection_method,
             })
         };
 

--- a/crates/trusty-git-analytics/src/report/formatters/csv.rs
+++ b/crates/trusty-git-analytics/src/report/formatters/csv.rs
@@ -83,6 +83,14 @@ pub fn write_weekly_csv(data: &ReportData, output_dir: &Path) -> Result<PathBuf>
         // Issue #660: net-new commit count excluding reverts, appended last
         // so existing column-index consumers are unaffected.
         "commit_count_net",
+        // #4418: `ai_assisted_count` split by the signal family that produced
+        // each verdict, so a consumer can cut the trailer-only subset out of
+        // it rather than reading the total as if it already were that subset.
+        // Appended after `commit_count_net` for the same index-stability
+        // reason.
+        "ai_trailer_count",
+        "ai_message_count",
+        "ai_email_count",
     ])?;
     for row in &data.weekly_activity {
         let categories = serialize_categories(&row.categories);
@@ -107,6 +115,9 @@ pub fn write_weekly_csv(data: &ReportData, output_dir: &Path) -> Result<PathBuf>
             &row.ai_assisted_count.to_string(),
             avg_complexity_str.as_str(),
             &row.commit_count_net.to_string(),
+            &row.ai_trailer_count.to_string(),
+            &row.ai_message_count.to_string(),
+            &row.ai_email_count.to_string(),
         ])?;
     }
     w.flush()?;

--- a/crates/trusty-git-analytics/src/report/models.rs
+++ b/crates/trusty-git-analytics/src/report/models.rs
@@ -92,9 +92,12 @@ pub struct WeeklyActivity {
     #[serde(default)]
     pub abandoned_pr_count: usize,
     /// Commits in this bucket where `is_ai_assisted = 1` (issue #445).
-    /// Counts commits with a recognised `Co-Authored-By:` AI tool trailer
-    /// (Claude, GitHub Copilot, Cursor). Additive — downstream can sum to
-    /// get an org-wide AI-adoption count.
+    /// Additive — downstream can sum to get an org-wide AI-adoption count.
+    ///
+    /// This is NOT a trailer-only count and never was a floor derivable from
+    /// commit messages: since #5249 a body footer or an agent-identifying
+    /// author address sets the flag too. The three `ai_*_count` fields below
+    /// break it down by which of those fired (#4418).
     #[serde(default)]
     pub ai_assisted_count: usize,
     /// Mean LLM-assigned complexity score (1–5) across commits in this bucket
@@ -113,6 +116,28 @@ pub struct WeeklyActivity {
     /// Counts inline-completion commits (Cursor, GitHub Copilot).
     #[serde(default)]
     pub ide_assisted_count: usize,
+    /// Why: [`Self::ai_assisted_count`] fuses three signal families, and a
+    /// consumer can independently re-derive only one of them — the literal
+    /// `Co-Authored-By:` trailer, by regexing commit messages. Read as if it
+    /// were that subset, the count is not the conservative floor it looks
+    /// like; read as the whole, it cannot be checked against anything. This
+    /// field is the subset (#4418), so the floor is stated rather than
+    /// assumed.
+    /// What: AI-assisted commits in this bucket whose evidence was a
+    /// `Co-Authored-By:` trailer. Additive — [`Self::ai_assisted_count`] keeps
+    /// its existing meaning.
+    /// Test: `report::tests::weekly_activity_splits_ai_count_by_detection_method`.
+    #[serde(default)]
+    pub ai_trailer_count: usize,
+    /// AI-assisted commits whose evidence was a message-body footer such as
+    /// `Generated with trusty-mpm` (#4418) — the rows a consumer's own trailer
+    /// regex cannot see.
+    #[serde(default)]
+    pub ai_message_count: usize,
+    /// AI-assisted commits whose evidence was an agent-identifying author or
+    /// committer address (#4418).
+    #[serde(default)]
+    pub ai_email_count: usize,
     /// Why: `commit_count` counts revert commits identically to original
     /// work, so a developer who lands N commits and reverts all N shows 2N
     /// commits with zero net code change — a 2x+ inflation downstream

--- a/crates/trusty-git-analytics/src/report/tests.rs
+++ b/crates/trusty-git-analytics/src/report/tests.rs
@@ -429,6 +429,88 @@ fn weekly_activity_commit_count_net_excludes_reverts() {
     );
 }
 
+/// Why: #4418 — `ai_assisted_count` is the number cto-reports published a
+/// bracket on, having read it as a trailer-only floor. It is not one: a body
+/// footer or a bot address sets `is_ai_assisted` too, and roughly half this
+/// repo's own AI commits are footer-only. Exporting the total without the
+/// split leaves the reader no way to tell the difference, so the same
+/// misreading is available to the next consumer.
+/// What: seeds one commit per signal family plus a human commit in one ISO
+/// week, and asserts the weekly row carries the split — with the three parts
+/// summing to `ai_assisted_count`, which is what makes the trailer count a
+/// floor rather than another opaque number.
+/// Test: this test itself.
+#[test]
+fn weekly_activity_splits_ai_count_by_detection_method() {
+    let db = Database::open_in_memory().expect("open db");
+    let conn = db.connection();
+    let rows = [
+        ("m1", 1_i64, Some("trailer")),
+        ("m2", 1, Some("message")),
+        ("m3", 1, Some("email")),
+        ("m4", 0, None),
+    ];
+    for (sha, is_ai, method) in rows {
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge, ticketed, \
+                 is_ai_assisted, ai_detection_method) \
+             VALUES (?1, 'Erin', 'erin@example.com', '2024-01-15T10:00:00+00:00', \
+                 'ENG-7 do work', 'repo-a', 1, 5, 1, 0, 1, ?2, ?3)",
+            rusqlite::params![sha, is_ai, method],
+        )
+        .expect("insert commit");
+    }
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    assert_eq!(data.weekly_activity.len(), 1);
+    let wa = &data.weekly_activity[0];
+
+    assert_eq!(wa.ai_assisted_count, 3, "the existing total is unchanged");
+    assert_eq!(wa.ai_trailer_count, 1);
+    assert_eq!(wa.ai_message_count, 1);
+    assert_eq!(wa.ai_email_count, 1);
+    assert_eq!(
+        wa.ai_trailer_count + wa.ai_message_count + wa.ai_email_count,
+        wa.ai_assisted_count,
+        "the split must partition the total on a corpus the current detector \
+         wrote, or the trailer count is not a floor of anything"
+    );
+}
+
+/// Why: #4418 — a database whose rows still predate migration v29 has a NULL
+/// method on every one of them. Folding those into a family would invent a
+/// signal nobody observed, and quietly inflate whichever count absorbed them.
+/// What: seeds AI-assisted commits with no recorded method and asserts the
+/// total still counts them while every split count stays zero, so the
+/// shortfall is visible as "unrecorded" rather than attributed.
+/// Test: this test itself.
+#[test]
+fn weekly_activity_leaves_an_unrecorded_method_unattributed() {
+    let db = Database::open_in_memory().expect("open db");
+    let conn = db.connection();
+    for i in 0..2 {
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge, ticketed, \
+                 is_ai_assisted, ai_detection_method) \
+             VALUES (?1, 'Frank', 'frank@example.com', '2024-01-15T10:00:00+00:00', \
+                 'ENG-8 legacy row', 'repo-a', 1, 5, 1, 0, 1, 1, NULL)",
+            [format!("legacy{i}")],
+        )
+        .expect("insert pre-v29 commit");
+    }
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let wa = &data.weekly_activity[0];
+    assert_eq!(wa.ai_assisted_count, 2);
+    assert_eq!(
+        (wa.ai_trailer_count, wa.ai_message_count, wa.ai_email_count),
+        (0, 0, 0),
+        "an unrecorded method is never assigned to a family"
+    );
+}
+
 #[test]
 fn weekly_quality_perfect_when_clean_and_ticketed() {
     // All commits ticketed, no reverts, no bugfixes ⇒ score 1.0, tshirt 5.
@@ -497,6 +579,65 @@ fn aggregator_counts_abandoned_prs() {
         data.weekly_activity[0].abandoned_pr_count, 1,
         "exactly one closed-unmerged PR attributed to eve"
     );
+}
+
+/// Why: #4418 — the weekly CSV is the file a downstream pipeline actually
+/// ingests, so the split reaching `WeeklyActivity` and not the writer would
+/// leave the consumer exactly where it started. The three columns are appended
+/// after `commit_count_net` for the same reason that one was appended last:
+/// an existing column-INDEX consumer must be unaffected.
+/// What: writes the CSV from the split fixture, asserts the header names the
+/// three columns AFTER every column that predates them, and asserts the data
+/// row carries the values rather than only the header naming them.
+/// Test: this test itself.
+#[test]
+fn weekly_csv_carries_the_ai_detection_method_split() {
+    let db = Database::open_in_memory().expect("open db");
+    let conn = db.connection();
+    for (sha, method) in [("s1", "trailer"), ("s2", "trailer"), ("s3", "message")] {
+        conn.execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, \
+                 repository, files_changed, insertions, deletions, is_merge, ticketed, \
+                 is_ai_assisted, ai_detection_method) \
+             VALUES (?1, 'Gina', 'gina@example.com', '2024-01-15T10:00:00+00:00', \
+                 'ENG-9 work', 'repo-a', 1, 5, 1, 0, 1, 1, ?2)",
+            rusqlite::params![sha, method],
+        )
+        .expect("insert commit");
+    }
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+
+    let dir = tmp_dir("weekly-ai-method-csv");
+    let path = csv_fmt::write_weekly_csv(&data, &dir).expect("write weekly");
+    let text = std::fs::read_to_string(&path).expect("read");
+    let header: Vec<&str> = text
+        .lines()
+        .next()
+        .expect("header line")
+        .split(',')
+        .collect();
+
+    let idx = |col: &str| {
+        header
+            .iter()
+            .position(|h| *h == col)
+            .unwrap_or_else(|| panic!("header missing {col}: {header:?}"))
+    };
+    let first_new = idx("ai_trailer_count");
+    assert_eq!(idx("ai_message_count"), first_new + 1);
+    assert_eq!(idx("ai_email_count"), first_new + 2);
+    assert!(
+        first_new > idx("commit_count_net"),
+        "the new columns must be appended, not inserted: {header:?}"
+    );
+
+    let row: Vec<&str> = text.lines().nth(1).expect("data row").split(',').collect();
+    assert_eq!(row[idx("ai_assisted_count")], "3");
+    assert_eq!(row[first_new], "2", "two trailer-detected commits");
+    assert_eq!(row[first_new + 1], "1");
+    assert_eq!(row[first_new + 2], "0");
+
+    std::fs::remove_dir_all(&dir).ok();
 }
 
 #[test]


### PR DESCRIPTION
Refs #4418

`commits.is_ai_assisted` is set by three different signals — a `Co-Authored-By:`
trailer, a message-body footer such as `Generated with trusty-mpm`, and an
agent-identifying author or committer address. The stored row said the verdict
but not which one fired, and a consumer can independently re-derive only the
first, by regexing commit messages. Read as a trailer-only floor the flag is not
one; read as the whole it cannot be checked against anything.

## The evidence, including the reporter's retraction

The reporter retracted the issue's motivating number: on their corpus 17,611 of
17,611 `is_ai_assisted = TRUE` commits carried a literal trailer, so the "roughly
half of positives lack one" premise was wrong, and they deferred to the
maintainer on whether the case still stands.

It stands on this repo's own history. `collect/ai_markers.rs` records 1058 of
2434 commits carrying the `Generated with trusty-mpm` footer and no
`Co-Authored-By:` trailer — a `Message`-scope match, invisible to a consumer's
trailer regex. The discriminator separates rows such a consumer can see from
rows it cannot, which is what was missing regardless of which corpus is measured.

## What changes

Migration **v29** adds `commits.ai_detection_method` `TEXT` NULL, holding the
scope of the marker that matched: `trailer`, `message`, or `email`, and NULL for
a commit no marker claimed — exactly the rows where `is_ai_assisted = 0`.

The column reuses `MarkerScope` rather than introducing a parallel enum, so the
persisted vocabulary and the operator marker-file vocabulary are one set of
words; `MarkerScope::as_str`/`FromStr` are the only mapping, pinned against the
YAML spellings by `marker_scope_strings_match_the_yaml_spellings`.

`Detection` carries `method` beside `tool` and `mode`, so one scan writes all
four columns and they cannot disagree; `tool` and `method` are always both
`Some` or both `None`. `Detection` gains **`#[non_exhaustive]`** in the same
change, so the next signal recorded beside a verdict is not another break.

**`DETECTOR_VERSION` moves 1 -> 2**, which makes the existing #6748
re-classification pass claim every stored row as stale and fill the column in on
the next `tga collect`. The migration itself backfills nothing and leaves every
existing verdict untouched. `tga backfill ai-detection-commits` writes it too,
and now rewrites a row whose method is missing even when its tool and mode
already agree — on a real corpus that is every row, so diffing on tool and mode
alone would have skipped exactly the rows the repair exists for and reported
"0 updated".

Additive throughout. The column is nullable with no default, so an older `tga`,
which names its columns in every SELECT and INSERT, is unaffected;
`migration_v29_preserves_an_existing_v28_database` asserts that off
`pragma_table_info` and by running an older binary's column-naming INSERT, not
off the SQL text.

`weekly_activity` and `weekly_activity.csv` gain `ai_trailer_count`,
`ai_message_count` and `ai_email_count`, appended after the existing columns so
a consumer reading by column index is unaffected. They partition
`ai_assisted_count` on a corpus the current detector wrote; a row whose method
is unrecorded counts in the total and is assigned to no family.

## Test ladder: rung 5

Persisted state (a `commits` schema change) plus a cross-crate contract.

```
cargo fmt --check                                    EXIT=0
cargo clippy -p tga --all-targets -- -D warnings     EXIT=0
cargo test -p tga --no-fail-fast                     EXIT=0
  1604 passed; 0 failed; 7 ignored   (lib)
  + 10 further targets, all ok: 0, 0, 0, 1, 1, 1, 2, 8, 1, 10 passed; 0 failed
cargo check --workspace                              EXIT=0
cargo test -p trusty-review --no-fail-fast           EXIT=0
  2209 passed; 0 failed; 5 ignored   (lib)
  + 14 further targets, all ok; 0 failed

bash scripts/check_line_cap.sh            4576 tracked .rs file(s); 0 violations
bash scripts/check_test_pointers.sh       31798 Test: citation(s); 0 dangling
bash scripts/check_sld.sh                 0 error(s), 0 warning(s)
bash scripts/check_changelog_fragment.sh  OK trusty-git-analytics
bash scripts/check-pr-version-bump.sh     [ OK ] tga 8.0.0 — not yet published
bash scripts/check_rustdoc_links.sh       26 crate(s); 0 broken link(s)
```

Counts are from runs carrying `--no-fail-fast`, so they cover every target.
`tga` stays at 8.0.0: it is not published on crates.io (`index.crates.io/tg/a/tga`
returns `NoSuchKey`), and the version-bump gate passes.

## Each new test fails without its fix

Verified by reverting one file at a time and restoring it.

- **Detector records the matching method / NULL when unclassified** — reverting
  `collect/ai_markers.rs` alone is a compile failure, `no field 'method' on type
  'Detection'` at three call sites, because the signature changed. Re-proved at
  the persisted-state level by reverting only the extractor's INSERT column and
  placeholder: `walk_records_the_ai_detection_method` fails with
  `left: None, right: Some("trailer")`.
- **A pre-migration database migrates and preserves every value** — reverting
  only the `ALTER TABLE` out of `0029_commit_ai_detection_method.sql`:
  `migration_v29_preserves_an_existing_v28_database` fails with
  `no such column: ai_detection_method`.
- **The export surface carries the field** — reverting only
  `report/formatters/csv.rs`: `weekly_csv_carries_the_ai_detection_method_split`
  fails with `header missing ai_trailer_count`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
