### PR TITLE
docs(claude-md): the changelog-fragment test-only exemption is by file path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,6 +399,16 @@ crates/<crate>/changelog.d/<issue-or-pr-number>-<short-slug>.md
 
 - Format and category line: `Skill(skill="tm-workflow")`. Assembler and CI-gate
   specifics: [changelog-fragments.md](docs/reference/changelog-fragments.md).
+- 🔴 **The test-only exemption is decided by FILE PATH, not by what changed
+  inside the file (#7033).** `check_changelog_fragment.sh` (via
+  `scripts/lib/source_class.sh`) classifies a path as test-only when its
+  basename is exactly `tests.rs`, ends `_test.rs`/`_tests.rs`, or a path
+  segment is `/tests/`, `/benches/`, or `/testdata/` — nothing else. An edit
+  confined to an inline `#[cfg(test)] mod tests { … }` block inside a
+  `src/**` production file still owes a fragment: the file itself is a
+  production path under that rule, even though `check_line_cap.sh` excludes
+  that exact block from the SLOC count (#5153). Same input, two different
+  rulings, by design.
 - 🟡 `check_changelog_fragment.sh` diffs `origin/main..HEAD`, so the default run
   sees nothing until the change is committed. Before committing, use
   `--staged` (the index plus untracked files) or `--file <path>` (one


### PR DESCRIPTION
Refs #7033
Refs #4476

## Summary

Adds one bullet to CLAUDE.md's "Per-PR Changelog Fragment" section: the changelog gate's test-only exemption is decided by file path (basename `tests.rs`, `_test.rs`/`_tests.rs` suffix, or a `/tests/`, `/benches/`, `/testdata/` path segment), not by what changed inside a file. An edit confined to an inline `#[cfg(test)] mod tests { … }` block inside a `src/**` production file is still a production path under `scripts/check_changelog_fragment.sh` / `scripts/lib/source_class.sh`, and still owes a fragment, even though `scripts/check_line_cap.sh` excludes that same block from the SLOC count (#5153).

## Test plan

Rung 1 (docs-only). Gates run and passed:
- `./scripts/check_sld.sh` — 0 errors, 0 warnings
- `./scripts/check_line_cap.sh` — 0 violations
- `./scripts/check_doc_numbers.sh` — 0 violations

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
