### PR TITLE
test(trusty-mpm): wedged-probe test stops demanding a pid the probe may never record

### DIFF
--- a/crates/trusty-mpm/src/runtime/claude_code_agents_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_agents_tests.rs
@@ -324,6 +324,36 @@ fn registry_sample_parses_every_entry_shape() {
     );
 }
 
+/// The pid the wedged stand-in recorded, or `None` when it recorded none.
+///
+/// Why (#7043): the stand-in writes its pid as its first action, which races
+/// `query_registry`'s own 3s deadline. `query_registry` SIGKILLs the probe and
+/// blocks on `waitpid` before it returns, so whatever the pid file holds when
+/// the call returns is what it holds forever — a starved probe that never
+/// reached its `echo` leaves no pid, and no amount of waiting afterwards
+/// produces one. Reading the file once and demanding a pid therefore failed a
+/// run whose only fault was losing that race.
+/// What: classifies the file into "the probe named itself" and "it did not".
+/// Absent or empty is the lost race; anything else is still a hard failure.
+/// Test: `query_registry_kills_and_reaps_a_wedged_probe`.
+#[cfg(unix)]
+fn recorded_probe_pid(pidfile: &Path) -> Option<libc::pid_t> {
+    let recorded = match std::fs::read_to_string(pidfile) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => panic!("pid file unreadable for a reason other than absence: {e}"),
+    };
+    let trimmed = recorded.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(
+        trimmed
+            .parse()
+            .unwrap_or_else(|e| panic!("a written pid file must hold a pid, got {trimmed:?}: {e}")),
+    )
+}
+
 /// Why (#6863): the probe is the module's only real spawn, and it runs on the
 /// interactive resume path. A `claude` that never answers must cost the deadline
 /// and nothing more — before this fix the reader thread owned the child and the
@@ -362,11 +392,13 @@ fn query_registry_kills_and_reaps_a_wedged_probe() {
         started.elapsed()
     );
 
-    let pid: libc::pid_t = std::fs::read_to_string(&pidfile)
-        .expect("the stand-in must have recorded its pid before wedging")
-        .trim()
-        .parse()
-        .expect("pid file must hold a pid");
+    // #7043: a probe starved past the deadline before it could record its pid
+    // is a probe that did not outlive the deadline — the liveness check below
+    // only has something to check when the stand-in named itself.
+    let Some(pid) = recorded_probe_pid(&pidfile) else {
+        eprintln!("stand-in was killed before recording a pid; liveness unchecked (#7043)");
+        return;
+    };
     // SAFETY: signal 0 performs the existence/permission check only.
     let alive = unsafe { libc::kill(pid, 0) };
     assert_eq!(


### PR DESCRIPTION
Refs #7043

## What changed

`query_registry_kills_and_reaps_a_wedged_probe` read the stand-in's pid file
once and required a pid, so a run that lost the race against the probe's own
3s deadline failed with `the stand-in must have recorded its pid before
wedging: Os { code: 2, kind: NotFound }`.

`recorded_probe_pid` now classifies the file. A recorded pid still gets the
full `kill(pid, 0)` / `ESRCH` liveness check; absent-or-empty is reported as
the lost race it is and leaves the liveness check with nothing to check; any
other content is still a hard failure.

Test-only — `crates/trusty-mpm/src/runtime/claude_code_agents_tests.rs`, 37
insertions / 5 deletions. No production code changed, so no changelog
fragment (the file is test-only by path).

## This corrects the assertion; it does not add the wait the issue proposed

#7043 proposes a bounded condition-wait on the pid file. That wait can never
succeed on the failing run. `query_registry` reaches its timeout through
`disclaimed_stdout_command_with_timeout`, which SIGKILLs the child and then
BLOCKS on `waitpid` before returning — `crates/trusty-mpm/src/core/spawn_disclaim/timeout.rs:137`,
`waiter.kill_and_reap()`, whose two arms are `Child::kill()` + `Child::wait()`
(native) and `libc::kill(SIGKILL)` + `macos::wait_for` (blocking
`waitpid(pid, &status, 0)`). The probe is dead and reaped before
`query_registry` returns, so whatever the pid file holds at that instant it
holds forever. Waiting afterwards would only make a lost race slower.

The reported `ENOENT` narrows it further: `>` opens the file with `O_CREAT`
before `echo` runs, so an empty file would mean "killed between open and
write". Absent means the shell had not executed its first line at all — a
probe starved for the full 3s `REGISTRY_TIMEOUT`. The test asserted something
the system does not guarantee.

## Test ladder

Rung 2 — test-only stabilization.

`cargo fmt --check` → exit 0.
`cargo clippy -p trusty-mpm --all-targets -- -D warnings` → exit 0.
`./scripts/check_line_cap.sh` → 4582 tracked .rs files, 0 violations.
`./scripts/check_test_pointers.sh` → 31880 citations, 0 dangling.
`./scripts/check_changelog_fragment.sh` → 1 changed path, 0 crate-source paths (test-only).

`cargo test -p trusty-mpm --no-fail-fast` (full, all targets) — exit 0, 54
`test result:` lines, zero `FAILED`. Leading targets:

```
test result: ok. 6083 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out; finished in 57.79s
test result: ok. 2211 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 13.46s
test result: ok. 2211 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 13.70s
```

Ten consecutive `cargo test -p trusty-mpm --lib --no-fail-fast`, with
`query_registry_kills_and_reaps_a_wedged_probe ... ok` in all ten:

```
test result: ok. 6083 passed; 0 failed; 8 ignored; finished in  84.16s   LIB_RUN_1_EXIT=0
test result: ok. 6083 passed; 0 failed; 8 ignored; finished in 102.66s   LIB_RUN_2_EXIT=0
test result: ok. 6083 passed; 0 failed; 8 ignored; finished in  77.32s   LIB_RUN_3_EXIT=0
test result: ok. 6083 passed; 0 failed; 8 ignored; finished in  86.19s   LIB_RUN_5_EXIT=0
test result: ok. 6083 passed; 0 failed; 8 ignored; finished in  92.21s   LIB_RUN_6_EXIT=0
test result: ok. 6083 passed; 0 failed; 8 ignored; finished in  68.80s   LIB_RUN_7_EXIT=0
test result: ok. 6083 passed; 0 failed; 8 ignored; finished in 107.70s   LIB_RUN_8_EXIT=0
test result: ok. 6083 passed; 0 failed; 8 ignored; finished in  67.19s   LIB_RUN_9_EXIT=0
```

Runs 4 and 10 exited 101 on a different test, tracked separately.

Stress, 30 runs of only this test under concurrent full-crate-test load:

```
30 x "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6090 filtered out"
STRESS_DONE failures=0 of 30
```

`--nocapture` shows the tolerated branch fired 0 times across those 30 runs —
every run recorded a pid, and on such a run the pre-fix and post-fix code
execute identically. Pre-fix failures over those 30 runs is therefore 0 by
construction. The race does not reproduce on demand.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
