### PR TITLE
fix(trusty-mpm): pr_index_from_gh_reads_this_repository skips a failed gh lookup (#7038)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7038-pr-index-gh-flake.md
+++ b/crates/trusty-mpm/changelog.d/7038-pr-index-gh-flake.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `pr_index_from_gh_reads_this_repository` no longer fails when the `gh pr list` it makes cannot reach GitHub. The test already skipped when its repository-identity probe failed, but the `PrIndex::from_gh` call after it was unguarded, and a transient `gh` or network failure there returns an empty index — which the test read as the argv bug it exists to catch. It now asks the index for a branch this repository cannot have: a lookup that FAILED reports `LookupFailed` and the test skips naming `gh`'s own reason, while a call that answered reports `NoPr` or `Unknown` and the row assertion runs unchanged. An answered call that resolved zero branches still fails, which is the bug shape (#7038).

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -362,9 +362,12 @@ impl PrIndex {
     /// How many branches this index resolved (#2919).
     ///
     /// Why: a successful `gh` call against a repository with pull requests
-    /// yields a non-zero count, and a FAILED one yields zero — which is what
-    /// makes `pr_index_from_gh_reads_this_repository` able to tell a working
-    /// call from the silently-blocking one the `-C` bug produced.
+    /// yields a non-zero count, so a zero count from a call that ANSWERED is
+    /// the silently-blocking shape the `-C` bug produced.
+    /// What: this counts branches only. A failed call also yields zero, so a
+    /// caller distinguishing the two reads [`state_for`](Self::state_for) on an
+    /// absent branch first — `pr_index_from_gh_reads_this_repository` does, and
+    /// skips on `LookupFailed` rather than blaming the argv (#7038).
     /// Test: `pr_index_from_gh_reads_this_repository`.
     pub(crate) fn branch_count(&self) -> usize {
         self.by_branch.len()

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
@@ -1617,6 +1617,12 @@ fn gh_command_runs_in_the_requested_directory() {
 /// a fork gets deleted by whoever hits it. Gating on the repository identity,
 /// rather than on "did we get rows", keeps the assertion meaningful wherever it
 /// DOES run.
+///
+/// #7038: the identity probe is not the only live call here — `from_gh` makes a
+/// second one, and a transient failure THERE returns an empty index, which the
+/// row assertion read as the `-C` bug. `PrIndex` records why a lookup failed, so
+/// the failed call is now skipped on the same terms as the probe. What still
+/// fails is a call that ANSWERED and answered nothing, which is the bug shape.
 #[test]
 fn pr_index_from_gh_reads_this_repository() {
     const UPSTREAM: &str = "bobmatnyc/trusty-tools";
@@ -1649,6 +1655,14 @@ fn pr_index_from_gh_reads_this_repository() {
         return;
     }
     let index = PrIndex::from_gh(repo_root);
+    // #7038: a branch this repository cannot have resolves to `LookupFailed`
+    // only when the `gh pr list` inside `from_gh` itself failed — a call that
+    // answered reports `NoPr` or `Unknown` instead.
+    const ABSENT: &str = "trusty-tools-7038/no-such-branch";
+    if let BranchPrState::LookupFailed { reason } = index.state_for(Some(ABSENT)) {
+        eprintln!("skipping: `gh pr list` failed — {reason}");
+        return;
+    }
     assert!(
         index.branch_count() > 0,
         "a successful `gh pr list` against {UPSTREAM} must yield branches; an empty \


### PR DESCRIPTION
`pr_index_from_gh_reads_this_repository` guarded its repository-identity probe against a `gh` failure but not the `PrIndex::from_gh` call after it. A transient `gh` or network failure there returns an empty index, and `assert!(index.branch_count() > 0)` read that as the `-C` argv bug the test exists to catch — one red run in twenty on 2026-09-07.

**Rung 2** (test-only stabilization). Refs #7038.

## Fix shape: the second one, because no seam exists

`PrIndex::from_gh` takes a `&Path` and builds its `gh` command inside a closure handed to a process-global gate (`gh_gate::shared().poll`) — there is nothing to inject a fixture through. What the sibling `worktree_reclaim_tests` fixture is `PrIndex::from_json`, the pure parse, which is the layer this test bypasses on purpose: its whole subject is that a real call succeeds. Driving it through `from_json` would delete the coverage it exists for, so the fix is a skip guard mirroring the identity probe above it. No `#[ignore]`, assertion intact.

The guard needed no new production API. `PrIndex::state_for` already reports `LookupFailed` for an absent branch when the lookup itself failed, so the test asks for a branch this repository cannot have:

- a **failed** call answers `LookupFailed` → skip, naming `gh`'s own reason;
- a call that **answered** answers `NoPr` or `Unknown` → the row assertion runs unchanged.

An answered call resolving zero branches still fails, which is the bug shape.

`branch_count`'s doc comment no longer claims the test tells a working call from a failed one by count alone.

## Verification

**Regression proof.** With a stub `gh` whose `repo view` succeeds and whose `pr list` fails, pre-fix code goes red on the real flake shape:

```
test ...::pr_index_from_gh_reads_this_repository ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 6090 filtered out
```

**Two `gh` stubs, and what each proved.**

1. `gh` exits 1 on every call — skips at the pre-existing probe guard, so it exercises the old guard only:
   `skipping: 'gh' cannot resolve a repository here — 'gh' exited 1: gh: stub failure (#7038)` → `ok`
2. `repo view` succeeds, `pr list` exits 1 — reproduces the actual flake and reaches the new guard:
   `skipping: 'gh pr list' failed — 'gh' exited 1: gh: stub pr-list failure (#7038)` → `ok`

**Ten consecutive `cargo test -p trusty-mpm --lib --no-fail-fast`** — the target test is `ok` in all ten:

```
run 1  ok. 6083 passed; 0 failed; 8 ignored     run 6   ok. 6083 passed; 0 failed; 8 ignored
run 2  ok. 6083 passed; 0 failed; 8 ignored     run 7   ok. 6083 passed; 0 failed; 8 ignored
run 3  FAILED. 6082 passed; 1 failed; 8 ignored run 8   ok. 6083 passed; 0 failed; 8 ignored
run 4  ok. 6083 passed; 0 failed; 8 ignored     run 9   ok. 6083 passed; 0 failed; 8 ignored
run 5  ok. 6083 passed; 0 failed; 8 ignored     run 10  ok. 6083 passed; 0 failed; 8 ignored
```

Run 3's single failure was `core::paths::tests::for_managed_workspace_under_matches_for_managed_workspace_at_home`, pre-rebase — the `$HOME` race in `paths.rs`, covered by #7033's fix (8583ec3d8), which this branch is now rebased onto.

**Post-rebase `cargo test -p trusty-mpm --lib --no-fail-fast`:**

```
test result: FAILED. 6082 passed; 1 failed; 8 ignored; 0 measured; 0 filtered out; finished in 76.05s
```

The one failure is `runtime::claude_code::claude_code_agents::tests::query_registry_kills_and_reaps_a_wedged_probe` — a spawn-timing race reading a pid file before the stand-in writes it (`claude_code_agents_tests.rs:366`, `NotFound`). Pre-existing and unrelated: this branch touches nothing under `src/runtime/`, and it passes in isolation (`ok. 1 passed`). No issue on file for it; reported separately.

**Other gates**, all clean: `cargo fmt --check`; `cargo clippy -p trusty-mpm --all-targets -- -D warnings`; `check_line_cap.sh` (0 violations); `check_test_pointers.sh` (0 dangling); `check_changelog_fragment.sh`; `check-pr-version-bump.sh` (clear — 1.5.18 unchanged).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
