### PR TITLE
feat(trusty-audit): verify a received handoff package from the CLI (refs #5563)

### DIFF
--- a/crates/trusty-audit/README.md
+++ b/crates/trusty-audit/README.md
@@ -575,13 +575,34 @@ property the engagement did not ask for.
 
 ### Checking a received package
 
-Verification is a library call today —
-`trusty_audit::package::signing::verify(&path, &retained_key)` — and reports one
-of: a signed package that checks out, an unsigned package, or one of several
-distinguishable failures. A member altered after signing, a signature member
-removed, a signature made by a different key, a manifest-listed member that is
-gone, and a member the manifest never listed are five different errors, not one
-"verification failed".
+```bash
+trusty-audit verify return-package.zip --public-key retained.pub
+```
+
+`retained.pub` is the file holding the public half the auditor kept out of band,
+as 64 hex characters. The flag is required and there is no fallback to
+`engagement.toml`: that file carries the PRIVATE key, it travelled to the
+recipient inside the inbound package, and a key that arrives with the thing it
+authenticates authenticates nothing.
+
+The verb reads and writes nothing — the package is left exactly as it arrived —
+and the exit status is the answer a script reads:
+
+| Status | Meaning |
+|---|---|
+| `0` | Signed, the signature verifies against your key, and every member still hashes to what the manifest records |
+| `3` | UNSIGNED — the package carries a manifest and no signature, so nothing in it is authenticated |
+| non-zero otherwise | One named failure, printed as its own line |
+
+Exit 3 is its own code because an unsigned package is what a rewritten manifest
+also produces. It is not a weaker pass, and it is not the same as a signed
+package whose signature member was removed.
+
+The same check is a library call — `trusty_audit::package::signing::verify(&path,
+&retained_key)` — and the verb is a thin arm over it, so the two cannot disagree.
+A member altered after signing, a signature member removed, a signature made by a
+different key, a manifest-listed member that is gone, and a member the manifest
+never listed are five different errors, not one "verification failed".
 
 Two more come before any of those, and before the manifest is even read. The
 `zip` crate keys its entry table by member name, so an archive whose central
@@ -591,9 +612,11 @@ verification walks the raw central directory itself, refuses a repeated name,
 and refuses any other disagreement between that walk and the parser. Member
 bytes are streamed through a fixed buffer rather than into an allocation sized
 from the archive's own declared size, which is a number whoever sent the package
-chose. The `trusty-audit verify` CLI arm over the same call is
-[#5563](https://github.com/bobmatnyc/trusty-tools/issues/5563); this crate keeps
-one implementation behind it and any front end.
+chose.
+
+One refusal the verb cannot show you: an archive whose central directory cannot
+be framed at all is rejected by the zip parser before the raw walk runs, so it
+arrives as "cannot read the package" rather than as the directory error.
 
 ### What the signature proves, and what it does not
 

--- a/crates/trusty-audit/changelog.d/5563-verify-cli.md
+++ b/crates/trusty-audit/changelog.d/5563-verify-cli.md
@@ -1,0 +1,9 @@
+Added
+
+- `trusty-audit verify <package.zip> --public-key <file>` checks a received
+  handoff package against the retained ed25519 public key. It exits 0 for a
+  package whose signature verifies and whose every member still hashes to the
+  signed manifest, 3 for one that carries no signature at all, and non-zero
+  naming the specific failure for anything else. The verb writes nothing, and
+  the key comes only from a file the operator names — never from the engagement
+  config, whose private half travelled inside the package it would be checking.

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -285,6 +285,26 @@ pub enum Verb {
         #[arg(long, value_name = "FILE")]
         review_bin: Option<PathBuf>,
     },
+    /// Check a package that came back against the key you retained (#5563).
+    ///
+    /// Exits 0 for a package whose signature verifies and whose every member
+    /// still hashes to what the signed manifest recorded, 3 for one that
+    /// carries no signature at all, and non-zero naming the specific failure
+    /// for anything else. Nothing is written: the package is read and left
+    /// exactly as it arrived.
+    ///
+    /// The key is REQUIRED and comes from a file you name. There is no default
+    /// and no fallback to `engagement.toml` — that file holds the private half,
+    /// it travelled to the recipient inside the package, and a key that arrives
+    /// with the thing it authenticates authenticates nothing.
+    Verify {
+        /// The package to check.
+        #[arg(value_name = "PACKAGE.ZIP")]
+        package: PathBuf,
+        /// A file holding the retained ed25519 public key, 64 hex characters.
+        #[arg(long, value_name = "FILE")]
+        public_key: PathBuf,
+    },
 }
 
 /// What `taudit add` was asked to register.
@@ -416,6 +436,15 @@ impl Cli {
                 out: out.clone(),
                 review: review_bin.clone(),
             }),
+            // #5563: both paths are operator input and neither has a default —
+            // the key especially, which must not be reachable from the package.
+            Some(Verb::Verify {
+                package,
+                public_key,
+            }) => Command::Verify {
+                package: package.clone(),
+                public_key: public_key.clone(),
+            },
         }
     }
 }
@@ -507,6 +536,15 @@ mod cli_tests {
             Command::Audit(_) => vec!["taudit", "audit"],
             Command::Distribute(_) => vec!["taudit", "distribute"],
             Command::Rerender(_) => vec!["taudit", "render"],
+            Command::Verify { .. } => {
+                vec![
+                    "taudit",
+                    "verify",
+                    "pkg.zip",
+                    "--public-key",
+                    "retained.pub",
+                ]
+            }
         }
     }
 
@@ -545,6 +583,10 @@ mod cli_tests {
             Command::Audit(ChainOptions::default()),
             Command::Distribute(DistributeOptions::default()),
             Command::Rerender(RerenderOptions::default()),
+            Command::Verify {
+                package: PathBuf::from("pkg.zip"),
+                public_key: PathBuf::from("retained.pub"),
+            },
         ]
     }
 

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -267,8 +267,12 @@ pub fn render(outcome: &Outcome) -> String {
         Outcome::Audit(report) => render_chain(report),
         Outcome::Distributed(package) => render_install_package(package),
         Outcome::Rerendered(report) => render_rerender(report),
+        Outcome::Verified(report) => verify::render(report),
     }
 }
+
+// #5563: the verify arm's own file, because this one is at the 500-SLOC cap.
+mod verify;
 
 /// The regenerated reports, where they landed, and what did not come back.
 ///

--- a/crates/trusty-audit/src/cli/render/verify.rs
+++ b/crates/trusty-audit/src/cli/render/verify.rs
@@ -1,0 +1,45 @@
+//! The line `trusty-audit verify` prints (#5563).
+//!
+//! Why: a check whose result a human has to interpret is not a check. The
+//! operator gets one verdict word, the fingerprint of the key that produced it,
+//! and how much of the package it covers — and, for a signed package, the limit
+//! on what that proves, in the same words `super::render_package` uses when the
+//! package is written.
+//!
+//! What: [`render`], one arm per [`Verdict`]. Its own file because
+//! `super`'s is at the 500-SLOC production cap.
+//! Test: `crate::session::verify::verify_tests::a_signed_package_verifies_through_the_session_seam`,
+//! `crate::session::verify::verify_tests::an_unsigned_package_has_its_own_exit_code`.
+
+use crate::package::signing::Verdict;
+use crate::session::verify::VerifyReport;
+
+/// The verdict as the CLI prints it.
+///
+/// Test: see the module docs.
+pub(super) fn render(report: &VerifyReport) -> String {
+    let package = report.package.display();
+    match &report.verdict {
+        Verdict::Signed {
+            key_fingerprint,
+            files,
+        } => format!(
+            "Verified: {package}\n  \
+             signed with engagement key {key_fingerprint} — tamper-evident in transit, \
+             not proof about the sender\n  \
+             {}, every one hashing to what the signed manifest records\n",
+            super::count_of(*files, "member", "members")
+        ),
+        // #5563: an unsigned package is what a rewritten manifest also produces,
+        // so this line says what is NOT known rather than reporting a weaker
+        // pass. `Outcome::exit_code` gives it a status of its own to match.
+        Verdict::Unsigned { files } => format!(
+            "UNSIGNED: {package}\n  \
+             the package carries a manifest and no signature, so nothing in it is \
+             authenticated — an engagement with no [signing] key produces this, and so \
+             does anyone who rewrites the manifest of one that had\n  \
+             {} listed, none of them checked against a key\n",
+            super::count_of(*files, "member", "members")
+        ),
+    }
+}

--- a/crates/trusty-audit/src/package/signing.rs
+++ b/crates/trusty-audit/src/package/signing.rs
@@ -844,12 +844,27 @@ fn from_hex(text: &str) -> Option<Vec<u8>> {
         .collect()
 }
 
+/// Packages for the tests that check what verification accepts and refuses.
+///
+/// Why (#5563): the `trusty-audit verify` CLI arm has to prove that each
+/// distinguishable refusal reaches the operator through
+/// [`crate::session::execute`], and those tests need exactly the archives this
+/// module's own tests need. A second builder of a signed zip would be free to
+/// drift from the one the check is written against, so there is one.
+/// What: [`fixture::package`] writes a well-formed package; each `with_*`
+/// function applies exactly one of the alterations verification must catch.
+/// Test-only, and `pub(crate)` for the seam tests alone.
+/// Test: `super::signing_tests`, `crate::session::verify::verify_tests`.
 #[cfg(test)]
-mod signing_tests {
+pub(crate) mod fixture {
     use super::*;
 
     /// A package with the members `entries` names, signed when `key` is set.
-    fn package(dir: &Path, entries: &[(&str, &str)], key: Option<&EngagementKey>) -> PathBuf {
+    pub(crate) fn package(
+        dir: &Path,
+        entries: &[(&str, &str)],
+        key: Option<&EngagementKey>,
+    ) -> PathBuf {
         let path = dir.join("package.zip");
         let file = std::fs::File::create(&path).expect("create");
         let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
@@ -878,7 +893,7 @@ mod signing_tests {
     }
 
     /// Rebuild `source`'s archive with `edit` applied to its member list.
-    fn rewrite(source: &Path, edit: impl Fn(&str, &[u8]) -> Option<Vec<u8>>) -> PathBuf {
+    pub(crate) fn rewrite(source: &Path, edit: impl Fn(&str, &[u8]) -> Option<Vec<u8>>) -> PathBuf {
         let destination = source.with_file_name("rewritten.zip");
         let mut archive = open(source).expect("open");
         let names: Vec<String> = archive.file_names().map(str::to_owned).collect();
@@ -898,13 +913,73 @@ mod signing_tests {
         destination
     }
 
-    fn retained(key: &EngagementKey) -> RetainedKey {
-        RetainedKey::from_hex(&key.public_hex()).expect("public half parses")
+    /// `source` with one more member the signed manifest never listed.
+    pub(crate) fn with_extra_member(source: &Path, entry: &str, body: &[u8]) -> PathBuf {
+        let destination = source.with_file_name("with-extra.zip");
+        let mut archive = open(source).expect("open");
+        let names: Vec<String> = archive.file_names().map(str::to_owned).collect();
+        let file = std::fs::File::create(&destination).expect("create");
+        let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        for name in names {
+            let bytes = read_member(&mut archive, source, &name)
+                .expect("read")
+                .expect("present");
+            zip.start_file(name, options).expect("start");
+            std::io::Write::write_all(&mut zip, &bytes).expect("write");
+        }
+        zip.start_file(entry.to_owned(), options).expect("start");
+        std::io::Write::write_all(&mut zip, body).expect("write");
+        zip.finish().expect("finish");
+        destination
+    }
+
+    /// `source` with a SECOND central-directory record under `name`, pointing
+    /// at `planted` bytes the parser will never show a caller.
+    pub(crate) fn with_duplicate_record(source: &Path, name: &str, planted: &[u8]) -> PathBuf {
+        let raw = std::fs::read(source).expect("read the package");
+        let eocd = eocd_at(&raw);
+        let entries = u16::from_le_bytes(raw[eocd + 10..eocd + 12].try_into().expect("two bytes"));
+        let directory_size = read_u32(&raw, eocd + 12) as usize;
+        let directory_at = read_u32(&raw, eocd + 16) as usize;
+
+        let mut forged = raw[..directory_at].to_vec();
+        let planted_at = forged.len() as u32;
+        forged.extend_from_slice(&local_header(name, planted));
+        let directory_moved_to = forged.len() as u32;
+        forged.extend_from_slice(&raw[directory_at..directory_at + directory_size]);
+        let duplicate = central_header(name, planted, planted_at);
+        let duplicate_len = duplicate.len();
+        forged.extend_from_slice(&duplicate);
+        // The EOCD, reframed: one more entry, a longer directory, a new offset.
+        let mut eocd_record = raw[eocd..].to_vec();
+        eocd_record[8..10].copy_from_slice(&le16(entries + 1));
+        eocd_record[10..12].copy_from_slice(&le16(entries + 1));
+        eocd_record[12..16].copy_from_slice(&le32((directory_size + duplicate_len) as u32));
+        eocd_record[16..20].copy_from_slice(&le32(directory_moved_to));
+        forged.extend_from_slice(&eocd_record);
+
+        let destination = source.with_file_name("forged.zip");
+        std::fs::write(&destination, &forged).expect("write the forged package");
+        destination
+    }
+
+    /// `source` with a whole fake EOCD planted in its archive comment, which
+    /// `zip` 2.4.2's backward scan takes and the raw walk does not.
+    pub(crate) fn with_decoy_directory(source: &Path) -> PathBuf {
+        let mut decoy = Vec::new();
+        decoy.extend_from_slice(&le32(0x0605_4b50));
+        decoy.extend_from_slice(&[0_u8; 18]);
+        decoy.extend_from_slice(b"trailing");
+        let raw = std::fs::read(source).expect("read");
+        let destination = source.with_file_name("decoy.zip");
+        std::fs::write(&destination, with_comment(&raw, &decoy)).expect("write");
+        destination
     }
 
     /// CRC-32 (IEEE), bitwise. Ten lines of test code rather than a dependency
     /// pulled in so one hand-built local header can be genuinely extractable.
-    fn crc32(bytes: &[u8]) -> u32 {
+    pub(crate) fn crc32(bytes: &[u8]) -> u32 {
         let mut crc = 0xFFFF_FFFF_u32;
         for byte in bytes {
             crc ^= u32::from(*byte);
@@ -919,20 +994,20 @@ mod signing_tests {
         !crc
     }
 
-    fn le16(v: u16) -> [u8; 2] {
+    pub(crate) fn le16(v: u16) -> [u8; 2] {
         v.to_le_bytes()
     }
 
-    fn le32(v: u32) -> [u8; 4] {
+    pub(crate) fn le32(v: u32) -> [u8; 4] {
         v.to_le_bytes()
     }
 
-    fn read_u32(bytes: &[u8], at: usize) -> u32 {
+    pub(crate) fn read_u32(bytes: &[u8], at: usize) -> u32 {
         u32::from_le_bytes(bytes[at..at + 4].try_into().expect("four bytes"))
     }
 
     /// The offset of the archive's end-of-central-directory record.
-    fn eocd_at(raw: &[u8]) -> usize {
+    pub(crate) fn eocd_at(raw: &[u8]) -> usize {
         (0..=raw.len() - 22)
             .rev()
             .find(|at| read_u32(raw, *at) == 0x0605_4b50)
@@ -940,7 +1015,7 @@ mod signing_tests {
     }
 
     /// A STORED local file header plus its data, for a hand-built second copy.
-    fn local_header(name: &str, body: &[u8]) -> Vec<u8> {
+    pub(crate) fn local_header(name: &str, body: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&le32(0x0403_4b50));
         out.extend_from_slice(&le16(20)); // version needed
@@ -959,7 +1034,7 @@ mod signing_tests {
     }
 
     /// A central-directory file header naming `name` at `header_start`.
-    fn central_header(name: &str, body: &[u8], header_start: u32) -> Vec<u8> {
+    pub(crate) fn central_header(name: &str, body: &[u8], header_start: u32) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&le32(0x0201_4b50));
         out.extend_from_slice(&le16(20)); // version made by
@@ -980,6 +1055,35 @@ mod signing_tests {
         out.extend_from_slice(&le32(header_start));
         out.extend_from_slice(name.as_bytes());
         out
+    }
+
+    /// `raw` with `comment` appended and the EOCD's comment length updated.
+    pub(crate) fn with_comment(raw: &[u8], comment: &[u8]) -> Vec<u8> {
+        let eocd = eocd_at(raw);
+        let mut out = raw[..eocd].to_vec();
+        let mut record = raw[eocd..].to_vec();
+        record[20..22].copy_from_slice(&le16(comment.len() as u16));
+        out.extend_from_slice(&record);
+        out.extend_from_slice(comment);
+        out
+    }
+
+    pub(crate) fn write(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, bytes).expect("write");
+        path
+    }
+}
+
+#[cfg(test)]
+mod signing_tests {
+    use super::*;
+    // #5563: one builder of a signed package, shared with the session seam's
+    // tests, rather than a second one free to drift from this one.
+    use super::fixture::*;
+
+    fn retained(key: &EngagementKey) -> RetainedKey {
+        RetainedKey::from_hex(&key.public_hex()).expect("public half parses")
     }
 
     #[test]
@@ -1091,23 +1195,7 @@ mod signing_tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let key = EngagementKey::generate();
         let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
-        let destination = dir.path().join("with-extra.zip");
-        let mut archive = open(&path).expect("open");
-        let names: Vec<String> = archive.file_names().map(str::to_owned).collect();
-        let file = std::fs::File::create(&destination).expect("create");
-        let mut zip = zip::ZipWriter::new(std::io::BufWriter::new(file));
-        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
-        for name in names {
-            let bytes = read_member(&mut archive, &path, &name)
-                .expect("read")
-                .expect("present");
-            zip.start_file(name, options).expect("start");
-            std::io::Write::write_all(&mut zip, &bytes).expect("write");
-        }
-        zip.start_file("reports/planted.md".to_owned(), options)
-            .expect("start");
-        std::io::Write::write_all(&mut zip, b"planted").expect("write");
-        zip.finish().expect("finish");
+        let destination = with_extra_member(&path, "reports/planted.md", b"planted");
         match verify(&destination, &retained(&key)) {
             Err(SigningError::MemberUnexpected { entry, .. }) => {
                 assert_eq!(entry, "reports/planted.md");
@@ -1226,32 +1314,7 @@ mod signing_tests {
             ],
             Some(&key),
         );
-        let raw = std::fs::read(&path).expect("read the package");
-
-        let eocd = eocd_at(&raw);
-        let entries = u16::from_le_bytes(raw[eocd + 10..eocd + 12].try_into().expect("two bytes"));
-        let directory_size = read_u32(&raw, eocd + 12) as usize;
-        let directory_at = read_u32(&raw, eocd + 16) as usize;
-
-        let planted = b"read MF";
-        let mut forged = raw[..directory_at].to_vec();
-        let planted_at = forged.len() as u32;
-        forged.extend_from_slice(&local_header("README.md", planted));
-        let directory_moved_to = forged.len() as u32;
-        forged.extend_from_slice(&raw[directory_at..directory_at + directory_size]);
-        let duplicate = central_header("README.md", planted, planted_at);
-        let duplicate_len = duplicate.len();
-        forged.extend_from_slice(&duplicate);
-        // The EOCD, reframed: one more entry, a longer directory, a new offset.
-        let mut eocd_record = raw[eocd..].to_vec();
-        eocd_record[8..10].copy_from_slice(&le16(entries + 1));
-        eocd_record[10..12].copy_from_slice(&le16(entries + 1));
-        eocd_record[12..16].copy_from_slice(&le32((directory_size + duplicate_len) as u32));
-        eocd_record[16..20].copy_from_slice(&le32(directory_moved_to));
-        forged.extend_from_slice(&eocd_record);
-
-        let forged_path = dir.path().join("forged.zip");
-        std::fs::write(&forged_path, &forged).expect("write the forged package");
+        let forged_path = with_duplicate_record(&path, "README.md", b"read MF");
 
         // The exploit is real: the parser hides the second record entirely, so
         // nothing downstream of it could have caught this.
@@ -1410,12 +1473,6 @@ mod signing_tests {
         out
     }
 
-    fn write(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {
-        let path = dir.join(name);
-        std::fs::write(&path, bytes).expect("write");
-        path
-    }
-
     /// The EOCD sits behind the archive comment, so the scan has to reach past
     /// one. An ordinary comment must leave the verdict alone.
     #[test]
@@ -1463,15 +1520,7 @@ mod signing_tests {
         let key = EngagementKey::generate();
         let path = package(dir.path(), &[("README.md", "read me")], Some(&key));
         // A whole fake EOCD inside the comment, with bytes after it.
-        let mut decoy = Vec::new();
-        decoy.extend_from_slice(&le32(0x0605_4b50));
-        decoy.extend_from_slice(&[0_u8; 18]);
-        decoy.extend_from_slice(b"trailing");
-        let doctored = write(
-            dir.path(),
-            "decoy.zip",
-            &with_comment(&std::fs::read(&path).expect("read"), &decoy),
-        );
+        let doctored = with_decoy_directory(&path);
 
         assert_eq!(
             super::super::zip_directory::member_names(&doctored)
@@ -1566,17 +1615,6 @@ mod signing_tests {
             }
             other => panic!("expected a content disagreement, got {other:?}"),
         }
-    }
-
-    /// `raw` with `comment` appended and the EOCD's comment length updated.
-    fn with_comment(raw: &[u8], comment: &[u8]) -> Vec<u8> {
-        let eocd = eocd_at(raw);
-        let mut out = raw[..eocd].to_vec();
-        let mut record = raw[eocd..].to_vec();
-        record[20..22].copy_from_slice(&le16(comment.len() as u16));
-        out.extend_from_slice(&record);
-        out.extend_from_slice(comment);
-        out
     }
 
     /// A directory that stops in the middle of a record is refused rather than

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -25,6 +25,11 @@ use std::path::{Path, PathBuf};
 // #6159: creating an engagement without a terminal. Its own module because this
 // file is at the 500-SLOC production cap.
 pub mod init;
+// #5563: the pre-sweep flow and the received-package check, each in its own
+// module for the same reason `init` is — this file is at that cap, and a
+// capability is the line available to split along.
+pub mod guided;
+pub mod verify;
 
 use crate::chain::{self, ChainOptions, ChainReport};
 // #6159: `PinResolver` is the seam that keeps `init`'s test off the release list.
@@ -44,6 +49,7 @@ use crate::tools::{self, InstalledTool, RequiredTool, ToolStatus};
 use crate::validate;
 use crate::workdir::{Area, WorkDir};
 use init::InitReport;
+use verify::VerifyReport;
 
 /// Everything `trusty-audit` can be asked to do.
 ///
@@ -152,6 +158,19 @@ pub enum Command {
     /// engagement config, no pinned tools. It carries its options because all
     /// three are operator choices with defaults; see [`crate::rerender`].
     Rerender(RerenderOptions),
+    /// Check a received handoff package against the retained key (#5563).
+    ///
+    /// The one capability the AUDITOR runs on a file that came back, so it
+    /// touches no engagement state at all — both paths are operator input, and
+    /// the key deliberately is not read from the engagement config. See
+    /// [`crate::session::verify`] for why a key that travelled with the package
+    /// cannot answer this question.
+    Verify {
+        /// The package to check.
+        package: PathBuf,
+        /// A file holding the retained ed25519 public half, as hex.
+        public_key: PathBuf,
+    },
 }
 
 /// How hard a front end should look for the inference credential (#5868).
@@ -221,7 +240,9 @@ impl Command {
             | Self::CloneRepos { .. }
             | Self::AddTarget { .. }
             | Self::ListTargets
-            | Self::RemoveTarget { .. } => CredentialNeed::None,
+            | Self::RemoveTarget { .. }
+            // #5563: the check reads a zip and a key file and sends nothing.
+            | Self::Verify { .. } => CredentialNeed::None,
         }
     }
 }
@@ -349,6 +370,13 @@ pub enum Outcome {
     /// the renders ran and some of them did not work, and those failures are
     /// data the front end must show.
     Rerendered(RerenderReport),
+    /// From [`Command::Verify`] — what the received package checks out as.
+    ///
+    /// [`crate::package::signing::Verdict::Unsigned`] is an ordinary `Ok` here,
+    /// for the same reason a partly-failed sweep is: it is the answer, not a
+    /// failure to produce one. [`Outcome::exit_code`] is what stops it reading
+    /// as success.
+    Verified(VerifyReport),
 }
 
 /// Exit status for a run that succeeded but did not cover everything asked for.
@@ -356,6 +384,14 @@ pub const EXIT_INCOMPLETE: i32 = 2;
 
 /// Exit status for a sweep that partly failed.
 pub const EXIT_PARTIAL: i32 = 1;
+
+/// Exit status for a package that carries no signature to check (#5563).
+///
+/// Its own code rather than [`EXIT_INCOMPLETE`]: an unsigned package is what a
+/// manifest rewritten by anyone at all also produces, so a caller must be able
+/// to tell it from every other outcome — including the removed-signature
+/// failure, which is an error and exits 1.
+pub const EXIT_UNSIGNED: i32 = 3;
 
 impl Outcome {
     /// The process exit status this outcome should produce.
@@ -410,6 +446,10 @@ impl Outcome {
             // did produce are worth having, and `taudit render && open …` must
             // not read that as a whole deliverable.
             Outcome::Rerendered(report) if report.failures().next().is_some() => EXIT_PARTIAL,
+            // #5563: a package nothing authenticates must not chain onward as
+            // if it had verified — `taudit verify pkg.zip && unzip pkg.zip`
+            // reads the status, not the UNSIGNED line above it.
+            Outcome::Verified(report) if report.is_unsigned() => EXIT_UNSIGNED,
             _ => 0,
         }
     }
@@ -639,7 +679,7 @@ impl Session {
     ///
     /// The cold-start launch reads it to decide whether to preflight and install
     /// after writing the config, so `--no-install` means the same thing there as
-    /// it does in [`Session::guided`] rather than only in one of the two.
+    /// it does in [`guided::guided`] rather than only in one of the two.
     pub fn auto_install(&self) -> bool {
         self.auto_install
     }
@@ -669,7 +709,7 @@ impl Session {
     /// capability a later milestone lands.
     pub async fn execute(&self, command: Command) -> Result<Outcome, AuditError> {
         match command {
-            Command::Guided => self.guided().await.map(Outcome::Guided),
+            Command::Guided => guided::guided(self).await.map(Outcome::Guided),
             // #6159: the cold start without the prompt. It shares
             // `bootstrap::create_engagement` with the interactive path rather
             // than growing a second writer of a plaintext key.
@@ -717,6 +757,12 @@ impl Session {
             // #6080: the render step of the sweep, run on its own against the
             // manifests a delivered package already carries.
             Command::Rerender(options) => self.rerender(&options).await.map(Outcome::Rerendered),
+            // #5563: no session state at all — both paths are operator input,
+            // and the check reads them without creating the working directory.
+            Command::Verify {
+                package,
+                public_key,
+            } => verify::verify(&package, &public_key).map(Outcome::Verified),
         }
     }
 
@@ -1137,111 +1183,6 @@ impl Session {
         Ok(AuditManifest::load_if_present(&self.manifest_path)?
             .map(|m| m.repositories)
             .unwrap_or_default())
-    }
-
-    async fn guided(&self) -> Result<GuidedStatus, AuditError> {
-        self.work.create()?;
-        let manifest = AuditManifest::load_if_present(&self.manifest_path)?;
-        // #5979: read ONCE here rather than twice below — the flow's repository
-        // check and its auto-install both need it, and reading the file twice
-        // lets the two disagree about an engagement edited in between.
-        let config = EngagementConfig::load_if_present(&self.config_path)?;
-
-        // #5502: the epic's pre-sweep order is repo selection, then tooling —
-        // so a missing repository set outranks a missing binary.
-        //
-        // #5885: the REGISTRY counts, not only the manifest. `SelectRepositories`
-        // tells the operator to run `add`, and `add` writes the registry — so
-        // reading only the manifest left the flow repeating that instruction
-        // after they had done it, with the manifest not written until a sweep
-        // finishes. Either record means the operator has named an engagement.
-        //
-        // #5896 review: REPOSITORIES, not any target. `Registry::targets` mixes
-        // repositories and boards, so `taudit add board jira:ACME` against an
-        // otherwise empty registry skipped `SelectRepositories`, triggered a
-        // real multi-tool download through `auto_install_tools`, and reported
-        // `ReadyForRun` over an engagement with nothing to sweep. A board is not
-        // a unit of the sweep — `crate::chain::split_targets` says the same.
-        let repos_known = manifest
-            .as_ref()
-            .is_some_and(|m| !m.repositories.is_empty())
-            || registry::engagement_targets(config.as_ref(), &self.work)?
-                .iter()
-                .any(|target| target.kind() == TargetKind::Repo);
-
-        // #5797: install at the point the flow would otherwise have printed
-        // "now go run `install`", and not one step earlier. Repository selection
-        // comes first, so a working directory with nothing chosen yet reports
-        // its state without this process reaching the network — the operator
-        // has not committed to an engagement here.
-        let installed = if self.auto_install && repos_known {
-            self.auto_install_tools(config.as_ref()).await?
-        } else {
-            None
-        };
-
-        let tools = tools::status(&self.work)?;
-        let missing: Vec<RequiredTool> = tools
-            .iter()
-            .filter(|s| !s.installed)
-            .map(|s| s.tool)
-            .collect();
-
-        // #5499: a finished sweep that audited something is the last state the
-        // guided flow can advance from — without this the flow's final word is
-        // "run the sweep", and the recipient is left holding a working directory
-        // with no instruction to send anything back.
-        //
-        // #5494: FINISHED, not merely recorded. A checkpoint left by a sweep
-        // that died names audited repositories too, and pointing at the return
-        // package there would send a partial engagement instead of resuming.
-        let audited = run::read_progress(&self.work)?.is_some_and(|progress| {
-            progress.complete && progress.repos.iter().any(|r| r.result.succeeded())
-        });
-
-        let next = if audited {
-            NextStep::ReturnPackage
-        } else if !repos_known {
-            NextStep::SelectRepositories
-        } else if !missing.is_empty() {
-            NextStep::InstallTools(missing)
-        } else {
-            NextStep::ReadyForRun
-        };
-
-        Ok(GuidedStatus {
-            root: self.work.root().to_path_buf(),
-            manifest,
-            tools,
-            installed,
-            next,
-        })
-    }
-
-    /// Install the pinned set for the guided flow, when there is a set to pin to.
-    ///
-    /// Why: #5797. The guided flow runs against a working directory that may
-    /// carry no engagement config — it is the flow you enter before anything is
-    /// set up — and that case has to keep reporting rather than fail. There are
-    /// no pins without a config, and installing without pins means installing
-    /// whatever is current, which is the #5454 defect. So an absent config
-    /// declines to install and the flow names the step, exactly as before.
-    ///
-    /// A config that is PRESENT and unreadable or malformed is not that case and
-    /// propagates: the caller's `load_if_present` tolerates only absence.
-    /// What: takes the config [`Session::guided`] already read, so the two
-    /// cannot see different files. `Ok(None)` when there is no config or the set
-    /// was already satisfied; `Ok(Some(installed))` naming what this call placed.
-    /// Test: `super::session_tests::guided_without_a_config_still_names_the_step`,
-    /// `super::session_tests::guided_propagates_a_malformed_config`.
-    async fn auto_install_tools(
-        &self,
-        config: Option<&EngagementConfig>,
-    ) -> Result<Option<Vec<InstalledTool>>, AuditError> {
-        let Some(config) = config else {
-            return Ok(None);
-        };
-        tools::ensure(&self.work, &config.tools, &self.progress).await
     }
 }
 

--- a/crates/trusty-audit/src/session/guided.rs
+++ b/crates/trusty-audit/src/session/guided.rs
@@ -1,0 +1,142 @@
+//! The pre-sweep flow: what the engagement still needs, and what to do next.
+//!
+//! Why: the epic (#5477) fixes an order — pick repositories, then install
+//! tooling, then sweep — and a recipient who double-clicked the binary has to
+//! be told where in it they are. Naming the next step as data lets the CLI
+//! print it and the Tauri shell highlight it from one decision.
+//!
+//! What: [`guided`], which reads the manifest, the engagement config and the
+//! registry, installs the pinned set when the flow has reached that step, and
+//! answers a [`GuidedStatus`]. It decides nothing the CLI could not; it only
+//! decides it once, in the library.
+//!
+//! A separate module rather than another method on [`Session`], for the reason
+//! [`super::init`] gives: `session.rs` sits at the 500-SLOC production cap
+//! (#5563).
+//!
+//! Test: `super::session_tests::guided_asks_for_repositories_before_tools`,
+//! `super::session_tests::guided_asks_for_tools_once_repositories_are_known`,
+//! `super::session_tests::guided_is_ready_once_repositories_and_tools_are_both_in_place`.
+
+use crate::config::EngagementConfig;
+use crate::error::AuditError;
+use crate::manifest::AuditManifest;
+use crate::registry::{self, TargetKind};
+use crate::run;
+use crate::tools::{self, InstalledTool, RequiredTool};
+
+use super::{GuidedStatus, NextStep, Session};
+
+/// Where the engagement stands, and the one step to take next.
+///
+/// # Postconditions
+/// The returned [`NextStep`] is derived from state read in this call, and the
+/// tool list reports what is on disk AFTER any install this call performed.
+///
+/// What: the checks run in the epic's own order, so a missing repository set
+/// outranks a missing binary.
+/// Test: see the module docs.
+pub(super) async fn guided(session: &Session) -> Result<GuidedStatus, AuditError> {
+    session.work.create()?;
+    let manifest = AuditManifest::load_if_present(&session.manifest_path)?;
+    // #5979: read ONCE here rather than twice below — the flow's repository
+    // check and its auto-install both need it, and reading the file twice
+    // lets the two disagree about an engagement edited in between.
+    let config = EngagementConfig::load_if_present(&session.config_path)?;
+
+    // #5502: the epic's pre-sweep order is repo selection, then tooling —
+    // so a missing repository set outranks a missing binary.
+    //
+    // #5885: the REGISTRY counts, not only the manifest. `SelectRepositories`
+    // tells the operator to run `add`, and `add` writes the registry — so
+    // reading only the manifest left the flow repeating that instruction
+    // after they had done it, with the manifest not written until a sweep
+    // finishes. Either record means the operator has named an engagement.
+    //
+    // #5896 review: REPOSITORIES, not any target. `Registry::targets` mixes
+    // repositories and boards, so `taudit add board jira:ACME` against an
+    // otherwise empty registry skipped `SelectRepositories`, triggered a
+    // real multi-tool download through `auto_install_tools`, and reported
+    // `ReadyForRun` over an engagement with nothing to sweep. A board is not
+    // a unit of the sweep — `crate::chain::split_targets` says the same.
+    let repos_known = manifest
+        .as_ref()
+        .is_some_and(|m| !m.repositories.is_empty())
+        || registry::engagement_targets(config.as_ref(), &session.work)?
+            .iter()
+            .any(|target| target.kind() == TargetKind::Repo);
+
+    // #5797: install at the point the flow would otherwise have printed
+    // "now go run `install`", and not one step earlier. Repository selection
+    // comes first, so a working directory with nothing chosen yet reports
+    // its state without this process reaching the network — the operator
+    // has not committed to an engagement here.
+    let installed = if session.auto_install && repos_known {
+        auto_install_tools(session, config.as_ref()).await?
+    } else {
+        None
+    };
+
+    let tools = tools::status(&session.work)?;
+    let missing: Vec<RequiredTool> = tools
+        .iter()
+        .filter(|s| !s.installed)
+        .map(|s| s.tool)
+        .collect();
+
+    // #5499: a finished sweep that audited something is the last state the
+    // guided flow can advance from — without this the flow's final word is
+    // "run the sweep", and the recipient is left holding a working directory
+    // with no instruction to send anything back.
+    //
+    // #5494: FINISHED, not merely recorded. A checkpoint left by a sweep
+    // that died names audited repositories too, and pointing at the return
+    // package there would send a partial engagement instead of resuming.
+    let audited = run::read_progress(&session.work)?.is_some_and(|progress| {
+        progress.complete && progress.repos.iter().any(|r| r.result.succeeded())
+    });
+
+    let next = if audited {
+        NextStep::ReturnPackage
+    } else if !repos_known {
+        NextStep::SelectRepositories
+    } else if !missing.is_empty() {
+        NextStep::InstallTools(missing)
+    } else {
+        NextStep::ReadyForRun
+    };
+
+    Ok(GuidedStatus {
+        root: session.work.root().to_path_buf(),
+        manifest,
+        tools,
+        installed,
+        next,
+    })
+}
+
+/// Install the pinned set for the guided flow, when there is a set to pin to.
+///
+/// Why: #5797. The guided flow runs against a working directory that may
+/// carry no engagement config — it is the flow you enter before anything is
+/// set up — and that case has to keep reporting rather than fail. There are
+/// no pins without a config, and installing without pins means installing
+/// whatever is current, which is the #5454 defect. So an absent config
+/// declines to install and the flow names the step, exactly as before.
+///
+/// A config that is PRESENT and unreadable or malformed is not that case and
+/// propagates: the caller's `load_if_present` tolerates only absence.
+/// What: takes the config [`guided`] already read, so the two cannot see
+/// different files. `Ok(None)` when there is no config or the set was already
+/// satisfied; `Ok(Some(installed))` naming what this call placed.
+/// Test: `super::session_tests::guided_without_a_config_still_names_the_step`,
+/// `super::session_tests::guided_propagates_a_malformed_config`.
+async fn auto_install_tools(
+    session: &Session,
+    config: Option<&EngagementConfig>,
+) -> Result<Option<Vec<InstalledTool>>, AuditError> {
+    let Some(config) = config else {
+        return Ok(None);
+    };
+    tools::ensure(&session.work, &config.tools, &session.progress).await
+}

--- a/crates/trusty-audit/src/session/verify.rs
+++ b/crates/trusty-audit/src/session/verify.rs
@@ -1,0 +1,413 @@
+//! Checking a received handoff package against the retained public key (#5563).
+//!
+//! Why: #5481 signed the return package and left the check a library call, so
+//! the only way to run it was to write a Rust program. The operator who
+//! receives a zip needs one command, and a status their shell can read — DOC-68
+//! §14 Q5 settles that as a CLI subcommand rather than a hand-run script.
+//!
+//! What: [`VerifyReport`] and [`verify`]. The check itself is
+//! [`crate::package::signing::verify`] and stays the single implementation
+//! behind every front end; this module reads the retained key off disk, hands
+//! it over, and adds no second opinion about what verifies.
+//!
+//! A separate module rather than another method on `Session`, for the reason
+//! [`super::init`] gives: `session.rs` sits at the 500-SLOC production cap.
+//!
+//! ## The key is named by the operator, never taken from the package
+//!
+//! There is no `[signing]` public half to fall back on. The engagement config
+//! carries the PRIVATE key, it travels inside the inbound package, and a key
+//! that arrives with the thing it authenticates authenticates nothing — so
+//! deriving the public half from a config the recipient held would verify a
+//! package against its own sender. `--public-key` names a file the auditor
+//! retained out of band, which is the only key that answers the question.
+//!
+//! A file rather than a value on argv: argv lands in shell history and in
+//! `ps`, and a retained key is already a file.
+//!
+//! ## Unsigned is not a pass
+//!
+//! An engagement that configured no key produces a package with no
+//! `[signature]` table, and so does anyone who rewrites the manifest of a
+//! signed one. [`crate::package::signing::verify`] reports both as
+//! [`Verdict::Unsigned`], which is why this capability gives it a non-zero exit
+//! of its own ([`super::EXIT_UNSIGNED`]) rather than folding it into success.
+//! It is distinct from a signed package whose signature member was removed —
+//! that is `SignatureMissing`, an error.
+//!
+//! Test: `verify_tests`.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::AuditError;
+use crate::package::signing::{self, RetainedKey, Verdict};
+
+/// What [`verify`] concluded, and about which file.
+///
+/// Why: the verdict alone does not name the package, and the CLI line has to —
+/// an operator checking a directory of returned zips reads the filename before
+/// the fingerprint.
+/// What: the package that was read, and the library's verdict over it,
+/// unmodified.
+/// Test: `verify_tests::a_signed_package_verifies_through_the_session_seam`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct VerifyReport {
+    /// The package that was checked.
+    pub package: PathBuf,
+    /// What [`crate::package::signing::verify`] answered.
+    pub verdict: Verdict,
+}
+
+impl VerifyReport {
+    /// Whether the package carries no signature to check.
+    ///
+    /// Read by [`super::Outcome::exit_code`], so the "nothing here is
+    /// authenticated" state reaches `$?` rather than only the printed text.
+    /// Test: `verify_tests::an_unsigned_package_has_its_own_exit_code`.
+    pub fn is_unsigned(&self) -> bool {
+        matches!(self.verdict, Verdict::Unsigned { .. })
+    }
+}
+
+/// Read the retained public key, then check `package` against it.
+///
+/// # Preconditions
+/// `public_key` is a file holding the retained ed25519 public half as 64
+/// lower-case hex characters, with surrounding whitespace ignored.
+///
+/// # Postconditions
+/// Neither `package` nor anything beside it is written, read-only being the
+/// whole point of a check. On `Ok`, the report's verdict is exactly what
+/// [`crate::package::signing::verify`] returned.
+///
+/// What: reads the key, parses it, and calls the library. The two failures it
+/// owns are its own — a key file that cannot be read, and one whose contents
+/// are not a key. Everything after that is the library's verdict, carried up
+/// unflattened by [`AuditError::Signing`]'s transparent wrapper so each of the
+/// distinguishable failures still reads as itself.
+/// Test: `verify_tests::a_signed_package_verifies_through_the_session_seam`,
+/// `verify_tests::a_missing_key_file_is_refused_before_the_package_is_read`,
+/// `verify_tests::a_key_file_that_is_not_a_key_is_refused`.
+///
+/// # Errors
+///
+/// [`AuditError::Read`] when `public_key` cannot be read, and
+/// [`AuditError::Signing`] for a key that does not parse or for any verdict
+/// [`crate::package::signing::verify`] refuses.
+pub fn verify(package: &Path, public_key: &Path) -> Result<VerifyReport, AuditError> {
+    let hex = std::fs::read_to_string(public_key).map_err(|source| AuditError::Read {
+        path: public_key.to_path_buf(),
+        source,
+    })?;
+    let retained = RetainedKey::from_hex(hex.trim())?;
+    Ok(VerifyReport {
+        package: package.to_path_buf(),
+        verdict: signing::verify(package, &retained)?,
+    })
+}
+
+#[cfg(test)]
+mod verify_tests {
+    use super::*;
+    use crate::package::signing::fixture;
+    use crate::package::signing::{EngagementKey, SigningError};
+    use crate::session::{Command, EXIT_UNSIGNED, Outcome, Session};
+    use crate::workdir::WorkDir;
+
+    /// Where a package and its key live, with nothing else in the directory —
+    /// so "did the check write anything" is answerable by listing it.
+    struct Received {
+        dir: tempfile::TempDir,
+        package: PathBuf,
+        key: PathBuf,
+    }
+
+    /// A package carrying two members, signed unless `signed` is false, beside
+    /// a key file holding the public half of the key that signed it.
+    fn received(signed: bool) -> Received {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = EngagementKey::generate();
+        let package = fixture::package(
+            dir.path(),
+            &[
+                ("README.md", "read me"),
+                ("reports/a/report.md", "findings"),
+            ],
+            signed.then_some(&key),
+        );
+        let key_path = dir.path().join("retained.pub");
+        std::fs::write(&key_path, format!("{}\n", key.public_hex())).expect("write the key");
+        Received {
+            dir,
+            package,
+            key: key_path,
+        }
+    }
+
+    /// Drive one check through the door every front end uses.
+    async fn execute(package: &Path, key: &Path) -> Result<Outcome, AuditError> {
+        let root = package
+            .parent()
+            .expect("the package has a parent")
+            .join("work");
+        Session::new(WorkDir::new(root))
+            .execute(Command::Verify {
+                package: package.to_path_buf(),
+                public_key: key.to_path_buf(),
+            })
+            .await
+    }
+
+    /// Every path under `dir`, relative and sorted — the "wrote nothing" probe.
+    fn tree(dir: &Path) -> Vec<PathBuf> {
+        let mut found: Vec<PathBuf> = walkdir::WalkDir::new(dir)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.path() != dir)
+            .map(|e| {
+                e.path()
+                    .strip_prefix(dir)
+                    .expect("under the root")
+                    .to_path_buf()
+            })
+            .collect();
+        found.sort();
+        found
+    }
+
+    fn signing_error(outcome: Result<Outcome, AuditError>) -> SigningError {
+        match outcome {
+            Err(AuditError::Signing { source }) => source,
+            other => panic!("expected a signing failure, got {other:?}"),
+        }
+    }
+
+    /// #5563 closure condition 1: a valid, untampered package verifies, exits
+    /// zero, and reports the key that signed it and how much it covers.
+    #[tokio::test]
+    async fn a_signed_package_verifies_through_the_session_seam() {
+        let received = received(true);
+        let outcome = execute(&received.package, &received.key)
+            .await
+            .expect("the package verifies");
+        assert_eq!(outcome.exit_code(), 0);
+        let Outcome::Verified(report) = &outcome else {
+            panic!("expected a verification outcome, got {outcome:?}");
+        };
+        // Two: the manifest covers the delivered members, and neither it nor
+        // the signature can appear in a manifest it is part of.
+        match &report.verdict {
+            Verdict::Signed {
+                key_fingerprint,
+                files,
+            } => {
+                assert_eq!(*files, 2);
+                assert!(
+                    crate::cli::render(&outcome).contains(key_fingerprint),
+                    "the rendered line must name the key: {}",
+                    crate::cli::render(&outcome)
+                );
+            }
+            other => panic!("expected a signed verdict, got {other:?}"),
+        }
+        assert!(crate::cli::render(&outcome).contains("2 members"));
+    }
+
+    /// #5563 closure condition 4, and the reason this capability is safe to run
+    /// on a file that arrived by email: it reads and writes nothing at all.
+    #[tokio::test]
+    async fn checking_a_package_writes_nothing_beside_it() {
+        let received = received(true);
+        let before = tree(received.dir.path());
+        let bytes = std::fs::read(&received.package).expect("read the package");
+        let modified = std::fs::metadata(&received.package)
+            .and_then(|m| m.modified())
+            .expect("the package has an mtime");
+
+        execute(&received.package, &received.key)
+            .await
+            .expect("the package verifies");
+
+        assert_eq!(tree(received.dir.path()), before, "no file may appear");
+        assert_eq!(
+            std::fs::read(&received.package).expect("read the package"),
+            bytes,
+            "the package's bytes may not change"
+        );
+        assert_eq!(
+            std::fs::metadata(&received.package)
+                .and_then(|m| m.modified())
+                .expect("the package has an mtime"),
+            modified,
+            "the package may not even be touched"
+        );
+    }
+
+    /// #5563 closure condition 3: an engagement that configured no key produces
+    /// a package nothing authenticates, and that is neither success nor the
+    /// removed-signature failure.
+    #[tokio::test]
+    async fn an_unsigned_package_has_its_own_exit_code() {
+        let received = received(false);
+        let outcome = execute(&received.package, &received.key)
+            .await
+            .expect("an unsigned package is a verdict, not an error");
+        assert_eq!(outcome.exit_code(), EXIT_UNSIGNED);
+        assert_ne!(EXIT_UNSIGNED, 0);
+        let rendered = crate::cli::render(&outcome);
+        assert!(rendered.contains("UNSIGNED"), "{rendered}");
+        assert!(
+            !rendered.contains("removed"),
+            "an unsigned package must not read as a stripped signature: {rendered}"
+        );
+    }
+
+    /// A signature member removed from a SIGNED package is the other outcome
+    /// the line above must not be confused with — an error, not a verdict.
+    #[tokio::test]
+    async fn a_removed_signature_is_an_error_rather_than_unsigned() {
+        let received = received(true);
+        let stripped = fixture::rewrite(&received.package, |name, bytes| {
+            (name != signing::SIGNATURE_ENTRY).then(|| bytes.to_vec())
+        });
+        let error = signing_error(execute(&stripped, &received.key).await);
+        assert!(
+            matches!(error, SigningError::SignatureMissing { .. }),
+            "{error:?}"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("was removed after it was written")
+        );
+    }
+
+    /// #5563 closure condition 2, first of four the archive itself can express:
+    /// a member whose bytes changed after the manifest was signed.
+    #[tokio::test]
+    async fn a_tampered_member_is_refused_with_its_own_line() {
+        let received = received(true);
+        let tampered = fixture::rewrite(&received.package, |name, bytes| {
+            Some(if name == "README.md" {
+                b"read me differently".to_vec()
+            } else {
+                bytes.to_vec()
+            })
+        });
+        let error = signing_error(execute(&tampered, &received.key).await);
+        match &error {
+            SigningError::ContentMismatch { entry, .. } => assert_eq!(entry, "README.md"),
+            other => panic!("expected a content mismatch, got {other:?}"),
+        }
+        assert!(error.to_string().contains("was altered after the package"));
+    }
+
+    /// A member the signed manifest lists and the archive no longer holds.
+    #[tokio::test]
+    async fn a_removed_member_is_refused_with_its_own_line() {
+        let received = received(true);
+        let short = fixture::rewrite(&received.package, |name, bytes| {
+            (name != "README.md").then(|| bytes.to_vec())
+        });
+        let error = signing_error(execute(&short, &received.key).await);
+        match &error {
+            SigningError::MemberMissing { entry, .. } => assert_eq!(entry, "README.md"),
+            other => panic!("expected a missing member, got {other:?}"),
+        }
+        assert!(error.to_string().contains("is not in the package"));
+    }
+
+    /// A member nobody signed, added to the archive afterwards.
+    #[tokio::test]
+    async fn an_added_member_is_refused_with_its_own_line() {
+        let received = received(true);
+        let extra =
+            fixture::with_extra_member(&received.package, "reports/b/report.md", b"planted");
+        let error = signing_error(execute(&extra, &received.key).await);
+        match &error {
+            SigningError::MemberUnexpected { entry, .. } => {
+                assert_eq!(entry, "reports/b/report.md");
+            }
+            other => panic!("expected an unexpected member, got {other:?}"),
+        }
+        assert!(error.to_string().contains("it was added"));
+    }
+
+    /// A key that is not the one the package was signed with — the closure
+    /// condition's "wrong public key fails closed, never passes".
+    #[tokio::test]
+    async fn a_key_that_did_not_sign_the_package_is_refused() {
+        let received = received(true);
+        let other = received.dir.path().join("someone-else.pub");
+        std::fs::write(&other, EngagementKey::generate().public_hex()).expect("write the key");
+        let error = signing_error(execute(&received.package, &other).await);
+        assert!(
+            matches!(error, SigningError::SignatureInvalid { .. }),
+            "{error:?}"
+        );
+        assert!(error.to_string().contains("does not verify"));
+    }
+
+    /// A second central-directory record under a name already in the archive.
+    /// The parser hides it; the check refuses the whole file.
+    #[tokio::test]
+    async fn a_duplicate_directory_record_is_refused_with_its_own_line() {
+        let received = received(true);
+        let forged = fixture::with_duplicate_record(&received.package, "README.md", b"read MF");
+        let error = signing_error(execute(&forged, &received.key).await);
+        match &error {
+            SigningError::DuplicateMember { entry, .. } => assert_eq!(entry, "README.md"),
+            other => panic!("expected a duplicate member, got {other:?}"),
+        }
+        assert!(error.to_string().contains("extracts differently"));
+    }
+
+    /// A decoy end-of-central-directory record planted in the archive comment,
+    /// which the parser takes and the raw walk does not. The two views then
+    /// disagree about the member set, and disagreement is a refusal.
+    ///
+    /// `DirectoryMalformed` is the one refusal this seam cannot reach: an
+    /// archive whose directory cannot be framed at all is refused by the zip
+    /// parser inside `open`, one step before the raw walk runs, so it arrives
+    /// as `Archive`. `super::super::signing::signing_tests` covers it against
+    /// `zip_directory::member_names` directly.
+    #[tokio::test]
+    async fn a_directory_the_parser_and_the_walk_disagree_on_is_refused() {
+        let received = received(true);
+        let doctored = fixture::with_decoy_directory(&received.package);
+        let error = signing_error(execute(&doctored, &received.key).await);
+        match &error {
+            SigningError::DirectoryMismatch { reason, .. } => {
+                assert!(reason.contains("collapsed"), "{reason}");
+            }
+            other => panic!("expected a directory disagreement, got {other:?}"),
+        }
+        assert!(error.to_string().contains("disagree about the members"));
+    }
+
+    /// The key file is the operator's input, so its absence is named as a file
+    /// they can go and find rather than as a verification failure.
+    #[tokio::test]
+    async fn a_missing_key_file_is_refused_before_the_package_is_read() {
+        let received = received(true);
+        let absent = received.dir.path().join("not-here.pub");
+        match execute(&received.package, &absent).await {
+            Err(AuditError::Read { path, .. }) => assert_eq!(path, absent),
+            other => panic!("expected a read failure, got {other:?}"),
+        }
+    }
+
+    /// A key file holding something that is not a key fails closed too.
+    #[tokio::test]
+    async fn a_key_file_that_is_not_a_key_is_refused() {
+        let received = received(true);
+        let bad = received.dir.path().join("junk.pub");
+        std::fs::write(&bad, "not a key").expect("write the file");
+        let error = signing_error(execute(&received.package, &bad).await);
+        assert!(
+            matches!(error, SigningError::KeyMalformed { .. }),
+            "{error:?}"
+        );
+    }
+}


### PR DESCRIPTION
#5481 signed the return package and left the check a library call, so the only
way to run it was to write a Rust program. This is that check as a capability: a
`session::Command::Verify` variant over `package::signing::verify`, which stays
the single implementation behind it and any front end.

Refs #5563
Refs #5481

## The verb, on a signed, an unsigned and a tampered package

```
$ trusty-audit verify .../signed/package.zip --public-key .../retained.pub
Verified: /private/tmp/.../pkgs-5563/signed/package.zip
  signed with engagement key 5314024c48928275 — tamper-evident in transit, not proof about the sender
  2 members, every one hashing to what the signed manifest records
exit=0

$ trusty-audit verify .../unsigned/package.zip --public-key .../retained.pub
UNSIGNED: /private/tmp/.../pkgs-5563/unsigned/package.zip
  the package carries a manifest and no signature, so nothing in it is authenticated — an engagement with no [signing] key produces this, and so does anyone who rewrites the manifest of one that had
  1 member listed, none of them checked against a key
exit=3

$ trusty-audit verify .../signed/rewritten.zip --public-key .../retained.pub
Error: /private/tmp/.../pkgs-5563/signed/rewritten.zip: README.md was altered after the package was signed — the manifest records SHA-256 3f22095641508576e91dc7c6c7f7e08a093985d53ea998043c6619ad240dc92c and the member in the package hashes to 1782ca232028afac0ba2ece7b449d733dbe4f76a72989441f5f2d0663c0aec6e
exit=1
```

That run printed `1 members`; both counts now go through `render::count_of`, and
every gate below was re-run on the amended commit.

## Four design calls

**`--public-key <FILE>` is required, and there is no config fallback.** The
issue's other option — read the `[signing]` public half — does not exist:
`SigningSettings` carries `private_key` only, that key travels to the recipient
inside the inbound package, and deriving the public half from a config the
recipient held would verify a package against its own sender. So the key comes
from a file the auditor retained out of band. A file rather than a value on argv
because argv lands in shell history and in `ps`.

**UNSIGNED exits 3**, a new `session::EXIT_UNSIGNED`. Never 0, and never
conflated with `SignatureMissing`, which is an error and exits 1. A rewritten
manifest produces `Unsigned` too, so it is not a weaker pass.

**`DirectoryMalformed` is the one refusal the verb cannot surface.** An archive
whose central directory cannot be framed is rejected by the zip parser inside
`signing::open`, one step before the raw walk runs, so it arrives as `Archive`
("cannot read the package"). The seam test covers `DirectoryMismatch` in its
place — a decoy EOCD in the archive comment, which the parser takes and the walk
does not. The README says so.

**Two splits ride along, both forced by the 500-SLOC production cap, both pure
moves.** `session.rs` was at 498/500 before a line was added: `session::guided`
takes the pre-sweep flow out unchanged, along the same line `session::init` was
split on and citing it. `cli/render.rs` was at 487, so the verify render arm gets
`cli/render/verify.rs`. Alongside them, `package::signing::fixture` is one
test-only builder of signed and forged archives, `pub(crate)`, shared by the
signing tests and the seam's — so there is no second builder free to drift from
the check it is written against. That is most of the `signing.rs` diff; no
production line in that file changed.

## Gates — rung 3 (localized behavior inside one crate)

Run on `d56c32d3`, rebased onto `origin/main` @ `642af40f7`.

```
cargo fmt --check                                          EXIT=0
cargo clippy -p trusty-audit --all-targets -- -D warnings   EXIT=0
cargo test -p trusty-audit --no-fail-fast                   EXIT=0
```

Per-target, with `--no-fail-fast`: `1046 passed; 0 failed; 5 ignored` (lib), then
0, 0, 3, 5, 4, 4 (2 ignored), 8, 9, 0 passed with 0 failed on every other target.
The eleven seam tests are inside that lib count.

Script gates:

```
line-cap: 4585 tracked .rs file(s); 4 allowlisted, 0 violations — OK
test-pointers: 31887 Test: citation(s) — 0 dangling pointers — OK
sld-lint: 63 spec doc(s) + 3713 code file(s); 0 error(s), 0 warning(s)
check_changelog_fragment: trusty-audit fragment present and valid
check-pr-version-bump: [ OK ] trusty-audit 0.14.4 — src changed, version not yet published
check_rustdoc_links: 26 crate(s), 0 broken link(s), baseline 0
```

Every closure condition fails on `origin/main` as a compile failure, the whole
seam being new — `git show HEAD~1:crates/trusty-audit/src/session.rs > …` then
`cargo test -p trusty-audit --lib verify_tests --no-fail-fast`:

```
error[E0432]: unresolved import `crate::session::verify`
error[E0599]: no variant named `Verify` found for enum `session::Command`
error[E0599]: no variant or associated item named `Verified` found for enum `session::Outcome`
error: could not compile `trusty-audit` (lib test) due to 5 previous errors
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
