### PR TITLE
fix(trusty-audit): preflight refuses a non-executable pinned tool; report.json names its build

### DIFF
--- a/crates/trusty-audit/changelog.d/6139-preflight-exec-bit.md
+++ b/crates/trusty-audit/changelog.d/6139-preflight-exec-bit.md
@@ -1,0 +1,21 @@
+Fixed
+
+- The pinned-tool preflight now refuses a binary it cannot execute. Its three
+  conditions — the file is there, this client verified a version for it, and
+  that version is the engagement's pin — answered which binary would run, never
+  whether it could. A pinned copy whose execute bit was lost to a `cp`, an
+  archive extraction or a hand edit satisfied all three, so the run started and
+  then failed once per repository at spawn with `Permission denied (os error
+  13)`, a message naming neither the tool nor the file. The refusal is a new
+  `AuditError::PinnedToolNotExecutable` naming the tool and the path and saying
+  the mode is the problem, raised before the first repository is touched, so
+  nothing is written when it fires. An operator's `TRUSTY_AUDIT_*_BIN` override
+  already refused on the same condition; this is that check on the pinned path.
+  Unix only — Windows has no execute bit, and spawn stays the arbiter there.
+- The bundle-level `reports/report.json` now carries `trusty_audit_version`, the
+  version of the binary that wrote it. It was the one generated artifact with no
+  version stamp — the index's "Produced by" line and Versions table, the excerpt
+  header and the error digest all already had one — so a recipient reading
+  `report.json` alone could not say which build's counting rules produced the
+  numbers. Additive: `generated_at` and `debt_rollup` are unchanged, and a
+  reader that does not model the new field ignores it (issue #6139).

--- a/crates/trusty-audit/src/debt_rollup.rs
+++ b/crates/trusty-audit/src/debt_rollup.rs
@@ -374,14 +374,24 @@ where
 /// Why: a named block rather than a bare roll-up at the document root, so a
 /// later run-level fact can join it without moving the counts a consumer has
 /// already wired to.
-/// What: the run's local timestamp — the same string the index states — and the
-/// `debt_rollup` block itself.
-/// Test: `debt_rollup_tests::the_json_carries_the_rollup_block`.
+/// What: the run's local timestamp — the same string the index states — the
+/// version of the binary that produced it, and the `debt_rollup` block itself.
+/// Test: `debt_rollup_tests::the_json_carries_the_rollup_block`,
+/// `debt_rollup_tests::the_json_names_the_binary_that_produced_it`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 pub struct BundleReport<'a> {
     /// Local time with its UTC offset, from `crate::index_report::local_now`.
     pub generated_at: &'a str,
+    /// The `trusty-audit` version that wrote this document.
+    ///
+    /// #6139: every other generated artifact already stamps it — the index's
+    /// "Produced by" line and Versions table, the excerpt and error-digest
+    /// headers — and this bundle-level document was the one that did not, so a
+    /// recipient reading `report.json` alone could not say which build's
+    /// counting rules produced the numbers. Additive: a reader that does not
+    /// model the field ignores it.
+    pub trusty_audit_version: &'static str,
     /// The counts, by tier, by dimension, by repository, and by tier × dimension.
     pub debt_rollup: &'a DebtRollup,
 }
@@ -391,11 +401,15 @@ pub struct BundleReport<'a> {
 /// Serialisation of `BTreeMap`s and `usize`s cannot fail, so the fallible arm is
 /// unreachable; it still yields an empty document rather than panicking, because
 /// a run that has just written every report must not die on its index.
-/// Test: `debt_rollup_tests::the_json_carries_the_rollup_block`.
+/// Test: `debt_rollup_tests::the_json_carries_the_rollup_block`,
+/// `debt_rollup_tests::the_json_names_the_binary_that_produced_it`.
 #[must_use]
 pub fn to_json(rollup: &DebtRollup, generated_at: &str) -> String {
     let document = BundleReport {
         generated_at,
+        // #6139: the stamp is this binary's own version, never a caller's
+        // argument — a report cannot then name a build that did not write it.
+        trusty_audit_version: env!("CARGO_PKG_VERSION"),
         debt_rollup: rollup,
     };
     serde_json::to_string_pretty(&document).unwrap_or_else(|_| "{}".to_owned())
@@ -404,7 +418,8 @@ pub fn to_json(rollup: &DebtRollup, generated_at: &str) -> String {
 /// Write `report.json` into `dir`, replacing any earlier one.
 ///
 /// # Postconditions
-/// On `Ok`, `dir/report.json` carries this run's `debt_rollup` block. Nothing
+/// On `Ok`, `dir/report.json` carries this run's `debt_rollup` block and the
+/// version of the binary that wrote it (#6139). Nothing
 /// outside `dir` is written, which is what keeps `crate::rerender`'s "the source
 /// package is only read" postcondition true.
 ///
@@ -617,6 +632,28 @@ mod debt_rollup_tests {
         assert_eq!(block["by_dimension"]["churn"], 1);
         assert_eq!(block["by_repo"]["acme-ops"]["RED"], 1);
         assert_eq!(block["by_tier_dimension"]["RED"]["secrets"], 2);
+    }
+
+    /// 🔴 #6139: the bundle-level `report.json` was the one generated artifact
+    /// carrying no version, so a recipient reading it alone could not say which
+    /// build's counting rules produced the numbers. The index states it, the
+    /// excerpt and error-digest headers state it, and now so does this.
+    ///
+    /// Read back off disk rather than out of [`to_json`], because the file is
+    /// what the recipient gets.
+    #[test]
+    fn the_json_names_the_binary_that_produced_it() {
+        let (tmp, rollup) = three_repositories();
+        let out = tmp.path().join("out");
+        std::fs::create_dir_all(&out).expect("mkdir out");
+        write(&rollup, "2026-09-04 11:00:00 -04:00", &out).expect("writes");
+
+        let text = std::fs::read_to_string(out.join(REPORT_FILE)).expect("reads");
+        let parsed: serde_json::Value = serde_json::from_str(&text).expect("valid JSON");
+        assert_eq!(parsed["trusty_audit_version"], env!("CARGO_PKG_VERSION"));
+        // Additive: the fields an older reader already models are untouched.
+        assert_eq!(parsed["generated_at"], "2026-09-04 11:00:00 -04:00");
+        assert_eq!(parsed["debt_rollup"]["total"], 6);
     }
 
     #[test]

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -384,6 +384,30 @@ pub enum AuditError {
         missing: Vec<&'static str>,
     },
 
+    /// A pinned tool is present at the pinned version but cannot be executed.
+    ///
+    /// Why: #6139 — the three pin conditions prove WHICH binary would run, not
+    /// that it CAN run. A pinned copy whose execute bit is gone satisfies all
+    /// three, so the preflight passed it and every repository then failed at
+    /// spawn with `Permission denied (os error 13)` — a message naming neither
+    /// the tool nor the file, repeated once per repository. An operator's
+    /// override already refuses on the same condition
+    /// ([`AuditError::ToolOverride`]); the pinned path had no such check.
+    /// What: names the tool and the path, and says the mode is the problem, so
+    /// the reader knows to restore the execute bit rather than to reinstall.
+    /// Test: `crate::run::run_tests::a_pinned_binary_without_its_execute_bit_is_refused`.
+    #[error(
+        "the pinned {tool} at {} is not executable; restore its execute bit \
+         (`chmod +x`) or reinstall it (`trusty-audit install`) — nothing was audited",
+        path.display()
+    )]
+    PinnedToolNotExecutable {
+        /// The tool whose binary cannot be run.
+        tool: &'static str,
+        /// The pinned binary's path.
+        path: PathBuf,
+    },
+
     /// An operator's tool override names a path that cannot be run.
     ///
     /// Why: #6132 gives an operator one documented way to point the chain at a

--- a/crates/trusty-audit/src/run.rs
+++ b/crates/trusty-audit/src/run.rs
@@ -1625,6 +1625,73 @@ exit 0
         );
     }
 
+    /// 🔴 #6139: the three pin conditions prove WHICH binary would run, never
+    /// that it CAN run. A pinned copy at the right version with its execute bit
+    /// gone satisfied all three, so the preflight passed it and every repository
+    /// then failed at spawn with `Permission denied (os error 13)` — a message
+    /// naming neither the tool nor the file.
+    ///
+    /// Both halves live here because the mode is the only thing that differs
+    /// between them: the same fixture is accepted at 0755 and refused at 0644.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_pinned_binary_without_its_execute_bit_is_refused() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        make_repo(&work, "acme-api");
+        select(&work, &[("acme-api", "repos/acme-api")]);
+        install_stubs(&work, "#!/bin/sh\nexit 0\n");
+        let none = ToolOverrides::default();
+
+        // Executable, installed, at the pin: accepted, exactly as before.
+        pinned_binaries(&work, &config().tools, &none).expect("0755 stubs are runnable");
+
+        // The same files, still present and still at the pinned version. Only
+        // the mode changes.
+        let tga = RequiredTool::Tga.path_in(&work);
+        std::fs::set_permissions(&tga, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+
+        let err = sweep(&work, &config(), &RunOptions::default(), &Progress::none())
+            .await
+            .expect_err("a binary that cannot be executed cannot be driven");
+        let AuditError::PinnedToolNotExecutable { tool, path } = err else {
+            panic!("expected PinnedToolNotExecutable, got {err:?}");
+        };
+        assert_eq!(tool, "tga");
+        assert_eq!(path, tga);
+
+        // The refusal came before the sweep, so the deliverable was never
+        // opened — this is the whole point of catching it in the preflight.
+        assert!(
+            std::fs::read_dir(work.path(Area::Output))
+                .expect("output area exists")
+                .next()
+                .is_none(),
+            "nothing may be written when the preflight refuses"
+        );
+
+        let rendered = AuditError::PinnedToolNotExecutable {
+            tool,
+            path: path.clone(),
+        }
+        .to_string();
+        assert!(rendered.contains("tga"), "names the tool: {rendered}");
+        assert!(
+            rendered.contains(&path.display().to_string()),
+            "names the path: {rendered}"
+        );
+        assert!(
+            rendered.contains("not executable"),
+            "says what is wrong: {rendered}"
+        );
+        assert!(
+            !rendered.contains("os error"),
+            "never a raw OS error: {rendered}"
+        );
+    }
+
     /// A stub `tga` that names ITSELF in the output, so a test can prove which
     /// binary ran rather than that one did (#6132).
     fn writes_a_manifest_naming(marker: &str) -> String {

--- a/crates/trusty-audit/src/run/pins.rs
+++ b/crates/trusty-audit/src/run/pins.rs
@@ -65,8 +65,9 @@ pub(super) struct PinnedBinaries {
 ///
 /// [`AuditError::ToolsNotInstalled`] naming every non-overridden tool that is
 /// missing or unverified, [`AuditError::VersionMismatch`] for the first such
-/// tool whose recorded version is not the engagement's pin, and whatever
-/// [`tools::status`] fails with.
+/// tool whose recorded version is not the engagement's pin,
+/// [`AuditError::PinnedToolNotExecutable`] for the first whose execute bit is
+/// gone (#6139), and whatever [`tools::status`] fails with.
 pub(super) fn pinned_binaries(
     work: &WorkDir,
     pins: &ToolPins,
@@ -100,7 +101,9 @@ pub(super) fn pinned_binaries(
         })?;
         // `version` is Some: the missing check above rejected every None.
         match status.version.as_deref() {
-            Some(v) if v == pinned => Ok(status.path.clone()),
+            // #6139: the pin is right, so the last question is whether the file
+            // can run at all.
+            Some(v) if v == pinned => runnable(tool, status.path.clone()),
             Some(v) => Err(AuditError::VersionMismatch {
                 tool: tool.crate_name(),
                 pinned: pinned.to_owned(),
@@ -118,4 +121,38 @@ pub(super) fn pinned_binaries(
         analyze: path_of(RequiredTool::TrustyAnalyze)?,
         review: path_of(RequiredTool::TrustyReview)?,
     })
+}
+
+/// `path` back, or a refusal because the pinned binary cannot be executed.
+///
+/// Why: #6139 — the three pin conditions answer which binary would run, never
+/// whether it can. A pinned copy whose mode was lost to a `cp`, an archive
+/// extraction or a hand edit passed all three, and the run then failed once per
+/// repository at `crate::run::child`'s spawn with a raw
+/// `Permission denied (os error 13)` naming neither the tool nor the file.
+/// [`crate::tool_overrides`] has always checked this for an override; this is
+/// the same check on the pinned path, and it runs before the first child.
+/// What: refuses when no execute bit is set. A path whose metadata cannot be
+/// read is left to spawn, which reports the specific OS error — the missing
+/// check above already established the file is there, so an unreadable mode is
+/// a different fault from the one this refuses.
+/// Test: `crate::run::run_tests::a_pinned_binary_without_its_execute_bit_is_refused`,
+/// `crate::run::run_tests::nothing_unsatisfied_is_exactly_what_the_preflight_accepts`.
+fn runnable(tool: RequiredTool, path: PathBuf) -> Result<PathBuf, AuditError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Ok(meta) = std::fs::metadata(&path)
+            && meta.permissions().mode() & 0o111 == 0
+        {
+            return Err(AuditError::PinnedToolNotExecutable {
+                tool: tool.crate_name(),
+                path,
+            });
+        }
+    }
+    // Windows has no execute bit; spawn stays the only arbiter there.
+    #[cfg(not(unix))]
+    let _ = tool;
+    Ok(path)
 }


### PR DESCRIPTION
Refs #6139

Two of the issue's three closure conditions were already met everywhere except one place each; this closes both gaps.

## Preflight for permissions, and a distinct error instead of a raw OS one

The pinned-tool preflight's three conditions — the file is there, this client verified a version for it, and that version is the engagement's pin — answer which binary would run, never whether it can. A pinned copy whose execute bit was lost to a `cp`, an archive extraction or a hand edit satisfied all three, so the sweep started and then failed once per repository at `run::child`'s spawn with `Permission denied (os error 13)` — a message naming neither the tool nor the file.

`run::pins::runnable` now reads the mode after the version check and refuses before the first child. An operator's `TRUSTY_AUDIT_*_BIN` override already refused on the same condition in `tool_overrides::validated`; this is that check on the pinned path.

New variant `AuditError::PinnedToolNotExecutable { tool, path }`. Display:

```
the pinned tga at /…/work/tools/tga is not executable; restore its execute bit
(`chmod +x`) or reinstall it (`trusty-audit install`) — nothing was audited
```

It names the tool, names the path, says the mode is the problem, and carries no `os error`. The existing variants were all wrong for this: `ToolsNotInstalled` says to install a tool that is already installed, `ToolOverride` names an environment variable nobody set, `ToolNotInstallable` is about a download, and `WorkDir` is about the directory.

**Unix only.** Windows has no execute bit, so `runnable` is the identity there and spawn stays the arbiter. A path whose metadata cannot be read also falls through to spawn — the missing-file check already ran, so an unreadable mode is a different fault from the one this refuses.

## Version stamped on report.json

The bundle-level `reports/report.json` was the one generated artifact carrying no version. The index's "Produced by" line and Versions table, the excerpt header and the error digest all already had one, so a recipient reading `report.json` alone could not say which build's counting rules produced the numbers.

`BundleReport` gains `trusty_audit_version`, filled in `to_json` from this binary's own `env!("CARGO_PKG_VERSION")` rather than from a caller's argument — a report cannot then name a build that did not write it.

Additive: `generated_at` and `debt_rollup` are unchanged, a reader that does not model the new field ignores it, and `BundleReport` was already `#[non_exhaustive]`.

## Both new tests fail on origin/main

**`run::run_tests::a_pinned_binary_without_its_execute_bit_is_refused`** carries both halves of the preflight condition, because the mode is the only thing that differs between them: `install_stubs` at 0755 is accepted by `pinned_binaries` unchanged, then `tools/tga` alone is chmod'd to 0644 and the same fixture is refused. The refusal comes out of `sweep`, and the test asserts the output area is empty — nothing was audited.

Reverting only `run/pins.rs` (`git show origin/main:… > …`) puts it back on the bug:

```
thread '…a_pinned_binary_without_its_execute_bit_is_refused' panicked at crates/trusty-audit/src/run.rs:1658:14:
a binary that cannot be executed cannot be driven: RunReport { repos: [RepoRun { … result: Failed { reason: "`tga audit` could not be started: Permission denied (os error 13)" } }], status: AllFailed, board_gaps: [] }
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1038 filtered out
```

**`debt_rollup::debt_rollup_tests::the_json_names_the_binary_that_produced_it`** reads `report.json` back off disk via `write`, not out of `to_json`, because the file is what the recipient gets. Removing only the two production lines (the field and its assignment, the test kept):

```
thread '…the_json_names_the_binary_that_produced_it' panicked at crates/trusty-audit/src/debt_rollup.rs:651:9:
assertion `left == right` failed
  left: Null
 right: "0.14.4"
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1038 filtered out
```

Both files were restored and every gate re-run on the restored tree, then again after rebasing onto `a61bd4352`.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                          EXIT=0
cargo check -p trusty-audit --all-targets                  EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings  EXIT=0
cargo test -p trusty-audit --no-fail-fast                  EXIT=0
```

Per-target counts, with `--no-fail-fast` named (#5354) — every target ran:

| target | result |
|---|---|
| `unittests src/lib.rs` | ok. 1034 passed; 0 failed; 5 ignored |
| `unittests src/main.rs` (taudit) | ok. 0 passed; 0 failed; 0 ignored |
| `unittests src/main.rs` (trusty-audit) | ok. 0 passed; 0 failed; 0 ignored |
| `tests/binary_names.rs` | ok. 3 passed; 0 failed; 0 ignored |
| `tests/cli_end_to_end.rs` | ok. 5 passed; 0 failed; 0 ignored |
| `tests/guided_launch.rs` | ok. 4 passed; 0 failed; 0 ignored |
| `tests/install_fails_closed.rs` | ok. 4 passed; 0 failed; 2 ignored |
| `tests/render_zero_arg.rs` | ok. 8 passed; 0 failed; 0 ignored |
| `tests/run_fails_closed.rs` | ok. 9 passed; 0 failed; 0 ignored |
| `Doc-tests trusty_audit` | ok. 0 passed; 0 failed; 0 ignored |

Script gates:

```
check_line_cap.sh             4582 tracked .rs; 4 allowlisted, 0 violations — OK
check_test_pointers.sh        31879 Test: citations, 0 dangling — OK
check_sld.sh                  0 errors, 0 warnings
check_changelog_fragment.sh   OK trusty-audit: fragment present and valid
check-pr-version-bump.sh      [ OK ] trusty-audit 0.14.4 — src changed, version not yet published
check_rustdoc_links.sh        26 crates, 0 broken links, baseline 0
```

No file crossed the 500-SLOC cap. Version stays at 0.14.4 — the gate passes on it being unpublished.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
