### PR TITLE
feat(trusty-installer): tctl install accepts core and agents bundle keywords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11907,7 +11907,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trusty-installer"
 # 0.13.4 (#6618, #6619): patch — 0.13.3 is published and this PR edits
 # `src/**` (launchd restart-race fix). No public API changes.
-version = "0.13.5"
+version = "0.13.6"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/changelog.d/4714-install-bundle-keywords.md
+++ b/crates/trusty-installer/changelog.d/4714-install-bundle-keywords.md
@@ -1,0 +1,11 @@
+Added
+- `tctl install` accepts two bundle keywords in place of member names (#4714):
+  `core` installs trusty-memory + trusty-search (the always-on substrate `tctl
+  up` boots as STAGE 1), and `agents` installs trusty-search, trusty-memory,
+  trusty-review and trusty-mpm plus their runtime dependencies. Both mix freely
+  with member names and expand transitively like any named member.
+  - Each keyword derives its membership from an existing table — `core` from
+    the boot manifest's `BootStage::Core`, `agents` from the stable set's
+    `required` flag — so the keywords cannot drift from what they name.
+  - An unknown member name now names the available keywords, so a mistyped
+    `cores` is recoverable from the error alone.

--- a/crates/trusty-installer/src/cli.rs
+++ b/crates/trusty-installer/src/cli.rs
@@ -231,6 +231,13 @@ pub enum Commands {
     /// (for the orchestrator) uv on PATH.
     Install {
         /// Specific member(s) to install; omit for all enabled members.
+        ///
+        /// Two bundle keywords stand in for a group of members (#4714):
+        /// `core` = trusty-memory, trusty-search (the always-on substrate
+        /// `tctl up` boots as STAGE 1); `agents` = trusty-search,
+        /// trusty-memory, trusty-review, trusty-mpm (the agent orchestrator
+        /// and the daemons it needs). Either may be mixed with member names,
+        /// and each expands transitively like any named member.
         members: Vec<String>,
 
         /// Install binaries only — skip the post-install launchd service

--- a/crates/trusty-installer/src/cli_tests.rs
+++ b/crates/trusty-installer/src/cli_tests.rs
@@ -602,3 +602,29 @@ fn parse_sign_invalid_target_rejected() {
     let result = Cli::try_parse_from(["trusty-installer", "sign", "not-a-target"]);
     assert!(result.is_err(), "unknown sign target must be rejected");
 }
+
+/// Why (#4714): the bundle keywords are only usable if `tctl install --help`
+/// names them — an undocumented keyword is an undiscoverable one. This pins the
+/// long help against `bundles::BUNDLE_KEYWORDS`, so adding a keyword without
+/// documenting it fails here.
+/// What: Renders the `install` subcommand's long help and asserts every keyword
+/// appears in it.
+/// Test: This is the test.
+#[test]
+fn install_long_help_documents_every_bundle_keyword() {
+    use clap::CommandFactory;
+
+    let mut install = Cli::command()
+        .get_subcommands()
+        .find(|c| c.get_name() == "install")
+        .cloned()
+        .expect("install subcommand exists");
+    let help = install.render_long_help().to_string();
+
+    for keyword in crate::commands::bundles::BUNDLE_KEYWORDS {
+        assert!(
+            help.contains(keyword),
+            "`tctl install --help` must document the `{keyword}` bundle:\n{help}"
+        );
+    }
+}

--- a/crates/trusty-installer/src/commands/bundles.rs
+++ b/crates/trusty-installer/src/commands/bundles.rs
@@ -1,0 +1,253 @@
+//! Bundle keywords for `tctl install` (#4714).
+//!
+//! Why: `tctl install` accepts only exact member names, so an operator who
+//! wants the always-on substrate has to already know it is spelled
+//! `trusty-memory trusty-search`. The vocabulary for those groupings already
+//! exists elsewhere in the crate — `up::manifest`'s `BootStage::Core` names
+//! memory+search, and `stable_set`'s `required` flag names the members a
+//! from-scratch install must always bring up — but neither is reachable from
+//! the install verb. This module exposes them as typed keywords.
+//!
+//! What: A keyword table ([`BUNDLE_KEYWORDS`]) plus [`bundle_members`], which
+//! DERIVES each keyword's membership from the existing tables rather than
+//! restating it, and [`expand_bundles`], which rewrites a caller's name list
+//! into explicit crate names before
+//! [`super::stable_set::select_members_transitive`] resolves it. Expansion is
+//! pure and order-preserving; the transitive closure and the topological order
+//! stay entirely the resolver's job.
+//!
+//! Deriving rather than hard-coding is what keeps the keywords honest: adding
+//! a member to `BootStage::Core`, or flipping a member to `required: true`,
+//! moves the matching bundle with it. `stable_set`'s own note to future
+//! editors — that a later lane inserts `trusty-agents` "as REQUIRED" — means
+//! that lane extends `agents` with no edit here.
+//!
+//! Test: `tests` pins both keywords' derived membership, the identity of a
+//! non-keyword name, order preservation, deduplication, and the
+//! [`keywords_hint`] string the unknown-member error carries.
+
+use super::stable_set::stable_set;
+use super::up::manifest::{default_manifest, members_in_stage, BootStage};
+
+/// Every bundle keyword `tctl install` accepts, alphabetically.
+///
+/// Why: One list, read by [`bundle_members`]'s dispatch, by [`keywords_hint`]
+/// (so the unknown-member error can never name a stale set), and by the
+/// `--help` text's test. A keyword added here without a `bundle_members` arm
+/// fails `tests::every_keyword_resolves`.
+///
+/// What: `agents` and `core` — see [`bundle_members`] for what each expands to.
+///
+/// Test: `tests::every_keyword_resolves`, `tests::keywords_hint_names_all`.
+pub const BUNDLE_KEYWORDS: &[&str] = &["agents", "core"];
+
+/// Expand one bundle keyword to the explicit crate names it stands for.
+///
+/// Why: `tctl install core` should mean exactly what `tctl up`'s STAGE 1
+/// means, and `tctl install agents` exactly what a verified from-scratch
+/// install must be able to bring up. Both are already declared as data
+/// elsewhere; re-typing either here would let the two drift silently.
+///
+/// What: `core` is every `up::manifest` member in [`BootStage::Core`] — today
+/// `trusty-memory`, `trusty-search`. `agents` is every [`stable_set`] member
+/// with `required: true` — today `trusty-search`, `trusty-memory`,
+/// `trusty-review`, `trusty-mpm`, the set whose closure is the agent
+/// orchestrator plus the daemons it and the review gate need. Returns `None`
+/// for any name that is not a keyword, which is how [`expand_bundles`] tells a
+/// keyword from a member name. The returned names are NOT closed over the
+/// dependency graph — `select_members_transitive` does that.
+///
+/// Test: `tests::core_is_the_boot_stage_core_members`,
+/// `tests::agents_is_the_required_members`, `tests::unknown_keyword_is_none`.
+pub fn bundle_members(keyword: &str) -> Option<Vec<String>> {
+    match keyword {
+        "core" => Some(
+            members_in_stage(&default_manifest(), BootStage::Core)
+                .into_iter()
+                .map(|m| m.id.clone())
+                .collect(),
+        ),
+        "agents" => Some(
+            stable_set()
+                .into_iter()
+                .filter(|m| m.required)
+                .map(|m| m.crate_name)
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+/// Rewrite a caller's name list, replacing every bundle keyword with the crate
+/// names it stands for.
+///
+/// Why: The install verb's resolver only understands member names. Expanding
+/// first — rather than teaching the resolver about keywords — keeps the
+/// keyword vocabulary in one place and leaves `select_members_transitive`'s
+/// unknown-name contract untouched, so a typo still errors exactly as before.
+///
+/// What: Maps each name through [`bundle_members`], splicing a keyword's
+/// members in at its position and passing any other name through unchanged.
+/// Duplicates are dropped, keeping first occurrence, so `tctl install core
+/// trusty-search` names trusty-search once. An empty input stays empty, which
+/// is how `install::run` keeps meaning "the full stable set".
+///
+/// Test: `tests::expands_core`, `tests::passes_member_names_through`,
+/// `tests::dedups_overlapping_bundle_and_member`,
+/// `tests::preserves_order_across_a_mixed_list`, `tests::empty_stays_empty`.
+pub fn expand_bundles(names: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut push = |name: String| {
+        if !out.contains(&name) {
+            out.push(name);
+        }
+    };
+    for name in names {
+        match bundle_members(name) {
+            Some(members) => members.into_iter().for_each(&mut push),
+            None => push(name.clone()),
+        }
+    }
+    out
+}
+
+/// The parenthetical the unknown-member error appends, naming every keyword.
+///
+/// Why: Before #4714 a mistyped `tctl install cores` said only "unknown
+/// member(s): cores", leaving the operator no way to discover that `core` was
+/// the word. The hint reads off [`BUNDLE_KEYWORDS`] so it cannot go stale.
+///
+/// What: `"bundle keywords: agents, core"`.
+///
+/// Test: `tests::keywords_hint_names_all`.
+pub fn keywords_hint() -> String {
+    format!("bundle keywords: {}", BUNDLE_KEYWORDS.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owned(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| (*n).to_owned()).collect()
+    }
+
+    /// Why: `core` must stay the same set `tctl up` boots as STAGE 1; a silent
+    /// divergence would make the two verbs disagree about what "core" is.
+    /// What: Pins the derived membership against the manifest's own filter.
+    /// Test: This is the test.
+    #[test]
+    fn core_is_the_boot_stage_core_members() {
+        assert_eq!(
+            bundle_members("core"),
+            Some(owned(&["trusty-memory", "trusty-search"]))
+        );
+    }
+
+    /// Why: `agents` is derived from `stable_set`'s `required` flag, so the
+    /// pin doubles as a guard on that classification changing unnoticed.
+    /// What: Pins the derived membership in stable-set order.
+    /// Test: This is the test.
+    #[test]
+    fn agents_is_the_required_members() {
+        assert_eq!(
+            bundle_members("agents"),
+            Some(owned(&[
+                "trusty-search",
+                "trusty-memory",
+                "trusty-review",
+                "trusty-mpm",
+            ]))
+        );
+    }
+
+    /// Why: A member name must NOT be treated as a keyword, or expansion would
+    /// shadow the stable set.
+    /// What: Asserts `None` for a member name and for a bogus name.
+    /// Test: This is the test.
+    #[test]
+    fn unknown_keyword_is_none() {
+        assert_eq!(bundle_members("trusty-search"), None);
+        assert_eq!(bundle_members("cores"), None);
+    }
+
+    /// Why: Every advertised keyword must resolve, or the `--help` text and
+    /// the error hint would promise a word the code rejects.
+    /// What: Asserts each [`BUNDLE_KEYWORDS`] entry yields a non-empty set.
+    /// Test: This is the test.
+    #[test]
+    fn every_keyword_resolves() {
+        for kw in BUNDLE_KEYWORDS {
+            let members = bundle_members(kw).unwrap_or_else(|| panic!("{kw} must resolve"));
+            assert!(
+                !members.is_empty(),
+                "{kw} must expand to at least one member"
+            );
+        }
+    }
+
+    /// Why: The expansion is what `install::run` actually calls.
+    /// What: `["core"]` becomes the two core member names.
+    /// Test: This is the test.
+    #[test]
+    fn expands_core() {
+        assert_eq!(
+            expand_bundles(&owned(&["core"])),
+            owned(&["trusty-memory", "trusty-search"])
+        );
+    }
+
+    /// Why: Naming members directly must keep working unchanged.
+    /// What: A non-keyword list passes through identically.
+    /// Test: This is the test.
+    #[test]
+    fn passes_member_names_through() {
+        let names = owned(&["trusty-mpm", "not-a-real-tool"]);
+        assert_eq!(expand_bundles(&names), names);
+    }
+
+    /// Why: `tctl install core trusty-search` must not name trusty-search
+    /// twice — a duplicate would be resolved twice by the picker-free path.
+    /// What: Asserts the overlap collapses, first occurrence winning.
+    /// Test: This is the test.
+    #[test]
+    fn dedups_overlapping_bundle_and_member() {
+        assert_eq!(
+            expand_bundles(&owned(&["core", "trusty-search"])),
+            owned(&["trusty-memory", "trusty-search"])
+        );
+    }
+
+    /// Why: Expansion happens in place, so a mixed list must keep the caller's
+    /// order — the resolver re-sorts topologically afterwards, but a reordering
+    /// here would scramble the unknown-name diagnostics.
+    /// What: A member, a keyword, then another member.
+    /// Test: This is the test.
+    #[test]
+    fn preserves_order_across_a_mixed_list() {
+        assert_eq!(
+            expand_bundles(&owned(&["tga", "core", "trusty-mpm"])),
+            owned(&["tga", "trusty-memory", "trusty-search", "trusty-mpm"])
+        );
+    }
+
+    /// Why: `install::run` treats an empty list as "the full stable set";
+    /// expansion must not invent members for it.
+    /// What: Asserts the empty input stays empty.
+    /// Test: This is the test.
+    #[test]
+    fn empty_stays_empty() {
+        assert!(expand_bundles(&[]).is_empty());
+    }
+
+    /// Why: The error hint is the operator's only discovery path from a typo.
+    /// What: Asserts it names every keyword.
+    /// Test: This is the test.
+    #[test]
+    fn keywords_hint_names_all() {
+        let hint = keywords_hint();
+        for kw in BUNDLE_KEYWORDS {
+            assert!(hint.contains(kw), "hint must name {kw}: {hint}");
+        }
+    }
+}

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -6,7 +6,9 @@
 //! Idempotent: an already-installed member is re-run through the prebuilt-first
 //! path (Phase 2 / #1760) or `cargo install` (cheap no-op when current) and reported.
 //!
-//! What: Resolves the requested members against [`super::stable_set`], installs
+//! What: Rewrites any bundle keyword in the request via
+//! [`super::bundles::expand_bundles`] (#4714 — `core`, `agents`), resolves the
+//! result against [`super::stable_set`], installs
 //! each in order via the prebuilt-first strategy: on a Tier-1 platform a prebuilt
 //! tarball is downloaded, SHA-256 verified, and atomically placed into the install
 //! directory (since #5777 the canonical `$CARGO_HOME/bin`, falling back to
@@ -43,6 +45,7 @@ use std::path::{Path, PathBuf};
 
 use trusty_progress::{Component, ComponentState, ComponentTracker, LiveChecklist, Mode};
 
+use super::bundles::{expand_bundles, keywords_hint};
 use super::dependency_graph::describe_added;
 use super::install_gate::{decide_install_gate, GateInputs, InstallGate};
 use super::progress_ui::{narrator, prompt_yes_no};
@@ -63,7 +66,8 @@ use install_report::{
 ///
 /// Why: Phase-1 entry point for the system install flow (#1316 priority 1).
 ///
-/// What: Resolves `members` against the stable set (empty = all). When no
+/// What: Expands any bundle keyword in `members` ([`super::bundles`], #4714),
+/// then resolves the result against the stable set (empty = all). When no
 /// members are given AND stdin is a TTY AND `--json` is not set AND not
 /// `--dry-run`, presents the Phase-4 interactive component picker so the
 /// operator can choose a subset without needing to know crate names.
@@ -131,11 +135,14 @@ pub fn run(
         members
     };
 
-    let resolved = select_members_transitive(members);
+    // #4714: rewrite bundle keywords (`core`, `agents`) into explicit member
+    // names before resolution, so the resolver's name contract is unchanged.
+    let expanded = expand_bundles(members);
+    let resolved = select_members_transitive(&expanded);
     let (selected, unknown) = (resolved.members, resolved.unknown);
 
     if !unknown.is_empty() {
-        let msg = format!("unknown member(s): {}", unknown.join(", "));
+        let msg = unknown_members_message(&unknown);
         if json {
             if render_json(&serde_json::json!({
                 "command": "install",
@@ -952,6 +959,28 @@ async fn install_one(m: &StableMember) -> anyhow::Result<InstalledBinary> {
 /// `tests::binary_size_is_zero_for_a_missing_path`.
 fn binary_size(path: &Path) -> u64 {
     std::fs::metadata(path).map(|md| md.len()).unwrap_or(0)
+}
+
+/// The operator-facing text for a request naming something the stable set does
+/// not contain.
+///
+/// Why (#4714): the message used to be just the offending names, so a mistyped
+/// `cores` gave the operator nothing to correct it with — the bundle keywords
+/// were undiscoverable from the failure. Naming them here, off
+/// [`super::bundles::BUNDLE_KEYWORDS`], means the hint cannot go stale as
+/// keywords are added.
+///
+/// What: `"unknown member(s): <names> (bundle keywords: agents, core)"`. The
+/// exit code and the JSON envelope's shape are unchanged — only the `error`
+/// string grows.
+///
+/// Test: `tests::unknown_members_message_names_bundle_keywords`.
+fn unknown_members_message(unknown: &[String]) -> String {
+    format!(
+        "unknown member(s): {} ({})",
+        unknown.join(", "),
+        keywords_hint()
+    )
 }
 
 /// Resolve the cargo binary install directory.

--- a/crates/trusty-installer/src/commands/install_tests.rs
+++ b/crates/trusty-installer/src/commands/install_tests.rs
@@ -1119,3 +1119,99 @@ fn plans_service_bootstrap_visits_a_retired_member() {
         "--no-service must still suppress the visit"
     );
 }
+
+// ── Bundle keywords (#4714) ──────────────────────────────────────────────────
+// These exercise the composition `run` itself performs — `expand_bundles`
+// feeding `select_members_transitive` — rather than re-deriving the sets, so a
+// regression in either half surfaces here.
+
+/// Why (#4714): `tctl install core` must resolve to exactly the always-on
+/// substrate `tctl up` boots as STAGE 1, in stable-set (topological) order.
+/// What: Expands the keyword and resolves it the way `run` does; asserts the
+/// resolved crate names and that nothing was reported unknown.
+/// Test: This is the test.
+#[test]
+fn bundle_core_resolves_to_the_two_core_daemons() {
+    let resolved = select_members_transitive(&expand_bundles(&["core".to_owned()]));
+    assert!(
+        resolved.unknown.is_empty(),
+        "core must resolve cleanly, got unknown: {:?}",
+        resolved.unknown
+    );
+    let names: Vec<&str> = resolved
+        .members
+        .iter()
+        .map(|m| m.crate_name.as_str())
+        .collect();
+    assert_eq!(names, ["trusty-search", "trusty-memory"]);
+}
+
+/// Why (#4714): `tctl install agents` must resolve to the members a verified
+/// from-scratch install has to bring up, CLOSED over the runtime-dependency
+/// graph — trusty-review pulls trusty-analyze in, so the closure is strictly
+/// larger than the four `required` members.
+/// What: Asserts the resolved order and that trusty-analyze arrives as a
+/// transitively-added member rather than an explicit one.
+/// Test: This is the test.
+#[test]
+fn bundle_agents_resolves_transitively_in_topological_order() {
+    let resolved = select_members_transitive(&expand_bundles(&["agents".to_owned()]));
+    assert!(
+        resolved.unknown.is_empty(),
+        "agents must resolve cleanly, got unknown: {:?}",
+        resolved.unknown
+    );
+    let names: Vec<&str> = resolved
+        .members
+        .iter()
+        .map(|m| m.crate_name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "trusty-search",
+            "trusty-memory",
+            "trusty-analyze",
+            "trusty-review",
+            "trusty-mpm",
+        ]
+    );
+    assert!(
+        resolved
+            .added
+            .iter()
+            .any(|a| a.crate_name == "trusty-analyze"),
+        "trusty-analyze must be reported as pulled in by trusty-review"
+    );
+}
+
+/// Why (#4714): `--dry-run` with a bundle keyword must preview and exit 0. On
+/// the pre-#4714 code `core` is an unknown member and this returns 3.
+/// What: Calls `run` in `--json --dry-run` mode with each keyword.
+/// Test: This is the test.
+#[test]
+fn run_dry_run_accepts_bundle_keywords() {
+    for keyword in ["core", "agents"] {
+        let code = run(&[keyword.to_owned()], false, true, false, true, false, true);
+        assert_eq!(code, 0, "--dry-run {keyword} must exit 0");
+    }
+}
+
+/// Why (#4714): a typo must still be a clean exit-3 error, and the message must
+/// now name the keywords so the operator can recover from `cores` → `core`.
+/// What: Pins the message text and re-asserts the unchanged exit code.
+/// Test: This is the test.
+#[test]
+fn unknown_members_message_names_bundle_keywords() {
+    let msg = unknown_members_message(&["cores".to_owned()]);
+    assert!(
+        msg.starts_with("unknown member(s): cores"),
+        "the pre-#4714 prefix must be unchanged: {msg}"
+    );
+    for keyword in crate::commands::bundles::BUNDLE_KEYWORDS {
+        assert!(msg.contains(keyword), "message must name {keyword}: {msg}");
+    }
+
+    let code = run(&["cores".to_owned()], true, true, false, false, false, true);
+    assert_eq!(code, 3, "an unknown keyword must still exit 3");
+}

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -13,6 +13,8 @@
 //! runs them all.
 
 pub mod auto_update;
+// #4714: `tctl install` bundle keywords (`core`, `agents`).
+pub mod bundles;
 pub mod config;
 pub mod dependency_graph;
 pub mod doctor;


### PR DESCRIPTION
`tctl install` took only exact member names, so installing the always-on substrate meant already knowing it is spelled `trusty-memory trusty-search`. The vocabulary existed elsewhere in the crate but was unreachable from the install verb.

Adds `commands/bundles.rs`: a keyword table plus `expand_bundles`, which rewrites a caller's name list into explicit crate names before `select_members_transitive` resolves it. The resolver's name contract is untouched, so a typo still errors exactly as before — the message just names the keywords now.

Each keyword derives its membership from an existing table rather than restating it, so the two cannot drift.

Refs #4714

## What each keyword means

- `core` = every `up::manifest` member in `BootStage::Core` — trusty-memory, trusty-search. This is what the issue quotes: "`tctl install trusty-memory trusty-search` installs a complete, correctly-provisioned closure today", and `tctl up` already boots exactly those two as STAGE 1.
- `agents` = every `stable_set` member with `required: true` — trusty-search, trusty-memory, trusty-review, trusty-mpm. The dependency graph then adds trusty-analyze, which trusty-review's #590 context gate needs.

## Why `agents` is derived rather than the issue's literal set

The issue never defines `agents`; its blockers do. #4713 calls the package "the 'agents + code' installer package", so the intended set was `trusty-agents` + `trusty-code`. Neither is buildable into `tctl install` today:

- Neither crate is a `stable_set()` member. Adding them would change what a bare `tctl install` (no args) installs from 7 members to 9 — and the issue itself calls widening that default "a **separate product decision**".
- #4712, the trusty-agents release-lane blocker, was closed by a backlog reset whose own comment says: "Closing as part of a 1.3.8 backlog reset. Current shipped behavior is being taken as the baseline, and open non-feature issues are being cleared rather than individually re-verified. **This is not a claim that the issue was fixed** — if it is still causing problems, please reopen with a current reproduction."
- It was not fixed. No `trusty-agents-v*` tag exists, and `.github/workflows/release.yml:592` still lists `trusty-agents*` among the "Library-only / internal crates (green-skip, no standalone binary)". `tctl` fetches prebuilt-from-Releases and falls back to `cargo install <crate>` by registry name — never `--path` — so both channels are closed.

So `agents` derives from `stable_set()`'s `required` flag instead, documented there as the members "a from-scratch install on a Tier-1 platform must always be able to bring up". Every member installs today, and `stable_set.rs:361`'s standing note — "a separate lane may add `trusty-agents` to this set as REQUIRED" — means that lane extends the bundle with no edit to this code.

Widening `agents` to trusty-agents + trusty-code needs the stable-set / default-install product decision made first and #4712 genuinely reopened with a working release lane.

## Test ladder — rung 3

Localized behavior inside one crate.

```
cargo test -p trusty-installer --no-fail-fast
```

Every target ran:

```
     Running unittests src/lib.rs (target/debug/deps/trusty_installer-6e19d7adbb7866d4)
test result: ok. 720 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 2.38s
     Running unittests src/main.rs (target/debug/deps/tctl-16f4b53b626326d2)
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
     Running unittests src/main.rs (target/debug/deps/trusty_installer-0346c01d4c8094fe)
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
     Running tests/config_mount.rs (target/debug/deps/config_mount-d174c4a5ca94e224)
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.55s
     Running tests/path_shadow_e2e.rs (target/debug/deps/path_shadow_e2e-b6a9b0ca11e54007)
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.33s
   Doc-tests trusty_installer
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Also green on this head: `cargo fmt --check`, `cargo clippy -p trusty-installer --all-targets -- -D warnings`, `check_line_cap.sh`, `check_test_pointers.sh`, `check_sld.sh`, `check_changelog_fragment.sh`, `check-pr-version-bump.sh`, `check_rustdoc_links.sh`.

15 new tests cover both keywords' derived membership, pass-through of member names, dedup, order preservation, the empty case, the `--dry-run` exit code for each keyword, the unknown-member message, and that `--help` documents every keyword.

Each of the five behaviors was confirmed absent on `origin/main` by reverting `install.rs`, `cli.rs` and `mod.rs` with `git show`, rebuilding `tctl`, and probing it: `install --dry-run core` and `--dry-run agents` both printed `unknown member(s)` and exited 3, the typo error named no keywords, and `--help` documented neither.

## Binary smoke — the two plans

```
$ tctl install --dry-run core
tctl install: DRY RUN — would install 2 tool(s): trusty-search, trusty-memory
tctl install: destination: /Users/masa/.cargo/bin
tctl install:   trusty-search -> trusty-search, trusty-embedderd (would bootstrap launchd service)
tctl install:   trusty-memory -> trusty-memory, trusty-memory-mcp-bridge (would bootstrap launchd service)
tctl install: dry run complete — no changes made.
EXIT=0
```

```
$ tctl install --dry-run agents
tctl install: adding trusty-analyze (required by trusty-review)
tctl install: DRY RUN — would install 5 tool(s): trusty-search, trusty-memory, trusty-analyze, trusty-review, trusty-mpm
tctl install: destination: /Users/masa/.cargo/bin
tctl install:   trusty-search -> trusty-search, trusty-embedderd (would bootstrap launchd service)
tctl install:   trusty-memory -> trusty-memory, trusty-memory-mcp-bridge (would bootstrap launchd service)
tctl install:   trusty-analyze -> trusty-analyze (would bootstrap launchd service)
tctl install:   trusty-review -> trusty-review (would bootstrap launchd service)
tctl install:   trusty-mpm -> tm, trusty-mpm (no service bootstrap)
tctl install: dry run complete — no changes made.
EXIT=0
```

Both in stable-set topological order; `agents` surfaces the transitive expansion with its requester.

```
$ tctl install --dry-run cores
tctl install: unknown member(s): cores (bundle keywords: agents, core)
EXIT=3
```

## Version

trusty-installer 0.13.5 → 0.13.6. `check-pr-version-bump.sh` failed on 0.13.5 (already published on crates.io). The root `[workspace.dependencies]` row pins `version = "0.13"`, which a patch bump does not widen.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
