### PR TITLE
feat(trusty-code,trusty-agents): task.run/session.status carry an actionable TaskResult (#4351)

### DIFF
--- a/crates/trusty-agents/changelog.d/4351-task-result.md
+++ b/crates/trusty-agents/changelog.d/4351-task-result.md
@@ -1,0 +1,5 @@
+Added
+
+- `dispatch_task` relays the coding backend's actionable result — the ref, the branch and a pass/fail classification — on the proposal envelope, instead of returning only a transcript (#4351).
+- The classification comes from the child's exit code, so a run that stopped at its turn budget with real work on disk reports `partial` rather than being discarded as a failure.
+- A backend that reports no result leaves the envelope byte-identical to before.

--- a/crates/trusty-agents/src/tools/cross_product.rs
+++ b/crates/trusty-agents/src/tools/cross_product.rs
@@ -37,6 +37,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use trusty_code::session::TaskResult;
+
 use crate::tools::execution_style::{ExecutionStyle, ResolvedStyle};
 
 /// Maximum serialized size of a [`HandoffContext`], in bytes (#2809 §5.2's
@@ -423,6 +425,19 @@ pub struct ProposalEnvelope {
     /// `an_unstyled_envelope_is_byte_identical`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub style: Option<ResolvedStyle>,
+    /// The specialist's actionable result — where the change landed and
+    /// whether it passed (#4351).
+    ///
+    /// Why: `result` below is the raw transcript, and a caller cannot reliably
+    /// read a branch name or a pass/fail out of prose. These are the fields
+    /// #4351 exists to carry.
+    /// What: `None` (and omitted from the JSON) for a backend that reports no
+    /// result — the `Tm` leg, and every pre-#4351 caller — keeping the
+    /// envelope byte-identical for them.
+    /// Test: `a_result_bearing_envelope_is_still_only_a_proposal`,
+    /// `an_envelope_without_a_task_result_is_byte_identical`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_result: Option<TaskResult>,
     /// The specialist's output, already branding-scrubbed by the tool layer.
     pub result: String,
 }
@@ -450,6 +465,7 @@ impl ProposalEnvelope {
             // Never `Action` — see the type docs and DOC-41 §5.5 line 1398.
             disposition: Disposition::Proposal,
             style: None,
+            task_result: None,
             result: result.into(),
         }
     }
@@ -468,6 +484,24 @@ impl ProposalEnvelope {
     /// `a_styled_envelope_is_still_only_a_proposal`.
     pub fn with_style(mut self, style: Option<ResolvedStyle>) -> Self {
         self.style = style;
+        self
+    }
+
+    /// Record the specialist's actionable result on an already-built envelope
+    /// (#4351).
+    ///
+    /// Why: the caller renders this envelope to a user, and "here is a wall of
+    /// transcript" is not a report. The refs — where the change landed, on
+    /// which branch, whether it passed — are what makes it one. Same builder
+    /// shape as [`Self::with_style`] and for the same reason: the propose-only
+    /// invariant stays hardcoded in the sole constructor, so attaching a result
+    /// cannot upgrade the disposition.
+    /// What: sets [`Self::task_result`]; `None` leaves the envelope
+    /// byte-identical to a pre-#4351 one.
+    /// Test: `a_result_bearing_envelope_is_still_only_a_proposal`,
+    /// `an_envelope_without_a_task_result_is_byte_identical`.
+    pub fn with_task_result(mut self, task_result: Option<TaskResult>) -> Self {
+        self.task_result = task_result;
         self
     }
 

--- a/crates/trusty-agents/src/tools/cross_product_tests.rs
+++ b/crates/trusty-agents/src/tools/cross_product_tests.rs
@@ -371,3 +371,48 @@ fn an_unstyled_envelope_is_byte_identical() {
     let json = serde_json::to_value(&env).expect("envelope serializes");
     assert!(json.get("style").is_none(), "unstyled envelope: {json}");
 }
+
+// =====================================================================
+// #4351 — the actionable result on the envelope
+// =====================================================================
+
+/// (#4351) Attaching a result carries the refs through and does NOT upgrade
+/// the disposition — the same invariant `with_style` had to preserve.
+#[test]
+fn a_result_bearing_envelope_is_still_only_a_proposal() {
+    let env = ProposalEnvelope::for_cross_product(
+        "assistant",
+        "coding-pm",
+        CallerAuthority::UserAuthority,
+        "transcript",
+    )
+    .with_task_result(Some(
+        TaskResult::new(trusty_code::session::TaskResultStatus::Partial)
+            .with_diff_ref(Some("abc123".to_string()))
+            .with_branch(Some("feat/x".to_string())),
+    ));
+
+    assert_eq!(env.disposition, Disposition::Proposal);
+    let json = serde_json::to_value(&env).expect("envelope serializes");
+    assert_eq!(json["disposition"], "proposal");
+    assert_eq!(json["task_result"]["status"], "partial");
+    assert_eq!(json["task_result"]["diff_ref"], "abc123");
+    assert_eq!(json["task_result"]["branch"], "feat/x");
+}
+
+/// (#4351) An envelope with no result omits the key entirely, so every
+/// pre-#4351 caller sees a byte-identical document.
+#[test]
+fn an_envelope_without_a_task_result_is_byte_identical() {
+    let env = ProposalEnvelope::for_cross_product(
+        "assistant",
+        "ticketing",
+        CallerAuthority::Standard,
+        "drafted",
+    );
+    let json = serde_json::to_value(&env).expect("envelope serializes");
+    assert!(
+        json.get("task_result").is_none(),
+        "resultless envelope must omit the key: {json}"
+    );
+}

--- a/crates/trusty-agents/src/tools/pm_bridge.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge.rs
@@ -77,6 +77,7 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use regex::Regex;
 use serde_json::{Value, json};
+use trusty_code::session::TaskResult;
 
 use crate::intent::route::{BridgeRoute, route_task};
 use crate::rbac::ServiceTier;
@@ -352,17 +353,21 @@ impl ToolExecutor for PmBridgeTool {
         };
         let reported_style = style.is_explicit().then_some(style);
 
+        // #4351: `run_result` keeps the backend's actionable refs alongside the
+        // transcript. Every backend that only implements `run` reaches this
+        // through the trait's default body and reports no result.
         match self
             .backend
-            .run(
+            .run_result(
                 route,
                 target.as_ref().and_then(DispatchTarget::backend_agent),
                 &body,
             )
             .await
         {
-            Ok(out) => {
-                let scrubbed = scrub_branding(&out);
+            Ok(outcome) => {
+                let scrubbed = scrub_branding(&outcome.transcript);
+                let task_result = outcome.result.map(scrub_task_result);
                 match target {
                     // #4028: a cross-product specialist's result is wrapped in
                     // the propose-only envelope — DOC-41 §5.5 line 1398.
@@ -377,6 +382,10 @@ impl ToolExecutor for PmBridgeTool {
                             scrubbed,
                         )
                         .with_style(reported_style)
+                        // #4351: the refs the backend reported, so the caller
+                        // can say where the change landed instead of pasting a
+                        // transcript.
+                        .with_task_result(task_result)
                         .render(),
                     ),
                     // Unnamed dispatch is the pre-#4026 opaque path, returned
@@ -435,6 +444,25 @@ fn branded_token_pattern() -> &'static Regex {
         Regex::new(r"(?i)\b(trusty[\s_-]*mpm|trusty[\s_-]*code|tcode|tm)\b")
             .expect("branded token pattern is a valid static regex")
     })
+}
+
+/// Scrub the free-form half of a backend-reported [`TaskResult`] (#4351).
+///
+/// Why: the tool layer, not the backend, owns branding removal (see
+/// `scrub_branding` below and the module docs). A `TaskResult`'s `summary` is
+/// generated prose and travels the same path a transcript does, so it gets the
+/// same treatment.
+/// What: scrubs `summary` only. `diff_ref`, `branch` and `pr_ref` are
+/// structured refs — a git SHA, a branch name, a PR URL — and the whole point
+/// of #4351 is that a caller can USE them; running a word-boundary substitution
+/// over a ref would silently corrupt the one field the caller acts on. They
+/// carry no backend identity: trusty-code's daemon builds them from git, never
+/// from its own name.
+/// Test: `a_reported_summary_is_branding_scrubbed`,
+/// `scrubbing_leaves_the_refs_intact`.
+fn scrub_task_result(result: TaskResult) -> TaskResult {
+    let scrubbed_summary = result.summary.as_deref().map(scrub_branding);
+    result.with_summary(scrubbed_summary)
 }
 
 /// Strip backend-identity tokens and session-id-shaped artifacts out of a

--- a/crates/trusty-agents/src/tools/pm_bridge_backend.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_backend.rs
@@ -29,6 +29,9 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use tokio::process::Command;
 use tokio::time::sleep;
+// #4351: the ONE definition of this wire type lives in the crate that produces
+// it — trusty-code's daemon. This crate relays, it does not redefine.
+use trusty_code::session::{TaskResult, TaskResultStatus};
 
 use crate::intent::route::BridgeRoute;
 use crate::plugins::stdio_mcp::StdioMcpClient;
@@ -71,6 +74,66 @@ const ACTIVITY_LINES: u64 = 200;
 #[async_trait]
 pub trait PmBridgeBackend: Send + Sync {
     async fn run(&self, route: BridgeRoute, target: Option<&str>, task: &str) -> Result<String>;
+
+    /// Same call as [`Self::run`], but keeping the backend's actionable result
+    /// alongside the transcript (#4351).
+    ///
+    /// Why: a transcript is prose. A caller that has to tell a user "the
+    /// change landed on branch X, here is the ref, it passed" cannot get that
+    /// out of prose reliably, which is exactly the gap #4351 names. This is a
+    /// SECOND method with a default body rather than a changed signature on
+    /// `run`, so every existing implementor — including the test doubles in
+    /// `pm_bridge_tests.rs` — keeps compiling untouched and simply reports no
+    /// result.
+    /// What: the default delegates to [`Self::run`] and reports `None`.
+    /// `ProcessPmBridge` overrides it.
+    /// Test: `pm_bridge_backend_tests::default_run_result_reports_no_result`.
+    async fn run_result(
+        &self,
+        route: BridgeRoute,
+        target: Option<&str>,
+        task: &str,
+    ) -> Result<BackendOutcome> {
+        Ok(BackendOutcome::opaque(self.run(route, target, task).await?))
+    }
+}
+
+/// What a backend produced: the raw transcript, plus the actionable result
+/// when the backend reports one (#4351).
+///
+/// Why: `run` has always returned a bare `String`, and everything downstream
+/// of it — the branding scrub, the `ProposalEnvelope` — is built around that.
+/// Widening it into a struct keeps the transcript exactly where it was while
+/// giving the refs somewhere to travel.
+/// What: `transcript` is the same un-scrubbed text `run` returns; `result` is
+/// `None` for a backend that cannot report one (the `Tm` leg, and every test
+/// double that only implements `run`). `#[non_exhaustive]`: construct through
+/// [`Self::opaque`] and [`Self::with_result`].
+/// Test: `pm_bridge_backend_tests::default_run_result_reports_no_result`,
+/// `pm_bridge_backend_tests::a_child_reporting_a_diff_relays_its_ref_and_partial_status`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct BackendOutcome {
+    /// The backend's raw, un-scrubbed output.
+    pub transcript: String,
+    /// The backend's actionable result, when it reports one.
+    pub result: Option<TaskResult>,
+}
+
+impl BackendOutcome {
+    /// An outcome carrying only a transcript — the pre-#4351 shape.
+    pub fn opaque(transcript: impl Into<String>) -> Self {
+        Self {
+            transcript: transcript.into(),
+            result: None,
+        }
+    }
+
+    /// Attach a result. `None` leaves the outcome opaque.
+    pub fn with_result(mut self, result: Option<TaskResult>) -> Self {
+        self.result = result;
+        self
+    }
 }
 
 /// The external agent the `Tcode` leg targets when no specialist is named.
@@ -131,7 +194,15 @@ impl ProcessPmBridge {
     /// The remote CLI already accepts any agent name (`run-task <AGENT>
     /// <TASK>`, `crates/trusty-code/src/cli/run_task.rs`) — the bottleneck was
     /// only ever this hardcoded argument.
-    async fn run_tcode(&self, target: Option<&str>, task: &str) -> Result<String> {
+    ///
+    /// #4351: `--json`'s snapshot now carries a `result` object
+    /// (`trusty_code::session::TaskResult`), so this leg no longer relays only
+    /// opaque prose — it hands the refs back up alongside the transcript. The
+    /// pass/fail classification comes from the CHILD'S EXIT CODE rather than
+    /// the reported one, because that is the value trusty-code computes from
+    /// the terminal session status and the on-disk diff together; see
+    /// [`extract_child_result`] for why exit 6 must not collapse into failure.
+    async fn run_tcode(&self, target: Option<&str>, task: &str) -> Result<BackendOutcome> {
         if !binary_on_path("tcode") {
             bail!("tcode backend unavailable: binary not found on PATH");
         }
@@ -156,11 +227,13 @@ impl ProcessPmBridge {
                 stderr.trim()
             );
         }
-        Ok(if stdout.trim().is_empty() {
+        let result = extract_child_result(&stdout, output.status.code());
+        let transcript = if stdout.trim().is_empty() {
             stderr
         } else {
             stdout
-        })
+        };
+        Ok(BackendOutcome::opaque(transcript).with_result(Some(result)))
     }
 
     /// Run the `Tm` route: spawn `tm serve --stdio` and drive the
@@ -192,7 +265,12 @@ impl ProcessPmBridge {
     /// content.
     /// Test: `process_pm_bridge_tm_route_fails_closed_without_binary`;
     /// `tm_route_smoke` (binary-gated).
-    async fn run_tm(&self, task: &str) -> Result<String> {
+    ///
+    /// #4351: this leg reports no [`TaskResult`]. tm's managed-session
+    /// lifecycle exposes tmux pane content and nothing structured — there is
+    /// no ref, branch or pass/fail to read — so the outcome stays opaque
+    /// rather than carrying invented fields.
+    async fn run_tm(&self, task: &str) -> Result<BackendOutcome> {
         if !binary_on_path("tm") {
             bail!("tm backend unavailable: binary not found on PATH");
         }
@@ -265,13 +343,22 @@ impl ProcessPmBridge {
         if transcript.trim().is_empty() {
             bail!("tm session produced no observable output within the poll window");
         }
-        Ok(transcript)
+        Ok(BackendOutcome::opaque(transcript))
     }
 }
 
 #[async_trait]
 impl PmBridgeBackend for ProcessPmBridge {
     async fn run(&self, route: BridgeRoute, target: Option<&str>, task: &str) -> Result<String> {
+        Ok(self.run_result(route, target, task).await?.transcript)
+    }
+
+    async fn run_result(
+        &self,
+        route: BridgeRoute,
+        target: Option<&str>,
+        task: &str,
+    ) -> Result<BackendOutcome> {
         match route {
             // #4026: only the Tcode leg can name a specialist; the Tm leg's
             // managed-session lifecycle has no per-agent selector, so a target
@@ -280,6 +367,35 @@ impl PmBridgeBackend for ProcessPmBridge {
             BridgeRoute::Tm => self.run_tm(task).await,
         }
     }
+}
+
+/// Fold a `tcode run-task --json` child's stdout and exit code into a
+/// [`TaskResult`] (#4351).
+///
+/// Why: the two halves arrive from different places and both matter. The
+/// child's stdout carries the refs the daemon recorded (`diff_ref`, `branch`,
+/// `summary`); its EXIT CODE carries the pass/fail classification, and that
+/// distinction is load-free only if exit 6 is preserved — trusty-code spends
+/// that code on "the turn budget ran out but a real deliverable is on disk"
+/// (`trusty_code::run_task::report::ExitCode::Partial`), so reading non-zero
+/// as failure would throw away working code.
+/// What: parses stdout as the `Session` snapshot, lifts its `result` object if
+/// present, and stamps the exit-code-derived status over whatever status the
+/// child reported. Unparseable stdout (an older child, or prose on the
+/// fallback stderr path) degrades to a status-only result rather than an
+/// error — this runs after the child has already finished, so there is nothing
+/// left to fail.
+/// Test: `pm_bridge_backend_tests::a_child_reporting_a_diff_relays_its_ref_and_partial_status`,
+/// `pm_bridge_backend_tests::a_child_with_no_diff_relays_nones_and_the_status`,
+/// `pm_bridge_backend_tests::unparseable_child_output_still_yields_a_status`.
+fn extract_child_result(stdout: &str, exit_code: Option<i32>) -> TaskResult {
+    let status = TaskResultStatus::from_exit_code(exit_code);
+    serde_json::from_str::<Value>(stdout)
+        .ok()
+        .and_then(|snapshot| snapshot.get("result").cloned())
+        .and_then(|reported| serde_json::from_value::<TaskResult>(reported).ok())
+        .unwrap_or_else(|| TaskResult::new(status))
+        .with_status(status)
 }
 
 /// Decide whether `name` is on `$PATH`, without spawning a subprocess.

--- a/crates/trusty-agents/src/tools/pm_bridge_backend_tests.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_backend_tests.rs
@@ -254,3 +254,111 @@ async fn tm_route_smoke() {
 fn default_tcode_agent_is_unchanged_by_the_4026_widening() {
     assert_eq!(super::DEFAULT_TCODE_AGENT, "pm");
 }
+
+// =====================================================================
+// #4351 — relaying the child's actionable result
+// =====================================================================
+
+/// The `--json` snapshot a `tcode run-task` child prints after a run that
+/// wrote something and then exhausted its turn budget.
+fn child_snapshot_with_a_diff() -> String {
+    json!({
+        "id": "s-1",
+        "task": "t",
+        "status": "turn_cap_exceeded",
+        "mode": "daily-driver",
+        "result": {
+            "status": "partial",
+            "diff_ref": "0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c",
+            "branch": "feat/thing",
+            "pr_ref": null,
+            "summary": "partial: changes captured at 0f1e2d3c on branch feat/thing"
+        }
+    })
+    .to_string()
+}
+
+/// #4351 acceptance: a run that produced a diff relays the child's ref AND
+/// classifies the outcome from the child's EXIT CODE — with exit 6 landing on
+/// `Partial`, never `Failed`.
+///
+/// Why: exit 6 is trusty-code's "the turn budget ran out but real work is on
+/// disk" code. Reading it as failure is how a caller throws away working code
+/// (`trusty_code::run_task::report::ExitCode::Partial`'s own docs).
+/// Test: this test.
+#[test]
+fn a_child_reporting_a_diff_relays_its_ref_and_partial_status() {
+    let result = extract_child_result(&child_snapshot_with_a_diff(), Some(6));
+
+    assert_eq!(result.status, TaskResultStatus::Partial);
+    assert_ne!(
+        result.status,
+        TaskResultStatus::Failed,
+        "exit 6 must not collapse into failure (#4351)"
+    );
+    assert_eq!(
+        result.diff_ref.as_deref(),
+        Some("0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c")
+    );
+    assert_eq!(result.branch.as_deref(), Some("feat/thing"));
+    assert_eq!(result.pr_ref, None);
+    assert!(result.summary.is_some());
+}
+
+/// #4351 acceptance: a run that changed nothing relays `None` refs and still
+/// reports its status.
+#[test]
+fn a_child_with_no_diff_relays_nones_and_the_status() {
+    let stdout = json!({
+        "id": "s-2",
+        "task": "t",
+        "status": "finished",
+        "result": { "status": "success", "summary": "success: no changes" }
+    })
+    .to_string();
+
+    let result = extract_child_result(&stdout, Some(0));
+    assert_eq!(result.status, TaskResultStatus::Success);
+    assert_eq!(result.diff_ref, None);
+    assert_eq!(result.branch, None);
+    assert_eq!(result.pr_ref, None);
+    assert_eq!(result.summary.as_deref(), Some("success: no changes"));
+}
+
+/// A child that printed prose rather than the JSON snapshot — an older binary,
+/// or the stderr fallback path — still yields a status rather than an error.
+/// The run has already finished by then; there is nothing left to fail.
+#[test]
+fn unparseable_child_output_still_yields_a_status() {
+    let result = extract_child_result("not json at all\n", Some(3));
+    assert_eq!(result.status, TaskResultStatus::Failed);
+    assert_eq!(result.diff_ref, None);
+    assert_eq!(result.summary, None);
+}
+
+/// A backend that only implements `run` — every pre-#4351 implementor,
+/// including the test doubles — reaches `run_result` through the trait's
+/// default body and honestly reports no result rather than an invented one.
+#[tokio::test]
+async fn default_run_result_reports_no_result() {
+    struct TranscriptOnlyBackend;
+
+    #[async_trait]
+    impl PmBridgeBackend for TranscriptOnlyBackend {
+        async fn run(
+            &self,
+            _route: BridgeRoute,
+            _target: Option<&str>,
+            _task: &str,
+        ) -> Result<String> {
+            Ok("just a transcript".to_string())
+        }
+    }
+
+    let outcome = TranscriptOnlyBackend
+        .run_result(BridgeRoute::Tcode, None, "t")
+        .await
+        .expect("the default body must not fail");
+    assert_eq!(outcome.transcript, "just a transcript");
+    assert_eq!(outcome.result, None);
+}

--- a/crates/trusty-agents/src/tools/pm_bridge_tests.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_tests.rs
@@ -776,3 +776,41 @@ fn schema_advertises_the_coding_pm_and_the_closed_style_vocabulary() {
         );
     }
 }
+
+// =====================================================================
+// #4351 — scrubbing a relayed TaskResult
+// =====================================================================
+
+/// A backend-reported `summary` is generated prose travelling the same path a
+/// transcript does, so it gets the same branding scrub.
+#[test]
+fn a_reported_summary_is_branding_scrubbed() {
+    let scrubbed = scrub_task_result(
+        TaskResult::new(trusty_code::session::TaskResultStatus::Success)
+            .with_summary(Some("tcode finished the run".to_string())),
+    );
+    let summary = scrubbed.summary.expect("summary survives");
+    assert!(
+        !summary.to_ascii_lowercase().contains("tcode"),
+        "summary leaked backend identity: {summary}"
+    );
+}
+
+/// The structured refs are NOT scrubbed — a word-boundary substitution over a
+/// SHA or a branch name would corrupt the one field a caller acts on, and they
+/// carry no backend identity to begin with (git builds them, not the harness).
+#[test]
+fn scrubbing_leaves_the_refs_intact() {
+    let scrubbed = scrub_task_result(
+        TaskResult::new(trusty_code::session::TaskResultStatus::Partial)
+            .with_diff_ref(Some("0f1e2d3c4b5a6978".to_string()))
+            .with_branch(Some("feat/tm-migration".to_string()))
+            .with_pr_ref(Some("https://example.invalid/pull/7".to_string())),
+    );
+    assert_eq!(scrubbed.diff_ref.as_deref(), Some("0f1e2d3c4b5a6978"));
+    assert_eq!(scrubbed.branch.as_deref(), Some("feat/tm-migration"));
+    assert_eq!(
+        scrubbed.pr_ref.as_deref(),
+        Some("https://example.invalid/pull/7")
+    );
+}

--- a/crates/trusty-code/changelog.d/4351-task-result.md
+++ b/crates/trusty-code/changelog.d/4351-task-result.md
@@ -1,0 +1,5 @@
+Added
+
+- `task.run` and `session.status` carry an additive `result` object — `status`, `diff_ref`, `branch`, `pr_ref`, `summary` — so a caller learns where a run's change landed and whether it passed instead of only its session id (#4351).
+- Every result field is nullable and the object is omitted entirely for a session that has never run, so an existing consumer sees an unchanged payload.
+- A run that exhausted its turn budget reports `partial`, not `failed`.

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -329,6 +329,7 @@ mod tests {
             created_at: Utc::now(),
             mode: None,
             workstream_id: None,
+            result: None,
         }
     }
 

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -13,7 +13,7 @@
 //! passes a real `LlmClient` and tests pass a scripted mock — no live key needed.
 //! Test: `run_task::tests` drive the whole PM→engineer path offline.
 
-mod diff;
+pub(crate) mod diff;
 mod recorder;
 mod redelegation;
 mod report;

--- a/crates/trusty-code/src/run_task/report.rs
+++ b/crates/trusty-code/src/run_task/report.rs
@@ -69,6 +69,33 @@ impl ExitCode {
     pub fn code(self) -> i32 {
         self as i32
     }
+
+    /// Recover the typed outcome from a child process's numeric exit code
+    /// (#4351).
+    ///
+    /// Why: a caller that SPAWNS `tcode` (see
+    /// `trusty_agents::tools::pm_bridge_backend::ProcessPmBridge`) gets an
+    /// `i32` back and has to classify it. Without this, every such caller
+    /// re-types the literals `0`/`4`/`5`/`6`, and renumbering a variant here
+    /// silently misclassifies runs at each of those sites — a `Partial` read
+    /// as a failure discards working code.
+    /// What: the inverse of [`Self::code`], written against `code()` rather
+    /// than literals so the two can never disagree. `None` for a number this
+    /// enum does not define, which the caller decides how to treat.
+    /// Test: `tests::from_code_is_the_inverse_of_code`,
+    /// `tests::from_code_rejects_an_undefined_number`.
+    pub fn from_code(code: i32) -> Option<Self> {
+        [
+            Self::Success,
+            Self::ConfigError,
+            Self::RunFailure,
+            Self::NoChanges,
+            Self::DeadlineExceeded,
+            Self::Partial,
+        ]
+        .into_iter()
+        .find(|candidate| candidate.code() == code)
+    }
 }
 
 /// The full result of a `run-task` invocation, ready to render.
@@ -284,6 +311,36 @@ pub fn aggregate_usage_per_role(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every variant this enum defines must survive `code()` -> `from_code()`.
+    /// The list is written out so a NEW variant that `from_code`'s own lookup
+    /// forgot shows up here as a failure rather than as a silent `None`.
+    #[test]
+    fn from_code_is_the_inverse_of_code() {
+        for exit in [
+            ExitCode::Success,
+            ExitCode::ConfigError,
+            ExitCode::RunFailure,
+            ExitCode::NoChanges,
+            ExitCode::DeadlineExceeded,
+            ExitCode::Partial,
+        ] {
+            assert_eq!(
+                ExitCode::from_code(exit.code()),
+                Some(exit),
+                "{exit:?} did not round-trip through its own numeric code"
+            );
+        }
+    }
+
+    /// A number this enum does not define — including a negative one, or the
+    /// `1` no variant claims — is `None`, not a wrong variant.
+    #[test]
+    fn from_code_rejects_an_undefined_number() {
+        for code in [-1, 1, 7, 137] {
+            assert_eq!(ExitCode::from_code(code), None, "code {code}");
+        }
+    }
 
     fn sample_report(exit: ExitCode, diff: &str) -> RunReport {
         RunReport {

--- a/crates/trusty-code/src/session/mod.rs
+++ b/crates/trusty-code/src/session/mod.rs
@@ -41,6 +41,8 @@ pub mod memory_sink;
 pub mod model;
 pub mod protocol;
 pub mod registry;
+/// (#4351) The actionable `TaskResult` carried beside a `Session` snapshot.
+pub mod task_result;
 pub mod transcript;
 
 /// (issue #3948) The per-session working-context floor `registry` folds into
@@ -53,4 +55,5 @@ pub use connector::TcodeConnector;
 pub use memory_sink::{MemoryFailureCategory, PalaceCreation, TurnMemorySink};
 pub use model::{Session, SessionStatus};
 pub use registry::SessionRegistry;
+pub use task_result::{TaskResult, TaskResultStatus};
 pub use transcript::{GoalSlotRecord, MemoryDurabilityStatus, TranscriptRecord};

--- a/crates/trusty-code/src/session/model.rs
+++ b/crates/trusty-code/src/session/model.rs
@@ -164,6 +164,20 @@ pub struct Session {
     /// (predating this field) reading back as unbound.
     #[serde(default)]
     pub workstream_id: Option<crate::workstreams::model::WorkstreamId>,
+    /// (#4351) The actionable outcome of this session's last run — where the
+    /// change landed and whether it passed — set once the run reaches a
+    /// terminal state (`crate::task::executor` -> `SessionRegistry::
+    /// set_task_result`).
+    ///
+    /// `None` until then, and OMITTED from the JSON entirely while `None`, so
+    /// every pre-#4351 consumer sees a byte-identical `session.status`
+    /// payload for a session that has never run. `#[serde(default)]` is the
+    /// other half: a persisted or hand-written snapshot predating this field
+    /// still reads back.
+    /// Test: `model::tests::session_without_result_deserialises_and_omits_it`,
+    /// `model::tests::session_round_trips_with_a_result`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<crate::session::task_result::TaskResult>,
 }
 
 #[cfg(test)]
@@ -264,6 +278,7 @@ mod tests {
             created_at: Utc::now(),
             mode: Some(crate::mode::HarnessMode::DailyDriver),
             workstream_id: None,
+            result: None,
         };
         let value = serde_json::to_value(&session).unwrap();
         assert_eq!(value["id"], "s-1");
@@ -276,6 +291,64 @@ mod tests {
         assert_eq!(back.id, session.id);
         assert_eq!(back.status, session.status);
         assert_eq!(back.mode, session.mode);
+    }
+
+    /// #4351 backward compatibility: the exact `session.status` payload a
+    /// pre-#4351 daemon emitted — no `result` key at all — must still
+    /// deserialise, and a session that has never run must still SERIALISE
+    /// without one, so a consumer written against the old shape sees a
+    /// byte-identical document.
+    #[test]
+    fn session_without_result_deserialises_and_omits_it() {
+        let legacy = json!({
+            "id": "s-1",
+            "task": "do the thing",
+            "agent": "engineer",
+            "project": null,
+            "status": "finished",
+            "created_at": "2026-01-01T00:00:00Z",
+            "mode": "daily-driver",
+            "binding": { "state": "projectless" },
+            "workstream_id": null
+        });
+
+        let parsed: Session = serde_json::from_value(legacy).expect("legacy payload deserialises");
+        assert_eq!(parsed.id, "s-1");
+        assert!(parsed.result.is_none());
+
+        let re_encoded = serde_json::to_value(&parsed).expect("serialize");
+        assert!(
+            re_encoded.get("result").is_none(),
+            "a session with no result must omit the key entirely, not emit null: {re_encoded}"
+        );
+    }
+
+    /// #4351: once a run finishes, the result rides along on the same snapshot.
+    #[test]
+    fn session_round_trips_with_a_result() {
+        let session = Session {
+            id: "s-2".to_string(),
+            task: "t".to_string(),
+            agent: None,
+            project: None,
+            binding: crate::binding::ProjectBinding::None,
+            status: SessionStatus::Finished,
+            created_at: Utc::now(),
+            mode: None,
+            workstream_id: None,
+            result: Some(
+                crate::session::TaskResult::new(crate::session::TaskResultStatus::Success)
+                    .with_diff_ref(Some("tree-sha".to_string())),
+            ),
+        };
+
+        let value = serde_json::to_value(&session).expect("serialize");
+        assert_eq!(value["result"]["status"], "success");
+        assert_eq!(value["result"]["diff_ref"], "tree-sha");
+        assert!(value["result"]["pr_ref"].is_null());
+
+        let back: Session = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(back.result, session.result);
     }
 }
 
@@ -297,6 +370,7 @@ mod binding_model_tests {
             created_at: Utc::now(),
             mode: None,
             workstream_id: None,
+            result: None,
         };
         let value = serde_json::to_value(&session).expect("serialize");
         assert_eq!(value["binding"]["state"], "projectless");
@@ -337,6 +411,7 @@ mod binding_model_tests {
             created_at: Utc::now(),
             mode: None,
             workstream_id: Some(ws_id),
+            result: None,
         };
         let value = serde_json::to_value(&session).expect("serialize");
         assert_eq!(value["workstream_id"], ws_id.to_string());

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -327,6 +327,7 @@ impl SessionRegistry {
             created_at: Utc::now(),
             mode: None,
             workstream_id: None,
+            result: None,
         };
         {
             let mut sessions = self.lock();
@@ -1083,6 +1084,11 @@ mod workstream_binding;
 /// `events` above.
 #[path = "registry_search_audit.rs"]
 mod search_audit;
+
+/// #4351's `SessionRegistry::set_task_result`, split out into its own file for
+/// the same 500-SLOC-cap reason as `events` above.
+#[path = "registry_task_result.rs"]
+mod task_result_ops;
 
 #[cfg(test)]
 #[path = "registry_tests.rs"]

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -436,9 +436,14 @@ impl SessionRegistry {
     /// `Event::SessionDone` (`status: "cancelled"`) — matching the vision
     /// spec's `started/status-changed/input/cancelled/done` taxonomy — and
     /// returns the updated snapshot.
+    ///
+    /// #4351: also records a refless `Cancelled` `TaskResult`, so cancelling is
+    /// not the one terminal state that answers `session.status` with no
+    /// `result` — see [`Self::set_cancelled_result`].
     /// Test: `registry_tests::cancel_transitions_to_cancelled_and_publishes`,
     /// `registry_tests::cancel_is_idempotent_on_terminal_session`,
-    /// `registry_tests::cancel_unknown_session_errors`.
+    /// `registry_tests::cancel_unknown_session_errors`,
+    /// `registry_tests::cancel_records_a_refless_cancelled_result`.
     pub fn cancel(&self, id: &str) -> Result<Session, RpcError> {
         let already_terminal = {
             let sessions = self.lock();
@@ -450,6 +455,9 @@ impl SessionRegistry {
         if already_terminal {
             return self.status(id);
         }
+        // #4351: record the result BEFORE the transition, so the snapshot this
+        // returns and every terminal path agree — see `set_cancelled_result`.
+        self.set_cancelled_result(id);
         self.transition(id, SessionStatus::Cancelled);
         self.record(
             id,

--- a/crates/trusty-code/src/session/registry_task_result.rs
+++ b/crates/trusty-code/src/session/registry_task_result.rs
@@ -1,0 +1,38 @@
+//! `SessionRegistry::set_task_result` (#4351), split out of `registry.rs` for
+//! the 500-SLOC cap — a child module of `registry` (declared via
+//! `#[path = ...] mod task_result_ops;`), so it keeps full access to
+//! `SessionRegistry`'s private `lock` helper and `SessionEntry`'s private
+//! fields exactly as if the method were still defined there.
+//!
+//! Why: `registry.rs` sits within a few lines of its cap; the same reason
+//! `registry_transcript.rs` and `registry_events.rs` exist.
+//! What: [`SessionRegistry::set_task_result`].
+//! Test: `registry_tests::set_task_result_stores_the_result`,
+//! `registry_tests::set_task_result_on_unknown_session_is_a_no_op`.
+
+use super::*;
+use crate::session::task_result::TaskResult;
+
+impl SessionRegistry {
+    /// Record this session's actionable run result (#4351).
+    ///
+    /// Why: `session.status` must be able to hand a caller the branch/ref/
+    /// pass-fail story, not just an opaque id — see
+    /// `crate::session::task_result` for why. `crate::task::executor` is the
+    /// only production caller; it fires exactly once, immediately before
+    /// `finish`, so the result and the terminal status become visible in the
+    /// same snapshot.
+    /// What: overwrites `Session::result` wholesale. A session that has
+    /// vanished (never created, or already pruned) is a silent no-op — the
+    /// same contract [`Self::set_run_outcome`] uses, and for the same reason:
+    /// this is called from a detached task that cannot meaningfully handle
+    /// "the session went away while I was running".
+    /// Test: `registry_tests::set_task_result_stores_the_result`,
+    /// `registry_tests::set_task_result_on_unknown_session_is_a_no_op`.
+    pub fn set_task_result(&self, id: &str, result: TaskResult) {
+        let mut sessions = self.lock();
+        if let Some(entry) = sessions.get_mut(id) {
+            entry.session.result = Some(result);
+        }
+    }
+}

--- a/crates/trusty-code/src/session/registry_task_result.rs
+++ b/crates/trusty-code/src/session/registry_task_result.rs
@@ -6,12 +6,14 @@
 //!
 //! Why: `registry.rs` sits within a few lines of its cap; the same reason
 //! `registry_transcript.rs` and `registry_events.rs` exist.
-//! What: [`SessionRegistry::set_task_result`].
+//! What: [`SessionRegistry::set_task_result`] and the `session.cancel`
+//! convenience [`SessionRegistry::set_cancelled_result`].
 //! Test: `registry_tests::set_task_result_stores_the_result`,
-//! `registry_tests::set_task_result_on_unknown_session_is_a_no_op`.
+//! `registry_tests::set_task_result_on_unknown_session_is_a_no_op`,
+//! `registry_tests::cancel_records_a_refless_cancelled_result`.
 
 use super::*;
-use crate::session::task_result::TaskResult;
+use crate::session::task_result::{TaskResult, TaskResultStatus};
 
 impl SessionRegistry {
     /// Record this session's actionable run result (#4351).
@@ -34,5 +36,27 @@ impl SessionRegistry {
         if let Some(entry) = sessions.get_mut(id) {
             entry.session.result = Some(result);
         }
+    }
+
+    /// Record the result for a user-initiated `session.cancel` (#4351).
+    ///
+    /// Why: [`Self::cancel`] transitions a session straight to `Cancelled`
+    /// without going through `crate::task::executor`, so without this a
+    /// cancelled session was the ONE terminal state answering `session.status`
+    /// with no `result` at all — a caller that reads the field to tell what
+    /// happened would see nothing for the one outcome it most likely caused.
+    /// A session with a LIVE run also gets a result from the executor when its
+    /// loop unwinds; that one arrives later and knows more, so it correctly
+    /// overwrites this one. A session with no live run gets only this.
+    /// What: a refless `Cancelled` result. There is nothing on disk to point
+    /// at — cancellation is a status transition, not a run outcome (vision
+    /// spec §12 11.6) — so the refs stay `None` rather than being guessed.
+    /// Test: `registry_tests::cancel_records_a_refless_cancelled_result`.
+    pub(super) fn set_cancelled_result(&self, id: &str) {
+        self.set_task_result(
+            id,
+            TaskResult::new(TaskResultStatus::Cancelled)
+                .with_summary(Some("cancelled: no changes recorded".to_string())),
+        );
     }
 }

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -2689,6 +2689,36 @@ fn set_task_result_stores_the_result() {
     assert_eq!(stored.pr_ref, None);
 }
 
+/// (#4351) `session.cancel` must not be the one terminal state that answers
+/// `session.status` with no result. Cancellation is a status transition, not a
+/// run outcome, so the refs are `None` — but the status and summary are there.
+#[test]
+fn cancel_records_a_refless_cancelled_result() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let snapshot = registry.cancel(&session.id).expect("cancel succeeds");
+    assert_eq!(snapshot.status, SessionStatus::Cancelled);
+
+    let result = snapshot
+        .result
+        .clone()
+        .expect("#4351: a cancelled session must carry a TaskResult");
+    assert_eq!(result.status, crate::session::TaskResultStatus::Cancelled);
+    assert_eq!(result.diff_ref, None);
+    assert_eq!(result.branch, None);
+    assert_eq!(result.pr_ref, None);
+    assert!(
+        result.summary.is_some(),
+        "a cancelled result must still say what happened"
+    );
+
+    // The snapshot `cancel` returns and a later `session.status` read must
+    // agree — the result is on the session, not synthesised per call.
+    let reread = registry.status(&session.id).expect("session exists");
+    assert_eq!(reread.result, snapshot.result);
+}
+
 /// A session that vanished between the run starting and finishing is a silent
 /// no-op, matching `set_run_outcome`'s contract — a detached background task
 /// has nothing useful to do with the error.

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -2656,3 +2656,48 @@ async fn context_floor_after_restart_is_absent_not_wrong() {
 
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// ── #4351: the actionable TaskResult on a session snapshot ────────────────────
+
+/// `set_task_result` must land on the session's own snapshot, where
+/// `session.status` reads it.
+#[test]
+fn set_task_result_stores_the_result() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    assert!(
+        registry.status(&session.id).unwrap().result.is_none(),
+        "a session that has never run carries no result"
+    );
+
+    registry.set_task_result(
+        &session.id,
+        crate::session::TaskResult::new(crate::session::TaskResultStatus::Partial)
+            .with_diff_ref(Some("tree-sha".to_string()))
+            .with_branch(Some("feat/x".to_string()))
+            .with_summary(Some("partial: changes captured".to_string())),
+    );
+
+    let stored = registry
+        .status(&session.id)
+        .unwrap()
+        .result
+        .expect("result must be readable back through session.status");
+    assert_eq!(stored.status, crate::session::TaskResultStatus::Partial);
+    assert_eq!(stored.diff_ref.as_deref(), Some("tree-sha"));
+    assert_eq!(stored.branch.as_deref(), Some("feat/x"));
+    assert_eq!(stored.pr_ref, None);
+}
+
+/// A session that vanished between the run starting and finishing is a silent
+/// no-op, matching `set_run_outcome`'s contract — a detached background task
+/// has nothing useful to do with the error.
+#[test]
+fn set_task_result_on_unknown_session_is_a_no_op() {
+    let registry = SessionRegistry::new();
+    registry.set_task_result(
+        "no-such-session",
+        crate::session::TaskResult::new(crate::session::TaskResultStatus::Failed),
+    );
+    assert!(registry.status("no-such-session").is_err());
+}

--- a/crates/trusty-code/src/session/task_result.rs
+++ b/crates/trusty-code/src/session/task_result.rs
@@ -14,12 +14,14 @@
 //! builders, never a struct literal from outside this crate.
 //! Test: `tests::status_maps_every_session_status`,
 //! `tests::partial_exit_code_is_its_own_status_not_a_failure`,
+//! `tests::exit_code_mapping_reads_the_numbers_from_the_enum`,
 //! `tests::task_result_round_trips_through_json`,
 //! `tests::absent_optional_fields_deserialise_as_none`.
 
 use serde::{Deserialize, Serialize};
 
 use super::model::SessionStatus;
+use crate::run_task::ExitCode;
 
 /// Pass/fail classification of a run, wider than a boolean.
 ///
@@ -86,26 +88,46 @@ impl TaskResultStatus {
         }
     }
 
-    /// Classify a `tcode` process exit code (`ExitCode`, #4351).
+    /// Classify a typed [`ExitCode`].
+    ///
+    /// Why: `ExitCode` is the ONE definition of what a run's outcome means in
+    /// this crate; this match is exhaustive over it, so adding a variant there
+    /// fails to compile here until somebody decides what it classifies as.
+    /// A catch-all would have let `Partial` be absorbed silently — the exact
+    /// shape of #3888.
+    /// What: `NoChanges` is a SUCCESS — the run completed, it simply changed
+    /// nothing. `Partial` keeps its own status rather than collapsing into
+    /// `Failed`, because it means real work is on disk (see that variant's own
+    /// docs).
+    /// Test: `tests::every_exit_code_variant_classifies_deliberately`.
+    pub fn from_exit_kind(exit: ExitCode) -> Self {
+        match exit {
+            ExitCode::Success | ExitCode::NoChanges => Self::Success,
+            ExitCode::ConfigError | ExitCode::RunFailure => Self::Failed,
+            ExitCode::DeadlineExceeded => Self::DeadlineExceeded,
+            ExitCode::Partial => Self::Partial,
+        }
+    }
+
+    /// Classify a `tcode` child process's numeric exit code (#4351).
     ///
     /// Why: a caller that shells out to `tcode run-task` (see
     /// `trusty_agents::tools::pm_bridge_backend::ProcessPmBridge`) reads the
     /// child's exit status, not a `SessionStatus`. Without this mapping the
     /// only honest reading of "non-zero" is "failed", which silently throws
-    /// away the `Partial` (6) distinction the exit code exists to draw.
-    /// What: `0`/`4` (`Success`/`NoChanges` — the run completed, it simply
-    /// changed nothing) report `Success`; `5` reports `DeadlineExceeded`; `6`
-    /// reports `Partial`; every other code, including a signal-killed child
-    /// with no code at all, reports `Failed`.
+    /// away the `Partial` distinction the exit code exists to draw.
+    /// What: routes the number through [`ExitCode::from_code`] and then
+    /// [`Self::from_exit_kind`], so the numbers live in `ExitCode` alone and
+    /// renumbering a variant there carries this mapping with it. A number that
+    /// enum does not define — and a signal-killed child, which reports no code
+    /// at all — fails closed as `Failed`.
     /// Test: `tests::partial_exit_code_is_its_own_status_not_a_failure`,
-    /// `tests::exit_code_mapping_covers_every_documented_code`.
+    /// `tests::exit_code_mapping_reads_the_numbers_from_the_enum`,
+    /// `tests::an_undefined_exit_number_fails_closed`.
     pub fn from_exit_code(code: Option<i32>) -> Self {
-        match code {
-            Some(0) | Some(4) => Self::Success,
-            Some(5) => Self::DeadlineExceeded,
-            Some(6) => Self::Partial,
-            _ => Self::Failed,
-        }
+        code.and_then(ExitCode::from_code)
+            .map(Self::from_exit_kind)
+            .unwrap_or(Self::Failed)
     }
 }
 
@@ -243,31 +265,73 @@ mod tests {
         }
     }
 
-    /// #4351: exit 6 is `Partial`, NOT `Failed` — the whole point of the code.
+    /// #4351: `ExitCode::Partial` is `Partial`, NOT `Failed` — the whole point
+    /// of that exit code. Asserted through the enum, never the literal `6`, so
+    /// renumbering it cannot make this test pass against the wrong number.
     #[test]
     fn partial_exit_code_is_its_own_status_not_a_failure() {
-        let status = TaskResultStatus::from_exit_code(Some(6));
+        let status = TaskResultStatus::from_exit_code(Some(ExitCode::Partial.code()));
         assert_eq!(status, TaskResultStatus::Partial);
         assert_ne!(status, TaskResultStatus::Failed);
     }
 
-    /// Every exit code `crate::run_task::report::ExitCode` documents maps
-    /// deliberately, and an absent code (signal-killed child) fails closed.
+    /// Every `ExitCode` variant classifies deliberately. The match in
+    /// `from_exit_kind` is exhaustive, so a new variant breaks the build there
+    /// first; this pins what each existing one means.
     #[test]
-    fn exit_code_mapping_covers_every_documented_code() {
-        for (code, expected) in [
-            (Some(0), TaskResultStatus::Success),
-            (Some(2), TaskResultStatus::Failed),
-            (Some(3), TaskResultStatus::Failed),
-            (Some(4), TaskResultStatus::Success),
-            (Some(5), TaskResultStatus::DeadlineExceeded),
-            (Some(6), TaskResultStatus::Partial),
-            (None, TaskResultStatus::Failed),
+    fn every_exit_code_variant_classifies_deliberately() {
+        for (exit, expected) in [
+            (ExitCode::Success, TaskResultStatus::Success),
+            (ExitCode::ConfigError, TaskResultStatus::Failed),
+            (ExitCode::RunFailure, TaskResultStatus::Failed),
+            (ExitCode::NoChanges, TaskResultStatus::Success),
+            (
+                ExitCode::DeadlineExceeded,
+                TaskResultStatus::DeadlineExceeded,
+            ),
+            (ExitCode::Partial, TaskResultStatus::Partial),
         ] {
             assert_eq!(
-                TaskResultStatus::from_exit_code(code),
+                TaskResultStatus::from_exit_kind(exit),
                 expected,
-                "exit code {code:?} mapped to the wrong result status"
+                "{exit:?} classified wrongly"
+            );
+        }
+    }
+
+    /// `from_exit_code` reads its numbers from `ExitCode` itself, so the
+    /// numeric path agrees with the typed one for every variant.
+    #[test]
+    fn exit_code_mapping_reads_the_numbers_from_the_enum() {
+        for exit in [
+            ExitCode::Success,
+            ExitCode::ConfigError,
+            ExitCode::RunFailure,
+            ExitCode::NoChanges,
+            ExitCode::DeadlineExceeded,
+            ExitCode::Partial,
+        ] {
+            assert_eq!(
+                TaskResultStatus::from_exit_code(Some(exit.code())),
+                TaskResultStatus::from_exit_kind(exit),
+                "the numeric and typed paths disagree for {exit:?}"
+            );
+        }
+    }
+
+    /// A number `ExitCode` does not define, and a signal-killed child that
+    /// reports no code at all, both fail closed.
+    #[test]
+    fn an_undefined_exit_number_fails_closed() {
+        assert_eq!(
+            TaskResultStatus::from_exit_code(None),
+            TaskResultStatus::Failed
+        );
+        for code in [1, 7, 137] {
+            assert_eq!(
+                TaskResultStatus::from_exit_code(Some(code)),
+                TaskResultStatus::Failed,
+                "undefined code {code}"
             );
         }
     }

--- a/crates/trusty-code/src/session/task_result.rs
+++ b/crates/trusty-code/src/session/task_result.rs
@@ -1,0 +1,343 @@
+//! The actionable outcome a caller gets back alongside a `Session` snapshot
+//! (#4351).
+//!
+//! Why: `task.run` and `session.status` used to hand back only `id`/`status`/
+//! `mode` — opaque to an external caller, which then had no way to tell a
+//! caller-facing story ("the change landed on branch X, here is the ref, the
+//! run passed"). [`TaskResult`] is the additive answer: the same snapshot
+//! still ships, with the actionable fields carried beside it.
+//! What: [`TaskResultStatus`] classifies the run; [`TaskResult`] carries that
+//! status plus `diff_ref`, `branch`, `pr_ref` and `summary`, every one of them
+//! nullable so a producer that cannot know a field says so rather than
+//! inventing it. `#[non_exhaustive]` keeps later fields additive: construct
+//! through [`TaskResult::new`] / [`TaskResult::pending`] and the `with_*`
+//! builders, never a struct literal from outside this crate.
+//! Test: `tests::status_maps_every_session_status`,
+//! `tests::partial_exit_code_is_its_own_status_not_a_failure`,
+//! `tests::task_result_round_trips_through_json`,
+//! `tests::absent_optional_fields_deserialise_as_none`.
+
+use serde::{Deserialize, Serialize};
+
+use super::model::SessionStatus;
+
+/// Pass/fail classification of a run, wider than a boolean.
+///
+/// Why: "did it work" has more than two useful answers. A run that exhausted
+/// its turn budget after writing a real, on-disk deliverable is NOT a failure
+/// — trusty-code's own CLI has spelled that `ExitCode::Partial` (6) since
+/// #2265, and collapsing it into `Failed` is exactly how a caller ends up
+/// discarding working code (see `crate::run_task::report::ExitCode`'s docs).
+/// What: `Pending` for a run that has not reached a terminal state yet;
+/// `Success`/`Partial`/`Failed`/`Cancelled`/`DeadlineExceeded` for the
+/// terminal ones. The wire form is snake_case, matching `SessionStatus`'s
+/// own convention.
+/// Test: `tests::status_maps_every_session_status`,
+/// `tests::partial_exit_code_is_its_own_status_not_a_failure`,
+/// `tests::status_serialises_snake_case`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskResultStatus {
+    /// The run has not reached a terminal state yet.
+    Pending,
+    /// The run reached a natural stop without error.
+    Success,
+    /// The run stopped early but produced a deliverable — resumable, not dead.
+    Partial,
+    /// The run errored.
+    Failed,
+    /// The run was cancelled by a caller.
+    Cancelled,
+    /// The run's wall-clock deadline elapsed first.
+    DeadlineExceeded,
+}
+
+impl TaskResultStatus {
+    /// The wire string, identical to the serde representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Success => "success",
+            Self::Partial => "partial",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::DeadlineExceeded => "deadline_exceeded",
+        }
+    }
+
+    /// Classify a daemon-side [`SessionStatus`].
+    ///
+    /// Why: the daemon's own producer (`crate::task::executor`) knows the
+    /// session's terminal status and nothing about process exit codes; this is
+    /// its one mapping point.
+    /// What: `Created`/`Running` are not terminal, so they report `Pending`.
+    /// `TurnCapExceeded` reports `Partial` — the same "not done, not dead"
+    /// reading `crate::cli_client::render::exit_code_for_status` already gives
+    /// it.
+    /// Test: `tests::status_maps_every_session_status`.
+    pub fn from_session_status(status: SessionStatus) -> Self {
+        match status {
+            SessionStatus::Created | SessionStatus::Running => Self::Pending,
+            SessionStatus::Finished => Self::Success,
+            SessionStatus::TurnCapExceeded => Self::Partial,
+            SessionStatus::Failed => Self::Failed,
+            SessionStatus::Cancelled => Self::Cancelled,
+            SessionStatus::DeadlineExceeded => Self::DeadlineExceeded,
+        }
+    }
+
+    /// Classify a `tcode` process exit code (`ExitCode`, #4351).
+    ///
+    /// Why: a caller that shells out to `tcode run-task` (see
+    /// `trusty_agents::tools::pm_bridge_backend::ProcessPmBridge`) reads the
+    /// child's exit status, not a `SessionStatus`. Without this mapping the
+    /// only honest reading of "non-zero" is "failed", which silently throws
+    /// away the `Partial` (6) distinction the exit code exists to draw.
+    /// What: `0`/`4` (`Success`/`NoChanges` — the run completed, it simply
+    /// changed nothing) report `Success`; `5` reports `DeadlineExceeded`; `6`
+    /// reports `Partial`; every other code, including a signal-killed child
+    /// with no code at all, reports `Failed`.
+    /// Test: `tests::partial_exit_code_is_its_own_status_not_a_failure`,
+    /// `tests::exit_code_mapping_covers_every_documented_code`.
+    pub fn from_exit_code(code: Option<i32>) -> Self {
+        match code {
+            Some(0) | Some(4) => Self::Success,
+            Some(5) => Self::DeadlineExceeded,
+            Some(6) => Self::Partial,
+            _ => Self::Failed,
+        }
+    }
+}
+
+/// The actionable result of a task run, carried beside the `Session` snapshot.
+///
+/// Why: see the module docs — the `ProposalEnvelope` a calling assistant
+/// renders needs something concrete ("branch, ref, pass/fail"), and a bare
+/// session id is not that.
+/// What: every field except `status` is nullable, and a producer that cannot
+/// know one leaves it `None` rather than guessing. `diff_ref` is whatever ref
+/// names where the change landed (this crate's daemon reports a git tree
+/// object SHA); `branch` is the checked-out branch; `pr_ref` is a PR URL or
+/// number; `summary` is a one-line user-facing description. `pr_ref` is never
+/// populated by this crate's daemon — nothing in it opens a pull request — and
+/// exists for a producer downstream that does.
+/// Test: `tests::task_result_round_trips_through_json`,
+/// `tests::absent_optional_fields_deserialise_as_none`,
+/// `tests::builders_set_each_field`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct TaskResult {
+    /// Pass/fail classification of the run.
+    pub status: TaskResultStatus,
+    /// Where the change landed — a commit hash, tree SHA, branch name, or path.
+    #[serde(default)]
+    pub diff_ref: Option<String>,
+    /// The branch the run left checked out.
+    #[serde(default)]
+    pub branch: Option<String>,
+    /// A pull-request URL or number, when a producer opened one.
+    #[serde(default)]
+    pub pr_ref: Option<String>,
+    /// One-line user-facing description of what happened.
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
+impl TaskResult {
+    /// A result carrying `status` and nothing else yet.
+    ///
+    /// Why: `#[non_exhaustive]` deliberately blocks struct-literal
+    /// construction outside this crate, so this plus the `with_*` builders are
+    /// the whole construction surface — a field added later cannot break a
+    /// downstream caller.
+    /// What: every optional field starts `None`.
+    /// Test: `tests::builders_set_each_field`.
+    pub fn new(status: TaskResultStatus) -> Self {
+        Self {
+            status,
+            diff_ref: None,
+            branch: None,
+            pr_ref: None,
+            summary: None,
+        }
+    }
+
+    /// The result `task.run` returns immediately, before the run has finished.
+    ///
+    /// Why: `task.run` is asynchronous — it mints the session, spawns the run
+    /// and returns. Reporting `Pending` with empty refs is the truthful
+    /// snapshot at that instant; the caller polls `session.status` for the
+    /// terminal one.
+    /// Test: `crate::task::protocol::tests::task_run_response_carries_a_pending_result`.
+    pub fn pending() -> Self {
+        Self::new(TaskResultStatus::Pending)
+    }
+
+    /// Replace the status, keeping every other field.
+    ///
+    /// Why: a relaying caller learns the outcome from its child's exit code
+    /// while the refs come from the child's own reported result — the two
+    /// arrive from different places and must be composable.
+    /// Test: `tests::builders_set_each_field`.
+    pub fn with_status(mut self, status: TaskResultStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    /// Set `diff_ref`. `None` leaves it absent.
+    /// Test: `tests::builders_set_each_field`.
+    pub fn with_diff_ref(mut self, diff_ref: Option<String>) -> Self {
+        self.diff_ref = diff_ref;
+        self
+    }
+
+    /// Set `branch`. `None` leaves it absent.
+    /// Test: `tests::builders_set_each_field`.
+    pub fn with_branch(mut self, branch: Option<String>) -> Self {
+        self.branch = branch;
+        self
+    }
+
+    /// Set `pr_ref`. `None` leaves it absent.
+    /// Test: `tests::builders_set_each_field`.
+    pub fn with_pr_ref(mut self, pr_ref: Option<String>) -> Self {
+        self.pr_ref = pr_ref;
+        self
+    }
+
+    /// Set `summary`. `None` leaves it absent.
+    /// Test: `tests::builders_set_each_field`.
+    pub fn with_summary(mut self, summary: Option<String>) -> Self {
+        self.summary = summary;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Every `SessionStatus` must land on a deliberate classification — the
+    /// non-terminal pair on `Pending`, and `TurnCapExceeded` on `Partial`
+    /// rather than being absorbed into `Failed`.
+    #[test]
+    fn status_maps_every_session_status() {
+        for (session, expected) in [
+            (SessionStatus::Created, TaskResultStatus::Pending),
+            (SessionStatus::Running, TaskResultStatus::Pending),
+            (SessionStatus::Finished, TaskResultStatus::Success),
+            (SessionStatus::TurnCapExceeded, TaskResultStatus::Partial),
+            (SessionStatus::Failed, TaskResultStatus::Failed),
+            (SessionStatus::Cancelled, TaskResultStatus::Cancelled),
+            (
+                SessionStatus::DeadlineExceeded,
+                TaskResultStatus::DeadlineExceeded,
+            ),
+        ] {
+            assert_eq!(
+                TaskResultStatus::from_session_status(session),
+                expected,
+                "session status {session:?} mapped to the wrong result status"
+            );
+        }
+    }
+
+    /// #4351: exit 6 is `Partial`, NOT `Failed` — the whole point of the code.
+    #[test]
+    fn partial_exit_code_is_its_own_status_not_a_failure() {
+        let status = TaskResultStatus::from_exit_code(Some(6));
+        assert_eq!(status, TaskResultStatus::Partial);
+        assert_ne!(status, TaskResultStatus::Failed);
+    }
+
+    /// Every exit code `crate::run_task::report::ExitCode` documents maps
+    /// deliberately, and an absent code (signal-killed child) fails closed.
+    #[test]
+    fn exit_code_mapping_covers_every_documented_code() {
+        for (code, expected) in [
+            (Some(0), TaskResultStatus::Success),
+            (Some(2), TaskResultStatus::Failed),
+            (Some(3), TaskResultStatus::Failed),
+            (Some(4), TaskResultStatus::Success),
+            (Some(5), TaskResultStatus::DeadlineExceeded),
+            (Some(6), TaskResultStatus::Partial),
+            (None, TaskResultStatus::Failed),
+        ] {
+            assert_eq!(
+                TaskResultStatus::from_exit_code(code),
+                expected,
+                "exit code {code:?} mapped to the wrong result status"
+            );
+        }
+    }
+
+    /// `as_str` and the serde representation must not drift apart.
+    #[test]
+    fn status_serialises_snake_case() {
+        for status in [
+            TaskResultStatus::Pending,
+            TaskResultStatus::Success,
+            TaskResultStatus::Partial,
+            TaskResultStatus::Failed,
+            TaskResultStatus::Cancelled,
+            TaskResultStatus::DeadlineExceeded,
+        ] {
+            assert_eq!(
+                serde_json::to_value(status).unwrap(),
+                json!(status.as_str())
+            );
+        }
+    }
+
+    /// A fully-populated result survives a JSON round trip unchanged.
+    #[test]
+    fn task_result_round_trips_through_json() {
+        let result = TaskResult::new(TaskResultStatus::Partial)
+            .with_diff_ref(Some("abc123".to_string()))
+            .with_branch(Some("feat/x".to_string()))
+            .with_pr_ref(Some("https://example.invalid/pull/7".to_string()))
+            .with_summary(Some("wrote one file".to_string()));
+
+        let round_tripped: TaskResult =
+            serde_json::from_value(serde_json::to_value(&result).unwrap()).unwrap();
+        assert_eq!(round_tripped, result);
+    }
+
+    /// A producer that only knows the status emits a result whose other fields
+    /// read back as `None` — and a payload that OMITS them entirely still
+    /// deserialises, so a leaner producer stays compatible.
+    #[test]
+    fn absent_optional_fields_deserialise_as_none() {
+        let parsed: TaskResult = serde_json::from_value(json!({ "status": "success" })).unwrap();
+        assert_eq!(parsed.status, TaskResultStatus::Success);
+        assert_eq!(parsed.diff_ref, None);
+        assert_eq!(parsed.branch, None);
+        assert_eq!(parsed.pr_ref, None);
+        assert_eq!(parsed.summary, None);
+    }
+
+    /// Each builder sets exactly its own field and leaves the rest alone.
+    #[test]
+    fn builders_set_each_field() {
+        let base = TaskResult::pending();
+        assert_eq!(base.status, TaskResultStatus::Pending);
+        assert_eq!(base.diff_ref, None);
+
+        let built = base
+            .clone()
+            .with_status(TaskResultStatus::Success)
+            .with_diff_ref(Some("d".to_string()))
+            .with_branch(Some("b".to_string()))
+            .with_pr_ref(Some("p".to_string()))
+            .with_summary(Some("s".to_string()));
+
+        assert_eq!(built.status, TaskResultStatus::Success);
+        assert_eq!(built.diff_ref.as_deref(), Some("d"));
+        assert_eq!(built.branch.as_deref(), Some("b"));
+        assert_eq!(built.pr_ref.as_deref(), Some("p"));
+        assert_eq!(built.summary.as_deref(), Some("s"));
+        // The builders consume `self`, so the original is untouched.
+        assert_eq!(base.status, TaskResultStatus::Pending);
+    }
+}

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -54,8 +54,9 @@ use crate::run_task::{
     RecordingLlmClient, SharedTranscript, aggregate_usage_per_role, resolve_agent_model_slug,
 };
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
-use crate::session::{SessionRegistry, SessionStatus};
+use crate::session::{SessionRegistry, SessionStatus, TaskResult, TaskResultStatus};
 use crate::skills::{FsSkillResolver, format_skill_catalog, locate_skills_dir};
+use crate::task::result_capture;
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, ClearGoalTool, DelegateToAgentTool, EditTool,
     FinishTaskTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, RecallSessionTool, RunContext,
@@ -245,6 +246,11 @@ async fn run_and_record(
             return;
         }
     };
+
+    // #4351: the "before" half of the run's on-disk footprint, taken before a
+    // single turn executes so the after-comparison names THIS run's change and
+    // not pre-existing dirty-tree noise. Non-mutating (see `run_task::diff`).
+    let before_snapshot = crate::run_task::diff::capture_snapshot(&work_root);
 
     // Trusty-search-first discovery (PR B): at task START, best-effort/detached,
     // ensure the working project is indexed so the delegated engineer's
@@ -581,6 +587,13 @@ async fn run_and_record(
             SessionStatus::Failed
         }
     };
+    // #4351: record the actionable result BEFORE `finish`, so the terminal
+    // status and the refs that go with it become visible in the same
+    // `session.status` snapshot rather than in two observable steps.
+    registry.set_task_result(
+        &session_id,
+        result_capture::build_task_result(terminal_status, &before_snapshot, &work_root),
+    );
     let _ = registry.finish(&session_id, terminal_status);
     registry.finish_execution(&session_id);
 }
@@ -857,8 +870,17 @@ fn resolve_engineer_model(params: &TaskRunParams) -> String {
 /// Why: a PM-config load failure happens before any loop runs, so there is
 /// no transcript/usage to persist — just the terminal state and a reason an
 /// operator (or a future `session.get_transcript`) can see.
+///
+/// #4351: also records a refless `Failed` `TaskResult` carrying `message`, so
+/// a caller reading `session.status` gets the same shaped answer here as it
+/// does from a run that actually executed. No turn ran, so there is nothing on
+/// disk to point at — every ref stays `None` rather than being guessed.
 async fn finish_with_failure(registry: &SessionRegistry, session_id: &str, message: &str) {
     let _ = registry.record_log(session_id, "error", message);
+    registry.set_task_result(
+        session_id,
+        TaskResult::new(TaskResultStatus::Failed).with_summary(Some(message.to_string())),
+    );
     let _ = registry.finish(session_id, SessionStatus::Failed);
     registry.finish_execution(session_id);
 }

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -676,6 +676,48 @@ async fn spawn_task_run_turn_cap_exceeded_is_resumable() {
     );
 }
 
+/// (#4351) A finished run must leave an actionable `TaskResult` on the
+/// session, not just a status.
+///
+/// Why: before #4351 `session.status` handed a caller `id`/`status`/`mode` and
+/// nothing it could report to a user. This is the daemon half of the fix: the
+/// executor is the only producer, and it must fire on the ordinary success
+/// path, not just on the interesting ones.
+/// What: runs `EchoLlmClient` (a deterministic natural stop) against a plain,
+/// non-git temp project. Non-git means there is no ref to point at, so this
+/// also pins the "no diff, no invented refs" half of the contract: `diff_ref`,
+/// `branch` and `pr_ref` all `None`, with the status and a real summary still
+/// present.
+/// Test: this test.
+#[tokio::test]
+async fn spawn_task_run_records_a_task_result_on_the_session() {
+    let registry = Arc::new(SessionRegistry::new());
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm: Arc<dyn InferenceAdapter> = Arc::new(EchoLlmClient::new());
+    spawn_task_run(
+        Arc::clone(&registry),
+        llm,
+        params(&agents, &project, &session.id),
+    )
+    .expect("run must start");
+    wait_for_terminal(&registry, &session.id).await;
+
+    let snapshot = registry.status(&session.id).expect("session must exist");
+    assert_eq!(snapshot.status, SessionStatus::Finished);
+    let result = snapshot
+        .result
+        .expect("#4351: a finished run must carry a TaskResult");
+    assert_eq!(result.status, crate::session::TaskResultStatus::Success);
+    assert_eq!(result.pr_ref, None, "the daemon never opens a pull request");
+    assert!(
+        result.summary.is_some(),
+        "a result must carry a user-facing summary"
+    );
+}
+
 // ── #2344: persistent session-scoped transcript across task.run calls ──────────
 
 /// Poll `registry.status(id)` until it reaches a terminal state, bounded by

--- a/crates/trusty-code/src/task/mod.rs
+++ b/crates/trusty-code/src/task/mod.rs
@@ -28,6 +28,10 @@
 pub mod executor;
 pub mod mock_llm;
 pub mod protocol;
+/// (#4351) Folds a finished run's terminal status and on-disk footprint into
+/// the `session::TaskResult` a caller reads back. Private to this module —
+/// `executor` is its only caller.
+mod result_capture;
 pub mod sink;
 
 pub use executor::{TaskRunParams, spawn_task_run};

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -331,11 +331,16 @@ async fn task_run(
     };
     spawn_task_run(registry, llm, task_params)?;
 
+    // #4351: `result` rides alongside the pre-existing keys, never in place of
+    // them. `task.run` returns the moment the run is spawned, so the only
+    // truthful result at this instant is `pending` with no refs — the caller
+    // polls `session.status` for the terminal one, which the executor fills in.
     Ok(json!({
         "session_id": session_id,
         "status": "running",
         "mode": mode.as_str(),
         "binding": binding.to_json(),
+        "result": crate::session::TaskResult::pending(),
     }))
 }
 

--- a/crates/trusty-code/src/task/protocol_tests.rs
+++ b/crates/trusty-code/src/task/protocol_tests.rs
@@ -166,6 +166,53 @@ async fn task_run_creates_session_when_none_given() {
     );
 }
 
+/// (#4351) `task.run`'s response carries a `result` object, and every key it
+/// carried before #4351 is still there and unchanged.
+///
+/// Why: the whole point of the change is that a caller gets something
+/// actionable back — and that adding it broke nothing. `task.run` is
+/// asynchronous, so the only truthful status at return time is `pending` with
+/// no refs; a `success` here would be a lie about a run that has not happened.
+/// Test: this test.
+#[tokio::test]
+async fn task_run_response_carries_a_pending_result() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let result = task_run(
+        Arc::clone(&registry),
+        json!({"task_description": "say hi"}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
+    )
+    .await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    let value = result.expect("task.run should succeed");
+
+    // Backward compatibility: the pre-#4351 keys are untouched.
+    assert!(value["session_id"].is_string());
+    assert_eq!(value["status"], "running");
+    assert!(value["mode"].is_string());
+    assert!(value["binding"].is_object());
+
+    assert_eq!(value["result"]["status"], "pending");
+    assert!(value["result"]["diff_ref"].is_null());
+    assert!(value["result"]["branch"].is_null());
+    assert!(value["result"]["pr_ref"].is_null());
+    assert!(value["result"]["summary"].is_null());
+}
+
 /// `task.run` must resolve `HarnessMode` per §5.9's three-tier
 /// precedence and report it BOTH in its own immediate response AND on
 /// the session (queryable via `session.status`/`get_transcript`

--- a/crates/trusty-code/src/task/result_capture.rs
+++ b/crates/trusty-code/src/task/result_capture.rs
@@ -1,0 +1,215 @@
+//! Turns a finished daemon run into the actionable [`TaskResult`] a caller
+//! gets back from `session.status` (#4351).
+//!
+//! Why: `task::executor` knows the terminal `SessionStatus` and nothing else a
+//! caller can act on. The refs it needs — did this run change anything, and
+//! where did that land — are on disk, so somebody has to look. Keeping that
+//! lookup here rather than inline keeps `executor.rs` under its SLOC cap and
+//! makes the mapping testable against real temp repos without spawning an
+//! agent loop.
+//! What: [`build_task_result`] captures the working root a second time,
+//! compares it against the before-snapshot the executor took, and folds the
+//! outcome into a `TaskResult`. It reuses `run_task::diff` (the crate's ONE
+//! working-tree snapshot implementation, which already stages into a throwaway
+//! index rather than touching the user's) and
+//! `trusty_common::catchup::git::capture_git_status` for the branch, rather
+//! than spawning its own git.
+//! Test: `tests::a_run_that_changed_a_file_reports_a_diff_ref_and_branch`,
+//! `tests::a_run_that_changed_nothing_reports_none_refs`,
+//! `tests::a_non_git_root_reports_no_diff_ref`,
+//! `tests::pr_ref_is_never_invented`.
+
+use std::path::Path;
+
+use crate::run_task::diff::{Snapshot, capture_snapshot, diff_snapshots};
+use crate::session::{SessionStatus, TaskResult, TaskResultStatus};
+
+/// Fold a finished run's terminal status and on-disk footprint into a
+/// [`TaskResult`].
+///
+/// Why: see the module docs. Called once, immediately before
+/// `SessionRegistry::finish`, so the result and the status land together.
+/// What: `before` is the snapshot the executor took at run start. A run whose
+/// after-snapshot differs reports `diff_ref` — the git tree object SHA naming
+/// the post-run state, which is a real ref a caller can `git show`. A non-git
+/// root has no such ref, so it reports `None` while still saying in `summary`
+/// that something changed. `pr_ref` is always `None`: nothing in this daemon
+/// opens a pull request, and inventing one would be worse than admitting it.
+/// Every probe is fail-open — a git error degrades a field to `None`, it never
+/// fails the run, which has already completed by the time this is called.
+/// Test: `tests::a_run_that_changed_a_file_reports_a_diff_ref_and_branch`,
+/// `tests::a_run_that_changed_nothing_reports_none_refs`,
+/// `tests::a_non_git_root_reports_no_diff_ref`,
+/// `tests::pr_ref_is_never_invented`.
+pub(super) fn build_task_result(
+    status: SessionStatus,
+    before: &Snapshot,
+    root: &Path,
+) -> TaskResult {
+    let after = capture_snapshot(root);
+    let changed = !diff_snapshots(before, &after).trim().is_empty();
+    let diff_ref = if changed { tree_ref(&after) } else { None };
+    let branch = trusty_common::catchup::git::capture_git_status(root).branch;
+    let result_status = TaskResultStatus::from_session_status(status);
+    let summary = summarise(
+        result_status,
+        changed,
+        diff_ref.as_deref(),
+        branch.as_deref(),
+    );
+
+    TaskResult::new(result_status)
+        .with_diff_ref(diff_ref)
+        .with_branch(branch)
+        .with_pr_ref(None)
+        .with_summary(Some(summary))
+}
+
+/// The git tree object SHA of a snapshot, when it has one.
+fn tree_ref(after: &Snapshot) -> Option<String> {
+    match after {
+        Snapshot::Git { tree, .. } if !tree.is_empty() => Some(tree.clone()),
+        _ => None,
+    }
+}
+
+/// One line a caller can show a user verbatim.
+fn summarise(
+    status: TaskResultStatus,
+    changed: bool,
+    diff_ref: Option<&str>,
+    branch: Option<&str>,
+) -> String {
+    let change = match (changed, diff_ref) {
+        (true, Some(r)) => format!("changes captured at {r}"),
+        (true, None) => "changes captured".to_string(),
+        (false, _) => "no changes".to_string(),
+    };
+    match branch {
+        Some(b) => format!("{}: {change} on branch {b}", status.as_str()),
+        None => format!("{}: {change}", status.as_str()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    /// Initialise a real git repo with one commit so `capture_snapshot` takes
+    /// the `Snapshot::Git` path and a branch name is resolvable.
+    fn git_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        for args in [
+            vec!["init", "--initial-branch=main"],
+            vec!["config", "user.email", "t@example.invalid"],
+            vec!["config", "user.name", "t"],
+        ] {
+            let ok = Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(&args)
+                .output()
+                .expect("git runs")
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        }
+        std::fs::write(root.join("seed.txt"), "seed\n").expect("write seed");
+        for args in [
+            vec!["add", "-A"],
+            vec!["commit", "-m", "seed", "--no-gpg-sign"],
+        ] {
+            let ok = Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(&args)
+                .output()
+                .expect("git runs")
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        }
+        dir
+    }
+
+    /// #4351 acceptance: a run that touched a file reports a real ref, the
+    /// branch it landed on, and a status derived from the session's own
+    /// terminal state.
+    #[test]
+    fn a_run_that_changed_a_file_reports_a_diff_ref_and_branch() {
+        let dir = git_repo();
+        let root = dir.path();
+        let before = capture_snapshot(root);
+
+        std::fs::write(root.join("written-by-the-run.txt"), "hello\n").expect("write");
+
+        let result = build_task_result(SessionStatus::Finished, &before, root);
+        assert_eq!(result.status, TaskResultStatus::Success);
+        let diff_ref = result.diff_ref.expect("a changed git tree yields a ref");
+        assert_eq!(
+            diff_ref.len(),
+            40,
+            "expected a git tree object SHA, got {diff_ref:?}"
+        );
+        assert_eq!(result.branch.as_deref(), Some("main"));
+        let summary = result.summary.expect("summary");
+        assert!(
+            summary.contains(&diff_ref) && summary.contains("main"),
+            "summary must name the ref and the branch: {summary}"
+        );
+    }
+
+    /// #4351 acceptance: a run that changed nothing reports `None` refs and
+    /// still reports its status.
+    #[test]
+    fn a_run_that_changed_nothing_reports_none_refs() {
+        let dir = git_repo();
+        let root = dir.path();
+        let before = capture_snapshot(root);
+
+        let result = build_task_result(SessionStatus::TurnCapExceeded, &before, root);
+        assert_eq!(result.status, TaskResultStatus::Partial);
+        assert_eq!(result.diff_ref, None);
+        assert_eq!(result.pr_ref, None);
+        assert_eq!(
+            result.summary.as_deref(),
+            Some("partial: no changes on branch main")
+        );
+    }
+
+    /// A plain directory has no git ref to report, but the run's status and
+    /// the fact that something changed still come through.
+    #[test]
+    fn a_non_git_root_reports_no_diff_ref() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let before = capture_snapshot(root);
+        std::fs::write(root.join("a.txt"), "a\n").expect("write");
+
+        let result = build_task_result(SessionStatus::Finished, &before, root);
+        assert_eq!(result.status, TaskResultStatus::Success);
+        assert_eq!(result.diff_ref, None);
+        assert_eq!(result.branch, None);
+        assert_eq!(result.summary.as_deref(), Some("success: changes captured"));
+    }
+
+    /// The daemon never opens a pull request, so it never claims one.
+    #[test]
+    fn pr_ref_is_never_invented() {
+        let dir = git_repo();
+        let root = dir.path();
+        let before = capture_snapshot(root);
+        std::fs::write(root.join("b.txt"), "b\n").expect("write");
+
+        for status in [
+            SessionStatus::Finished,
+            SessionStatus::Failed,
+            SessionStatus::Cancelled,
+            SessionStatus::DeadlineExceeded,
+        ] {
+            assert_eq!(build_task_result(status, &before, root).pr_ref, None);
+        }
+    }
+}


### PR DESCRIPTION
`task.run` and `session.status` used to hand a caller `id`/`status`/`mode` and nothing it could report to a user. Both now carry an additive `result` object — `status`, `diff_ref`, `branch`, `pr_ref`, `summary` — so the calling assistant can say where a run's change landed and whether it passed.

Refs #4351

## Scope finding: trusty-code is the producer, not trusty-agents

The issue title says `[trusty-code]`, and that is where the work belongs. `ProcessPmBridge::run_tcode` in trusty-agents only relays whatever `tcode run-task --json` prints, and that was the bare `Session` snapshot — there were no result fields to relay. So the type is defined once in trusty-code, whose daemon builds it from the terminal session status and the run's on-disk footprint; trusty-agents consumes it.

`pr_ref` is never populated by the daemon: nothing in it opens a pull request. The field exists per the issue's field list, documented as reserved for a producer that does, rather than guessed.

## What changed

trusty-code:

- `session::TaskResult` / `TaskResultStatus`, `#[non_exhaustive]` with builder construction, every field but `status` nullable.
- `Session::result` is `#[serde(default, skip_serializing_if)]`, so a session that has never run serialises exactly as before and a pre-#4351 payload still deserialises.
- `task::result_capture` folds the terminal status and the run's footprint into a result at the end of every run, reusing `run_task::diff` (the crate's one non-mutating working-tree snapshot) for the ref and `trusty_common::catchup::git` for the branch. No new git spawning.
- `task.run` returns `pending` with no refs — the truth at the instant it returns, since the run has only just been spawned.

trusty-agents relays that type rather than redefining it. `PmBridgeBackend` gains a `run_result` method with a default body, so every existing implementor compiles untouched and reports no result; `ProcessPmBridge` overrides it and reads the child's `--json` snapshot. The pass/fail classification comes from the child's exit code, and `ExitCode::Partial` maps to `partial`, not `failed` — that code means the turn budget ran out with real work on disk, so reading it as failure discards working code. The refs ride on `ProposalEnvelope` as an omitted-when-absent field; the reported `summary` is branding-scrubbed like any transcript, while the structured refs are left intact.

## Critic: WARN → APPROVE

Two HIGH findings on the first head, both fixed in `aa1e7dc86`:

1. **`session.cancel` recorded no result.** `SessionRegistry::cancel` transitioned straight to `Cancelled` without going through the executor, so a cancelled session was the one terminal state answering `session.status` with no `result` at all. It now records a refless `cancelled` result before the transition. Refless because cancellation is a status transition, not a run outcome (vision spec §12 11.6). A session with a live run still gets the executor's own result when its loop unwinds; that one arrives later, knows more, and overwrites this one.
2. **The exit-code mapping re-typed `ExitCode`'s numbers.** `from_exit_code` matched bare `0`/`4`/`5`/`6` while `run_task::report::ExitCode` is the one definition of those numbers in the same crate, so renumbering a variant would silently misclassify runs. The numbers now come from the enum: `ExitCode::from_code` inverts `code()` without literals, and `from_exit_kind` classifies a typed variant in an **exhaustive** match, so adding a variant fails to compile until someone decides what it means. Tests assert through `ExitCode::Partial.code()`.

## Test ladder: rung 4

A new wire type crosses the crate boundary, so this is rung 4. `trusty-code`'s direct dependents are **two**, not more: `trusty-agents` (normal dependency) and `trusty-code-gui` (dev-dependency only), resolved from `cargo metadata --no-deps`. Both are covered — `trusty-agents` by its own full suite below, `trusty-code-gui` by `cargo check --workspace`, since a dev-dependency edge affects only its test targets.

```
cargo fmt --check
SKIP_UI_BUILD=1 cargo clippy -p trusty-code -p trusty-agents --all-targets -- -D warnings
SKIP_UI_BUILD=1 cargo test -p trusty-code --no-fail-fast
SKIP_UI_BUILD=1 cargo test -p trusty-agents --no-fail-fast
SKIP_UI_BUILD=1 cargo check --workspace
```

All green on the rebased head. `--no-fail-fast` on both test runs, so the counts below cover every target rather than stopping at the first failing one.

`cargo test -p trusty-code --no-fail-fast` — 20 targets, all `ok`:

```
unittests src/lib.rs            1810 passed; 0 failed; 4 ignored
unittests src/main.rs             21 passed; 0 failed; 0 ignored
tests/agent_fallback_e2e.rs        3 passed; 0 failed; 0 ignored
tests/agent_id_e2e.rs              1 passed; 0 failed; 0 ignored
tests/agents_e2e.rs                2 passed; 0 failed; 0 ignored
tests/bakeoff_gate_e2e.rs          7 passed; 0 failed; 0 ignored
tests/cli_e2e.rs                  25 passed; 0 failed; 0 ignored
tests/config_mount.rs              2 passed; 0 failed; 0 ignored
tests/connector_e2e.rs             7 passed; 0 failed; 0 ignored
tests/inference_shared_adapter_e2e.rs  4 passed; 0 failed; 0 ignored
tests/logging_e2e.rs               2 passed; 0 failed; 0 ignored
tests/m1_cutline_e2e.rs            5 passed; 0 failed; 0 ignored
tests/readiness_e2e.rs             2 passed; 0 failed; 0 ignored
tests/recall_content_e2e.rs        1 passed; 0 failed; 0 ignored
tests/roster_deploy_e2e.rs         4 passed; 0 failed; 0 ignored
tests/search_hits_e2e.rs           1 passed; 0 failed; 0 ignored
tests/session_e2e.rs               2 passed; 0 failed; 0 ignored
tests/task_e2e.rs                  6 passed; 0 failed; 0 ignored
tests/tui_client_engine.rs         7 passed; 0 failed; 0 ignored
Doc-tests trusty_code              0 passed; 0 failed; 0 ignored
```

`cargo test -p trusty-agents --no-fail-fast` — 15 targets, all `ok`:

```
unittests src/lib.rs            3654 passed; 0 failed; 13 ignored
unittests src/main.rs              0 passed; 0 failed; 0 ignored
tests/api_e2e.rs                   6 passed; 0 failed; 3 ignored
tests/cli_project.rs               4 passed; 0 failed; 0 ignored
tests/config_mount.rs              3 passed; 0 failed; 0 ignored
tests/home_lock_discipline.rs      1 passed; 0 failed; 0 ignored
tests/inference_shared_adapter_e2e.rs  2 passed; 0 failed; 0 ignored
tests/persona_python_plugin_wiring.rs  1 passed; 0 failed; 0 ignored
tests/plain_cli_repl.rs            9 passed; 0 failed; 0 ignored
tests/process_tracker_fail_open.rs 7 passed; 0 failed; 0 ignored
tests/slack_wss_crypto_provider.rs 2 passed; 0 failed; 0 ignored
tests/system_status_cli.rs         2 passed; 0 failed; 0 ignored
tests/version_provenance.rs        4 passed; 0 failed; 0 ignored
Doc-tests trusty_agents            0 passed; 0 failed; 0 ignored
```

Doc gates: `check_line_cap.sh` (0 violations), `check_test_pointers.sh` (0 dangling pointers), `check_sld.sh` (0 errors), `check_changelog_fragment.sh` (both crates recorded), `check-pr-version-bump.sh` (clear, no bump needed), `check_rustdoc_links.sh` (0 broken links).

## Each acceptance criterion fails without its fix

Proven by reverting only the fix and re-running.

- `task.run` carrying the result — reverting `task/protocol.rs` fails `task_run_response_carries_a_pending_result` with `left: Null, right: "pending"`.
- A run reporting its ref, or its `None`s, plus the status — reverting `task/executor.rs` fails `spawn_task_run_records_a_task_result_on_the_session` with "#4351: a finished run must carry a TaskResult".
- The exit-6 mapping and the relay — reverting `pm_bridge_backend.rs` is a compile failure, since the symbol and the trait method are what changed: `use of undeclared type TaskResultStatus`, `no method named run_result`.
- Backward compatibility — `session_without_result_deserialises_and_omits_it` feeds the exact pre-#4351 payload and asserts it round-trips without a `result` key; it fails to compile on main, where `Session` has no such field.
- The cancel fix — dropping the `set_cancelled_result` call fails `cancel_records_a_refless_cancelled_result`.
- The `ExitCode` derivation — renumbering `ExitCode::Partial` from 6 to 9 leaves all 9 `task_result` tests green with the new code. Restoring the old literal body under that same renumber fails `partial_exit_code_is_its_own_status_not_a_failure` (`left: Failed, right: Partial`), which is exactly the silent misclassification the finding named.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
