### PR TITLE
test(trusty-mpm): serialize the two $HOME-reading paths.rs tests (#7033)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7033-paths-home-race.md
+++ b/crates/trusty-mpm/changelog.d/7033-paths-home-race.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Serialize the two `core::paths` tests that read `$HOME` twice and compare the results, so a concurrent `$HOME`-repointing writer in the `--lib` binary can no longer split the two reads and fail the run (#7033).

--- a/crates/trusty-mpm/src/core/paths.rs
+++ b/crates/trusty-mpm/src/core/paths.rs
@@ -845,9 +845,16 @@ mod tests {
     /// from — otherwise a test built on the explicit form would prove something
     /// production never does.
     ///
-    /// Needs no `$HOME` redirect and no `#[serial]`: both sides read the same
-    /// `home_base()` within one expression, so a concurrent `$HOME` mutation
-    /// cannot make them disagree in a way that means anything.
+    /// Needs no `$HOME` redirect, but does need `#[serial]` (#7033). The
+    /// earlier claim here — that both sides read one `home_base()` within a
+    /// single expression — was wrong: the left side captures `home_base()`
+    /// into `base`, while `for_managed_workspace` on the right calls
+    /// `home_base()` again internally. That is two separate `$HOME` reads
+    /// compared for equality, so a writer repointing `$HOME` between them
+    /// splits the sides. Same race class as
+    /// `home_base_is_what_default_resolves_against` below.
+    // #7033: serialized against this binary's `$HOME`-repointing writers.
+    #[serial_test::serial]
     #[test]
     fn for_managed_workspace_under_matches_for_managed_workspace_at_home() {
         let base = FrameworkPaths::home_base();
@@ -859,6 +866,18 @@ mod tests {
 
     /// #5040: `home_base` must be exactly the base `default` nests under, so a
     /// caller threading the base explicitly stays on the production layout.
+    ///
+    /// #7033: reads `$HOME` twice — once through `home_base()` on the left,
+    /// once inside `default()` on the right — and compares the two. A
+    /// `$HOME`-repointing writer landing between the reads makes the sides
+    /// disagree (observed: left a temp-dir root, right the real
+    /// `~/.trusty-mpm`), which is a race, not a `home_base` logic failure.
+    /// Joining the same `#[serial_test::serial]` group the writers and the
+    /// other two-read readers in this binary already use closes that window.
+    /// Only `cargo test`'s shared-process `--lib` binary is affected; under
+    /// `cargo nextest` every test gets its own process (#4162).
+    // #7033: serialized against this binary's `$HOME`-repointing writers.
+    #[serial_test::serial]
     #[test]
     fn home_base_is_what_default_resolves_against() {
         assert_eq!(


### PR DESCRIPTION
Refs #7033

**Rung 2** (test-only stabilization).

## What changed

Two `#[serial_test::serial]` attributes in `crates/trusty-mpm/src/core/paths.rs`, each with a `// #7033:` marker at the change site. No new mechanism — this is the crate's existing unnamed serial group, the one its `$HOME` writers (`services/manifest.rs`, `core/home_trust_seed.rs`, `runtime/claude_code_tests.rs`) and its three already-serial two-read readers use.

- `home_base_is_what_default_resolves_against` — the reported flake. Reads `$HOME` through `home_base()` on the left and again inside `default()` on the right, then compares.
- `for_managed_workspace_under_matches_for_managed_workspace_at_home` — the same defect, also unguarded, found while auditing. Its doc comment claimed both sides read one `home_base()` within a single expression. That was wrong: the left side captures `home_base()` into `base`, while `for_managed_workspace` on the right calls `home_base()` again internally. The comment is corrected rather than left as a stale justification for removing the guard later.

## Every `$HOME` reader in paths.rs

The real readers are the constructors that call `dirs::home_dir()` — `home_base()`, and `default()` / `for_managed_workspace()` through it.

| Test | Reads | Guard |
|---|---|---|
| `default_resolves_under_trusty_mpm` | `default()` x1 | none needed — one snapshot, all assertions derived from it |
| `default_is_a_single_global_path_never_project_relative` | `default()` x2 | `#[serial]` pre-existing |
| `for_managed_workspace_targets_workspace_local_claude_dirs` | `for_managed_workspace()` x1 | none needed — every assertion is workspace-derived |
| `for_managed_workspace_keeps_framework_source_at_default_root` | `default()` + `for_managed_workspace()` | `#[serial]` pre-existing |
| `for_managed_workspace_under_matches_for_managed_workspace_at_home` | `home_base()` + `for_managed_workspace()` | **`#[serial]` added** |
| `home_base_is_what_default_resolves_against` | `home_base()` + `default()` | **`#[serial]` added** |
| `claude_home_dir_matches_default_home` | `default()` + `dirs::home_dir()` | `#[serial]` pre-existing |

No unguarded multi-read test remains.

## The race did not reproduce in ten unguarded runs

Stating that plainly. Ten runs of `cargo test -p trusty-mpm --lib --no-fail-fast` on the unmodified code — the guard-absent state, since neither test carried `#[serial]` before — all showed `core::paths::tests::home_base_is_what_default_resolves_against ... ok`.

**The fix rests on the code reading, not a captured repro.** Two `dirs::home_dir()` reads compared for equality, in a binary whose `$HOME`-repointing writers are `#[serial]`-guarded and mutate the process-global variable in-process. The reporter observed the failure once in the wild with exactly that signature — left a temp-dir root, right the real `~/.trusty-mpm`. The window is two adjacent expressions, which is consistent with ten local runs not landing in it.

Only `cargo test`'s shared-process `--lib` binary is affected; under `cargo nextest` every test gets its own process (#4162), so CI's shards never see this class.

## Verification

Ten unguarded runs (reproduction attempt) and ten guarded runs (fix confirmation), each `cargo test -p trusty-mpm --lib --no-fail-fast`. All ten guarded runs:

```
test result: ok. 6077 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out
```

Full crate, every target, `--no-fail-fast` — 51 targets plus doc-tests, all `ok` with `0 failed`:

```
     Running unittests src/lib.rs
test result: ok. 6077 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out; finished in 55.37s
     Running unittests src/bin/tm/main.rs
test result: ok. 2185 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 12.93s
   Doc-tests trusty_mpm
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.30s
EXIT=0
```

Confirmation run after rebasing onto `5698de315`:

```
test core::paths::tests::for_managed_workspace_under_matches_for_managed_workspace_at_home ... ok
test core::paths::tests::home_base_is_what_default_resolves_against ... ok
test result: ok. 6083 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out; finished in 56.55s
```

Gates, all exit 0: `cargo fmt --check`; `cargo clippy -p trusty-mpm --all-targets -- -D warnings`; `cargo test -p trusty-mpm --no-fail-fast`; `check_line_cap.sh`; `check_test_pointers.sh`; `check_changelog_fragment.sh`; `check-pr-version-bump.sh` (1.5.18 unchanged, `src changed, version not yet published`).

## Changelog fragment

Included, though the edit is confined to the inline `#[cfg(test)] mod tests` block. `check_changelog_fragment.sh` classifies test files by PATH (`scripts/lib/source_class.sh`: basename `tests.rs`, ending `_test.rs`/`_tests.rs`, or a `/tests/` or `/benches/` segment), and `src/core/paths.rs` matches none — so the gate reads this as a source change and fails without one.

## Out of scope

`session_manager::worktree_reclaim::worktree_reclaim_tests::pr_index_from_gh_reads_this_repository` failed once across the twenty full-lib runs. It shells out to `gh` against this repository, so it depends on network and API availability — a separate flake, not touched here, and it did not recur in the other nineteen runs.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
