### PR TITLE
feat(trusty-audit): sign the return package's content manifest with ed25519 (refs #5481)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -2282,6 +2288,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2540,16 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
@@ -2645,7 +2688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -2862,6 +2905,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3172,6 +3240,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -6606,7 +6680,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7388,6 +7462,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -9511,6 +9595,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
 name = "spm_precompiled"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11499,7 +11593,9 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 5.0.1",
+ "ed25519-dalek",
  "libc",
+ "rand_core 0.6.4",
  "reqwest 0.12.28",
  "rpassword",
  "serde",
@@ -12468,7 +12564,7 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "der",
+ "der 0.8.0",
  "flate2",
  "log",
  "native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,6 +259,16 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 # reqwest, so this adds no new tree.
 url = "2"
 sha2 = "0.10"
+# #5481: detached ed25519 signatures over the audit return package's content
+# manifest. The workspace carried no asymmetric signing at all — the
+# Developer-ID codesign in `trusty-installer` proves who BUILT a binary, a
+# different question — so this is the first and only answer to "sign this
+# content", and any second signing implementation is a defect under
+# CLAUDE.md's common-entry-point rule. `rand_core` supplies the `OsRng` its
+# key generation takes; both are already in `Cargo.lock` transitively, and
+# `signature 2.2.0` (the trait crate ed25519-dalek 2 builds on) is too.
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 # NFC canonical composition for the memory content-hash contract (#5902): two
 # machines that typed the same sentence must produce one digest even when their
 # editors disagree about composition form. Already in `Cargo.lock` transitively,

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -149,6 +149,14 @@ zip = { workspace = true }
 # prove it is scanning outbound files with the credential that produced them
 # rather than a freshly re-resolved one that never touched those files.
 sha2 = { workspace = true }
+# #5481: the detached ed25519 signature over the return package's content
+# manifest, and the check that reads it back. The workspace has no other
+# asymmetric-signing implementation to route through — `trusty-installer`'s
+# Developer-ID codesign answers a different question (who built the binary),
+# which #5481 and #5484 both warn against conflating. `rand_core` is only for
+# `OsRng` when a fresh engagement keypair is minted.
+ed25519-dalek = { workspace = true }
+rand_core = { workspace = true }
 # #5499: walking each audited repository's output directory. Not followed
 # through symlinks — `package::collect_dir` refuses one rather than reading a
 # file from outside the working directory into a package that leaves the

--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -5,11 +5,12 @@ codebases, and returns a report. It installs the pinned tools it needs
 (`tga`, `trusty-analyze`, `trusty-review`) and drives the audit workflow —
 "really an installer runner".
 
-**Status (#5502, #5495, #5555, #5499).** The crate, its working-directory
-layout, the CLI surface, pinned tool installation, the audit run, and the return
-package exist. Content signing and the desktop shell do not — they are later
-milestones on #5473 / #5477. The run reads a selection file; its shape is
-documented under "Running the sweep".
+**Status (#5502, #5495, #5555, #5499, #5481).** The crate, its
+working-directory layout, the CLI surface, pinned tool installation, the audit
+run, the return package, and that package's signed content manifest exist. The
+`verify` CLI arm over the signature (#5563) and the desktop shell do not — they
+are later milestones on #5473 / #5477. The run reads a selection file; its shape
+is documented under "Running the sweep".
 
 ## Shape: a library with a CLI over it
 
@@ -524,12 +525,10 @@ that state takes a deliberate `ln`, `cp -l`, or a hardlink-based backup tool
 pointed into the working directory. If you hit it, copy the file instead of
 linking it.
 
-Two things it does not claim. The extract database holds no file content,
+One thing it does not claim. The extract database holds no file content,
 diffs, patches, hunks or blobs — but it does hold free-text fields (commit
 messages, PR and work-item titles, classification notes), so a snippet someone
-pasted into one of those is in it. And nothing here is signed yet: content
-signing is #5481, and until it lands nothing proves the package was not altered
-after it was written.
+pasted into one of those is in it.
 
 A sweep that audited nothing produces no package. A sweep that audited some
 repositories does, and it names the ones it does not cover — in the printed
@@ -537,6 +536,70 @@ output, in `package.toml`, and in a non-zero exit status.
 
 `--out` is the one path on which this client writes outside the working
 directory, and only when you name one.
+
+## Signing the return package (#5481)
+
+Every package carries `manifest.sha256.toml`: one row per delivered file, with
+its SHA-256 and its size. When the engagement has a signing key, it also carries
+`manifest.sha256.sig` — a detached ed25519 signature over that manifest's exact
+bytes. Signing one small manifest rather than each file is the whole reason the
+manifest exists.
+
+### Setting the key up
+
+The auditor mints one keypair per engagement, keeps the public half, and writes
+the private half into the engagement config that ships to the recipient:
+
+```toml
+[signing]
+private_key = "9d61b19d…"   # 32 bytes of hex
+```
+
+The private key travels IN the inbound package on purpose, so the recipient
+signs on their own machine with no call back to the auditor. The public half
+never appears in either package — a key that arrives with the thing it
+authenticates authenticates nothing — so the auditor retains it out of band, the
+same way the OpenRouter key reaches the recipient out of band.
+
+Nothing else needs configuring. `trusty-audit package` reads the key, hashes
+every member as it writes it, and signs. The printed output names the key's
+short fingerprint so the operator can confirm it is the engagement's own.
+
+### No key configured is not a failure
+
+An engagement with no `[signing]` table still packages. The manifest is still
+written, without a `[signature]` block; `trusty-audit package` prints an
+`UNSIGNED` line beside the file it wrote, and the package README says the same
+thing in the recipient's own words. The deliverable is never withheld for a
+property the engagement did not ask for.
+
+### Checking a received package
+
+Verification is a library call today —
+`trusty_audit::package::signing::verify(&path, &retained_key)` — and reports one
+of: a signed package that checks out, an unsigned package, or one of five
+distinguishable failures. A member altered after signing, a signature member
+removed, a signature made by a different key, a manifest-listed member that is
+gone, and a member the manifest never listed are five different errors, not one
+"verification failed". The `trusty-audit verify` CLI arm over the same call is
+[#5563](https://github.com/bobmatnyc/trusty-tools/issues/5563); this crate keeps
+one implementation behind it and any front end.
+
+### What the signature proves, and what it does not
+
+**Tamper-evidence, not proof about the recipient.** The signing key is on
+hardware the recipient fully controls, so a recipient who wanted to could alter
+the package and re-sign it. What the signature does show is that the package was
+not altered between that machine and the auditor — in transit, or by a third
+party who got hold of the file. The alternatives that would close the remaining
+gap — submitting to an endpoint the auditor controls, or the auditor re-running
+the audit — were offered and declined. This is the accepted trust model, not an
+interim step toward a stronger one.
+
+It is also a different thing from the Developer-ID signature on the client
+binary ([#5484](https://github.com/bobmatnyc/trusty-tools/issues/5484)), which
+authenticates who *built* the binary and says nothing about the report. Treating
+either as if it vouched for the other is the error both issues warn against.
 
 ## Re-rendering a delivered audit
 

--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -552,7 +552,7 @@ the private half into the engagement config that ships to the recipient:
 
 ```toml
 [signing]
-private_key = "9d61b19d…"   # 32 bytes of hex
+private_key = "<64 hex characters>"   # the ed25519 seed, 32 bytes
 ```
 
 The private key travels IN the inbound package on purpose, so the recipient
@@ -577,11 +577,21 @@ property the engagement did not ask for.
 
 Verification is a library call today —
 `trusty_audit::package::signing::verify(&path, &retained_key)` — and reports one
-of: a signed package that checks out, an unsigned package, or one of five
+of: a signed package that checks out, an unsigned package, or one of several
 distinguishable failures. A member altered after signing, a signature member
 removed, a signature made by a different key, a manifest-listed member that is
 gone, and a member the manifest never listed are five different errors, not one
-"verification failed". The `trusty-audit verify` CLI arm over the same call is
+"verification failed".
+
+Two more come before any of those, and before the manifest is even read. The
+`zip` crate keys its entry table by member name, so an archive whose central
+directory carries two records under one name presents one member to this crate
+and can present the other to Python's `zipfile`, Info-ZIP or Finder. So
+verification walks the raw central directory itself, refuses a repeated name,
+and refuses any other disagreement between that walk and the parser. Member
+bytes are streamed through a fixed buffer rather than into an allocation sized
+from the archive's own declared size, which is a number whoever sent the package
+chose. The `trusty-audit verify` CLI arm over the same call is
 [#5563](https://github.com/bobmatnyc/trusty-tools/issues/5563); this crate keeps
 one implementation behind it and any front end.
 

--- a/crates/trusty-audit/changelog.d/5481-audit-package-signing.md
+++ b/crates/trusty-audit/changelog.d/5481-audit-package-signing.md
@@ -13,7 +13,11 @@ Added
   Before any of those it establishes the member set from the RAW central
   directory — the `zip` crate keys its entry table by name, so an archive
   repeating a name would present one member here and another to `zipfile` or
-  Info-ZIP — refusing a repeated name and any disagreement with the parser.
+  Info-ZIP — refusing a repeated name and any disagreement with the parser. That
+  walk identifies the end-of-central-directory record by its own framing rather
+  than by being last, so an archive comment carrying a planted `PK\x05\x06` does
+  not move it, and it compares raw name bytes rather than decoded names, so a
+  legitimate CP437-flagged member is not refused.
   Member bytes are streamed through a fixed buffer, never into an allocation
   sized from the archive's own declared size. An engagement with no key still
   packages —

--- a/crates/trusty-audit/changelog.d/5481-audit-package-signing.md
+++ b/crates/trusty-audit/changelog.d/5481-audit-package-signing.md
@@ -6,10 +6,17 @@ Added
   `manifest.sha256.sig`. Both are written last, so the manifest covers every
   other member; each digest is taken from the bytes as they reach the archive,
   in the same pass that scans them for credentials. `package::signing::verify`
-  checks a received package against the retained public key and tells five
-  failures apart: a member altered after signing, a removed signature, a
-  signature made by another key, a manifest-listed member that is gone, and a
-  member the manifest never listed. An engagement with no key still packages —
+  checks a received package against the retained public key and tells its
+  failures apart rather than reporting one "verification failed": a member
+  altered after signing, a removed signature, a signature made by another key, a
+  manifest-listed member that is gone, and a member the manifest never listed.
+  Before any of those it establishes the member set from the RAW central
+  directory — the `zip` crate keys its entry table by name, so an archive
+  repeating a name would present one member here and another to `zipfile` or
+  Info-ZIP — refusing a repeated name and any disagreement with the parser.
+  Member bytes are streamed through a fixed buffer, never into an allocation
+  sized from the archive's own declared size. An engagement with no key still
+  packages —
   the manifest ships without a `[signature]` table, `verify` answers `Unsigned`,
   and the CLI and the package README both say so. The signature is
   tamper-evidence in transit only: the key is on hardware the recipient

--- a/crates/trusty-audit/changelog.d/5481-audit-package-signing.md
+++ b/crates/trusty-audit/changelog.d/5481-audit-package-signing.md
@@ -1,0 +1,19 @@
+Added
+
+- The return package now carries `manifest.sha256.toml` — one row per delivered
+  file with its SHA-256 and size — and, when the engagement config sets
+  `[signing] private_key`, a detached ed25519 signature over that manifest in
+  `manifest.sha256.sig`. Both are written last, so the manifest covers every
+  other member; each digest is taken from the bytes as they reach the archive,
+  in the same pass that scans them for credentials. `package::signing::verify`
+  checks a received package against the retained public key and tells five
+  failures apart: a member altered after signing, a removed signature, a
+  signature made by another key, a manifest-listed member that is gone, and a
+  member the manifest never listed. An engagement with no key still packages —
+  the manifest ships without a `[signature]` table, `verify` answers `Unsigned`,
+  and the CLI and the package README both say so. The signature is
+  tamper-evidence in transit only: the key is on hardware the recipient
+  controls, so it proves nothing about what happened there. The signing key
+  joins the outbound credential scan, and `config::generate_for_new_engagement`
+  drops a `[signing]` table so one engagement's key cannot reach another's
+  package.

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -1257,6 +1257,9 @@ mod cli_tests {
             total_bytes: 900 + 3 * 1024 * 1024,
             packaged_bytes: 1024 * 1024,
             excluded: Vec::new(),
+            signature: crate::package::SignatureOutcome::Signed {
+                key_fingerprint: "0badc0ffee001122".to_owned(),
+            },
         };
         let text = render(&Outcome::Package(package));
         assert!(text.contains("/work/audit-return-package.zip"), "{text}");
@@ -1320,6 +1323,7 @@ mod cli_tests {
             total_bytes: 0,
             packaged_bytes: 0,
             excluded,
+            signature: crate::package::SignatureOutcome::Unsigned,
         };
         assert_eq!(Outcome::Package(package(Vec::new())).exit_code(), 0);
 
@@ -1382,6 +1386,7 @@ mod cli_tests {
                 total_bytes: 0,
                 packaged_bytes: 0,
                 excluded: Vec::new(),
+                signature: crate::package::SignatureOutcome::Unsigned,
             },
             gaps: vec!["jira:ACME was not audited".to_owned()],
         };

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -480,6 +480,20 @@ fn render_package(package: &crate::package::ReturnPackage) -> String {
             file.entry
         ));
     }
+    // #5481: an unsigned package is a warning the operator has to see before
+    // they send it — an absent `manifest.sha256.sig` is not something anyone
+    // discovers by reading the member list above.
+    out.push_str(&match &package.signature {
+        crate::package::SignatureOutcome::Signed { key_fingerprint } => format!(
+            "  signed with engagement key {key_fingerprint} — tamper-evident in transit, \
+             not proof about the sender\n"
+        ),
+        crate::package::SignatureOutcome::Unsigned => {
+            "  UNSIGNED — no [signing] key in engagement.toml, so nothing here shows the \
+             package was not altered after it was written\n"
+                .to_owned()
+        }
+    });
     for line in &package.excluded {
         out.push_str(&format!("Not included: {line}\n"));
     }

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -319,6 +319,36 @@ pub struct BoardCredentials {
     pub linear: Option<LinearCredentials>,
 }
 
+/// The key this engagement signs its return package with (#5481).
+///
+/// Why: the signing keypair is minted per engagement, and the PRIVATE half
+/// travels to the recipient so they sign locally with no call back to the
+/// auditor. That makes it engagement configuration, in the same file and with
+/// the same readability, rather than something the client fetches. The public
+/// half is retained by the auditor out of band and never appears here — a key
+/// that arrives with the thing it authenticates authenticates nothing.
+/// What: one optional hex seed under a `[signing]` table. Absent means this
+/// engagement signs nothing, which is a supported state: the package is still
+/// built and its manifest still written, without a `[signature]` table. Held as
+/// a [`SecretKey`] so it has no `Serialize`, redacts in `Debug`, and joins
+/// [`EngagementConfig::configured_secrets`] — which is what makes the outbound
+/// scan refuse a package member carrying it.
+///
+/// ```toml
+/// [signing]
+/// private_key = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+/// ```
+///
+/// Test: `super::config_tests::a_signing_key_loads_and_joins_the_scanned_secrets`,
+/// `super::config_tests::a_config_with_no_signing_table_still_loads`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[non_exhaustive]
+pub struct SigningSettings {
+    /// The ed25519 private seed, 32 bytes of hex. Absent means unsigned.
+    #[serde(default)]
+    pub private_key: Option<SecretKey>,
+}
+
 /// What the engagement asks the investigation pass to read, per repository.
 ///
 /// Why (#6247): the investigation budget had no declaration point an operator
@@ -562,6 +592,10 @@ pub struct EngagementConfig {
     /// engagement registers no boards.
     #[serde(default)]
     pub boards: BoardCredentials,
+    /// The key this engagement signs its return package with (#5481). Absent
+    /// means the package ships unsigned rather than failing to build.
+    #[serde(default)]
+    pub signing: SigningSettings,
     /// What this engagement asks the investigation pass to read (#6247).
     ///
     /// Absent means the machine's environment overrides, then the compiled
@@ -774,7 +808,41 @@ impl EngagementConfig {
         if let Some(linear) = self.boards.linear.as_ref() {
             secrets.push(linear.api_key.expose());
         }
+        // #5481: the signing private key is the one secret that must not come
+        // BACK in the package it signed. It is a needle here for the same
+        // reason the board credentials are — the members are files other
+        // programs wrote, and no type governs those.
+        if let Some(key) = self.signing.private_key.as_ref() {
+            secrets.push(key.expose());
+        }
         secrets
+    }
+
+    /// The engagement's signing key, parsed, or `None` when none is configured.
+    ///
+    /// Why (#5481): the config carries the key as text and the packaging path
+    /// needs it as a key. Parsing it HERE rather than at the call site means a
+    /// malformed key is one error with one message, raised at the moment the
+    /// package is assembled and naming what is wrong with the field.
+    /// What: `None` for an absent or empty field — a template ships
+    /// `private_key = ""` the same way it ships `openrouter_key = ""`, and an
+    /// empty string is an unconfigured key, not a malformed one.
+    /// Test: `super::config_tests::a_signing_key_loads_and_joins_the_scanned_secrets`,
+    /// `super::config_tests::an_empty_signing_key_is_absent_not_malformed`.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::package::signing::SigningError::KeyMalformed`] when the field
+    /// is present and is not 32 bytes of hex.
+    pub fn signing_key(
+        &self,
+    ) -> Result<Option<crate::package::signing::EngagementKey>, AuditError> {
+        let Some(raw) = self.signing.private_key.as_ref().filter(|k| !k.is_empty()) else {
+            return Ok(None);
+        };
+        Ok(Some(crate::package::signing::EngagementKey::from_hex(
+            raw.expose(),
+        )?))
     }
 }
 
@@ -866,7 +934,13 @@ pub const BOARDS_FIELD: &str = "boards";
 /// registering a board with no credential is
 /// [`AuditError::BoardCredentialMissing`](crate::error::AuditError::BoardCredentialMissing),
 /// which names the field to set.
+/// #5481 puts a second credential in the same position: `[signing]`'s private
+/// key belongs to ONE engagement, and carrying a template's copy into another
+/// client's package would let that client sign as the first. It is dropped for
+/// the same reason and by the same rule — the in-place render keeps it, because
+/// there it is the recipient's own key.
 /// Test: `config_tests::a_generated_config_never_carries_the_templates_board_credentials`,
+/// `config_tests::a_generated_config_never_carries_another_engagements_signing_key`,
 /// `config_tests::an_in_place_render_keeps_the_recipients_own_board_credentials`.
 ///
 /// # Errors
@@ -878,9 +952,19 @@ pub fn generate_for_new_engagement(
     path: &Path,
 ) -> Result<(String, Vec<String>), AuditError> {
     let mut table = parse_template(template, path)?;
-    let dropped = drop_board_credentials(&mut table);
+    let mut dropped = drop_board_credentials(&mut table);
+    // #5481: one engagement's signing key must never reach another's package.
+    if table.remove(SIGNING_FIELD).is_some() {
+        dropped.push(SIGNING_FIELD.to_owned());
+    }
     Ok((render_with_key(table, key, path)?, dropped))
 }
+
+/// The TOML table holding this engagement's signing key (#5481).
+///
+/// Named once so [`generate_for_new_engagement`] and [`SigningSettings`] cannot
+/// drift apart.
+pub const SIGNING_FIELD: &str = "signing";
 
 /// The template as a TOML table.
 fn parse_template(template: &str, path: &Path) -> Result<toml::Table, AuditError> {
@@ -1612,6 +1696,86 @@ trusty-review = "0.15.1"
             EngagementConfig::from_toml(SAMPLE, Path::new("engagement.toml")).expect("parses");
         assert!(cfg.boards.jira.is_none());
         assert!(cfg.boards.linear.is_none());
+    }
+
+    /// #5481: an engagement written before `[signing]` existed still loads, and
+    /// loads as unsigned rather than as an error.
+    #[test]
+    fn a_config_with_no_signing_table_still_loads() {
+        let cfg =
+            EngagementConfig::from_toml(SAMPLE, Path::new("engagement.toml")).expect("parses");
+        assert!(cfg.signing.private_key.is_none());
+        assert!(cfg.signing_key().expect("no key is not an error").is_none());
+    }
+
+    /// 🔴 #5481: the signing key is a secret the RETURN package must refuse, so
+    /// it has to be one of the needles the outbound scan searches for.
+    #[test]
+    fn a_signing_key_loads_and_joins_the_scanned_secrets() {
+        let seed = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+        let cfg = EngagementConfig::from_toml(
+            &format!("{SAMPLE}\n[signing]\nprivate_key = \"{seed}\"\n"),
+            Path::new("engagement.toml"),
+        )
+        .expect("parses");
+
+        assert!(
+            cfg.configured_secrets().contains(&seed),
+            "not a scan needle"
+        );
+        assert!(cfg.signing_key().expect("a valid key").is_some());
+        // The same posture `SecretKey` takes everywhere: the bytes never reach a
+        // log through an enclosing `Debug`.
+        assert!(!format!("{cfg:?}").contains(seed), "{cfg:?}");
+    }
+
+    /// A template ships `private_key = ""` the way it ships `openrouter_key =
+    /// ""`. That is an unconfigured key, not a malformed one — reading it as a
+    /// parse failure would refuse to package an engagement that simply does not
+    /// sign.
+    #[test]
+    fn an_empty_signing_key_is_absent_not_malformed() {
+        let cfg = EngagementConfig::from_toml(
+            &format!("{SAMPLE}\n[signing]\nprivate_key = \"\"\n"),
+            Path::new("engagement.toml"),
+        )
+        .expect("parses");
+        assert!(cfg.signing_key().expect("empty is not an error").is_none());
+    }
+
+    /// 🔴 #5481, the #5861 hazard one field over: an auditor reusing a template
+    /// would otherwise ship engagement A's signing PRIVATE key inside client
+    /// B's package, letting B sign as A.
+    #[test]
+    fn a_generated_config_never_carries_another_engagements_signing_key() {
+        let path = Path::new("engagement.toml");
+        let seed = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+        let (text, dropped) = generate_for_new_engagement(
+            &format!("{SAMPLE}\n[signing]\nprivate_key = \"{seed}\"\n"),
+            &SecretKey::new("sk-or-v1-client-b"),
+            path,
+        )
+        .expect("generates");
+
+        assert!(!text.contains(seed), "{text}");
+        assert!(dropped.contains(&SIGNING_FIELD.to_owned()), "{dropped:?}");
+        let loaded = EngagementConfig::from_toml(&text, path).expect("loads");
+        assert!(loaded.signing.private_key.is_none());
+    }
+
+    /// The other direction, as for `[boards]`: the recipient's own key survives
+    /// an in-place re-render, or saving a newly-entered OpenRouter key would
+    /// silently unsign every package they build afterwards.
+    #[test]
+    fn an_in_place_render_keeps_the_recipients_own_signing_key() {
+        let seed = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60";
+        let text = generate(
+            &format!("{SAMPLE}\n[signing]\nprivate_key = \"{seed}\"\n"),
+            &SecretKey::new("sk-or-v1-re-entered"),
+            Path::new("engagement.toml"),
+        )
+        .expect("generates");
+        assert!(text.contains(seed), "{text}");
     }
 
     /// 🔴 #6246: a key this version does not act on is CAPTURED, not discarded.

--- a/crates/trusty-audit/src/config.rs
+++ b/crates/trusty-audit/src/config.rs
@@ -336,8 +336,12 @@ pub struct BoardCredentials {
 ///
 /// ```toml
 /// [signing]
-/// private_key = "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
+/// private_key = "0000000000000000000000000000000000000000000000000000000000000000"
 /// ```
+///
+/// The 64 zeros are a placeholder, not a usable key. Real key material never
+/// appears in this crate's production source — a credential scan over the
+/// source tree must not have to decide whether a quoted seed is live.
 ///
 /// Test: `super::config_tests::a_signing_key_loads_and_joins_the_scanned_secrets`,
 /// `super::config_tests::a_config_with_no_signing_table_still_loads`.

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -1185,6 +1185,24 @@ pub enum AuditError {
         /// The issue that lands it.
         issue: u32,
     },
+
+    /// Signing the return package, or checking a received one, failed (#5481).
+    ///
+    /// Why: a transparent wrapper rather than a flattened string, because the
+    /// three failures #5481 requires be told apart — a member altered after
+    /// signing, a signature removed, a signature made by another key — are
+    /// distinct variants of
+    /// [`SigningError`](crate::package::signing::SigningError), and a caller
+    /// that collapsed them would report "verification failed" for all three.
+    /// What: `#[from]`, so the packaging path's `?` carries the specific
+    /// variant up unchanged.
+    /// Test: `crate::package::signing::signing_tests`.
+    #[error(transparent)]
+    Signing {
+        /// What the signing or verification step refused, verbatim.
+        #[from]
+        source: crate::package::signing::SigningError,
+    },
 }
 
 /// Every searched directory on one line, for [`AuditError::NothingToRerender`].

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -41,9 +41,9 @@
 //!
 //! ## What this milestone is not
 //!
-//! Content signing (#5481) and the GUI are later milestones on #5473/#5477's
-//! tree. [`package::assemble`] carries everything under `out/` verbatim, so
-//! #5481's signed manifest rides along with no change there. [`run::sweep`] reads
+//! The GUI is a later milestone on #5473/#5477's tree, and so is the `verify`
+//! CLI arm over #5481's signature (#5563) — [`package::signing::verify`] is the
+//! library call that arm will drive. [`run::sweep`] reads
 //! the selection those will write — see [`run::SELECTION_FILE`] for the exact
 //! file and shape. [`tools::install`] fetches the pinned triple, but it
 //! contains no download implementation — it calls `trusty-installer`'s pinned,

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -71,19 +71,29 @@
 //! patches, hunks, or blobs, but it does carry whatever free text a human
 //! pasted into a commit message or work-item title.
 //!
-//! ## The boundary with signing (#5481)
+//! ## Signing (#5481)
 //!
-//! This module signs nothing and hashes nothing. #5481 owns the ed25519 manifest
-//! — filename plus SHA-256 per delivered file, signed with the per-engagement
-//! key — and writes it into `out/`. Everything under `out/` is packaged
-//! verbatim, so that manifest and its signature ride along with no change here.
-//! Until #5481 lands, the generated README says the package is unsigned rather
-//! than leaving the recipient to infer it.
+//! Every member's SHA-256 goes into one manifest, and that manifest carries a
+//! detached ed25519 signature made with the engagement's own key. Both are
+//! written by [`fill_archive`] as the LAST two members, which is the one thing
+//! that changed from the shape #5499 anticipated: the manifest was to be
+//! written into `out/` and packaged verbatim, but a manifest written there
+//! cannot cover the members this module generates, because they do not exist
+//! until the archive is being filled. So the hashes are taken from the bytes as
+//! they are written, in the same pass that scans them.
+//!
+//! An engagement with no key configured still packages — the manifest is
+//! written without a `[signature]` table, [`ReturnPackage::signature`] says so,
+//! and the generated README and the CLI both state it. See [`signing`] for the
+//! verification side, and for the tamper-evidence limit this must not be worded
+//! as more than.
 //!
 //! Test: `super::package_tests`.
 
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
+
+use sha2::Digest as _;
 
 use crate::config::EngagementConfig;
 use crate::error::AuditError;
@@ -114,6 +124,12 @@ mod error_digest;
 // file for the same reason the three above are — this file decides what goes
 // into the archive; that one decides what an excerpt may contain.
 mod excerpts;
+
+// #5481: the content manifest, its detached ed25519 signature, and the check
+// that reads both back out of a received package. `pub` because #5563's
+// `trusty-audit verify` CLI arm drives `signing::verify` — one implementation
+// behind the CLI, the Tauri shell, and this module's own write path.
+pub mod signing;
 
 use generated::{
     Generated, exclusions, render_failures, render_index, render_metadata, render_readme,
@@ -245,6 +261,30 @@ pub struct ReturnPackage {
     /// `unattempted` — a repository that never cloned reaches the sweep's
     /// records nowhere, so it can only arrive that way (#5824).
     pub excluded: Vec<String>,
+    /// Whether this package carries a signature, and under which key (#5481).
+    pub signature: SignatureOutcome,
+}
+
+/// What the signing step did while this package was written (#5481).
+///
+/// Why: "the package is unsigned" is a fact the operator sending it has to be
+/// able to see, and an absent `manifest.sha256.sig` is not something anyone
+/// reads a zip listing to discover. Modelling it as a field rather than a
+/// warning line means the CLI, the README and any front end state the same
+/// thing from the same value.
+/// Test: `super::package_tests::a_package_with_no_signing_key_is_unsigned_and_says_so`,
+/// `super::package_tests::a_configured_key_signs_the_package_and_it_verifies`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SignatureOutcome {
+    /// The manifest was signed with the engagement's key.
+    Signed {
+        /// The signing key's short fingerprint, as the manifest records it.
+        key_fingerprint: String,
+    },
+    /// No `[signing]` key is configured, so the manifest carries no signature.
+    /// The package was still built — this is a warning, not a refusal.
+    Unsigned,
 }
 
 /// Build the return package from what a completed sweep produced.
@@ -380,6 +420,12 @@ pub fn assemble(
         });
     }
 
+    // #5481: read the key BEFORE any member is written, so a malformed
+    // `[signing] private_key` refuses at the top rather than after a
+    // multi-gigabyte archive has been built. `None` is the unsigned engagement,
+    // which is not an error — see `SignatureOutcome`.
+    let signing_key = config.signing_key()?;
+
     let mut collected = Vec::new();
     for run in &audited {
         let stem = output_stem(run);
@@ -412,7 +458,9 @@ pub fn assemble(
     let (index, debt) = render_index(work, report, &collected);
     let generated = Generated {
         metadata: render_metadata(work, config, report, &audited, unattempted)?,
-        readme: render_readme(config, &audited, &excluded),
+        // #5481: the README states signed-or-not, and it is written before the
+        // manifest exists — so it is told from the key, which is already known.
+        readme: render_readme(config, &audited, &excluded, signing_key.is_some()),
         // #6080: built from `collected`, so the index links the members that are
         // actually going into this archive rather than the files the sweep left
         // on disk. Before `fill_archive`, because it is one of the members.
@@ -441,6 +489,7 @@ pub fn assemble(
         collected,
         excluded,
         github_token,
+        signing_key.as_ref(),
     )
 }
 
@@ -675,6 +724,7 @@ fn write_archive(
     collected: Vec<(String, PathBuf)>,
     excluded: Vec<String>,
     github_token: Option<&str>,
+    signing_key: Option<&signing::EngagementKey>,
 ) -> Result<ReturnPackage, AuditError> {
     if let Some(parent) = destination.parent() {
         std::fs::create_dir_all(parent).map_err(|source| AuditError::Package {
@@ -683,7 +733,14 @@ fn write_archive(
         })?;
     }
     let temporary = destination.with_extension("zip.part");
-    let result = fill_archive(&temporary, config, generated, collected, github_token);
+    let result = fill_archive(
+        &temporary,
+        config,
+        generated,
+        collected,
+        github_token,
+        signing_key,
+    );
     let mut files = match result {
         Ok(files) => files,
         Err(e) => {
@@ -713,6 +770,12 @@ fn write_archive(
         total_bytes,
         packaged_bytes,
         excluded,
+        signature: match signing_key {
+            Some(key) => SignatureOutcome::Signed {
+                key_fingerprint: key.fingerprint(),
+            },
+            None => SignatureOutcome::Unsigned,
+        },
     })
 }
 
@@ -722,6 +785,7 @@ fn fill_archive(
     generated: Generated,
     collected: Vec<(String, PathBuf)>,
     github_token: Option<&str>,
+    signing_key: Option<&signing::EngagementKey>,
 ) -> Result<Vec<PackagedFile>, AuditError> {
     let file = std::fs::File::create(temporary).map_err(|source| AuditError::Package {
         path: temporary.to_path_buf(),
@@ -729,6 +793,8 @@ fn fill_archive(
     })?;
     let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
     let mut files = Vec::with_capacity(collected.len() + 3);
+    // #5481: one entry per member as it is written, in the order it is written.
+    let mut manifest = Vec::with_capacity(files.capacity());
 
     let members = [
         (README_ENTRY, Some(generated.readme)),
@@ -763,6 +829,11 @@ fn fill_archive(
                 path: temporary.to_path_buf(),
                 source,
             })?;
+        manifest.push(signing::ManifestFile {
+            entry: entry.to_owned(),
+            sha256: hex_digest(sha2::Sha256::digest(text.as_bytes())),
+            bytes: text.len() as u64,
+        });
         files.push(PackagedFile {
             entry: entry.to_owned(),
             source: None,
@@ -771,6 +842,9 @@ fn fill_archive(
     }
 
     for (entry, source) in collected {
+        // #5481: hashed in the same pass that scans and copies, so the digest
+        // is over the bytes that actually reached the archive.
+        let mut digest = sha2::Sha256::new();
         let bytes = credential_scan::copy_member(
             &mut zip,
             &entry,
@@ -778,11 +852,41 @@ fn fill_archive(
             config,
             temporary,
             github_token,
+            &mut digest,
         )?;
+        manifest.push(signing::ManifestFile {
+            entry: entry.clone(),
+            sha256: hex_digest(digest.finalize()),
+            bytes,
+        });
         files.push(PackagedFile {
             entry,
             source: Some(source),
             bytes,
+        });
+    }
+
+    // #5481: last, because the manifest covers every member before it and
+    // nothing can hash itself. `signing::verify` skips both when it re-checks
+    // the archive for members the manifest does not list.
+    let signed = signing::render(manifest, signing_key)?;
+    for (entry, text) in [
+        (signing::MANIFEST_ENTRY, Some(signed.manifest)),
+        (signing::SIGNATURE_ENTRY, signed.signature),
+    ]
+    .into_iter()
+    .filter_map(|(e, t)| t.map(|t| (e, t)))
+    {
+        start(&mut zip, entry, text.len() as u64, temporary)?;
+        zip.write_all(text.as_bytes())
+            .map_err(|source| AuditError::Package {
+                path: temporary.to_path_buf(),
+                source,
+            })?;
+        files.push(PackagedFile {
+            entry: entry.to_owned(),
+            source: None,
+            bytes: text.len() as u64,
         });
     }
 
@@ -791,6 +895,14 @@ fn fill_archive(
         source: std::io::Error::other(e),
     })?;
     Ok(files)
+}
+
+/// A SHA-256 digest as lower-case hex — the form the manifest records.
+///
+/// The `GithubAccess::fingerprint` spelling (#5980), so the crate writes hex
+/// one way rather than acquiring a `hex` dependency for four lines.
+fn hex_digest(digest: impl AsRef<[u8]>) -> String {
+    digest.as_ref().iter().map(|b| format!("{b:02x}")).collect()
 }
 
 type Archive = zip::ZipWriter<std::io::BufWriter<std::fs::File>>;
@@ -992,6 +1104,171 @@ trusty-review = "0.15.1"
         let mut text = String::new();
         entry.read_to_string(&mut text).expect("read entry");
         text
+    }
+
+    /// A config that carries `key` as its `[signing]` private half.
+    fn signing_config(key: &signing::EngagementKey) -> EngagementConfig {
+        EngagementConfig::from_toml(
+            &format!(
+                "{CONFIG}\n[signing]\nprivate_key = \"{}\"\n",
+                key.private_hex()
+            ),
+            Path::new("engagement.toml"),
+        )
+        .expect("parses")
+    }
+
+    /// 🔴 #5481 closure conditions 1 and 2, over the REAL assembler: the
+    /// manifest covers every member the package actually holds, the signature
+    /// over it verifies against the retained public half, and the two signing
+    /// members are the last two written.
+    #[test]
+    fn a_configured_key_signs_the_package_and_it_verifies() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let key = signing::EngagementKey::generate();
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+
+        let package = assemble(
+            &work,
+            &signing_config(&key),
+            &report,
+            &[],
+            &destination,
+            None,
+        )
+        .expect("assembles");
+
+        assert_eq!(
+            package.signature,
+            SignatureOutcome::Signed {
+                key_fingerprint: key.fingerprint()
+            }
+        );
+        let names = entries(&destination);
+        assert_eq!(
+            names.iter().rev().take(2).collect::<Vec<_>>(),
+            vec![signing::SIGNATURE_ENTRY, signing::MANIFEST_ENTRY],
+            "the two signing members go last, so the manifest covers the rest: {names:?}"
+        );
+        let retained =
+            signing::RetainedKey::from_hex(&key.public_hex()).expect("the public half parses");
+        match signing::verify(&destination, &retained).expect("verifies") {
+            signing::Verdict::Signed {
+                key_fingerprint,
+                files,
+            } => {
+                assert_eq!(key_fingerprint, key.fingerprint());
+                // Every member except the two the manifest cannot cover.
+                assert_eq!(files, names.len() - 2, "{names:?}");
+            }
+            other => panic!("expected a signed verdict, got {other:?}"),
+        }
+        let readme = read_entry(&destination, README_ENTRY);
+        assert!(
+            readme.contains("tamper-evidence, not proof about you"),
+            "the limit must be stated, not softened: {readme}"
+        );
+    }
+
+    /// 🔴 #5481: a missing key must not stop the package being built. The
+    /// engagement still gets its deliverable, the manifest is still written, and
+    /// `verify` answers `Unsigned` rather than an error.
+    #[test]
+    fn a_package_with_no_signing_key_is_unsigned_and_says_so() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+
+        let package =
+            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+
+        assert_eq!(package.signature, SignatureOutcome::Unsigned);
+        let names = entries(&destination);
+        assert!(
+            names.contains(&signing::MANIFEST_ENTRY.to_owned()),
+            "{names:?}"
+        );
+        assert!(
+            !names.contains(&signing::SIGNATURE_ENTRY.to_owned()),
+            "an unsigned package carries no signature member: {names:?}"
+        );
+        let manifest = read_entry(&destination, signing::MANIFEST_ENTRY);
+        assert!(
+            !manifest.contains("[signature]"),
+            "the absent table is what tells `Unsigned` from a removed signature: {manifest}"
+        );
+        let retained =
+            signing::RetainedKey::from_hex(&signing::EngagementKey::generate().public_hex())
+                .expect("parses");
+        assert!(matches!(
+            signing::verify(&destination, &retained).expect("reads"),
+            signing::Verdict::Unsigned { .. }
+        ));
+    }
+
+    /// A manifest entry records the digest of the bytes IN the archive, so a
+    /// collected member (streamed through the credential scan) and a generated
+    /// one (written from memory) are both covered.
+    #[test]
+    fn the_manifest_digest_matches_a_collected_members_own_bytes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let key = signing::EngagementKey::generate();
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+        assemble(
+            &work,
+            &signing_config(&key),
+            &report,
+            &[],
+            &destination,
+            None,
+        )
+        .expect("assembles");
+
+        let manifest: toml::Value = read_entry(&destination, signing::MANIFEST_ENTRY)
+            .parse()
+            .expect("the manifest is TOML");
+        let listed = manifest["file"].as_array().expect("an array of files");
+        let database = listed
+            .iter()
+            .find(|f| f["entry"].as_str() == Some("extract/00-acme-api.db"))
+            .expect("the extract database is listed");
+        assert_eq!(
+            database["sha256"].as_str(),
+            Some(hex_digest(sha2::Sha256::digest(b"SQLite format 3\0extract")).as_str()),
+            "{database:?}"
+        );
+    }
+
+    /// A `[signing]` key that is not a key refuses BEFORE the archive is
+    /// written, so a malformed field costs no packaging work and leaves no zip.
+    #[test]
+    fn a_malformed_signing_key_refuses_before_anything_is_written() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let broken = EngagementConfig::from_toml(
+            &format!("{CONFIG}\n[signing]\nprivate_key = \"not-a-key\"\n"),
+            Path::new("engagement.toml"),
+        )
+        .expect("parses");
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+
+        let refused = assemble(&work, &broken, &report, &[], &destination, None);
+
+        assert!(
+            matches!(refused, Err(AuditError::Signing { .. })),
+            "{refused:?}"
+        );
+        assert!(!destination.exists(), "a refused assembly leaves no zip");
     }
 
     /// The whole path: a completed sweep becomes one openable file carrying the
@@ -1199,6 +1476,9 @@ trusty-review = "0.15.1"
             vec![
                 "README.md",
                 "extract/00-acme-api.db",
+                // #5481: the content manifest, on every package. Its signature
+                // is absent here because this config configures no key.
+                signing::MANIFEST_ENTRY,
                 "package.toml",
                 "reports/00-acme-api/manifest.toml",
                 "reports/00-acme-api/report.md",
@@ -1454,9 +1734,11 @@ trusty-review = "0.15.1"
             readme.contains("no file content, diffs, patches, hunks, or blobs"),
             "{readme}"
         );
+        // #5481: this config configures no signing key, and the README says so
+        // in those words rather than leaving the recipient to infer it.
         assert!(
-            readme.contains("#5481"),
-            "the unsigned state must be stated"
+            readme.contains("**This package is unsigned.**"),
+            "the unsigned state must be stated: {readme}"
         );
 
         let metadata = read_entry(&destination, METADATA_ENTRY);

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -131,6 +131,12 @@ mod excerpts;
 // behind the CLI, the Tauri shell, and this module's own write path.
 pub mod signing;
 
+// #5481 security review: reading the central directory as it is on disk. `zip`
+// keys its entry table by member name, so a repeated name never reaches a
+// caller — see that module's docs. Its own file because it is zip-format
+// parsing, not signing.
+mod zip_directory;
+
 use generated::{
     Generated, exclusions, render_failures, render_index, render_metadata, render_readme,
 };

--- a/crates/trusty-audit/src/package/credential_scan.rs
+++ b/crates/trusty-audit/src/package/credential_scan.rs
@@ -101,6 +101,12 @@ pub(super) fn refuse_if_credential(
 }
 
 /// Copy one file into the archive, refusing it if it carries any credential.
+///
+/// #5481: `digest` is fed every byte that reaches the archive, so the content
+/// manifest's SHA-256 comes out of the SAME pass that scans and copies. Hashing
+/// the source file separately would hash bytes this function never wrote — a
+/// file rewritten mid-copy would then be recorded under a digest the package
+/// does not contain.
 pub(super) fn copy_member(
     zip: &mut Archive,
     entry: &str,
@@ -108,6 +114,7 @@ pub(super) fn copy_member(
     config: &EngagementConfig,
     temporary: &Path,
     github_token: Option<&str>,
+    digest: &mut sha2::Sha256,
 ) -> Result<u64, AuditError> {
     let mut input = std::fs::File::open(source).map_err(|e| AuditError::Package {
         path: source.to_path_buf(),
@@ -138,6 +145,7 @@ pub(super) fn copy_member(
                 path: temporary.to_path_buf(),
                 source,
             })?;
+        sha2::Digest::update(digest, &buffer[..read]);
         written += read as u64;
     }
     Ok(written)

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -462,7 +462,7 @@ pub(super) fn render_readme(
     }
     // #5481: the "no signature yet" bullet is gone — the Signature section
     // below states what this package actually carries, either way.
-    out.push_str("\n");
+    out.push('\n');
     out.push_str(if signed {
         // #5481: the limit is stated in the same paragraph as the property, so
         // no reader takes a valid signature for more than it is.

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -393,10 +393,15 @@ pub(super) fn render_metadata(
 /// file, and it is the only place they are told which way it went.
 /// Test: `super::package_tests::{the_readme_states_the_excerpt_member_when_it_is_on,
 /// the_readme_states_excerpts_are_off_when_they_are}`.
+///
+/// #5481: `signed` is whether the engagement configured a signing key. It is
+/// passed rather than read back from the archive because this member is written
+/// before the manifest it would have to read.
 pub(super) fn render_readme(
     config: &EngagementConfig,
     audited: &[&RepoRun],
     excluded: &[String],
+    signed: bool,
 ) -> String {
     let mut out = String::from(
         "# Audit return package\n\n\
@@ -417,6 +422,12 @@ pub(super) fn render_readme(
              cited line, so the auditor can confirm it without a checkout |\n",
         );
     }
+    // #5481: last in the table because they are last in the archive — the
+    // manifest covers every member above it.
+    out.push_str(
+        "| `manifest.sha256.toml` | every file above, with its SHA-256 |\n\
+         | `manifest.sha256.sig` | the signature over that manifest, when this engagement signs |\n",
+    );
     out.push_str(
         "\n## What is not inside\n\n\
          - **No credential.** The OpenRouter key in your engagement config never \
@@ -449,10 +460,28 @@ pub(super) fn render_readme(
              findings.\n",
         );
     }
-    out.push_str(
-        "- **No signature yet.** Content signing is separate work (#5481); until it \
-         lands nothing here proves the package was not altered after it was written.\n\n",
-    );
+    // #5481: the "no signature yet" bullet is gone — the Signature section
+    // below states what this package actually carries, either way.
+    out.push_str("\n");
+    out.push_str(if signed {
+        // #5481: the limit is stated in the same paragraph as the property, so
+        // no reader takes a valid signature for more than it is.
+        "## Signature\n\n\
+         `manifest.sha256.toml` lists every file above with its SHA-256, and \
+         `manifest.sha256.sig` is a detached ed25519 signature over that manifest, made \
+         with this engagement's own key. Your auditor holds the matching public key and \
+         checks both on receipt.\n\n\
+         This is **tamper-evidence, not proof about you**. The signing key is on this \
+         machine, so it shows the package was not altered in transit or by a third party; \
+         it cannot show that whoever holds the key did not alter it before signing.\n\n"
+    } else {
+        "## Signature\n\n\
+         **This package is unsigned.** No `[signing]` key is configured in \
+         `engagement.toml`, so `manifest.sha256.toml` lists each file's SHA-256 with no \
+         signature over it, and nothing here shows the package was not altered after it \
+         was written. Ask your auditor for the engagement's signing key if they expected \
+         a signed deliverable.\n\n"
+    });
     if let Some(client) = &config.client {
         out.push_str(&format!("Engagement: {client}\n\n"));
     }

--- a/crates/trusty-audit/src/package/signing.rs
+++ b/crates/trusty-audit/src/package/signing.rs
@@ -524,27 +524,34 @@ pub fn verify(package: &Path, retained: &RetainedKey) -> Result<Verdict, Signing
 /// record under an existing name never reaches a caller — see
 /// [`super::zip_directory`]'s module docs for what that lets an archive do.
 /// What: walks the raw directory, refuses two records carrying the same name
-/// BYTES, then refuses any count that differs from what the parser exposes.
+/// BYTES, then refuses either a count or a SET that differs from what the
+/// parser holds. Both checks are load-bearing and neither implies the other: a
+/// count alone accepts two independently walkable directories of equal size and
+/// different contents, which `super::zip_directory`'s candidate scan makes
+/// constructible; a set alone would miss two records that collapse into one.
 ///
-/// Comparing bytes and counts rather than decoded names is deliberate. `zip`
-/// picks UTF-8 or CP437 by general-purpose flag bit 11, so a decoded comparison
-/// would refuse a legitimate CP437-flagged member — and it would still have to
-/// answer the harder case, two records whose different bytes decode alike,
-/// which the parser also collapses. The count catches that one without this
-/// module owning an encoding rule at all: a collapse of any kind leaves the
-/// parser exposing fewer members than the directory holds records.
+/// The comparison is raw bytes against the parser's OWN raw bytes
+/// (`ZipFile::name_raw`), not decoded names. `zip` picks UTF-8 or CP437 by
+/// general-purpose flag bit 11 (`read.rs:1313-1316`) and its CP437 table is
+/// private, so any decode written here would be a second implementation of that
+/// rule and free to drift from it. Comparing what the parser actually stored
+/// answers the question exactly — are these the same records? — and cannot
+/// disagree with a decode it never performs.
 ///
 /// # Postconditions
-/// On `Ok`, the returned names are the parser's, and the raw directory holds
-/// exactly as many records with no two carrying the same bytes.
+/// On `Ok`, the raw directory and the parser hold the same number of records
+/// carrying the same set of name bytes, and no two records carry the same
+/// bytes. The returned names are the parser's decoded ones, for the manifest
+/// comparison downstream.
 /// Test: `super::signing_tests::a_duplicate_central_directory_record_is_refused`,
 /// `super::signing_tests::the_raw_directory_matches_what_the_zip_parser_exposes`,
+/// `super::signing_tests::a_second_self_consistent_directory_is_refused`,
 /// `super::signing_tests::a_cp437_flagged_name_is_not_refused`.
 fn agreed_members(archive: &mut Archive, package: &Path) -> Result<Vec<String>, SigningError> {
     let raw = super::zip_directory::member_names(package)?;
-    let mut seen: std::collections::BTreeSet<&[u8]> = std::collections::BTreeSet::new();
+    let mut walked: std::collections::BTreeSet<&[u8]> = std::collections::BTreeSet::new();
     for name in &raw {
-        if !seen.insert(name.as_slice()) {
+        if !walked.insert(name.as_slice()) {
             return Err(SigningError::DuplicateMember {
                 path: package.to_path_buf(),
                 // Lossy for the MESSAGE only. Nothing decides anything on it.
@@ -552,19 +559,40 @@ fn agreed_members(archive: &mut Archive, package: &Path) -> Result<Vec<String>, 
             });
         }
     }
-    let exposed: Vec<String> = archive.file_names().map(str::to_owned).collect();
-    if exposed.len() != raw.len() {
+
+    let mut held = Vec::with_capacity(archive.len());
+    for index in 0..archive.len() {
+        let member = archive
+            .by_index_raw(index)
+            .map_err(|e| SigningError::Archive {
+                path: package.to_path_buf(),
+                source: std::io::Error::other(e),
+            })?;
+        held.push(member.name_raw().to_vec());
+    }
+    if held.len() != raw.len() {
         return Err(SigningError::DirectoryMismatch {
             path: package.to_path_buf(),
             reason: format!(
-                "the directory holds {} record(s) and the parser exposes {} member(s), so at \
-                 least one record was collapsed",
+                "the directory holds {} record(s) and the parser holds {}, so at least one \
+                 record was collapsed",
                 raw.len(),
-                exposed.len()
+                held.len()
             ),
         });
     }
-    Ok(exposed)
+    let held_set: std::collections::BTreeSet<&[u8]> = held.iter().map(Vec::as_slice).collect();
+    if held_set != walked {
+        return Err(SigningError::DirectoryMismatch {
+            path: package.to_path_buf(),
+            reason: format!(
+                "the directory and the parser hold {} record(s) each but not the same ones — \
+                 the archive carries more than one central directory",
+                raw.len()
+            ),
+        });
+    }
+    Ok(archive.file_names().map(str::to_owned).collect())
 }
 
 /// The detached-signature half of [`verify`].
@@ -1466,6 +1494,80 @@ mod signing_tests {
         }
     }
 
+    /// 🔴 Two central directories, each self-framing and self-consistent, with
+    /// the SAME entry count and different member names. A count-only comparison
+    /// accepts this: the walk reports three records, the parser reports three
+    /// members, and they are not the same three.
+    ///
+    /// The decoy EOCD is last, so `zip` 2.4.2's backward scan takes it and lists
+    /// the planted name. The walk rejects it — its directory does not end where
+    /// the record describing it begins — and falls through to the real EOCD.
+    /// Both then hold three records, so only comparing WHICH names exist catches
+    /// it.
+    #[test]
+    fn a_second_self_consistent_directory_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
+        let raw = std::fs::read(&path).expect("read");
+        let eocd = eocd_at(&raw);
+        let real_directory_at = read_u32(&raw, eocd + 16) as usize;
+        let real_directory_size = read_u32(&raw, eocd + 12) as usize;
+
+        // A three-record decoy directory: the planted name in place of
+        // README.md, the two signing members kept so the counts match.
+        let mut decoy = Vec::new();
+        for name in ["PLANTED.md", MANIFEST_ENTRY, SIGNATURE_ENTRY] {
+            decoy.extend_from_slice(&central_header(name, b"", 0));
+        }
+
+        let mut forged = raw[..real_directory_at].to_vec();
+        let decoy_at = forged.len() as u32;
+        forged.extend_from_slice(&decoy);
+        // The real directory, then the real EOCD naming it, then the decoy EOCD
+        // naming the decoy directory. Each frames itself; only the real one's
+        // directory ends where the record describing it begins.
+        let real_moved_to = forged.len() as u32;
+        forged.extend_from_slice(&raw[real_directory_at..real_directory_at + real_directory_size]);
+        let mut real_eocd = raw[eocd..eocd + 22].to_vec();
+        real_eocd[16..20].copy_from_slice(&le32(real_moved_to));
+        // Its comment is the decoy EOCD that follows, so it still frames to EOF.
+        real_eocd[20..22].copy_from_slice(&le16(22));
+        forged.extend_from_slice(&real_eocd);
+        let mut decoy_eocd = raw[eocd..eocd + 22].to_vec();
+        decoy_eocd[8..10].copy_from_slice(&le16(3));
+        decoy_eocd[10..12].copy_from_slice(&le16(3));
+        decoy_eocd[12..16].copy_from_slice(&le32(decoy.len() as u32));
+        decoy_eocd[16..20].copy_from_slice(&le32(decoy_at));
+        decoy_eocd[20..22].copy_from_slice(&le16(0));
+        forged.extend_from_slice(&decoy_eocd);
+        let forged_path = write(dir.path(), "two-directories.zip", &forged);
+
+        let walked = super::super::zip_directory::member_names(&forged_path).expect("walks");
+        let mut parser = open(&forged_path).expect("opens");
+        let held: Vec<Vec<u8>> = (0..parser.len())
+            .map(|i| parser.by_index_raw(i).expect("member").name_raw().to_vec())
+            .collect();
+
+        assert_eq!(walked.len(), held.len(), "equal cardinality is the premise");
+        assert_eq!(walked.len(), 3);
+        assert!(
+            walked.iter().any(|n| n.as_slice() == b"README.md"),
+            "the walk must take the real directory"
+        );
+        assert!(
+            held.iter().any(|n| n.as_slice() == b"PLANTED.md"),
+            "zip is expected to take the decoy — that is what makes the two disagree"
+        );
+
+        match verify(&forged_path, &retained(&key)) {
+            Err(SigningError::DirectoryMismatch { reason, .. }) => {
+                assert!(reason.contains("not the same ones"), "{reason}");
+            }
+            other => panic!("expected a content disagreement, got {other:?}"),
+        }
+    }
+
     /// `raw` with `comment` appended and the EOCD's comment length updated.
     fn with_comment(raw: &[u8], comment: &[u8]) -> Vec<u8> {
         let eocd = eocd_at(raw);
@@ -1553,6 +1655,15 @@ mod signing_tests {
 
         let walked = super::super::zip_directory::member_names(&path).expect("walks");
         assert_eq!(walked, vec![b"gr\x81ss.md".to_vec()], "raw, undecoded");
+
+        // The set comparison holds because both sides are the parser's own raw
+        // bytes — not because names stopped being compared.
+        let mut parser = open(&path).expect("open");
+        assert_eq!(
+            parser.by_index_raw(0).expect("member").name_raw(),
+            walked[0].as_slice(),
+            "the parser's stored bytes are what the walk is compared against"
+        );
 
         let archive = open(&path).expect("open");
         let exposed: Vec<String> = archive.file_names().map(str::to_owned).collect();

--- a/crates/trusty-audit/src/package/signing.rs
+++ b/crates/trusty-audit/src/package/signing.rs
@@ -36,6 +36,17 @@
 //! signature member was removed, which is [`SigningError::SignatureMissing`].
 //! The manifest's `[signature]` table is what separates the two.
 //!
+//! ## The member set is established before anything is read
+//!
+//! `zip` keys its entry table by member name, so an archive whose central
+//! directory repeats a name presents one member here and a different one to
+//! `zipfile` or Info-ZIP. [`verify`] therefore walks the raw directory itself
+//! ([`super::zip_directory`]) before reading the manifest, refuses a repeat as
+//! [`SigningError::DuplicateMember`], and refuses any other disagreement with
+//! the parser as [`SigningError::DirectoryMismatch`]. Nothing after that point
+//! sizes an allocation from the archive's own declared sizes either — members
+//! are streamed through a fixed buffer.
+//!
 //! Test: `super::signing_tests`.
 
 use std::path::{Path, PathBuf};
@@ -170,6 +181,49 @@ pub enum SigningError {
         path: PathBuf,
         /// The member the manifest does not account for.
         entry: String,
+    },
+
+    /// The raw central directory holds two records under one member name.
+    ///
+    /// Why (security review of #5481): `zip` 2.4.2 keys its entry table by name
+    /// and collapses the second record before any caller sees it, so `verify`
+    /// would check whichever copy that parser picked while `zipfile`, Info-ZIP
+    /// or Finder extracted the other. A repeated name is refused outright — it
+    /// has no legitimate use in a package this crate wrote.
+    #[error(
+        "{path}: the central directory holds more than one record named {entry} — the archive \
+         extracts differently depending on which tool opens it, so nothing about it can be verified"
+    )]
+    DuplicateMember {
+        /// The package that was read.
+        path: PathBuf,
+        /// The name carried by more than one record.
+        entry: String,
+    },
+
+    /// The raw directory and the zip parser disagree about the member set.
+    ///
+    /// The duplicate check above catches a repeated name; this catches every
+    /// other way the two views could diverge, so a shape neither this crate nor
+    /// its review anticipated fails closed rather than passing on the parser's
+    /// word.
+    #[error(
+        "{path}: the raw central directory and the zip parser disagree about the members: {reason}"
+    )]
+    DirectoryMismatch {
+        /// The package that was read.
+        path: PathBuf,
+        /// How the two views differ.
+        reason: String,
+    },
+
+    /// The central directory could not be framed.
+    #[error("{path}: the central directory cannot be read: {reason}")]
+    DirectoryMalformed {
+        /// The package that was read.
+        path: PathBuf,
+        /// What stopped the walk.
+        reason: String,
     },
 
     /// The package could not be opened or read.
@@ -426,6 +480,12 @@ pub(super) fn render(
 /// is raised by [`RetainedKey::from_hex`] before this is reached.
 pub fn verify(package: &Path, retained: &RetainedKey) -> Result<Verdict, SigningError> {
     let mut archive = open(package)?;
+    // Security review of #5481: FIRST, before a single member is read. The zip
+    // parser's view of the archive is deduped by name, so an archive whose raw
+    // directory repeats a name has no single answer to "what is in it" — and
+    // reading the manifest through the parser would already have picked one
+    // copy. See `super::zip_directory`.
+    let members = agreed_members(&mut archive, package)?;
     let manifest = match read_member(&mut archive, package, MANIFEST_ENTRY)? {
         Some(bytes) => bytes,
         None => {
@@ -451,11 +511,51 @@ pub fn verify(package: &Path, retained: &RetainedKey) -> Result<Verdict, Signing
         });
     };
     verify_signature(&mut archive, package, &manifest, block, retained)?;
-    check_members(&mut archive, package, &doc.file)?;
+    check_members(&mut archive, package, &doc.file, &members)?;
     Ok(Verdict::Signed {
         key_fingerprint: block.key_fingerprint.clone(),
         files: doc.file.len(),
     })
+}
+
+/// The member set, once the raw directory and the zip parser agree on it.
+///
+/// Why: `zip` 2.4.2 keys its entry table by name, so a second central-directory
+/// record under an existing name never reaches a caller — see
+/// [`super::zip_directory`]'s module docs for what that lets an archive do.
+/// What: walks the raw directory, refuses a repeated name, then refuses any
+/// other disagreement between that walk and `ZipArchive::file_names`. Callers
+/// downstream may then treat either view as the member set.
+///
+/// # Postconditions
+/// On `Ok`, the returned names are exactly `ZipArchive`'s and exactly the raw
+/// directory's, with no repeat in either.
+/// Test: `super::signing_tests::a_duplicate_central_directory_record_is_refused`,
+/// `super::signing_tests::the_raw_directory_matches_what_the_zip_parser_exposes`.
+fn agreed_members(archive: &mut Archive, package: &Path) -> Result<Vec<String>, SigningError> {
+    let raw = super::zip_directory::member_names(package)?;
+    let mut unique = std::collections::BTreeSet::new();
+    for name in &raw {
+        if !unique.insert(name.clone()) {
+            return Err(SigningError::DuplicateMember {
+                path: package.to_path_buf(),
+                entry: name.clone(),
+            });
+        }
+    }
+    let exposed: std::collections::BTreeSet<String> =
+        archive.file_names().map(str::to_owned).collect();
+    if exposed != unique {
+        return Err(SigningError::DirectoryMismatch {
+            path: package.to_path_buf(),
+            reason: format!(
+                "the directory holds {} member(s) and the parser exposes {}",
+                unique.len(),
+                exposed.len()
+            ),
+        });
+    }
+    Ok(raw)
 }
 
 /// The detached-signature half of [`verify`].
@@ -498,15 +598,17 @@ fn check_members(
     archive: &mut Archive,
     package: &Path,
     listed: &[ManifestFile],
+    members: &[String],
 ) -> Result<(), SigningError> {
     for file in listed {
-        let bytes = read_member(archive, package, &file.entry)?.ok_or_else(|| {
+        // Streamed, never materialized: a member can be a multi-gigabyte
+        // extract database, and its declared size is attacker-controlled.
+        let actual = digest_member(archive, package, &file.entry)?.ok_or_else(|| {
             SigningError::MemberMissing {
                 path: package.to_path_buf(),
                 entry: file.entry.clone(),
             }
         })?;
-        let actual = to_hex(&Sha256::digest(&bytes));
         if actual != file.sha256 {
             return Err(SigningError::ContentMismatch {
                 path: package.to_path_buf(),
@@ -519,15 +621,17 @@ fn check_members(
     // #5481: an addition is as much an alteration as an edit, and hashing only
     // what the manifest lists would never see one. The two signing members
     // account for themselves — neither can be in a manifest it is part of.
-    let names: Vec<String> = archive.file_names().map(str::to_owned).collect();
-    for name in names {
+    // `members` is the raw central directory's own list, already proven to
+    // agree with the parser's by `agreed_members` — so a member the parser
+    // hides is not a member this loop can miss.
+    for name in members {
         if name == MANIFEST_ENTRY || name == SIGNATURE_ENTRY || name.ends_with('/') {
             continue;
         }
-        if !listed.iter().any(|f| f.entry == name) {
+        if !listed.iter().any(|f| &f.entry == name) {
             return Err(SigningError::MemberUnexpected {
                 path: package.to_path_buf(),
-                entry: name,
+                entry: name.clone(),
             });
         }
     }
@@ -548,33 +652,114 @@ fn open(package: &Path) -> Result<Archive, SigningError> {
     })
 }
 
+/// Bytes read per turn of either member loop.
+///
+/// Fixed, because the alternative is sizing an allocation from the archive's own
+/// declared size — which is attacker-controlled metadata, not a measurement
+/// (security review of #5481). `credential_scan::copy_member` streams the same
+/// way on the write side.
+const CHUNK_BYTES: usize = 64 * 1024;
+
+/// A member this module reads WHOLE — the manifest and its signature — is
+/// refused past this size rather than buffered.
+///
+/// Both are small by construction: the manifest is one row per delivered file
+/// and the signature is 129 bytes. A package claiming otherwise is not one this
+/// crate wrote, and reading it would mean trusting an attacker about how much
+/// memory to spend. The ceiling is generous enough for a package with hundreds
+/// of thousands of members.
+const MAX_INLINE_MEMBER_BYTES: u64 = 32 * 1024 * 1024;
+
 /// One member's uncompressed bytes, or `None` when the archive has no such
 /// entry. An unreadable entry that IS present is an error, never a `None` —
 /// silently treating a read failure as absence is how a tampered archive passes.
+///
+/// Only for the two small members this module reads whole; everything else goes
+/// through [`digest_member`], which never materializes one. The read streams
+/// through a fixed buffer and stops at [`MAX_INLINE_MEMBER_BYTES`], so no
+/// allocation here is sized from the archive's own claim about the member.
+/// Test: `super::signing_tests::a_forged_member_size_does_not_size_an_allocation`.
 fn read_member(
     archive: &mut Archive,
     package: &Path,
     entry: &str,
 ) -> Result<Option<Vec<u8>>, SigningError> {
-    use std::io::Read as _;
-    let mut member = match archive.by_name(entry) {
-        Ok(m) => m,
-        Err(zip::result::ZipError::FileNotFound) => return Ok(None),
-        Err(e) => {
-            return Err(SigningError::Archive {
+    let Some(mut member) = member(archive, package, entry)? else {
+        return Ok(None);
+    };
+    let mut bytes = Vec::new();
+    let mut buffer = vec![0_u8; CHUNK_BYTES];
+    loop {
+        let read = read_chunk(&mut member, package, &mut buffer)?;
+        if read == 0 {
+            return Ok(Some(bytes));
+        }
+        if bytes.len() as u64 + read as u64 > MAX_INLINE_MEMBER_BYTES {
+            return Err(SigningError::DirectoryMalformed {
                 path: package.to_path_buf(),
-                source: std::io::Error::other(e),
+                reason: format!(
+                    "{entry} is larger than the {MAX_INLINE_MEMBER_BYTES} bytes this reader will \
+                     hold for it"
+                ),
             });
         }
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+}
+
+/// One member's SHA-256, computed without holding the member in memory.
+///
+/// Why: an extract database can exceed 4 GiB, and its declared size in the
+/// archive is a number an attacker chose. Streaming answers both — the hash is
+/// over the bytes that actually decompress, and the only allocation is one
+/// fixed buffer (security review of #5481).
+/// Test: `super::signing_tests::a_tampered_member_fails_verification`,
+/// `super::signing_tests::a_forged_member_size_does_not_size_an_allocation`.
+fn digest_member(
+    archive: &mut Archive,
+    package: &Path,
+    entry: &str,
+) -> Result<Option<String>, SigningError> {
+    let Some(mut member) = member(archive, package, entry)? else {
+        return Ok(None);
     };
-    let mut bytes = Vec::with_capacity(usize::try_from(member.size()).unwrap_or_default());
-    member
-        .read_to_end(&mut bytes)
-        .map_err(|source| SigningError::Archive {
+    let mut digest = Sha256::new();
+    let mut buffer = vec![0_u8; CHUNK_BYTES];
+    loop {
+        let read = read_chunk(&mut member, package, &mut buffer)?;
+        if read == 0 {
+            return Ok(Some(to_hex(&digest.finalize())));
+        }
+        digest.update(&buffer[..read]);
+    }
+}
+
+/// The named member, or `None` when the archive does not hold one.
+fn member<'a>(
+    archive: &'a mut Archive,
+    package: &Path,
+    entry: &str,
+) -> Result<Option<zip::read::ZipFile<'a>>, SigningError> {
+    match archive.by_name(entry) {
+        Ok(m) => Ok(Some(m)),
+        Err(zip::result::ZipError::FileNotFound) => Ok(None),
+        Err(e) => Err(SigningError::Archive {
             path: package.to_path_buf(),
-            source,
-        })?;
-    Ok(Some(bytes))
+            source: std::io::Error::other(e),
+        }),
+    }
+}
+
+fn read_chunk(
+    member: &mut zip::read::ZipFile<'_>,
+    package: &Path,
+    buffer: &mut [u8],
+) -> Result<usize, SigningError> {
+    use std::io::Read as _;
+    member.read(buffer).map_err(|source| SigningError::Archive {
+        path: package.to_path_buf(),
+        source,
+    })
 }
 
 /// The short fingerprint form both halves of a keypair produce.
@@ -678,6 +863,86 @@ mod signing_tests {
 
     fn retained(key: &EngagementKey) -> RetainedKey {
         RetainedKey::from_hex(&key.public_hex()).expect("public half parses")
+    }
+
+    /// CRC-32 (IEEE), bitwise. Ten lines of test code rather than a dependency
+    /// pulled in so one hand-built local header can be genuinely extractable.
+    fn crc32(bytes: &[u8]) -> u32 {
+        let mut crc = 0xFFFF_FFFF_u32;
+        for byte in bytes {
+            crc ^= u32::from(*byte);
+            for _ in 0..8 {
+                crc = if crc & 1 == 1 {
+                    (crc >> 1) ^ 0xEDB8_8320
+                } else {
+                    crc >> 1
+                };
+            }
+        }
+        !crc
+    }
+
+    fn le16(v: u16) -> [u8; 2] {
+        v.to_le_bytes()
+    }
+
+    fn le32(v: u32) -> [u8; 4] {
+        v.to_le_bytes()
+    }
+
+    fn read_u32(bytes: &[u8], at: usize) -> u32 {
+        u32::from_le_bytes(bytes[at..at + 4].try_into().expect("four bytes"))
+    }
+
+    /// The offset of the archive's end-of-central-directory record.
+    fn eocd_at(raw: &[u8]) -> usize {
+        (0..=raw.len() - 22)
+            .rev()
+            .find(|at| read_u32(raw, *at) == 0x0605_4b50)
+            .expect("an EOCD")
+    }
+
+    /// A STORED local file header plus its data, for a hand-built second copy.
+    fn local_header(name: &str, body: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&le32(0x0403_4b50));
+        out.extend_from_slice(&le16(20)); // version needed
+        out.extend_from_slice(&le16(0)); // flags
+        out.extend_from_slice(&le16(0)); // method: stored
+        out.extend_from_slice(&le16(0)); // time
+        out.extend_from_slice(&le16(0)); // date
+        out.extend_from_slice(&le32(crc32(body)));
+        out.extend_from_slice(&le32(body.len() as u32));
+        out.extend_from_slice(&le32(body.len() as u32));
+        out.extend_from_slice(&le16(name.len() as u16));
+        out.extend_from_slice(&le16(0)); // extra
+        out.extend_from_slice(name.as_bytes());
+        out.extend_from_slice(body);
+        out
+    }
+
+    /// A central-directory file header naming `name` at `header_start`.
+    fn central_header(name: &str, body: &[u8], header_start: u32) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&le32(0x0201_4b50));
+        out.extend_from_slice(&le16(20)); // version made by
+        out.extend_from_slice(&le16(20)); // version needed
+        out.extend_from_slice(&le16(0)); // flags
+        out.extend_from_slice(&le16(0)); // method: stored
+        out.extend_from_slice(&le16(0)); // time
+        out.extend_from_slice(&le16(0)); // date
+        out.extend_from_slice(&le32(crc32(body)));
+        out.extend_from_slice(&le32(body.len() as u32));
+        out.extend_from_slice(&le32(body.len() as u32));
+        out.extend_from_slice(&le16(name.len() as u16));
+        out.extend_from_slice(&le16(0)); // extra
+        out.extend_from_slice(&le16(0)); // comment
+        out.extend_from_slice(&le16(0)); // disk
+        out.extend_from_slice(&le16(0)); // internal attrs
+        out.extend_from_slice(&le32(0)); // external attrs
+        out.extend_from_slice(&le32(header_start));
+        out.extend_from_slice(name.as_bytes());
+        out
     }
 
     #[test]
@@ -897,5 +1162,159 @@ mod signing_tests {
         let rendered = format!("{key:?}");
         assert!(!rendered.contains(&key.private_hex()), "{rendered}");
         assert!(rendered.contains(&key.fingerprint()), "{rendered}");
+    }
+
+    /// 🔴 Security review of #5481: `zip` 2.4.2 keys its entry table by member
+    /// name, so a second central-directory record under an already-signed name
+    /// collapses before any caller sees it — `file_names()` yields the name
+    /// once and `by_name` resolves to one record. `verify` would then report
+    /// `Signed` over whichever copy this parser picked while Python's
+    /// `zipfile`, Info-ZIP or Finder extracted the other.
+    ///
+    /// The archive here is hand-built from a valid signed package's bytes: a
+    /// second STORED local header carrying altered data is appended, then a
+    /// duplicate central-directory record naming the same member and pointing
+    /// at it, with the EOCD's entry count, directory size and directory offset
+    /// patched to frame the enlarged directory. Both copies are genuinely
+    /// extractable — the planted one carries a correct CRC.
+    #[test]
+    fn a_duplicate_central_directory_record_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(
+            dir.path(),
+            &[
+                ("README.md", "read me"),
+                ("reports/a/report.md", "findings"),
+            ],
+            Some(&key),
+        );
+        let raw = std::fs::read(&path).expect("read the package");
+
+        let eocd = eocd_at(&raw);
+        let entries = u16::from_le_bytes(raw[eocd + 10..eocd + 12].try_into().expect("two bytes"));
+        let directory_size = read_u32(&raw, eocd + 12) as usize;
+        let directory_at = read_u32(&raw, eocd + 16) as usize;
+
+        let planted = b"read MF";
+        let mut forged = raw[..directory_at].to_vec();
+        let planted_at = forged.len() as u32;
+        forged.extend_from_slice(&local_header("README.md", planted));
+        let directory_moved_to = forged.len() as u32;
+        forged.extend_from_slice(&raw[directory_at..directory_at + directory_size]);
+        let duplicate = central_header("README.md", planted, planted_at);
+        let duplicate_len = duplicate.len();
+        forged.extend_from_slice(&duplicate);
+        // The EOCD, reframed: one more entry, a longer directory, a new offset.
+        let mut eocd_record = raw[eocd..].to_vec();
+        eocd_record[8..10].copy_from_slice(&le16(entries + 1));
+        eocd_record[10..12].copy_from_slice(&le16(entries + 1));
+        eocd_record[12..16].copy_from_slice(&le32((directory_size + duplicate_len) as u32));
+        eocd_record[16..20].copy_from_slice(&le32(directory_moved_to));
+        forged.extend_from_slice(&eocd_record);
+
+        let forged_path = dir.path().join("forged.zip");
+        std::fs::write(&forged_path, &forged).expect("write the forged package");
+
+        // The exploit is real: the parser hides the second record entirely, so
+        // nothing downstream of it could have caught this.
+        let hidden = open(&forged_path).expect("the forged archive still opens");
+        assert_eq!(
+            hidden.file_names().filter(|n| *n == "README.md").count(),
+            1,
+            "the parser is expected to collapse the duplicate — that is the whole finding"
+        );
+        assert_eq!(
+            super::super::zip_directory::member_names(&forged_path)
+                .expect("the raw directory walks")
+                .iter()
+                .filter(|n| *n == "README.md")
+                .count(),
+            2,
+            "the raw directory must show what the parser hides"
+        );
+
+        match verify(&forged_path, &retained(&key)) {
+            Err(SigningError::DuplicateMember { entry, .. }) => assert_eq!(entry, "README.md"),
+            other => panic!("expected a duplicate member, got {other:?}"),
+        }
+    }
+
+    /// The raw walk and the parser agree on an archive nobody tampered with, so
+    /// the check above refuses forgeries rather than ordinary packages.
+    #[test]
+    fn the_raw_directory_matches_what_the_zip_parser_exposes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(
+            dir.path(),
+            &[
+                ("README.md", "read me"),
+                ("reports/a/report.md", "findings"),
+            ],
+            Some(&key),
+        );
+        let archive = open(&path).expect("open");
+        let exposed: std::collections::BTreeSet<String> =
+            archive.file_names().map(str::to_owned).collect();
+        let raw: std::collections::BTreeSet<String> =
+            super::super::zip_directory::member_names(&path)
+                .expect("walks")
+                .into_iter()
+                .collect();
+        assert_eq!(raw, exposed);
+        assert_eq!(raw.len(), 4, "two members plus the manifest and signature");
+    }
+
+    /// 🔴 Security review of #5481: a member's declared uncompressed size is
+    /// metadata an attacker writes, so it must never size an allocation. Here
+    /// the central-directory record claims ~2 GiB for a seven-byte member; the
+    /// read streams through a fixed buffer, so the call returns a verdict
+    /// instead of trying to reserve what the archive asked for.
+    #[test]
+    fn a_forged_member_size_does_not_size_an_allocation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
+        let mut raw = std::fs::read(&path).expect("read the package");
+
+        let eocd = eocd_at(&raw);
+        let directory_at = read_u32(&raw, eocd + 16) as usize;
+        // Walk to the record for README.md and overwrite its uncompressed size.
+        let mut at = directory_at;
+        let patched = loop {
+            assert_eq!(
+                read_u32(&raw, at),
+                0x0201_4b50,
+                "a central-directory record"
+            );
+            let name_len =
+                u16::from_le_bytes(raw[at + 28..at + 30].try_into().expect("two bytes")) as usize;
+            let extra_len =
+                u16::from_le_bytes(raw[at + 30..at + 32].try_into().expect("two bytes")) as usize;
+            let comment_len =
+                u16::from_le_bytes(raw[at + 32..at + 34].try_into().expect("two bytes")) as usize;
+            let name = String::from_utf8_lossy(&raw[at + 46..at + 46 + name_len]).into_owned();
+            if name == "README.md" {
+                raw[at + 24..at + 28].copy_from_slice(&le32(0x7FFF_FFF0));
+                break true;
+            }
+            at += 46 + name_len + extra_len + comment_len;
+        };
+        assert!(patched);
+
+        let forged_path = dir.path().join("forged-size.zip");
+        std::fs::write(&forged_path, &raw).expect("write");
+
+        // The point is that this RETURNS. A verdict either way is a pass; an
+        // abort or an out-of-memory kill is the failure this guards against.
+        let outcome = verify(&forged_path, &retained(&key));
+        assert!(
+            matches!(
+                outcome,
+                Ok(Verdict::Signed { .. }) | Err(SigningError::Archive { .. })
+            ),
+            "expected a verdict rather than an abort, got {outcome:?}"
+        );
     }
 }

--- a/crates/trusty-audit/src/package/signing.rs
+++ b/crates/trusty-audit/src/package/signing.rs
@@ -523,39 +523,48 @@ pub fn verify(package: &Path, retained: &RetainedKey) -> Result<Verdict, Signing
 /// Why: `zip` 2.4.2 keys its entry table by name, so a second central-directory
 /// record under an existing name never reaches a caller — see
 /// [`super::zip_directory`]'s module docs for what that lets an archive do.
-/// What: walks the raw directory, refuses a repeated name, then refuses any
-/// other disagreement between that walk and `ZipArchive::file_names`. Callers
-/// downstream may then treat either view as the member set.
+/// What: walks the raw directory, refuses two records carrying the same name
+/// BYTES, then refuses any count that differs from what the parser exposes.
+///
+/// Comparing bytes and counts rather than decoded names is deliberate. `zip`
+/// picks UTF-8 or CP437 by general-purpose flag bit 11, so a decoded comparison
+/// would refuse a legitimate CP437-flagged member — and it would still have to
+/// answer the harder case, two records whose different bytes decode alike,
+/// which the parser also collapses. The count catches that one without this
+/// module owning an encoding rule at all: a collapse of any kind leaves the
+/// parser exposing fewer members than the directory holds records.
 ///
 /// # Postconditions
-/// On `Ok`, the returned names are exactly `ZipArchive`'s and exactly the raw
-/// directory's, with no repeat in either.
+/// On `Ok`, the returned names are the parser's, and the raw directory holds
+/// exactly as many records with no two carrying the same bytes.
 /// Test: `super::signing_tests::a_duplicate_central_directory_record_is_refused`,
-/// `super::signing_tests::the_raw_directory_matches_what_the_zip_parser_exposes`.
+/// `super::signing_tests::the_raw_directory_matches_what_the_zip_parser_exposes`,
+/// `super::signing_tests::a_cp437_flagged_name_is_not_refused`.
 fn agreed_members(archive: &mut Archive, package: &Path) -> Result<Vec<String>, SigningError> {
     let raw = super::zip_directory::member_names(package)?;
-    let mut unique = std::collections::BTreeSet::new();
+    let mut seen: std::collections::BTreeSet<&[u8]> = std::collections::BTreeSet::new();
     for name in &raw {
-        if !unique.insert(name.clone()) {
+        if !seen.insert(name.as_slice()) {
             return Err(SigningError::DuplicateMember {
                 path: package.to_path_buf(),
-                entry: name.clone(),
+                // Lossy for the MESSAGE only. Nothing decides anything on it.
+                entry: String::from_utf8_lossy(name).into_owned(),
             });
         }
     }
-    let exposed: std::collections::BTreeSet<String> =
-        archive.file_names().map(str::to_owned).collect();
-    if exposed != unique {
+    let exposed: Vec<String> = archive.file_names().map(str::to_owned).collect();
+    if exposed.len() != raw.len() {
         return Err(SigningError::DirectoryMismatch {
             path: package.to_path_buf(),
             reason: format!(
-                "the directory holds {} member(s) and the parser exposes {}",
-                unique.len(),
+                "the directory holds {} record(s) and the parser exposes {} member(s), so at \
+                 least one record was collapsed",
+                raw.len(),
                 exposed.len()
             ),
         });
     }
-    Ok(raw)
+    Ok(exposed)
 }
 
 /// The detached-signature half of [`verify`].
@@ -1228,7 +1237,7 @@ mod signing_tests {
             super::super::zip_directory::member_names(&forged_path)
                 .expect("the raw directory walks")
                 .iter()
-                .filter(|n| *n == "README.md")
+                .filter(|n| n.as_slice() == b"README.md")
                 .count(),
             2,
             "the raw directory must show what the parser hides"
@@ -1260,7 +1269,8 @@ mod signing_tests {
         let raw: std::collections::BTreeSet<String> =
             super::super::zip_directory::member_names(&path)
                 .expect("walks")
-                .into_iter()
+                .iter()
+                .map(|n| String::from_utf8_lossy(n).into_owned())
                 .collect();
         assert_eq!(raw, exposed);
         assert_eq!(raw.len(), 4, "two members plus the manifest and signature");
@@ -1315,6 +1325,254 @@ mod signing_tests {
                 Ok(Verdict::Signed { .. }) | Err(SigningError::Archive { .. })
             ),
             "expected a verdict rather than an abort, got {outcome:?}"
+        );
+    }
+
+    /// A minimal one-member archive, built byte by byte, with `flags` on both
+    /// headers and `comment` after the EOCD. The escape hatch the framing tests
+    /// need: a real `ZipWriter` cannot produce any of these shapes.
+    fn hand_built(name: &[u8], body: &[u8], flags: u16, comment: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&le32(0x0403_4b50));
+        out.extend_from_slice(&le16(20));
+        out.extend_from_slice(&le16(flags));
+        out.extend_from_slice(&le16(0));
+        out.extend_from_slice(&le16(0));
+        out.extend_from_slice(&le16(0));
+        out.extend_from_slice(&le32(crc32(body)));
+        out.extend_from_slice(&le32(body.len() as u32));
+        out.extend_from_slice(&le32(body.len() as u32));
+        out.extend_from_slice(&le16(name.len() as u16));
+        out.extend_from_slice(&le16(0));
+        out.extend_from_slice(name);
+        out.extend_from_slice(body);
+
+        let directory_at = out.len() as u32;
+        let mut record = Vec::new();
+        record.extend_from_slice(&le32(0x0201_4b50));
+        record.extend_from_slice(&le16(20));
+        record.extend_from_slice(&le16(20));
+        record.extend_from_slice(&le16(flags));
+        record.extend_from_slice(&le16(0));
+        record.extend_from_slice(&le16(0));
+        record.extend_from_slice(&le16(0));
+        record.extend_from_slice(&le32(crc32(body)));
+        record.extend_from_slice(&le32(body.len() as u32));
+        record.extend_from_slice(&le32(body.len() as u32));
+        record.extend_from_slice(&le16(name.len() as u16));
+        record.extend_from_slice(&le16(0));
+        record.extend_from_slice(&le16(0));
+        record.extend_from_slice(&le16(0));
+        record.extend_from_slice(&le16(0));
+        record.extend_from_slice(&le32(0));
+        record.extend_from_slice(&le32(0));
+        record.extend_from_slice(name);
+        let directory_size = record.len() as u32;
+        out.extend_from_slice(&record);
+
+        out.extend_from_slice(&le32(0x0605_4b50));
+        out.extend_from_slice(&le16(0));
+        out.extend_from_slice(&le16(0));
+        out.extend_from_slice(&le16(1));
+        out.extend_from_slice(&le16(1));
+        out.extend_from_slice(&le32(directory_size));
+        out.extend_from_slice(&le32(directory_at));
+        out.extend_from_slice(&le16(comment.len() as u16));
+        out.extend_from_slice(comment);
+        out
+    }
+
+    fn write(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, bytes).expect("write");
+        path
+    }
+
+    /// The EOCD sits behind the archive comment, so the scan has to reach past
+    /// one. An ordinary comment must leave the verdict alone.
+    #[test]
+    fn an_ordinary_archive_comment_does_not_change_the_verdict() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let commented = write(
+            dir.path(),
+            "commented.zip",
+            &with_comment(
+                &std::fs::read(package(dir.path(), &[("README.md", "read me")], Some(&key)))
+                    .expect("read"),
+                b"delivered 2026-09-07",
+            ),
+        );
+
+        assert_eq!(
+            super::super::zip_directory::member_names(&commented)
+                .expect("the EOCD is found behind the comment")
+                .len(),
+            3,
+            "one member plus the manifest and its signature"
+        );
+        let outcome = verify(&commented, &retained(&key));
+        assert!(
+            matches!(outcome, Ok(Verdict::Signed { .. })),
+            "a comment must not change the verdict: {outcome:?}"
+        );
+    }
+
+    /// 🔴 The archive comment is arbitrary bytes whoever sent the package
+    /// wrote, so "the last EOCD signature in the file" is a rule they can
+    /// answer: a planted `PK\x05\x06` sits at a HIGHER offset than the real
+    /// record. The walk is not fooled — a candidate must frame itself, its
+    /// declared comment length reaching exactly the end of the file, and its
+    /// directory must end where the record describing it begins.
+    ///
+    /// `zip` 2.4.2's own scan IS fooled by this archive and reports it empty,
+    /// which is the case this whole check exists for: the two views disagree,
+    /// so verification refuses rather than reporting Signed over a member set
+    /// that is not what the file would extract.
+    #[test]
+    fn a_comment_carrying_a_fake_eocd_signature_is_refused_not_believed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
+        // A whole fake EOCD inside the comment, with bytes after it.
+        let mut decoy = Vec::new();
+        decoy.extend_from_slice(&le32(0x0605_4b50));
+        decoy.extend_from_slice(&[0_u8; 18]);
+        decoy.extend_from_slice(b"trailing");
+        let doctored = write(
+            dir.path(),
+            "decoy.zip",
+            &with_comment(&std::fs::read(&path).expect("read"), &decoy),
+        );
+
+        assert_eq!(
+            super::super::zip_directory::member_names(&doctored)
+                .expect("the real EOCD is still found")
+                .len(),
+            3,
+            "the walk must not take the decoy"
+        );
+        let parser = open(&doctored).expect("opens");
+        assert_eq!(
+            parser.file_names().count(),
+            0,
+            "zip 2.4.2 is expected to take the decoy — that is why the two views are compared"
+        );
+        match verify(&doctored, &retained(&key)) {
+            Err(SigningError::DirectoryMismatch { reason, .. }) => {
+                assert!(reason.contains("collapsed"), "{reason}");
+            }
+            other => panic!("expected a refusal rather than a verdict, got {other:?}"),
+        }
+    }
+
+    /// `raw` with `comment` appended and the EOCD's comment length updated.
+    fn with_comment(raw: &[u8], comment: &[u8]) -> Vec<u8> {
+        let eocd = eocd_at(raw);
+        let mut out = raw[..eocd].to_vec();
+        let mut record = raw[eocd..].to_vec();
+        record[20..22].copy_from_slice(&le16(comment.len() as u16));
+        out.extend_from_slice(&record);
+        out.extend_from_slice(comment);
+        out
+    }
+
+    /// A directory that stops in the middle of a record is refused rather than
+    /// walked off the end of the buffer.
+    #[test]
+    fn a_directory_truncated_mid_record_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut raw = hand_built(b"README.md", b"read me", 0, b"");
+        let eocd = eocd_at(&raw);
+        // Claim the whole directory but leave twenty bytes of it: the record's
+        // fixed part no longer fits, let alone its name.
+        let size = read_u32(&raw, eocd + 12);
+        raw[eocd + 12..eocd + 16].copy_from_slice(&le32(size));
+        let directory_at = read_u32(&raw, eocd + 16) as usize;
+        let mut truncated = raw[..directory_at + 20].to_vec();
+        truncated.extend_from_slice(&raw[eocd..]);
+        let eocd = eocd_at(&truncated);
+        truncated[eocd + 16..eocd + 20].copy_from_slice(&le32(directory_at as u32));
+        let path = write(dir.path(), "truncated.zip", &truncated);
+
+        let outcome = super::super::zip_directory::member_names(&path);
+        assert!(
+            matches!(outcome, Err(SigningError::DirectoryMalformed { .. })),
+            "{outcome:?}"
+        );
+    }
+
+    /// A saturated entry count says zip64, and a zip64 archive with no locator
+    /// is refused rather than read as if the classic fields meant anything.
+    #[test]
+    fn a_saturated_eocd_with_no_zip64_locator_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut raw = hand_built(b"README.md", b"read me", 0, b"");
+        let eocd = eocd_at(&raw);
+        raw[eocd + 10..eocd + 12].copy_from_slice(&le16(u16::MAX));
+        let path = write(dir.path(), "saturated.zip", &raw);
+
+        let outcome = super::super::zip_directory::member_names(&path);
+        assert!(
+            matches!(outcome, Err(SigningError::DirectoryMalformed { .. })),
+            "{outcome:?}"
+        );
+    }
+
+    /// An entry count far past what the directory can hold is refused on the
+    /// record that does not frame, without indexing past the buffer.
+    #[test]
+    fn a_forged_entry_count_is_refused_without_a_panic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut raw = hand_built(b"README.md", b"read me", 0, b"");
+        let eocd = eocd_at(&raw);
+        // 0xFFFE rather than 0xFFFF: a huge count that is NOT the zip64
+        // sentinel, so the walk runs rather than diverting to the locator.
+        raw[eocd + 8..eocd + 10].copy_from_slice(&le16(0xFFFE));
+        raw[eocd + 10..eocd + 12].copy_from_slice(&le16(0xFFFE));
+        let path = write(dir.path(), "forged-count.zip", &raw);
+
+        let outcome = super::super::zip_directory::member_names(&path);
+        assert!(
+            matches!(outcome, Err(SigningError::DirectoryMalformed { .. })),
+            "{outcome:?}"
+        );
+    }
+
+    /// 🔴 `zip` decodes a member name as UTF-8 or CP437 by general-purpose flag
+    /// bit 11 (`read.rs:1313-1316`). A walk that decoded every name one fixed
+    /// way would disagree with the parser about a legitimate CP437-flagged
+    /// name — 0x81 is `ü` there and not valid UTF-8 on its own — and refuse an
+    /// ordinary archive. The comparison is bytes and counts, so it does not.
+    #[test]
+    fn a_cp437_flagged_name_is_not_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Flags 0: bit 11 clear, so the name is CP437 to every reader.
+        let raw = hand_built(b"gr\x81ss.md", b"hello", 0, b"");
+        let path = write(dir.path(), "cp437.zip", &raw);
+
+        let walked = super::super::zip_directory::member_names(&path).expect("walks");
+        assert_eq!(walked, vec![b"gr\x81ss.md".to_vec()], "raw, undecoded");
+
+        let archive = open(&path).expect("open");
+        let exposed: Vec<String> = archive.file_names().map(str::to_owned).collect();
+        assert_eq!(
+            exposed,
+            vec!["grüss.md".to_owned()],
+            "the parser decodes CP437"
+        );
+        assert_ne!(
+            String::from_utf8_lossy(&walked[0]),
+            exposed[0],
+            "a decoded comparison would have disagreed here — that is the finding"
+        );
+
+        // The archive carries no manifest, so this stops at the manifest rather
+        // than at the member set: the encoding did not refuse it.
+        let outcome = verify(&path, &retained(&EngagementKey::generate()));
+        assert!(
+            matches!(outcome, Err(SigningError::ManifestMissing { .. })),
+            "a CP437 name must not be refused as a directory disagreement: {outcome:?}"
         );
     }
 }

--- a/crates/trusty-audit/src/package/signing.rs
+++ b/crates/trusty-audit/src/package/signing.rs
@@ -1,0 +1,901 @@
+//! Content signing for the return package, and the check that reads it back.
+//!
+//! Why (#5481): the return channel is manual (#5642) — the recipient emails a
+//! zip. Nothing about a file that arrived that way says it is the file that was
+//! written. This module makes an alteration between writing and receiving
+//! detectable: every delivered member's SHA-256 goes into one small manifest,
+//! and that manifest carries a detached ed25519 signature made with the
+//! per-engagement private key. Signing one manifest rather than N files is the
+//! whole reason the manifest exists.
+//!
+//! What: [`EngagementKey`] signs, [`RetainedKey`] verifies, and [`verify`]
+//! reads a finished zip and reports one [`Verdict`]. The manifest and its
+//! signature are two members of the same archive
+//! ([`MANIFEST_ENTRY`], [`SIGNATURE_ENTRY`]), written last so they cover every
+//! member that precedes them. Neither covers itself, which is why the manifest
+//! names the signature's file rather than hashing it.
+//!
+//! ## The limit, stated rather than softened
+//!
+//! This is **tamper-evidence, not proof against the recipient**. The private
+//! key travels to the recipient inside the inbound package, so the signature is
+//! made on hardware they fully control and they can re-sign an altered bundle
+//! with it. It defends against alteration in transit and by an unrelated third
+//! party. The alternatives that would close the remaining gap — submission to
+//! an endpoint the auditor controls, or the auditor re-running the audit — were
+//! offered and declined (#5481). This is the accepted trust model, not an
+//! interim one. Nothing in this module's output may be worded as if a valid
+//! signature proved the recipient did not alter the content.
+//!
+//! ## No key configured is not a failure
+//!
+//! An engagement with no `[signing]` key still packages. The manifest is still
+//! written — the hashes are worth having on their own — with no `[signature]`
+//! table, and [`verify`] answers [`Verdict::Unsigned`]. That is its own outcome
+//! rather than an error, and it is distinct from a signed package whose
+//! signature member was removed, which is [`SigningError::SignatureMissing`].
+//! The manifest's `[signature]` table is what separates the two.
+//!
+//! Test: `super::signing_tests`.
+
+use std::path::{Path, PathBuf};
+
+use ed25519_dalek::{Signature, Signer as _, SigningKey, Verifier as _, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+/// The manifest listing every delivered member's SHA-256.
+pub const MANIFEST_ENTRY: &str = "manifest.sha256.toml";
+
+/// The detached ed25519 signature over [`MANIFEST_ENTRY`]'s exact bytes.
+pub const SIGNATURE_ENTRY: &str = "manifest.sha256.sig";
+
+/// Schema version of the manifest this module writes and reads.
+const MANIFEST_VERSION: u32 = 1;
+
+/// Bytes in an ed25519 private seed and in a compressed public key alike.
+const KEY_BYTES: usize = 32;
+
+/// What went wrong signing a package, or checking one.
+///
+/// Why: the three failures #5481 requires be told apart — a member altered
+/// after signing, a signature removed, and a signature that does not belong to
+/// the retained key — are three variants rather than three strings, so a caller
+/// can act on them and a test can assert which one happened. Two more close the
+/// same door from the other side: a manifest-listed member that is gone, and a
+/// member the manifest never listed.
+/// What: one enum for both directions. Key parsing is shared by them, so its
+/// failure is shared too.
+/// Test: `super::signing_tests`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SigningError {
+    /// Key material is not `KEY_BYTES` bytes of lower-case hex.
+    #[error("the {what} signing key is not {KEY_BYTES} bytes of hex: {reason}")]
+    KeyMalformed {
+        /// `engagement` for the private half, `retained` for the public one.
+        what: &'static str,
+        /// Why the material was rejected.
+        reason: String,
+    },
+
+    /// The package carries no [`MANIFEST_ENTRY`], so there is nothing to check.
+    #[error(
+        "{path} carries no {MANIFEST_ENTRY} — it was not written by a version of \
+         trusty-audit that hashes its members, or the manifest was removed"
+    )]
+    ManifestMissing {
+        /// The package that was read.
+        path: PathBuf,
+    },
+
+    /// [`MANIFEST_ENTRY`] is present but is not a manifest this version reads.
+    #[error("{path}: {MANIFEST_ENTRY} is not a manifest this version reads: {reason}")]
+    ManifestMalformed {
+        /// The package that was read.
+        path: PathBuf,
+        /// Why the parse failed.
+        reason: String,
+    },
+
+    /// The manifest declares a signature and the signature member is gone.
+    #[error(
+        "{path}: the manifest was signed by key {key_fingerprint} but {SIGNATURE_ENTRY} \
+         is not in the package — the signature was removed after it was written"
+    )]
+    SignatureMissing {
+        /// The package that was read.
+        path: PathBuf,
+        /// The key the manifest says signed it.
+        key_fingerprint: String,
+    },
+
+    /// The signature member is present but is not 64 bytes of hex.
+    #[error("{path}: {SIGNATURE_ENTRY} is not an ed25519 signature: {reason}")]
+    SignatureMalformed {
+        /// The package that was read.
+        path: PathBuf,
+        /// Why the signature could not be read.
+        reason: String,
+    },
+
+    /// The signature does not verify against the key that was supplied.
+    ///
+    /// Both fingerprints are named because the two causes look identical from
+    /// here: the package was signed by a different engagement's key, or the
+    /// manifest was altered after signing. A fingerprint that differs from the
+    /// supplied key's says which.
+    #[error(
+        "{path}: the manifest signature does not verify — the package was signed by key \
+         {package_key} and the key supplied is {supplied_key}"
+    )]
+    SignatureInvalid {
+        /// The package that was read.
+        path: PathBuf,
+        /// The key fingerprint the manifest claims.
+        package_key: String,
+        /// The fingerprint of the key the caller supplied.
+        supplied_key: String,
+    },
+
+    /// A member's bytes no longer hash to what the signed manifest recorded.
+    #[error(
+        "{path}: {entry} was altered after the package was signed — the manifest records \
+         SHA-256 {expected} and the member in the package hashes to {actual}"
+    )]
+    ContentMismatch {
+        /// The package that was read.
+        path: PathBuf,
+        /// The member whose bytes changed.
+        entry: String,
+        /// What the signed manifest recorded.
+        expected: String,
+        /// What the member actually hashes to.
+        actual: String,
+    },
+
+    /// The manifest lists a member the package does not contain.
+    #[error("{path}: the signed manifest lists {entry}, which is not in the package")]
+    MemberMissing {
+        /// The package that was read.
+        path: PathBuf,
+        /// The member named by the manifest and absent from the archive.
+        entry: String,
+    },
+
+    /// The package contains a member the signed manifest never listed.
+    #[error("{path}: {entry} is in the package but not in the signed manifest — it was added")]
+    MemberUnexpected {
+        /// The package that was read.
+        path: PathBuf,
+        /// The member the manifest does not account for.
+        entry: String,
+    },
+
+    /// The package could not be opened or read.
+    #[error("cannot read the package {path}: {source}")]
+    Archive {
+        /// The package that was read.
+        path: PathBuf,
+        /// The underlying failure.
+        source: std::io::Error,
+    },
+}
+
+/// The per-engagement private key that signs one package's manifest.
+///
+/// Why: #5478's config generator mints one keypair per engagement and puts the
+/// private half in the inbound package, so the recipient signs locally with no
+/// call back to the auditor. This type is what that key becomes once read out
+/// of [`crate::config::EngagementConfig`].
+/// What: an ed25519 signing key, parsed from the hex the config carries. It
+/// prints as its fingerprint, never as its bytes — the same posture
+/// [`crate::config::SecretKey`] takes, so a key cannot reach a log through a
+/// `Debug` on an enclosing struct.
+/// Test: `super::signing_tests::a_signed_package_verifies_against_the_public_half`.
+#[derive(Clone)]
+pub struct EngagementKey(SigningKey);
+
+impl std::fmt::Debug for EngagementKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EngagementKey({})", self.fingerprint())
+    }
+}
+
+impl EngagementKey {
+    /// Mint a fresh keypair from the operating system's randomness.
+    ///
+    /// #5478's generator is the production caller — one keypair per engagement,
+    /// its public half retained by the auditor out of band. Until that lands
+    /// this is reachable only from the library, which is why the crate README
+    /// says an engagement is unsigned unless a key was written into its config
+    /// by hand.
+    #[must_use]
+    pub fn generate() -> Self {
+        Self(SigningKey::generate(&mut rand_core::OsRng))
+    }
+
+    /// Read a key from the `KEY_BYTES`-byte hex seed a config carries.
+    ///
+    /// # Errors
+    ///
+    /// [`SigningError::KeyMalformed`] when the text is not exactly
+    /// `KEY_BYTES` bytes of hex.
+    pub fn from_hex(text: &str) -> Result<Self, SigningError> {
+        Ok(Self(SigningKey::from_bytes(&key_bytes(
+            text,
+            "engagement",
+        )?)))
+    }
+
+    /// The private seed as hex — the form [`Self::from_hex`] reads back.
+    ///
+    /// This is the one function that turns a key into printable text, so
+    /// `git grep private_hex` finds every site that could write one out.
+    #[must_use]
+    pub fn private_hex(&self) -> String {
+        to_hex(&self.0.to_bytes())
+    }
+
+    /// The public half as hex — what the auditor retains out of band.
+    #[must_use]
+    pub fn public_hex(&self) -> String {
+        to_hex(self.0.verifying_key().as_bytes())
+    }
+
+    /// The short fingerprint the manifest records for this key.
+    #[must_use]
+    pub fn fingerprint(&self) -> String {
+        fingerprint(&self.0.verifying_key())
+    }
+}
+
+/// The public half the auditor retained, which checks a received package.
+///
+/// Retained OUT OF BAND — it never travels in either package, because a key
+/// that arrives with the thing it authenticates authenticates nothing.
+#[derive(Debug, Clone)]
+pub struct RetainedKey(VerifyingKey);
+
+impl RetainedKey {
+    /// Read the retained public key from its hex form.
+    ///
+    /// # Errors
+    ///
+    /// [`SigningError::KeyMalformed`] when the text is not `KEY_BYTES` bytes of
+    /// hex, or is not a point on the curve.
+    pub fn from_hex(text: &str) -> Result<Self, SigningError> {
+        let bytes = key_bytes(text, "retained")?;
+        VerifyingKey::from_bytes(&bytes)
+            .map(Self)
+            .map_err(|e| SigningError::KeyMalformed {
+                what: "retained",
+                reason: e.to_string(),
+            })
+    }
+
+    /// The short fingerprint of this key, in the manifest's own form.
+    #[must_use]
+    pub fn fingerprint(&self) -> String {
+        fingerprint(&self.0)
+    }
+}
+
+/// What [`verify`] concluded about a package.
+///
+/// `Unsigned` is deliberately not an error: an engagement with no key
+/// configured produces a package with no signature, and that is a supported
+/// state (see the module docs). A caller deciding whether to trust the contents
+/// must still treat it as "not authenticated" — it is a distinct outcome, not a
+/// weaker pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Verdict {
+    /// Every member hashes to what the signed manifest records, and the
+    /// signature over that manifest verifies against the retained key.
+    Signed {
+        /// The key that signed it, as a short fingerprint.
+        key_fingerprint: String,
+        /// How many members the manifest covers.
+        files: usize,
+    },
+    /// The package carries a manifest and no signature, because the engagement
+    /// configured no signing key. Nothing here is authenticated.
+    Unsigned {
+        /// How many members the manifest covers.
+        files: usize,
+    },
+}
+
+/// One delivered member, as the manifest records it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManifestFile {
+    /// Path inside the zip.
+    pub entry: String,
+    /// Lower-case hex SHA-256 of the member's uncompressed bytes.
+    pub sha256: String,
+    /// Uncompressed size.
+    pub bytes: u64,
+}
+
+/// The `[signature]` table, present exactly when the manifest was signed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct SignatureBlock {
+    scheme: String,
+    key_fingerprint: String,
+    file: String,
+}
+
+/// The manifest document itself.
+///
+/// Field order is the emitted order: TOML puts every scalar before the first
+/// table, so `version` and `algorithm` must precede `signature`, and the array
+/// of file tables must come last.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ManifestDoc {
+    version: u32,
+    algorithm: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    signature: Option<SignatureBlock>,
+    #[serde(default, rename = "file")]
+    file: Vec<ManifestFile>,
+}
+
+/// The two members [`render`] produced, ready to write into the archive.
+#[derive(Debug, Clone)]
+pub(super) struct SignedManifest {
+    /// [`MANIFEST_ENTRY`]'s exact bytes.
+    pub(super) manifest: String,
+    /// [`SIGNATURE_ENTRY`]'s bytes, or `None` when no key was configured.
+    pub(super) signature: Option<String>,
+}
+
+/// Build the manifest over `files`, signing it when a key was configured.
+///
+/// Why: `key` is an `Option` because a missing key must not stop a package
+/// being built — an engagement that never configured one still has a
+/// deliverable to send, and refusing to write it would trade a real report for
+/// a property that engagement never asked for.
+/// What: renders the manifest, then signs its exact bytes. The signature covers
+/// the rendered text rather than the structure, so verification re-reads the
+/// stored bytes and never re-serializes.
+/// Test: `super::signing_tests::a_signed_package_verifies_against_the_public_half`,
+/// `super::signing_tests::a_package_with_no_key_configured_is_unsigned_not_refused`.
+///
+/// # Errors
+///
+/// [`SigningError::ManifestMalformed`] when the manifest cannot be serialized,
+/// which needs a `ManifestFile` TOML rejects.
+pub(super) fn render(
+    files: Vec<ManifestFile>,
+    key: Option<&EngagementKey>,
+) -> Result<SignedManifest, SigningError> {
+    let doc = ManifestDoc {
+        version: MANIFEST_VERSION,
+        algorithm: "sha256".to_owned(),
+        signature: key.map(|k| SignatureBlock {
+            scheme: "ed25519".to_owned(),
+            key_fingerprint: k.fingerprint(),
+            file: SIGNATURE_ENTRY.to_owned(),
+        }),
+        file: files,
+    };
+    let manifest = toml::to_string_pretty(&doc).map_err(|e| SigningError::ManifestMalformed {
+        path: PathBuf::from(MANIFEST_ENTRY),
+        reason: e.to_string(),
+    })?;
+    let signature = key.map(|k| format!("{}\n", to_hex(&k.0.sign(manifest.as_bytes()).to_bytes())));
+    Ok(SignedManifest {
+        manifest,
+        signature,
+    })
+}
+
+/// Check a received package against the retained public key.
+///
+/// Why (#5481 closure condition 2): a signature nobody checks is decoration.
+/// This is the check, as a library call — #5563 owns the `trusty-audit verify`
+/// CLI arm that drives it, so that issue adds a `session::Command` variant and
+/// this function stays the single implementation behind both it and any front
+/// end.
+///
+/// # Preconditions
+/// `package` is a zip this crate assembled. Any other zip fails
+/// [`SigningError::ManifestMissing`] rather than passing vacuously.
+///
+/// # Postconditions
+/// [`Verdict::Signed`] is returned only when the signature verifies against
+/// `retained` AND every manifest-listed member hashes to its recorded digest
+/// AND the archive holds no member the manifest does not list. Every other
+/// state is an `Err` or [`Verdict::Unsigned`]; there is no path on which a
+/// failed check returns `Signed`.
+///
+/// What: opens the archive, reads the manifest's stored bytes, verifies the
+/// detached signature over exactly those bytes, then re-hashes every member.
+/// The signature is checked BEFORE the hashes, so a package whose manifest was
+/// rewritten reports the signature failure rather than a list of content
+/// mismatches derived from an unauthenticated manifest.
+/// Test: `super::signing_tests::a_tampered_member_fails_verification`,
+/// `super::signing_tests::a_removed_signature_fails_verification`,
+/// `super::signing_tests::a_different_key_fails_verification`,
+/// `super::signing_tests::an_added_member_fails_verification`.
+///
+/// # Errors
+///
+/// Every [`SigningError`] variant except [`SigningError::KeyMalformed`], which
+/// is raised by [`RetainedKey::from_hex`] before this is reached.
+pub fn verify(package: &Path, retained: &RetainedKey) -> Result<Verdict, SigningError> {
+    let mut archive = open(package)?;
+    let manifest = match read_member(&mut archive, package, MANIFEST_ENTRY)? {
+        Some(bytes) => bytes,
+        None => {
+            return Err(SigningError::ManifestMissing {
+                path: package.to_path_buf(),
+            });
+        }
+    };
+    let doc: ManifestDoc = toml::from_str(&String::from_utf8_lossy(&manifest)).map_err(|e| {
+        SigningError::ManifestMalformed {
+            path: package.to_path_buf(),
+            reason: e.to_string(),
+        }
+    })?;
+
+    let Some(block) = doc.signature.as_ref() else {
+        // No `[signature]` table means the engagement configured no key. The
+        // hashes are NOT checked here on purpose: an unsigned manifest is
+        // rewritable by anyone holding the zip, so checking members against it
+        // would report an integrity result that means nothing.
+        return Ok(Verdict::Unsigned {
+            files: doc.file.len(),
+        });
+    };
+    verify_signature(&mut archive, package, &manifest, block, retained)?;
+    check_members(&mut archive, package, &doc.file)?;
+    Ok(Verdict::Signed {
+        key_fingerprint: block.key_fingerprint.clone(),
+        files: doc.file.len(),
+    })
+}
+
+/// The detached-signature half of [`verify`].
+fn verify_signature(
+    archive: &mut Archive,
+    package: &Path,
+    manifest: &[u8],
+    block: &SignatureBlock,
+    retained: &RetainedKey,
+) -> Result<(), SigningError> {
+    let raw = read_member(archive, package, &block.file)?.ok_or_else(|| {
+        SigningError::SignatureMissing {
+            path: package.to_path_buf(),
+            key_fingerprint: block.key_fingerprint.clone(),
+        }
+    })?;
+    let text = String::from_utf8_lossy(&raw);
+    let bytes: [u8; Signature::BYTE_SIZE] = from_hex(text.trim())
+        .and_then(|b| b.try_into().ok())
+        .ok_or_else(|| SigningError::SignatureMalformed {
+        path: package.to_path_buf(),
+        reason: format!(
+            "expected {} bytes of hex, found {} characters",
+            Signature::BYTE_SIZE,
+            text.trim().len()
+        ),
+    })?;
+    retained
+        .0
+        .verify(manifest, &Signature::from_bytes(&bytes))
+        .map_err(|_| SigningError::SignatureInvalid {
+            path: package.to_path_buf(),
+            package_key: block.key_fingerprint.clone(),
+            supplied_key: retained.fingerprint(),
+        })
+}
+
+/// The content half of [`verify`]: every listed member, and nothing else.
+fn check_members(
+    archive: &mut Archive,
+    package: &Path,
+    listed: &[ManifestFile],
+) -> Result<(), SigningError> {
+    for file in listed {
+        let bytes = read_member(archive, package, &file.entry)?.ok_or_else(|| {
+            SigningError::MemberMissing {
+                path: package.to_path_buf(),
+                entry: file.entry.clone(),
+            }
+        })?;
+        let actual = to_hex(&Sha256::digest(&bytes));
+        if actual != file.sha256 {
+            return Err(SigningError::ContentMismatch {
+                path: package.to_path_buf(),
+                entry: file.entry.clone(),
+                expected: file.sha256.clone(),
+                actual,
+            });
+        }
+    }
+    // #5481: an addition is as much an alteration as an edit, and hashing only
+    // what the manifest lists would never see one. The two signing members
+    // account for themselves — neither can be in a manifest it is part of.
+    let names: Vec<String> = archive.file_names().map(str::to_owned).collect();
+    for name in names {
+        if name == MANIFEST_ENTRY || name == SIGNATURE_ENTRY || name.ends_with('/') {
+            continue;
+        }
+        if !listed.iter().any(|f| f.entry == name) {
+            return Err(SigningError::MemberUnexpected {
+                path: package.to_path_buf(),
+                entry: name,
+            });
+        }
+    }
+    Ok(())
+}
+
+type Archive = zip::ZipArchive<std::io::BufReader<std::fs::File>>;
+
+/// Open the package, mapping every failure onto one path-naming variant.
+fn open(package: &Path) -> Result<Archive, SigningError> {
+    let file = std::fs::File::open(package).map_err(|source| SigningError::Archive {
+        path: package.to_path_buf(),
+        source,
+    })?;
+    zip::ZipArchive::new(std::io::BufReader::new(file)).map_err(|e| SigningError::Archive {
+        path: package.to_path_buf(),
+        source: std::io::Error::other(e),
+    })
+}
+
+/// One member's uncompressed bytes, or `None` when the archive has no such
+/// entry. An unreadable entry that IS present is an error, never a `None` —
+/// silently treating a read failure as absence is how a tampered archive passes.
+fn read_member(
+    archive: &mut Archive,
+    package: &Path,
+    entry: &str,
+) -> Result<Option<Vec<u8>>, SigningError> {
+    use std::io::Read as _;
+    let mut member = match archive.by_name(entry) {
+        Ok(m) => m,
+        Err(zip::result::ZipError::FileNotFound) => return Ok(None),
+        Err(e) => {
+            return Err(SigningError::Archive {
+                path: package.to_path_buf(),
+                source: std::io::Error::other(e),
+            });
+        }
+    };
+    let mut bytes = Vec::with_capacity(usize::try_from(member.size()).unwrap_or_default());
+    member
+        .read_to_end(&mut bytes)
+        .map_err(|source| SigningError::Archive {
+            path: package.to_path_buf(),
+            source,
+        })?;
+    Ok(Some(bytes))
+}
+
+/// The short fingerprint form both halves of a keypair produce.
+///
+/// The `GithubAccess::fingerprint` shape (#5980): the leading 8 bytes of a
+/// SHA-256, hex. Short enough to read out loud, long enough that two
+/// engagements' keys will not collide.
+fn fingerprint(key: &VerifyingKey) -> String {
+    Sha256::digest(key.as_bytes())
+        .iter()
+        .take(8)
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// `KEY_BYTES` bytes of hex, or the one error that says which key it was.
+fn key_bytes(text: &str, what: &'static str) -> Result<[u8; KEY_BYTES], SigningError> {
+    from_hex(text.trim())
+        .and_then(|b| b.try_into().ok())
+        .ok_or_else(|| SigningError::KeyMalformed {
+            what,
+            reason: format!(
+                "expected {} hex characters, found {}",
+                KEY_BYTES * 2,
+                text.trim().len()
+            ),
+        })
+}
+
+/// Lower-case hex, the form every digest and key in this module is written in.
+fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// The inverse, returning `None` for anything that is not whole lower-case or
+/// upper-case hex. Hand-rolled rather than a `hex` dependency, because
+/// `to_hex`'s counterpart is four lines and the crate already hand-rolls the
+/// forward direction for the credential fingerprint (#5980).
+fn from_hex(text: &str) -> Option<Vec<u8>> {
+    if !text.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..text.len() / 2)
+        .map(|i| u8::from_str_radix(text.get(i * 2..i * 2 + 2)?, 16).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod signing_tests {
+    use super::*;
+
+    /// A package with the members `entries` names, signed when `key` is set.
+    fn package(dir: &Path, entries: &[(&str, &str)], key: Option<&EngagementKey>) -> PathBuf {
+        let path = dir.join("package.zip");
+        let file = std::fs::File::create(&path).expect("create");
+        let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        let mut files = Vec::new();
+        for (entry, body) in entries {
+            zip.start_file((*entry).to_owned(), options).expect("start");
+            std::io::Write::write_all(&mut zip, body.as_bytes()).expect("write");
+            files.push(ManifestFile {
+                entry: (*entry).to_owned(),
+                sha256: to_hex(&Sha256::digest(body.as_bytes())),
+                bytes: body.len() as u64,
+            });
+        }
+        let signed = render(files, key).expect("render");
+        zip.start_file(MANIFEST_ENTRY.to_owned(), options)
+            .expect("start");
+        std::io::Write::write_all(&mut zip, signed.manifest.as_bytes()).expect("write");
+        if let Some(sig) = signed.signature {
+            zip.start_file(SIGNATURE_ENTRY.to_owned(), options)
+                .expect("start");
+            std::io::Write::write_all(&mut zip, sig.as_bytes()).expect("write");
+        }
+        zip.finish().expect("finish");
+        path
+    }
+
+    /// Rebuild `source`'s archive with `edit` applied to its member list.
+    fn rewrite(source: &Path, edit: impl Fn(&str, &[u8]) -> Option<Vec<u8>>) -> PathBuf {
+        let destination = source.with_file_name("rewritten.zip");
+        let mut archive = open(source).expect("open");
+        let names: Vec<String> = archive.file_names().map(str::to_owned).collect();
+        let file = std::fs::File::create(&destination).expect("create");
+        let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        for name in names {
+            let bytes = read_member(&mut archive, source, &name)
+                .expect("read")
+                .expect("present");
+            if let Some(replacement) = edit(&name, &bytes) {
+                zip.start_file(name, options).expect("start");
+                std::io::Write::write_all(&mut zip, &replacement).expect("write");
+            }
+        }
+        zip.finish().expect("finish");
+        destination
+    }
+
+    fn retained(key: &EngagementKey) -> RetainedKey {
+        RetainedKey::from_hex(&key.public_hex()).expect("public half parses")
+    }
+
+    #[test]
+    fn a_signed_package_verifies_against_the_public_half() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(
+            dir.path(),
+            &[
+                ("README.md", "read me"),
+                ("reports/a/report.md", "findings"),
+            ],
+            Some(&key),
+        );
+        assert_eq!(
+            verify(&path, &retained(&key)).expect("verifies"),
+            Verdict::Signed {
+                key_fingerprint: key.fingerprint(),
+                files: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn a_key_round_trips_through_its_hex_form() {
+        let key = EngagementKey::generate();
+        let read_back = EngagementKey::from_hex(&key.private_hex()).expect("parses");
+        assert_eq!(read_back.public_hex(), key.public_hex());
+        assert_eq!(read_back.fingerprint(), key.fingerprint());
+    }
+
+    #[test]
+    fn a_key_that_is_not_thirty_two_bytes_of_hex_is_refused() {
+        let short = EngagementKey::from_hex("abcd");
+        assert!(matches!(short, Err(SigningError::KeyMalformed { .. })));
+        let not_hex = RetainedKey::from_hex(&"zz".repeat(32));
+        assert!(matches!(not_hex, Err(SigningError::KeyMalformed { .. })));
+    }
+
+    /// The first of #5481's three distinguishable failures.
+    #[test]
+    fn a_tampered_member_fails_verification() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
+        let tampered = rewrite(&path, |name, bytes| {
+            Some(if name == "README.md" {
+                b"read mf".to_vec()
+            } else {
+                bytes.to_vec()
+            })
+        });
+        match verify(&tampered, &retained(&key)) {
+            Err(SigningError::ContentMismatch { entry, .. }) => assert_eq!(entry, "README.md"),
+            other => panic!("expected a content mismatch, got {other:?}"),
+        }
+    }
+
+    /// The second: the signature member removed from a package that had one.
+    #[test]
+    fn a_removed_signature_fails_verification() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
+        let stripped = rewrite(&path, |name, bytes| {
+            (name != SIGNATURE_ENTRY).then(|| bytes.to_vec())
+        });
+        match verify(&stripped, &retained(&key)) {
+            Err(SigningError::SignatureMissing {
+                key_fingerprint, ..
+            }) => assert_eq!(key_fingerprint, key.fingerprint()),
+            other => panic!("expected a missing signature, got {other:?}"),
+        }
+    }
+
+    /// The third: a valid package checked against somebody else's key.
+    #[test]
+    fn a_different_key_fails_verification() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let other = EngagementKey::generate();
+        let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
+        match verify(&path, &retained(&other)) {
+            Err(SigningError::SignatureInvalid {
+                package_key,
+                supplied_key,
+                ..
+            }) => {
+                assert_eq!(package_key, key.fingerprint());
+                assert_eq!(supplied_key, other.fingerprint());
+                assert_ne!(package_key, supplied_key);
+            }
+            other => panic!("expected an invalid signature, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_package_with_no_key_configured_is_unsigned_not_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = package(dir.path(), &[("README.md", "read me")], None);
+        assert_eq!(
+            verify(&path, &retained(&EngagementKey::generate())).expect("reads"),
+            Verdict::Unsigned { files: 1 }
+        );
+    }
+
+    #[test]
+    fn an_added_member_fails_verification() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
+        let destination = dir.path().join("with-extra.zip");
+        let mut archive = open(&path).expect("open");
+        let names: Vec<String> = archive.file_names().map(str::to_owned).collect();
+        let file = std::fs::File::create(&destination).expect("create");
+        let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        for name in names {
+            let bytes = read_member(&mut archive, &path, &name)
+                .expect("read")
+                .expect("present");
+            zip.start_file(name, options).expect("start");
+            std::io::Write::write_all(&mut zip, &bytes).expect("write");
+        }
+        zip.start_file("reports/planted.md".to_owned(), options)
+            .expect("start");
+        std::io::Write::write_all(&mut zip, b"planted").expect("write");
+        zip.finish().expect("finish");
+        match verify(&destination, &retained(&key)) {
+            Err(SigningError::MemberUnexpected { entry, .. }) => {
+                assert_eq!(entry, "reports/planted.md");
+            }
+            other => panic!("expected an unexpected member, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_removed_member_fails_verification() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(
+            dir.path(),
+            &[
+                ("README.md", "read me"),
+                ("reports/a/report.md", "findings"),
+            ],
+            Some(&key),
+        );
+        let stripped = rewrite(&path, |name, bytes| {
+            (name != "reports/a/report.md").then(|| bytes.to_vec())
+        });
+        match verify(&stripped, &retained(&key)) {
+            Err(SigningError::MemberMissing { entry, .. }) => {
+                assert_eq!(entry, "reports/a/report.md");
+            }
+            other => panic!("expected a missing member, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_rewritten_manifest_fails_the_signature_before_the_hashes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
+        // Re-render the manifest over a digest the forger prefers, keeping the
+        // original signature. The hashes would now agree with the altered file;
+        // only the signature says the manifest is not the one that was signed.
+        let forged = rewrite(&path, |name, bytes| {
+            Some(if name == MANIFEST_ENTRY {
+                let doc = ManifestDoc {
+                    version: MANIFEST_VERSION,
+                    algorithm: "sha256".to_owned(),
+                    signature: Some(SignatureBlock {
+                        scheme: "ed25519".to_owned(),
+                        key_fingerprint: key.fingerprint(),
+                        file: SIGNATURE_ENTRY.to_owned(),
+                    }),
+                    file: vec![ManifestFile {
+                        entry: "README.md".to_owned(),
+                        sha256: to_hex(&Sha256::digest(b"read me")),
+                        bytes: 7,
+                    }],
+                };
+                let mut text = toml::to_string_pretty(&doc).expect("render");
+                text.push_str("\n# forged\n");
+                text.into_bytes()
+            } else {
+                bytes.to_vec()
+            })
+        });
+        assert!(matches!(
+            verify(&forged, &retained(&key)),
+            Err(SigningError::SignatureInvalid { .. })
+        ));
+    }
+
+    #[test]
+    fn a_zip_that_carries_no_manifest_is_refused_rather_than_passing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("plain.zip");
+        let file = std::fs::File::create(&path).expect("create");
+        let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        zip.start_file("README.md".to_owned(), options)
+            .expect("start");
+        std::io::Write::write_all(&mut zip, b"read me").expect("write");
+        zip.finish().expect("finish");
+        assert!(matches!(
+            verify(&path, &retained(&EngagementKey::generate())),
+            Err(SigningError::ManifestMissing { .. })
+        ));
+    }
+
+    #[test]
+    fn a_key_never_prints_its_bytes_through_debug() {
+        let key = EngagementKey::generate();
+        let rendered = format!("{key:?}");
+        assert!(!rendered.contains(&key.private_hex()), "{rendered}");
+        assert!(rendered.contains(&key.fingerprint()), "{rendered}");
+    }
+}

--- a/crates/trusty-audit/src/package/zip_directory.rs
+++ b/crates/trusty-audit/src/package/zip_directory.rs
@@ -1,0 +1,251 @@
+//! Reading a zip's central directory as it is on disk, not as a parser dedupes it.
+//!
+//! Why (#5481 security review): `zip` 2.4.2 holds its entry table as an
+//! `IndexMap<Box<str>, ZipFileData>` keyed by member name (`read.rs:50`), so a
+//! central directory carrying two records under one name collapses to one
+//! before any caller sees it. `file_names()` yields the name once, `len()`
+//! returns the deduped count, and `by_name` resolves to whichever record won.
+//! Python's `zipfile`, Info-ZIP and Finder each pick a record by their own rule,
+//! so a package could verify here and extract different bytes there. Every
+//! public accessor on `ZipArchive` reads that same map — verified against the
+//! vendored 2.4.2 source — so there is no accessor to reach for and the
+//! directory has to be walked by hand.
+//!
+//! What: [`member_names`] finds the end-of-central-directory record, follows the
+//! zip64 locator when the classic fields are saturated, and walks each
+//! central-directory file header in order, returning every name INCLUDING
+//! repeats. Deciding what a repeat means is [`super::signing::verify`]'s job;
+//! this module only refuses to hide one.
+//!
+//! Scope: names and record framing. Nothing here reads a local header, a
+//! compressed byte, or a declared size — a size in this directory is
+//! attacker-controlled and is never used to size an allocation.
+//!
+//! Test: `super::signing::signing_tests::a_duplicate_central_directory_record_is_refused`.
+
+use std::io::{Read as _, Seek as _, SeekFrom};
+use std::path::Path;
+
+use super::signing::SigningError;
+
+/// End of central directory record.
+const EOCD_SIGNATURE: u32 = 0x0605_4b50;
+/// Zip64 end of central directory locator, 20 bytes ahead of the classic EOCD.
+const EOCD64_LOCATOR_SIGNATURE: u32 = 0x0706_4b50;
+/// Zip64 end of central directory record.
+const EOCD64_SIGNATURE: u32 = 0x0606_4b50;
+/// Central directory file header.
+const CENTRAL_HEADER_SIGNATURE: u32 = 0x0201_4b50;
+
+/// Bytes in an EOCD record with no archive comment.
+const EOCD_LEN: usize = 22;
+/// Bytes in the fixed part of a central-directory file header.
+const CENTRAL_HEADER_LEN: usize = 46;
+/// Bytes in the zip64 locator.
+const EOCD64_LOCATOR_LEN: usize = 20;
+
+/// A central directory larger than this is refused rather than buffered.
+///
+/// The directory holds one ~100-byte record per member, so a package with tens
+/// of thousands of files stays far inside this. It exists so a forged EOCD
+/// cannot ask for an arbitrary allocation — the same rule the member reads
+/// follow.
+const MAX_DIRECTORY_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Every member name in the raw central directory, repeats included.
+///
+/// Why: see the module docs — a repeated name is invisible through `ZipArchive`,
+/// and it is exactly the shape that makes one archive verify here and extract
+/// differently elsewhere.
+/// What: locates the EOCD (scanning back over any archive comment), resolves the
+/// zip64 record when the classic count, size or offset is saturated, then walks
+/// the declared number of file headers, checking each signature and framing.
+/// The names come back in directory order.
+///
+/// # Postconditions
+/// The returned vector has exactly the length the directory declares. A record
+/// whose signature or framing is wrong is [`SigningError::DirectoryMalformed`],
+/// never a short read that would under-report the member set.
+/// Test: `super::signing::signing_tests::a_duplicate_central_directory_record_is_refused`,
+/// `super::signing::signing_tests::the_raw_directory_matches_what_the_zip_parser_exposes`.
+///
+/// # Errors
+///
+/// [`SigningError::DirectoryMalformed`] when no EOCD is found, a zip64 record
+/// is required and absent, the directory exceeds [`MAX_DIRECTORY_BYTES`], or a
+/// record's signature or lengths do not frame the directory; and
+/// [`SigningError::Archive`] for any read failure.
+pub(super) fn member_names(package: &Path) -> Result<Vec<String>, SigningError> {
+    let mut file = std::fs::File::open(package).map_err(|source| SigningError::Archive {
+        path: package.to_path_buf(),
+        source,
+    })?;
+    let length = file
+        .metadata()
+        .map_err(|source| SigningError::Archive {
+            path: package.to_path_buf(),
+            source,
+        })?
+        .len();
+
+    let tail_len = length.min((EOCD_LEN + usize::from(u16::MAX)) as u64);
+    let tail = read_at(&mut file, package, length - tail_len, tail_len)?;
+    let eocd =
+        find_eocd(&tail).ok_or_else(|| malformed(package, "no end-of-central-directory record"))?;
+
+    let (entries, size, offset) = locate(&mut file, package, &tail, eocd)?;
+    if size > MAX_DIRECTORY_BYTES {
+        return Err(malformed(
+            package,
+            &format!("the central directory declares {size} bytes, past this reader's ceiling"),
+        ));
+    }
+    if offset.saturating_add(size) > length {
+        return Err(malformed(
+            package,
+            "the central directory runs past the end of the file",
+        ));
+    }
+    let directory = read_at(&mut file, package, offset, size)?;
+    walk(package, &directory, entries)
+}
+
+/// The EOCD's entry count, directory size and directory offset, widened through
+/// the zip64 record whenever a classic field is saturated.
+///
+/// A package member can exceed the 4 GiB classic ceiling (`super::start` writes
+/// a zip64 local header for one), so zip64 is handled rather than refused.
+fn locate(
+    file: &mut std::fs::File,
+    package: &Path,
+    tail: &[u8],
+    eocd: usize,
+) -> Result<(u64, u64, u64), SigningError> {
+    let entries = u64::from(u16(tail, eocd + 10));
+    let size = u64::from(u32(tail, eocd + 12));
+    let offset = u64::from(u32(tail, eocd + 16));
+    let saturated = entries == u64::from(u16::MAX)
+        || size == u64::from(u32::MAX)
+        || offset == u64::from(u32::MAX);
+    if !saturated {
+        return Ok((entries, size, offset));
+    }
+
+    let locator = eocd
+        .checked_sub(EOCD64_LOCATOR_LEN)
+        .filter(|at| u32(tail, *at) == EOCD64_LOCATOR_SIGNATURE)
+        .ok_or_else(|| malformed(package, "a zip64 archive with no zip64 locator"))?;
+    let record_at = u64(tail, locator + 8);
+    let record = read_at(file, package, record_at, 56)?;
+    if u32(&record, 0) != EOCD64_SIGNATURE {
+        return Err(malformed(
+            package,
+            "the zip64 locator does not point at a zip64 record",
+        ));
+    }
+    Ok((u64(&record, 32), u64(&record, 40), u64(&record, 48)))
+}
+
+/// One pass over the directory, returning a name per declared record.
+fn walk(package: &Path, directory: &[u8], entries: u64) -> Result<Vec<String>, SigningError> {
+    let entries = usize::try_from(entries).map_err(|_| {
+        malformed(
+            package,
+            "the central directory declares more entries than fit in memory",
+        )
+    })?;
+    let mut names = Vec::with_capacity(entries.min(4096));
+    let mut at = 0_usize;
+    for index in 0..entries {
+        if at + CENTRAL_HEADER_LEN > directory.len()
+            || u32(directory, at) != CENTRAL_HEADER_SIGNATURE
+        {
+            return Err(malformed(
+                package,
+                &format!("central-directory record {index} is not a file header"),
+            ));
+        }
+        let name_len = usize::from(u16(directory, at + 28));
+        let extra_len = usize::from(u16(directory, at + 30));
+        let comment_len = usize::from(u16(directory, at + 32));
+        let name_at = at + CENTRAL_HEADER_LEN;
+        let end = name_at + name_len + extra_len + comment_len;
+        if end > directory.len() {
+            return Err(malformed(
+                package,
+                &format!("central-directory record {index} runs past the directory"),
+            ));
+        }
+        // Lossy on purpose: a name this reader cannot decode still has to be
+        // COUNTED, because refusing to name it is how a duplicate hides.
+        names.push(String::from_utf8_lossy(&directory[name_at..name_at + name_len]).into_owned());
+        at = end;
+    }
+    Ok(names)
+}
+
+/// The last EOCD signature in `tail` that leaves a whole record behind it.
+///
+/// Scanned backwards because the archive comment is arbitrary bytes and may
+/// itself contain the signature; the real record is the last viable one.
+fn find_eocd(tail: &[u8]) -> Option<usize> {
+    (0..=tail.len().checked_sub(EOCD_LEN)?)
+        .rev()
+        .find(|at| u32(tail, *at) == EOCD_SIGNATURE)
+}
+
+fn read_at(
+    file: &mut std::fs::File,
+    package: &Path,
+    offset: u64,
+    length: u64,
+) -> Result<Vec<u8>, SigningError> {
+    let length = usize::try_from(length).map_err(|_| {
+        malformed(
+            package,
+            "a zip structure larger than this machine's address space",
+        )
+    })?;
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|source| SigningError::Archive {
+            path: package.to_path_buf(),
+            source,
+        })?;
+    let mut bytes = vec![0_u8; length];
+    file.read_exact(&mut bytes)
+        .map_err(|source| SigningError::Archive {
+            path: package.to_path_buf(),
+            source,
+        })?;
+    Ok(bytes)
+}
+
+fn malformed(package: &Path, reason: &str) -> SigningError {
+    SigningError::DirectoryMalformed {
+        path: package.to_path_buf(),
+        reason: reason.to_owned(),
+    }
+}
+
+/// Little-endian reads that answer 0 past the end, so a truncated buffer fails
+/// the signature check above rather than panicking on a slice.
+fn u16(bytes: &[u8], at: usize) -> u16 {
+    bytes
+        .get(at..at + 2)
+        .and_then(|b| b.try_into().ok())
+        .map_or(0, u16::from_le_bytes)
+}
+
+fn u32(bytes: &[u8], at: usize) -> u32 {
+    bytes
+        .get(at..at + 4)
+        .and_then(|b| b.try_into().ok())
+        .map_or(0, u32::from_le_bytes)
+}
+
+fn u64(bytes: &[u8], at: usize) -> u64 {
+    bytes
+        .get(at..at + 8)
+        .and_then(|b| b.try_into().ok())
+        .map_or(0, u64::from_le_bytes)
+}

--- a/crates/trusty-audit/src/package/zip_directory.rs
+++ b/crates/trusty-audit/src/package/zip_directory.rs
@@ -17,11 +17,19 @@
 //! repeats. Deciding what a repeat means is [`super::signing::verify`]'s job;
 //! this module only refuses to hide one.
 //!
+//! Names come back as RAW BYTES, undecoded. `zip` picks UTF-8 or CP437 by
+//! general-purpose flag bit 11 (`read.rs:1313-1316`), so decoding here with one
+//! fixed rule would make a legitimate CP437-flagged name disagree with the
+//! parser's and refuse an ordinary archive. The caller compares bytes and
+//! counts, which needs no encoding rule at all and catches a collision between
+//! two records that decode alike as readily as one between identical bytes.
+//!
 //! Scope: names and record framing. Nothing here reads a local header, a
 //! compressed byte, or a declared size — a size in this directory is
 //! attacker-controlled and is never used to size an allocation.
 //!
-//! Test: `super::signing::signing_tests::a_duplicate_central_directory_record_is_refused`.
+//! Test: `super::signing::signing_tests::a_duplicate_central_directory_record_is_refused`,
+//! `super::signing::signing_tests::a_cp437_flagged_name_is_not_refused`.
 
 use std::io::{Read as _, Seek as _, SeekFrom};
 use std::path::Path;
@@ -52,22 +60,40 @@ const EOCD64_LOCATOR_LEN: usize = 20;
 /// follow.
 const MAX_DIRECTORY_BYTES: u64 = 64 * 1024 * 1024;
 
-/// Every member name in the raw central directory, repeats included.
+/// How many self-framing EOCD candidates are tried before the archive is
+/// refused. A real archive offers one; a comment can be stuffed with decoys.
+const MAX_EOCD_CANDIDATES: usize = 64;
+
+/// Every member name in the raw central directory, as bytes, repeats included.
 ///
 /// Why: see the module docs — a repeated name is invisible through `ZipArchive`,
 /// and it is exactly the shape that makes one archive verify here and extract
 /// differently elsewhere.
 /// What: locates the EOCD (scanning back over any archive comment), resolves the
-/// zip64 record when the classic count, size or offset is saturated, then walks
-/// the declared number of file headers, checking each signature and framing.
-/// The names come back in directory order.
+/// zip64 record when the classic count or offset is saturated, then walks the
+/// declared number of file headers, checking each signature and framing. The
+/// names come back undecoded, in directory order.
+///
+/// # Preconditions
+/// `package` is an archive this crate assembled: the zip begins at byte 0 with
+/// no prepended data. The EOCD's central-directory offset is therefore used as
+/// an absolute file offset, where `zip` corrects for a prefix with its own
+/// `archive_offset` (`read.rs:531`). An archive with prepended bytes — a
+/// self-extracting stub, a concatenated file — fails
+/// [`SigningError::DirectoryMalformed`] here rather than being misread, so the
+/// narrower assumption fails closed; it is stated because the failure would
+/// otherwise look like corruption.
 ///
 /// # Postconditions
 /// The returned vector has exactly the length the directory declares. A record
 /// whose signature or framing is wrong is [`SigningError::DirectoryMalformed`],
 /// never a short read that would under-report the member set.
 /// Test: `super::signing::signing_tests::a_duplicate_central_directory_record_is_refused`,
-/// `super::signing::signing_tests::the_raw_directory_matches_what_the_zip_parser_exposes`.
+/// `super::signing::signing_tests::the_raw_directory_matches_what_the_zip_parser_exposes`,
+/// `super::signing::signing_tests::a_comment_carrying_a_fake_eocd_signature_is_refused_not_believed`,
+/// `super::signing::signing_tests::a_directory_truncated_mid_record_is_refused`,
+/// `super::signing::signing_tests::a_saturated_eocd_with_no_zip64_locator_is_refused`,
+/// `super::signing::signing_tests::a_forged_entry_count_is_refused_without_a_panic`.
 ///
 /// # Errors
 ///
@@ -75,7 +101,7 @@ const MAX_DIRECTORY_BYTES: u64 = 64 * 1024 * 1024;
 /// is required and absent, the directory exceeds [`MAX_DIRECTORY_BYTES`], or a
 /// record's signature or lengths do not frame the directory; and
 /// [`SigningError::Archive`] for any read failure.
-pub(super) fn member_names(package: &Path) -> Result<Vec<String>, SigningError> {
+pub(super) fn member_names(package: &Path) -> Result<Vec<Vec<u8>>, SigningError> {
     let mut file = std::fs::File::open(package).map_err(|source| SigningError::Archive {
         path: package.to_path_buf(),
         source,
@@ -89,11 +115,35 @@ pub(super) fn member_names(package: &Path) -> Result<Vec<String>, SigningError> 
         .len();
 
     let tail_len = length.min((EOCD_LEN + usize::from(u16::MAX)) as u64);
-    let tail = read_at(&mut file, package, length - tail_len, tail_len)?;
-    let eocd =
-        find_eocd(&tail).ok_or_else(|| malformed(package, "no end-of-central-directory record"))?;
+    let tail_at = length - tail_len;
+    let tail = read_at(&mut file, package, tail_at, tail_len)?;
 
-    let (entries, size, offset) = locate(&mut file, package, &tail, eocd)?;
+    // A comment can carry a whole well-framed EOCD of its own — an empty one
+    // sitting at the end of the file satisfies every check a single candidate
+    // could make — so candidates are tried in turn and the first that describes
+    // a directory it can actually walk wins. An attacker can only satisfy that
+    // by supplying a real directory, which the caller's duplicate and count
+    // checks then judge.
+    let mut refusal = None;
+    for eocd in eocd_candidates(&tail, tail_at, length) {
+        match resolve(&mut file, package, &tail, eocd, tail_at, length) {
+            Ok(names) => return Ok(names),
+            Err(e) => refusal = Some(e),
+        }
+    }
+    Err(refusal.unwrap_or_else(|| malformed(package, "no end-of-central-directory record")))
+}
+
+/// One candidate EOCD, resolved through to a walked directory.
+fn resolve(
+    file: &mut std::fs::File,
+    package: &Path,
+    tail: &[u8],
+    eocd: usize,
+    tail_at: u64,
+    length: u64,
+) -> Result<Vec<Vec<u8>>, SigningError> {
+    let (entries, size, offset, directory_end) = locate(file, package, tail, eocd)?;
     if size > MAX_DIRECTORY_BYTES {
         return Err(malformed(
             package,
@@ -106,7 +156,19 @@ pub(super) fn member_names(package: &Path) -> Result<Vec<String>, SigningError> 
             "the central directory runs past the end of the file",
         ));
     }
-    let directory = read_at(&mut file, package, offset, size)?;
+    // The directory ends where the record that describes it begins. This is
+    // what tells a real EOCD from a well-framed decoy in a comment, and it is
+    // also the check that turns the no-prepended-bytes precondition from an
+    // assumption into a refusal: a prefixed archive's stored offsets are short
+    // by the prefix, so they do not meet their own record.
+    let directory_end = directory_end.unwrap_or(tail_at + eocd as u64);
+    if offset.saturating_add(size) != directory_end {
+        return Err(malformed(
+            package,
+            "the central directory does not end where the record describing it begins",
+        ));
+    }
+    let directory = read_at(file, package, offset, size)?;
     walk(package, &directory, entries)
 }
 
@@ -115,20 +177,27 @@ pub(super) fn member_names(package: &Path) -> Result<Vec<String>, SigningError> 
 ///
 /// A package member can exceed the 4 GiB classic ceiling (`super::start` writes
 /// a zip64 local header for one), so zip64 is handled rather than refused.
+///
+/// The fourth element is where the directory must end when zip64 answered —
+/// the zip64 record's own offset, since that record and its locator sit between
+/// the directory and the classic EOCD. `None` means the classic EOCD is the end.
 fn locate(
     file: &mut std::fs::File,
     package: &Path,
     tail: &[u8],
     eocd: usize,
-) -> Result<(u64, u64, u64), SigningError> {
+) -> Result<(u64, u64, u64, Option<u64>), SigningError> {
     let entries = u64::from(u16(tail, eocd + 10));
     let size = u64::from(u32(tail, eocd + 12));
     let offset = u64::from(u32(tail, eocd + 16));
-    let saturated = entries == u64::from(u16::MAX)
-        || size == u64::from(u32::MAX)
-        || offset == u64::from(u32::MAX);
+    // The parser's own rule, matched exactly: `spec.rs:369`'s `may_be_zip64`
+    // tests the entry count and the directory offset, and NOT the directory
+    // size. A directory that happens to be 0xFFFFFFFF bytes long is a classic
+    // archive to `zip`, and reading it as zip64 here would disagree with the
+    // parser on an archive neither of us should refuse.
+    let saturated = entries == u64::from(u16::MAX) || offset == u64::from(u32::MAX);
     if !saturated {
-        return Ok((entries, size, offset));
+        return Ok((entries, size, offset, None));
     }
 
     let locator = eocd
@@ -143,11 +212,16 @@ fn locate(
             "the zip64 locator does not point at a zip64 record",
         ));
     }
-    Ok((u64(&record, 32), u64(&record, 40), u64(&record, 48)))
+    Ok((
+        u64(&record, 32),
+        u64(&record, 40),
+        u64(&record, 48),
+        Some(record_at),
+    ))
 }
 
-/// One pass over the directory, returning a name per declared record.
-fn walk(package: &Path, directory: &[u8], entries: u64) -> Result<Vec<String>, SigningError> {
+/// One pass over the directory, returning a raw name per declared record.
+fn walk(package: &Path, directory: &[u8], entries: u64) -> Result<Vec<Vec<u8>>, SigningError> {
     let entries = usize::try_from(entries).map_err(|_| {
         malformed(
             package,
@@ -176,22 +250,37 @@ fn walk(package: &Path, directory: &[u8], entries: u64) -> Result<Vec<String>, S
                 &format!("central-directory record {index} runs past the directory"),
             ));
         }
-        // Lossy on purpose: a name this reader cannot decode still has to be
-        // COUNTED, because refusing to name it is how a duplicate hides.
-        names.push(String::from_utf8_lossy(&directory[name_at..name_at + name_len]).into_owned());
+        // Undecoded: `zip` chooses UTF-8 or CP437 by flag bit 11, so any single
+        // rule applied here would disagree with it on a legitimate archive.
+        names.push(directory[name_at..name_at + name_len].to_vec());
         at = end;
     }
     Ok(names)
 }
 
-/// The last EOCD signature in `tail` that leaves a whole record behind it.
+/// Candidate EOCD positions, latest first.
 ///
-/// Scanned backwards because the archive comment is arbitrary bytes and may
-/// itself contain the signature; the real record is the last viable one.
-fn find_eocd(tail: &[u8]) -> Option<usize> {
-    (0..=tail.len().checked_sub(EOCD_LEN)?)
+/// The archive comment is arbitrary bytes and may carry the EOCD signature, so
+/// "the last signature in the file" is a rule an attacker writes the answer to.
+/// A candidate must at least frame itself — its declared comment length has to
+/// end exactly at the end of the file, since the comment is the archive's last
+/// bytes by definition. That still admits a decoy, which is why the caller
+/// judges each one by whether its directory walks.
+///
+/// Capped, so a comment stuffed with signatures costs a bounded number of
+/// seeks rather than one per byte.
+fn eocd_candidates(tail: &[u8], tail_at: u64, length: u64) -> Vec<usize> {
+    let Some(last) = tail.len().checked_sub(EOCD_LEN) else {
+        return Vec::new();
+    };
+    (0..=last)
         .rev()
-        .find(|at| u32(tail, *at) == EOCD_SIGNATURE)
+        .filter(|at| {
+            u32(tail, *at) == EOCD_SIGNATURE
+                && tail_at + *at as u64 + EOCD_LEN as u64 + u64::from(u16(tail, at + 20)) == length
+        })
+        .take(MAX_EOCD_CANDIDATES)
+        .collect()
 }
 
 fn read_at(

--- a/crates/trusty-audit/templates/engagement.template.toml
+++ b/crates/trusty-audit/templates/engagement.template.toml
@@ -159,6 +159,29 @@ code_only = true
 # api_key = "lin_api_…"
 
 # ---------------------------------------------------------------------------
+# Signing the return package
+# ---------------------------------------------------------------------------
+
+# The ed25519 private key this engagement signs its return package with
+# (#5481). 32 bytes of hex. Your auditor mints one keypair per engagement, puts
+# the private half here, and keeps the public half to check what you send back.
+#
+# Absent or blank means the package ships UNSIGNED: the manifest of file
+# hashes is still written, `taudit` prints an UNSIGNED line beside the file it
+# wrote, and the package README says so. Nothing refuses to build.
+#
+# This key is yours for this engagement only. `taudit distribute` drops the
+# table when it builds a package for a DIFFERENT engagement, so no client's
+# key can reach another's package.
+#
+# What a signature here proves and does not: it shows the package was not
+# altered between this machine and your auditor. It cannot show anything about
+# what happened on this machine, because the key is on it.
+#
+# [signing]
+# private_key = "…"
+
+# ---------------------------------------------------------------------------
 # Inference identity
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The return channel is manual (#5642) — the recipient emails a zip — and nothing
about a file that arrived that way said it was the file that was written. Every
member's SHA-256 now goes into `manifest.sha256.toml`, and when the engagement
config sets `[signing] private_key`, a detached ed25519 signature over that
manifest's exact bytes goes into `manifest.sha256.sig`. Signing one small
manifest rather than each file is the whole reason the manifest exists.

`package::signing::verify` checks a received package against the retained public
key. An engagement with no key still packages: the manifest ships without a
`[signature]` table, `verify` answers `Unsigned` as its own outcome, and the CLI
line and package README both say so. The limit is stated wherever the property
is claimed and is not softened — the key is on hardware the recipient controls,
so this is tamper-evidence in transit, not proof about the sender.

#5563 owns the `trusty-audit verify` CLI arm over this library call; this PR
keeps one implementation behind it and any front end. See DOC-68 §10 and §14 Q5
for that split.

## Crate: trusty-audit, not tga

The issue is titled `feat(tga)` and predates #5499, which moved package assembly
into `trusty-audit`. DOC-68 §10 names `trusty-audit` as the owner of "Step 5 —
Assemble and Sign", and #5499's own commit states the boundary: "this module
signs nothing and hashes nothing. #5481 owns the ed25519 manifest."
`crates/trusty-git-analytics/src/audit/` assembles no package.

## Design departure from what #5499 anticipated

That commit expected the manifest to be written into `out/` and packaged
verbatim. It cannot work: a manifest written there cannot cover `README.md`,
`package.toml`, `reports/index.md`, `reports/report.json` or
`errors/digest.json`, none of which exist until the archive is being filled. So
the manifest and signature are the LAST two members, and each digest is taken
from the bytes as they reach the archive, inside the pass `credential_scan`
already makes over them. Hashing the source file separately would record a
digest for bytes the package does not contain.

## Two security fixes shipped alongside

- The signing key joins `EngagementConfig::configured_secrets`, so the outbound
  scan refuses a package member carrying it. The private half must not come back
  inside the package it signed.
- `config::generate_for_new_engagement` drops a `[signing]` table, for the same
  reason it drops `[boards]` (#5861): an auditor reusing a template would
  otherwise ship engagement A's signing key inside client B's package, letting B
  sign as A. The in-place render keeps it, because there it is the recipient's
  own key.

## Review rounds

Four `code-critic` rounds; the first three found real defects.

**Round 1 (BLOCK), two findings plus a scan hit.**

1. `zip` 2.4.2 keys its entry table by member name (`read.rs:50`), so a second
   central-directory record under an already-signed name collapsed before any
   caller saw it — `verify` would report Signed over the copy this parser picked
   while Python's `zipfile`, Info-ZIP or Finder extracted the other. Every public
   accessor reads that same map, so `package::zip_directory` walks the central
   directory by hand and `verify` establishes the member set before reading
   anything.
2. `read_member` sized its buffer with `Vec::with_capacity(member.size())`, from
   metadata whoever sent the package wrote. Members now stream through a fixed
   64 KiB buffer; `digest_member` hashes without materializing one at all.
3. Scan hit: the `SigningSettings` doc comment quoted the RFC 8032 test-vector
   seed in full. Replaced with 64 zeros.

**Round 2 (WARN), four findings.** Failure-path tests for the walker; names
decoded with one fixed rule where `zip` picks UTF-8 or CP437 by flag bit 11;
`saturated` also firing on `size == u32::MAX` where `may_be_zip64` checks only
entries and offset; the no-prepended-bytes precondition undocumented.

Writing those tests exposed a further defect: "the last EOCD signature in the
file" is a rule whoever sends the package answers, since a comment carrying
`PK\x05\x06` sits at a higher offset than the real record. A candidate must now
frame itself and its directory must end where the record describing it begins,
with candidates tried in order and capped at 64.

**Round 3 (BLOCK), one finding.** Round 2 had replaced a set equality with a
count comparison, which accepts two independently walkable directories of equal
size and different contents — constructible by the candidate scan added in the
same commit. Both checks are now present: the count catches records that collapse
into one, the set catches directories that do not. The comparison is raw bytes
against the parser's own raw bytes via `ZipFile::name_raw`, because zip's CP437
table is a private module and any decode written here would be a second
implementation of the rule it exists to agree with.

**Round 4: APPROVE.**

## Residual scope limit

Both sides read the CENTRAL directory. A member's LOCAL header name is not
compared against its central-directory name, so an archive whose two copies of a
name disagree is not detected here. Every member's content is still hashed
through the parser, which reads data at the offset the central directory gives,
so a mismatched local name cannot change what was verified — it could only
change what a different extractor writes to disk.

## Gates — rung 5 (security)

```
cargo fmt --check                                            EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings     EXIT=0
cargo check --workspace --all-targets                         EXIT=0
cargo test -p trusty-audit --no-fail-fast                     EXIT=0
```

Per-target, with `--no-fail-fast`: `1032 passed; 0 failed; 5 ignored` (lib), then
0, 0, 3, 5, 4, 4 (2 ignored), 8, 9, 0 passed with 0 failed on every other target.
The signing module's own 22 tests are inside that lib count.

Script gates:

```
line-cap: 4578 tracked .rs file(s); 4 allowlisted, 0 violations — OK
test-pointers: 31822 Test: citation(s) — 0 dangling pointers — OK
sld-lint: 63 spec doc(s) + 3716 code file(s); 0 error(s), 0 warning(s)
check_workspace_dep_versions: all 12 internal row(s) accept their member version
check_changelog_fragment: trusty-audit fragment present and valid
check-pr-version-bump: clear — trusty-audit 0.14.4, version not yet published
check_rustdoc_links: 26 crate(s), 0 broken link(s), baseline 0
```

Each closure-condition test was mutation-proved: disabling the check it covers
makes it fail, restoring it makes it pass.

`ed25519-dalek` and `rand_core` are new `[workspace.dependencies]` rows, both
already in `Cargo.lock` transitively. Hex is hand-rolled in the
`GithubAccess::fingerprint` spelling (#5980) rather than adding `hex`.

Refs #5481

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
