### PR TITLE
feat(trusty-mpm): stable per-agent identity color in tm terminal output

### DIFF
--- a/crates/trusty-mpm/changelog.d/4068-agent-colors.md
+++ b/crates/trusty-mpm/changelog.d/4068-agent-colors.md
@@ -1,0 +1,11 @@
+Added
+
+- Every `tm` line naming an agent renders that name in a stable per-agent
+  identity color, so parallel agents are tellable apart at a glance: the
+  `tm agent list` / `tm agent show` roster, the `tm session breakers` AGENT
+  column, the `tm doctor` builder-slot census, and `tm catalog ls`. The color is
+  an FNV-1a hash of the name into a fixed eight-entry truecolor palette, so one
+  name is always one color across sessions and builds. The palette claims none
+  of the reserved slots — green/red/yellow for service status, cyan/yellow for
+  agent scope — and `NO_COLOR`, a pipe, or any non-TTY renders byte-identical
+  output to before (#4068).

--- a/crates/trusty-mpm/src/bin/tm/commands/agent.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/agent.rs
@@ -23,6 +23,9 @@ use trusty_mpm::core::skill_tiers::{
 };
 
 use crate::cli::AgentAction;
+// #4068: agent NAME renders in its stable identity color; the skill-tier
+// labels beside it keep their existing uncolored rendering.
+use crate::formatters::agent_color::agent_label;
 
 /// `tm agent <list|show>` — dispatch to the requested view.
 pub(crate) async fn agent(action: AgentAction) -> anyhow::Result<()> {
@@ -127,14 +130,14 @@ fn list_agents(paths: &FrameworkPaths, json: bool) -> anyhow::Result<()> {
     for name in &names {
         let meta = read_agent_metadata(&agents_dir.join(format!("{name}.md")));
         if meta.skills.is_empty() {
-            println!("  {name}");
+            println!("  {}", agent_label(name));
         } else {
             let rendered: Vec<String> = meta
                 .skills
                 .iter()
                 .map(|s| format!("{s} ({})", tiers.tier_label(s)))
                 .collect();
-            println!("  {name}  skills: {}", rendered.join(", "));
+            println!("  {}  skills: {}", agent_label(name), rendered.join(", "));
         }
     }
     Ok(())
@@ -180,7 +183,13 @@ fn render_agent_show(
         return Ok(());
     }
 
-    println!("Name: {}", meta.name.as_deref().unwrap_or(name));
+    // #4068: the identity color keys off the SAME string that is printed, so
+    // an agent whose front-matter `name` differs from its file stem still
+    // renders under one consistent color everywhere that name appears.
+    println!(
+        "Name: {}",
+        agent_label(meta.name.as_deref().unwrap_or(name))
+    );
     if let Some(role) = &meta.role {
         println!("Role: {role}");
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/doctor_builder_cap.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/doctor_builder_cap.rs
@@ -104,8 +104,31 @@ fn configured(cap: u32) -> String {
 
 /// `agent (running 12m)`, comma-separated.
 fn render(rows: &[CensusRow]) -> String {
+    render_with(rows, crate::formatters::agent_color::color_enabled())
+}
+
+/// [`render`] with the color decision passed in.
+///
+/// Why (#4068): this is the closest thing `tm` prints to a dispatch line — the
+/// agents currently holding a builder slot — so each name carries its identity
+/// color. Taking `use_color` explicitly rather than probing `colored`'s
+/// process-global override keeps both paths testable without the shared
+/// mutable state that made the #1858 color tests flaky.
+/// What: paints each agent name via
+/// [`crate::formatters::agent_color::agent_label_with`]; the elapsed-minutes
+/// suffix and the separators stay uncolored, so with `use_color` false the
+/// line is byte-identical to what this rendered before #4068.
+/// Test: `the_census_line_names_each_agent_in_its_identity_color`,
+/// `the_census_line_is_byte_identical_when_color_is_disabled`.
+fn render_with(rows: &[CensusRow], use_color: bool) -> String {
     rows.iter()
-        .map(|r| format!("{} (running {}m)", r.agent, r.elapsed_secs / 60))
+        .map(|r| {
+            format!(
+                "{} (running {}m)",
+                crate::formatters::agent_color::agent_label_with(&r.agent, use_color),
+                r.elapsed_secs / 60
+            )
+        })
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -190,6 +213,51 @@ mod tests {
             agent: agent.to_string(),
             elapsed_secs,
         }
+    }
+
+    /// #4068: each agent holding a builder slot is named in ITS OWN color, so
+    /// two concurrent agents are tellable apart on this line. Before #4068 the
+    /// line carried no escape at all, so this fails on the pre-change render.
+    #[test]
+    fn the_census_line_names_each_agent_in_its_identity_color() {
+        let rows = [row("rust-engineer", 720), row("code-critic", 60)];
+        let rendered = render_with(&rows, true);
+        // `rust-engineer` hashes to palette slot 3, periwinkle.
+        assert!(
+            rendered.contains("\u{1b}[38;2;130;170;255mrust-engineer\u{1b}[0m (running 12m)"),
+            "{rendered:?}"
+        );
+        // …and `code-critic` to a DIFFERENT slot, which is the whole point.
+        assert!(
+            rendered.contains("\u{1b}[38;2;176;176;208mcode-critic\u{1b}[0m (running 1m)"),
+            "{rendered:?}"
+        );
+        // Status colors stay the exclusive property of `formatters::services`:
+        // nothing here emits a plain green/red/yellow/cyan foreground.
+        for reserved in ["\u{1b}[32m", "\u{1b}[31m", "\u{1b}[33m", "\u{1b}[36m"] {
+            assert!(
+                !rendered.contains(reserved),
+                "census line must not emit the reserved sequence {reserved:?}"
+            );
+        }
+    }
+
+    /// #4068: with color disabled — `NO_COLOR`, a pipe, any non-TTY — the line
+    /// must stay byte-identical to what `format!("{} (running {}m)", …)`
+    /// produced before that change, so scripts and the doctor's own
+    /// assertions see no drift.
+    #[test]
+    fn the_census_line_is_byte_identical_when_color_is_disabled() {
+        let rows = [row("rust-engineer", 720), row("code-critic", 60)];
+        let rendered = render_with(&rows, false);
+        assert_eq!(
+            rendered,
+            "rust-engineer (running 12m), code-critic (running 1m)"
+        );
+        assert!(
+            !rendered.contains('\u{1b}'),
+            "no-color census line must carry no ANSI escape: {rendered:?}"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -812,7 +812,8 @@ pub(crate) async fn catalog(action: CatalogAction) -> anyhow::Result<()> {
             } else {
                 println!("agents ({}):", agents.len());
                 for a in &agents {
-                    println!("  {a}");
+                    // #4068: same identity color the roster and census use.
+                    println!("  {}", crate::formatters::agent_color::agent_label(a));
                 }
                 println!("skills ({}):", skills.len());
                 for s in &skills {

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -245,7 +245,15 @@ pub(crate) async fn session(
                         .get("consecutive_failures")
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0);
-                    println!("{:<24} {:<12} {}", r.agent, state, failures);
+                    // #4068: the AGENT cell carries the identity color and is
+                    // padded outside the color run, so the STATE and FAILURES
+                    // columns stay aligned; state text is left uncolored.
+                    println!(
+                        "{} {:<12} {}",
+                        crate::formatters::agent_color::agent_label_padded(&r.agent, 24),
+                        state,
+                        failures
+                    );
                 }
             }
         }

--- a/crates/trusty-mpm/src/bin/tm/formatters/agent_color.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/agent_color.rs
@@ -1,0 +1,293 @@
+//! Per-agent identity color for `tm` terminal output (#4068).
+//!
+//! Why: trusty-mpm's operating model is multi-agent delegation, and every line
+//! naming an agent rendered in the same default foreground, so an operator
+//! watching several agents could not tell them apart at a glance. A stable
+//! per-name color makes agent IDENTITY visible, which is a third axis
+//! orthogonal to the status and scope colors already in use.
+//! What: [`agent_rgb`] hashes an agent name with FNV-1a into a fixed
+//! eight-entry truecolor palette, so the same name always renders in the same
+//! color within a session, across sessions, and across builds.
+//! [`agent_label_with`] paints it, taking `use_color` explicitly so it stays
+//! pure; [`agent_label`] and [`agent_label_padded`] bind that flag to
+//! `colored`'s own gate for production call sites.
+//! Test: `agent_color_is_stable_for_the_same_name`,
+//! `agent_color_differs_between_names`,
+//! `agent_palette_indices_are_pinned_across_runs`,
+//! `agent_palette_avoids_the_reserved_status_and_scope_colors`,
+//! `agent_label_paints_the_identity_color_when_color_is_on`,
+//! `agent_label_is_plain_when_color_is_off`,
+//! `agent_label_padded_matches_plain_padding_when_color_is_off`.
+
+/// The eight identity colors, as raw truecolor triples.
+///
+/// Why: four ANSI slots already carry meaning in this workspace and must keep
+/// meaning only that, so none of them may also mean "this agent":
+/// - `Color::Green` — a service is running, and health is `ok`
+///   (`formatters::services`).
+/// - `Color::Red` — a service is down (`formatters::services`).
+/// - `Color::Yellow` — a running service's health check failed
+///   (`formatters::services`), and project-level agent scope in
+///   `trusty-agents`' REPL label.
+/// - `Color::Cyan` — user-level agent scope in `trusty-agents`' REPL label.
+///
+/// What: eight triples drawn from the blue / violet / magenta / tan bands,
+/// deliberately away from the pure red, green, yellow, and cyan primaries
+/// those four slots render as. Emitting them as `38;2;r;g;b` means an identity
+/// color can never collide with a reserved named slot, even on a terminal that
+/// has remapped its 16-color table.
+///
+/// #4068: index order is part of the contract — reordering these repaints
+/// every agent, so append rather than insert if the palette ever grows.
+/// Test: `agent_palette_avoids_the_reserved_status_and_scope_colors`.
+pub(crate) const AGENT_PALETTE: [(u8, u8, u8); 8] = [
+    (86, 156, 214),  // steel blue
+    (197, 134, 192), // orchid
+    (206, 145, 120), // terracotta
+    (130, 170, 255), // periwinkle
+    (240, 130, 200), // hot pink
+    (152, 118, 220), // indigo
+    (224, 168, 108), // tan
+    (176, 176, 208), // slate lavender
+];
+
+/// FNV-1a 64-bit offset basis.
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+
+/// FNV-1a 64-bit prime.
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// The palette slot an agent name hashes to.
+///
+/// Why (#4068): the hash must be pinned in this source, not borrowed from
+/// [`std::collections::hash_map::DefaultHasher`], whose output std explicitly
+/// does not guarantee across releases. A borrowed hash would repaint the whole
+/// roster on a toolchain bump, which is exactly the instability this function
+/// exists to rule out. FNV-1a is a few lines, allocation-free, and fixed
+/// forever by its published constants.
+/// What: FNV-1a over the name's UTF-8 bytes, reduced modulo the palette length.
+/// Pure — no environment, no clock, no global state.
+/// Test: `agent_palette_indices_are_pinned_across_runs`.
+pub(crate) fn palette_index(name: &str) -> usize {
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in name.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    (hash % AGENT_PALETTE.len() as u64) as usize
+}
+
+/// The identity color for an agent name, as an RGB triple.
+///
+/// Why: the raw triple is what the escape sequence needs, and what a test can
+/// assert on without constructing a `colored` value.
+/// What: indexes [`AGENT_PALETTE`] by [`palette_index`]. Deterministic: the
+/// same name yields the same triple in every process and every build.
+/// Test: `agent_color_is_stable_for_the_same_name`,
+/// `agent_color_differs_between_names`.
+pub(crate) fn agent_rgb(name: &str) -> (u8, u8, u8) {
+    AGENT_PALETTE[palette_index(name)]
+}
+
+/// Whether `tm` should emit color right now.
+///
+/// Why: one place reads the decision, so every agent-name call site agrees.
+/// What: delegates to `colored`'s own gate, which already accounts for
+/// `NO_COLOR`, `CLICOLOR`/`CLICOLOR_FORCE`, whether stdout is a terminal, and
+/// any explicit `colored::control` override.
+/// Test: exercised through [`agent_label`]; the pure paths are covered
+/// directly via [`agent_label_with`].
+pub(crate) fn color_enabled() -> bool {
+    colored::control::SHOULD_COLORIZE.should_colorize()
+}
+
+/// An agent name painted in its identity color, with the decision passed in.
+///
+/// Why (#1858): taking `use_color` as a parameter instead of probing
+/// `colored`'s process-global override keeps this pure and deterministic, so
+/// tests exercise the color-on and color-off paths directly with no shared
+/// mutable state to race against. `formatters::banner::shade_image` takes the
+/// same shape for the same reason, and emits the same `38;2;r;g;b` form.
+/// What: with `use_color` false, returns the bare name — byte-identical to
+/// printing it unstyled. With it true, wraps the name in the truecolor
+/// foreground sequence for [`agent_rgb`] and a reset.
+/// Test: `agent_label_paints_the_identity_color_when_color_is_on`,
+/// `agent_label_is_plain_when_color_is_off`.
+pub(crate) fn agent_label_with(name: &str, use_color: bool) -> String {
+    if !use_color {
+        return name.to_string();
+    }
+    let (r, g, b) = agent_rgb(name);
+    format!("\u{1b}[38;2;{r};{g};{b}m{name}\u{1b}[0m")
+}
+
+/// An agent name painted in its identity color.
+///
+/// Why: the one call every rendering site should use, so a single decision
+/// governs how agent identity looks everywhere `tm` prints it.
+/// What: [`agent_label_with`] bound to [`color_enabled`].
+/// Test: the pure form is covered by
+/// `agent_label_paints_the_identity_color_when_color_is_on` and
+/// `agent_label_is_plain_when_color_is_off`.
+pub(crate) fn agent_label(name: &str) -> String {
+    agent_label_with(name, color_enabled())
+}
+
+/// An agent name painted in its identity color, then padded to a column width.
+///
+/// Why: a `{:<24}` format spec counts the escape sequence's bytes as visible
+/// width, so colorizing a table cell through `format!` misaligns every
+/// following column. Padding OUTSIDE the color run keeps the alignment the
+/// uncolored table already had.
+/// What: emits [`agent_label_with`] followed by enough plain spaces to reach
+/// `width` columns, matching `format!("{name:<width$}")` exactly whenever
+/// `use_color` is false — including the case where the name already meets or
+/// exceeds `width` and no padding is added.
+/// Test: `agent_label_padded_matches_plain_padding_when_color_is_off`.
+pub(crate) fn agent_label_padded_with(name: &str, width: usize, use_color: bool) -> String {
+    let pad = width.saturating_sub(name.chars().count());
+    format!("{}{}", agent_label_with(name, use_color), " ".repeat(pad))
+}
+
+/// [`agent_label_padded_with`] bound to [`color_enabled`].
+pub(crate) fn agent_label_padded(name: &str, width: usize) -> String {
+    agent_label_padded_with(name, width, color_enabled())
+}
+
+#[cfg(test)]
+mod tests {
+    use colored::Color;
+
+    use super::*;
+
+    #[test]
+    fn agent_color_is_stable_for_the_same_name() {
+        for _ in 0..100 {
+            assert_eq!(agent_rgb("rust-engineer"), agent_rgb("rust-engineer"));
+        }
+        assert_eq!(agent_rgb("code-critic"), agent_rgb("code-critic"));
+    }
+
+    #[test]
+    fn agent_color_differs_between_names() {
+        assert_ne!(agent_rgb("rust-engineer"), agent_rgb("code-critic"));
+        assert_ne!(agent_rgb("engineer"), agent_rgb("documentation"));
+        assert_ne!(agent_rgb("research"), agent_rgb("engineer"));
+    }
+
+    /// Pins the hash itself: these indices follow from the FNV-1a constants
+    /// above and must not move, because moving one repaints an agent the
+    /// operator has already learned to recognise (#4068).
+    #[test]
+    fn agent_palette_indices_are_pinned_across_runs() {
+        assert_eq!(palette_index("engineer"), 0);
+        assert_eq!(palette_index("documentation"), 1);
+        assert_eq!(palette_index("rust-engineer"), 3);
+        assert_eq!(palette_index("research"), 4);
+        assert_eq!(palette_index("code-critic"), 7);
+        assert_eq!(agent_rgb("rust-engineer"), (130, 170, 255));
+    }
+
+    #[test]
+    fn agent_palette_avoids_the_reserved_status_and_scope_colors() {
+        // green/red/yellow are service STATUS in `formatters::services`;
+        // yellow/cyan are agent SCOPE in trusty-agents' REPL label. Identity
+        // is a third axis and must claim none of them.
+        for reserved in [Color::Green, Color::Red, Color::Yellow, Color::Cyan] {
+            let reserved_fg = reserved.to_fg_str().to_string();
+            for (r, g, b) in AGENT_PALETTE {
+                let identity = Color::TrueColor { r, g, b };
+                assert_ne!(identity, reserved, "palette reuses {reserved:?}");
+                // The same claim on the bytes actually written to the terminal.
+                assert_ne!(
+                    identity.to_fg_str().to_string(),
+                    reserved_fg,
+                    "identity color {identity:?} emits the reserved sequence {reserved_fg}"
+                );
+            }
+        }
+        // Every entry is distinct, or two agents would share a color.
+        for (i, entry) in AGENT_PALETTE.iter().enumerate() {
+            assert_eq!(
+                AGENT_PALETTE.iter().filter(|c| *c == entry).count(),
+                1,
+                "palette entry {i} is duplicated"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_label_paints_the_identity_color_when_color_is_on() {
+        // Slot 3 is periwinkle (130, 170, 255).
+        assert_eq!(
+            agent_label_with("rust-engineer", true),
+            "\u{1b}[38;2;130;170;255mrust-engineer\u{1b}[0m"
+        );
+        // A different agent gets a visibly different sequence.
+        assert_ne!(
+            agent_label_with("code-critic", true),
+            agent_label_with("rust-engineer", true)
+        );
+    }
+
+    #[test]
+    fn agent_label_is_plain_when_color_is_off() {
+        for name in ["rust-engineer", "code-critic", "qa", "documentation"] {
+            let rendered = agent_label_with(name, false);
+            assert_eq!(rendered, name);
+            assert!(
+                !rendered.contains('\u{1b}'),
+                "no-color rendering must carry no ANSI escape: {rendered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_label_padded_matches_plain_padding_when_color_is_off() {
+        // Short name pads; a name at or beyond the width does not — the same
+        // two cases `{:<24}` handles.
+        assert_eq!(
+            agent_label_padded_with("qa", 24, false),
+            format!("{:<24}", "qa")
+        );
+        assert_eq!(
+            agent_label_padded_with("rust-engineer", 24, false),
+            format!("{:<24}", "rust-engineer")
+        );
+        let long = "an-agent-name-that-is-longer-than-the-column";
+        assert_eq!(
+            agent_label_padded_with(long, 24, false),
+            format!("{long:<24}")
+        );
+        assert!(!agent_label_padded_with("qa", 24, false).contains('\u{1b}'));
+    }
+
+    #[test]
+    fn agent_label_padded_keeps_the_column_width_visible_when_color_is_on() {
+        // The escape bytes sit inside the cell, so the PLAIN width is still 24
+        // and the next column stays aligned.
+        let cell = agent_label_padded_with("qa", 24, true);
+        assert!(cell.starts_with("\u{1b}[38;2;"));
+        assert!(cell.ends_with(&("\u{1b}[0m".to_string() + &" ".repeat(22))));
+        let visible: String = strip_escapes(&cell);
+        assert_eq!(visible, format!("{:<24}", "qa"));
+    }
+
+    /// Drop every `ESC [ … m` sequence, leaving the visible characters.
+    fn strip_escapes(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                for inner in chars.by_ref() {
+                    if inner == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/formatters/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! Why: keeping formatting helpers separate from handler logic makes each
 //! file focused and keeps the handler files below the 500-line cap.
-//! What: re-exports from `banner`, `services`, and `session` sub-modules.
+//! What: re-exports from `agent_color`, `banner`, `services`, and `session`
+//! sub-modules.
 //! Test: formatters are exercised by the unit tests in `tests.rs`.
 
+pub(crate) mod agent_color;
 pub(crate) mod banner;
 pub(crate) mod info_box;
 pub(crate) mod services;


### PR DESCRIPTION
Every `tm` line that names an agent rendered in the same default foreground, so an operator watching several agents could not tell them apart at a glance. Each agent name now renders in a color derived from the name itself.

`formatters::agent_color::agent_rgb` hashes the name with FNV-1a into a fixed eight-entry truecolor palette. FNV-1a rather than `DefaultHasher`, whose output std does not guarantee across releases — a borrowed hash would repaint the whole roster on a toolchain bump. One name is therefore one color within a session, across sessions, and across builds.

The palette claims none of the reserved slots: green/red/yellow carry service status in `formatters::services`, and yellow/cyan carry agent scope in trusty-agents' REPL label. Identity is a third, orthogonal axis, so it uses truecolor triples from the blue/violet/magenta/tan bands instead.

Refs #4068

## Where it applies

| Site | File |
|---|---|
| `tm agent list` / `tm agent show` roster | `commands/agent.rs` |
| `tm session breakers` AGENT column | `commands/session.rs` |
| `tm doctor` builder-slot census — the agents currently holding a slot | `commands/doctor_builder_cap.rs` |
| `tm catalog ls` | `commands/managed.rs` |

Status and skill-tier text beside those names stays uncolored. The breakers cell pads outside the color run, so the STATE and FAILURES columns keep their alignment.

`agent_label_with` takes the color decision as a parameter and `color_enabled` binds it to `colored`'s own gate. Both paths are therefore testable without mutating the process-global override that made the #1858 color tests flaky.

## Not in this PR

trusty-mpm prints no dispatch line, no completion notification, and no streamed agent output — Claude Code prints those, not `tm`. The user/project **scope** coloring #4068 mentions lives in `trusty-agents` (`src/repl/tui/chat.rs`, `AgentScope::User => Color::Cyan` / `Project => Color::Yellow`). Coloring that crate's TUI dispatch and streamed lines is a separate change in `trusty-agents`, and this PR leaves it untouched.

## Test ladder — rung 3

Localized behavior inside one crate.

```
cargo fmt --check                                          EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings    EXIT=0
cargo test -p trusty-mpm --no-fail-fast                    EXIT=0
```

`--no-fail-fast`: 54 test targets ran, 0 FAILED. The three largest:

```
test result: ok. 6083 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out   (lib)
test result: ok. 2221 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out   (bin tm)
test result: ok. 2221 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out   (bin trusty-mpm)
```

Doc and changelog gates:

```
./scripts/check_line_cap.sh            4586 tracked .rs file(s); 0 violations — OK
./scripts/check_test_pointers.sh       31908 Test: citation(s) — 0 dangling — OK
./scripts/check_sld.sh                 0 error(s), 0 warning(s)
./scripts/check_changelog_fragment.sh  OK trusty-mpm: fragment present and valid
./scripts/check-pr-version-bump.sh     [ OK ] trusty-mpm 1.5.18 — src changed, version not yet published
./scripts/check_rustdoc_links.sh       26 crate(s), 0 broken link(s)
```

### Failing-first proof

Reverting only the fix's core (`agent_label_with` returning the plain name — the pre-#4068 behavior) fails the three color-ON tests:

```
test formatters::agent_color::tests::agent_label_paints_the_identity_color_when_color_is_on ... FAILED
test formatters::agent_color::tests::agent_label_padded_keeps_the_column_width_visible_when_color_is_on ... FAILED
test commands::doctor_builder_cap::tests::the_census_line_names_each_agent_in_its_identity_color ... FAILED

assertion `left == right` failed
  left: "rust-engineer"
 right: "\u{1b}[38;2;130;170;255mrust-engineer\u{1b}[0m"

test result: FAILED. 7 passed; 3 failed; 0 ignored; 0 measured; 2212 filtered out
```

The three no-color tests correctly still pass under that revert — preserving the pre-change rendering is what they assert.

## NO_COLOR / non-TTY byte-identity

`the_census_line_is_byte_identical_when_color_is_disabled` pins the production renderer to the exact pre-change string. Against the built binary:

```
ESC bytes in NO_COLOR run: 0
ESC bytes in plain-pipe run: 0
NO_COLOR and plain-pipe outputs are byte-identical
```

## Binary smoke — `target/debug/tm`, through `cat -v`

```
===== NO_COLOR=1 tm agent list =====
agents (43):
  BASE-AGENT
  BASE-ENGINEER  skills: documentation-style (bundled)
  code-critic  skills: code-review-standards (bundled), contract-driven-testing (bundled)

===== CLICOLOR_FORCE=1 tm agent list =====
agents (43):
  ^[[38;2;240;130;200mBASE-AGENT^[[0m
  ^[[38;2;206;145;120mBASE-ENGINEER^[[0m  skills: documentation-style (bundled)
  ^[[38;2;176;176;208mcode-critic^[[0m  skills: code-review-standards (bundled), ...
```

Status colors in the same session, unchanged — plain `\e[32m`/`\e[31m`/`\e[33m`, never truecolor, so the two families cannot be confused:

```
===== CLICOLOR_FORCE=1 tm services list =====
NAME                     STATUS     PORT     VERSION      HEALTH
trusty-analyze           ^[[32mrunning^[[0m 7879     trusty-analyze 0.12.5 ^[[33mfail^[[0m
trusty-embedderd         ^[[31mdown^[[0m
trusty-mpm-daemon        ^[[32mrunning^[[0m 7880     trusty-mpm 1.5.18 ^[[32mok^[[0m

===== NO_COLOR=1 tm services list =====
trusty-analyze           running    7879     trusty-analyze 0.12.5 fail
trusty-mpm-daemon        running    7880     trusty-mpm 1.5.18 ok
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
