### PR TITLE
docs(release-workflow): trusty-review and trusty-audit stay ad-hoc signed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,9 +380,10 @@ exactly like an OOM kill.
 🟢 **macOS TCC scope split — read before re-granting anything:** `trusty-search`
 (and other external-volume daemons) needs **Full Disk Access**; `trusty-mpm` /
 `tm` needs the separate **App Data** category only, and must never be granted
-Full Disk Access. Certificates, signed-install scripts, the `launchctl bootout`
-restart playbook, and orphan-listener verification (#873, #2558, #534, #2486,
-#4230): [release-workflow.md](docs/reference/release-workflow.md).
+Full Disk Access. `trusty-review` and `trusty-audit` need no signing at all —
+neither is a persistent daemon (#4750). Certificates, signed-install scripts,
+the `launchctl bootout` restart playbook, and orphan-listener verification
+(#873, #2558, #534, #2486, #4230): [release-workflow.md](docs/reference/release-workflow.md).
 
 ### Per-PR Changelog Fragment (issue #4476)
 

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -473,6 +473,19 @@ reason; an application's own data directory is not TCC-protected. See
 [Signed Install: trusty-memory](#signed-install-trusty-memory) and
 [Signed Install: trusty-analyze](#signed-install-trusty-analyze) below.
 
+🟢 **`trusty-review` and `trusty-audit` need no Developer-ID signing — neither
+is a persistent daemon.** `trusty-review` runs only as a Claude Code MCP stdio
+child per the managed `.mcp.json` (`serve --stdio`,
+`crates/trusty-mpm/src/core/mcp_config.rs`), or as a one-shot `report` child of
+`tga`/`trusty-audit`; `trusty-audit` itself is a one-shot CLI (`trusty-audit`
+and `taudit` are the same `src/main.rs`, no daemon mode). Neither walks `$HOME`
+nor touches a TCC-protected category, and each reads only the repository
+checkout and the config paths its caller names. Ad-hoc signing is the correct
+end state for both — owner ruling 2026-09-07 for `trusty-audit` ("leave ad hoc
+for now") and #4750 for `trusty-review` — so neither has a `tctl sign` target
+and neither belongs in `SIGNABLE_BINARIES`
+(`crates/trusty-installer/src/commands/macos_signing/mod.rs`).
+
 **Do not cross the categories:** granting `trusty-search` Full Disk Access does
 nothing for the `trusty-mpm` App-Data prompt, and `trusty-mpm` never needs —
 and should never be granted — Full Disk Access. Re-signing with a stable


### PR DESCRIPTION
Refs #4750

Rung 1 (docs-only).

`trusty-review` and `trusty-audit` never appear in `SIGNABLE_BINARIES`
(`crates/trusty-installer/src/commands/macos_signing/mod.rs`) because neither
runs as a persistent daemon: `trusty-review` is a Claude Code MCP stdio child
per the managed `.mcp.json`, or a one-shot `report` child of `tga`/`trusty-audit`,
and `trusty-audit` itself is a one-shot CLI. Neither walks `$HOME` or touches a
TCC-protected category, so there is no stable-identity grant to preserve and
ad-hoc signing is the correct end state for both — owner ruling 2026-09-07 for
`trusty-audit` ("leave ad hoc for now") and #4750 for `trusty-review`. This PR
adds one 🟢 bullet documenting that determination in
`docs/reference/release-workflow.md`'s TCC Scope Summary, plus one sentence in
`CLAUDE.md`'s macOS TCC scope split callout.

Gates (rung 1, docs-only):
- `./scripts/check_sld.sh` — 0 errors, 0 warnings
- `./scripts/check_line_cap.sh` — 0 violations
- `./scripts/check_doc_numbers.sh` — 0 violations
