### PR TITLE
feat(trusty-agents-common): agent frontmatter records who wrote the file (#4698)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/4698-agent-provenance-frontmatter-changed.md
+++ b/crates/trusty-agents-common/changelog.d/4698-agent-provenance-frontmatter-changed.md
@@ -1,0 +1,6 @@
+Changed
+
+- `agents::builder::AgentBuildError` gained an `InvalidProvenance` variant. An
+  unrecognised `provenance:` value is rejected rather than degraded to the absent
+  default, which would read a typo as user-authored and freeze a framework file
+  permanently — #4408's unrecoverable shape reached through a new door (#4698).

--- a/crates/trusty-agents-common/changelog.d/4698-agent-provenance-frontmatter-fixed.md
+++ b/crates/trusty-agents-common/changelog.d/4698-agent-provenance-frontmatter-fixed.md
@@ -1,0 +1,9 @@
+Fixed
+
+- An untracked target file written before the `provenance:` stamp existed is
+  still adopted rather than skipped forever. Adoption's test was byte equality
+  with the fresh composition, which the stamp broke for every pre-#4698 file;
+  `agents::provenance::without_provenance_line` lets adoption accept the
+  pre-stamp spelling too. The ledger now records the checksum of the bytes on
+  disk rather than of the composition, so an adopted file matches its own row
+  and the next deploy upgrades it into the stamped form (#4698).

--- a/crates/trusty-agents-common/changelog.d/4698-agent-provenance-frontmatter.md
+++ b/crates/trusty-agents-common/changelog.d/4698-agent-provenance-frontmatter.md
@@ -13,13 +13,17 @@ Added
   writes. Provenance is a property of the write, not of the source, so the writer
   supplies it — which also means a new bundled asset has no per-file declaration
   to forget (#4698).
-- `agents::provenance::reconcile_with_ledger` and
-  `agents::tier_audit::ownership_of_declared` check a file's declaration against
-  its ledger row. The ledger wins in both directions — it is the record the
-  deployer wrote under a lock and checksummed, while the frontmatter is the copy
-  anyone with an editor can change — and a disagreement is warned with the file
-  named. An untracked file is exempt from the check entirely: a declaration
-  cannot stand in for a ledger entry, which would manufacture the user-owned
+- `agents::provenance::reconcile_with_ledger` checks a file's declaration
+  against its ledger row. The ledger wins in both directions — it is the record
+  the deployer wrote under a lock and checksummed, while the frontmatter is the
+  copy anyone with an editor can change (#4698).
+- `agents::tier_audit::audit_provenance` scans a directory and returns one
+  `ProvenanceDisagreement` per file whose declaration contradicts its ledger row,
+  naming the file and both records. Deliberately separate from
+  `audit_agent_tier`: that answers "is this file misplaced?", and it must never
+  run on the canonical deploy directory — which is exactly where a hand-edited
+  DEPLOYED agent lives. A file with no ledger entry yields nothing; a
+  declaration cannot stand in for one, which would manufacture the user-owned
   quarantine exemption out of a field anybody can type (#4698).
 - `agents::metadata::AgentMetadata` projects the declared `provenance:` so the
   read-only surfaces that already report a file's `Origin` can report both

--- a/crates/trusty-agents-common/changelog.d/4698-agent-provenance-frontmatter.md
+++ b/crates/trusty-agents-common/changelog.d/4698-agent-provenance-frontmatter.md
@@ -1,0 +1,26 @@
+Added
+
+- Agent frontmatter carries a `provenance:` field naming which of the three
+  writers produced the file — `framework-owned`, `tm-agent-manager-built`, or
+  `user-authored`. `agents::manifest::Origin::is_framework_owned` answers only
+  from the ownership ledger, so a file with no ledger entry — every hand-written
+  agent and every stale leftover — read identically to a framework one. The new
+  `agents::provenance` module owns the three values, the parse, and the absence
+  rule: an absent field resolves to `user-authored`, never to a framework-owned
+  default (#4698).
+- `agents::builder::compose_agent_with_provenance` composes an agent and stamps
+  the field, and the deployer calls it with `framework-owned` for every file it
+  writes. Provenance is a property of the write, not of the source, so the writer
+  supplies it — which also means a new bundled asset has no per-file declaration
+  to forget (#4698).
+- `agents::provenance::reconcile_with_ledger` and
+  `agents::tier_audit::ownership_of_declared` check a file's declaration against
+  its ledger row. The ledger wins in both directions — it is the record the
+  deployer wrote under a lock and checksummed, while the frontmatter is the copy
+  anyone with an editor can change — and a disagreement is warned with the file
+  named. An untracked file is exempt from the check entirely: a declaration
+  cannot stand in for a ledger entry, which would manufacture the user-owned
+  quarantine exemption out of a field anybody can type (#4698).
+- `agents::metadata::AgentMetadata` projects the declared `provenance:` so the
+  read-only surfaces that already report a file's `Origin` can report both
+  records (#4698).

--- a/crates/trusty-agents-common/src/agents/builder.rs
+++ b/crates/trusty-agents-common/src/agents/builder.rs
@@ -33,7 +33,10 @@ use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use super::builder_yaml::{escape_yaml_double_quoted, render_scalar, unescape_yaml_double_quoted};
 use super::frontmatter::{parse_kv_line, parse_list_value};
+// #4698: the `provenance:` field's typed value and parse error.
+use super::provenance::{PROVENANCE_KEY, Provenance, UnknownProvenance};
 
 /// Maximum inheritance-chain depth before [`compose_agent`] gives up.
 ///
@@ -61,6 +64,11 @@ pub enum AgentBuildError {
     DepthExceeded(usize),
     /// An underlying filesystem operation failed.
     Io(std::io::Error),
+    /// #4698: the `provenance:` key carried a value outside the three accepted
+    /// spellings. A distinct variant, not a
+    /// [`AgentBuildError::FrontmatterParse`] string, so a caller can act on
+    /// exactly this fault — the typed payload names the offending value.
+    InvalidProvenance(UnknownProvenance),
 }
 
 impl fmt::Display for AgentBuildError {
@@ -75,6 +83,7 @@ impl fmt::Display for AgentBuildError {
                 write!(f, "inheritance chain exceeded depth limit of {depth}")
             }
             Self::Io(err) => write!(f, "io error: {err}"),
+            Self::InvalidProvenance(err) => write!(f, "frontmatter parse error: {err}"),
         }
     }
 }
@@ -83,8 +92,15 @@ impl std::error::Error for AgentBuildError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(err) => Some(err),
+            Self::InvalidProvenance(err) => Some(err),
             _ => None,
         }
+    }
+}
+
+impl From<UnknownProvenance> for AgentBuildError {
+    fn from(err: UnknownProvenance) -> Self {
+        Self::InvalidProvenance(err)
     }
 }
 
@@ -234,6 +250,24 @@ pub(crate) struct Frontmatter {
     pub(crate) description: Option<String>,
     pub(crate) model: Option<String>,
     pub(crate) extends: Option<String>,
+    /// Who wrote this file (#4698).
+    ///
+    /// Why: see [`super::provenance`]. The declaration is what lets a reader
+    /// tell a framework-deployed agent from a `tm-agent-manager`-composed one
+    /// from a hand-written one WITHOUT a ledger entry, which is the case the
+    /// ownership manifest cannot answer at all.
+    /// What: `None` when the key is absent — which
+    /// [`super::provenance::declared_or_default`] resolves to
+    /// [`Provenance::UserAuthored`], never to a framework-owned default. An
+    /// unrecognised value is REJECTED
+    /// ([`AgentBuildError::InvalidProvenance`]), not coerced. Merges SCALAR
+    /// CHILD-WINS across an `extends` chain, same as `model:`, and is
+    /// re-emitted by [`merge_frontmatter`] so a composed file stays
+    /// self-describing.
+    /// Test: `provenance_parsed_merged_and_emitted`,
+    /// `provenance_child_wins_across_chain`,
+    /// `unknown_provenance_value_is_rejected`.
+    pub(crate) provenance: Option<Provenance>,
     /// Auto-submitted first turn when the agent is spawned (claude-mpm parity).
     pub(crate) initial_prompt: Option<String>,
     /// Resource tier (`intensive`/`high`/`standard`/`lightweight`) used to
@@ -519,6 +553,22 @@ pub(crate) fn split_frontmatter(raw: &str) -> Result<(Frontmatter, String), Agen
         }
     });
 
+    // #4698: `provenance:` is a closed three-value scalar. Unlike every other
+    // malformed value above — which warns and degrades — an unrecognised value
+    // here HARD-ERRORS: silently degrading it to the absent default would read
+    // a typo'd `framework-owned` as user-authored and freeze a framework file
+    // permanently, which is #4408's unrecoverable shape reached through a new
+    // door. `parse_kv_line` lower-cases keys, and `PROVENANCE_KEY` is already
+    // lowercase, so the lookup matches directly.
+    let provenance = match fields.remove(PROVENANCE_KEY) {
+        None => None,
+        Some(raw_value) => Some(
+            unescape_yaml_double_quoted(&raw_value)
+                .parse::<Provenance>()
+                .map_err(AgentBuildError::from)?,
+        ),
+    };
+
     let fm = Frontmatter {
         // #3556: `merge_frontmatter`/`render_scalar` now double-quotes and
         // escapes any of these scalars that needed it on emit (mirroring the
@@ -559,6 +609,7 @@ pub(crate) fn split_frontmatter(raw: &str) -> Result<(Frontmatter, String), Agen
         skills: skills_block.or(inline_skills).unwrap_or_default(),
         max_tokens,
         tools,
+        provenance,
     };
     Ok((fm, body))
 }
@@ -574,152 +625,6 @@ fn first_line_len(s: &str) -> usize {
     match s.find('\n') {
         Some(idx) => idx + 1,
         None => s.len(),
-    }
-}
-
-/// Escape a string for emission inside a YAML double-quoted scalar.
-///
-/// Why: `merge_frontmatter` wraps the `initialPrompt` value — and, since
-/// issue #3556, any other scalar [`render_scalar`] decided needs quoting —
-/// in double-quotes. A raw `"` or `\` in the value would otherwise terminate
-/// the quote early or be misread as an escape, and a raw embedded newline
-/// would break the single-line frontmatter grammar entirely; either produces
-/// malformed YAML. claude-mpm parity requires the emitted frontmatter always
-/// be parseable.
-/// What: a single pass over `value`'s characters that escapes `\` → `\\`,
-/// `"` → `\"`, and a literal newline → the two-character sequence `\n` (so a
-/// multi-line description/model/etc. value still composes to one physical
-/// frontmatter line). Every other character passes through unchanged. The
-/// exact inverse of [`unescape_yaml_double_quoted`].
-/// Test: `initial_prompt_with_embedded_quote_round_trips`,
-/// `initial_prompt_with_backslash_round_trips`,
-/// `description_with_embedded_newline_round_trips` in builder_tests.rs.
-fn escape_yaml_double_quoted(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for c in value.chars() {
-        match c {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\n' => out.push_str("\\n"),
-            other => out.push(other),
-        }
-    }
-    out
-}
-
-/// Reverse [`escape_yaml_double_quoted`] on a parsed scalar value.
-///
-/// Why: a value parsed back from emitted frontmatter still carries the `\"`
-/// and `\\` escapes after [`parse_kv_line`] strips the single outer quote pair.
-/// Decoding them here makes a compose→deploy→re-compose round-trip yield the
-/// original `initialPrompt` string unchanged.
-/// What: collapses `\\` → `\`, `\"` → `"`, and `\n` (the two-character
-/// escape sequence) → a literal newline; any other `\x` sequence (and a
-/// trailing lone `\`) is left verbatim so non-escaped backslashes survive.
-/// Test: `initial_prompt_with_embedded_quote_round_trips`,
-/// `initial_prompt_with_backslash_round_trips`,
-/// `description_with_embedded_newline_round_trips` in builder_tests.rs.
-fn unescape_yaml_double_quoted(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    let mut chars = value.chars();
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            match chars.next() {
-                Some('\\') => out.push('\\'),
-                Some('"') => out.push('"'),
-                Some('n') => out.push('\n'),
-                Some(other) => {
-                    out.push('\\');
-                    out.push(other);
-                }
-                None => out.push('\\'),
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
-/// Whether a frontmatter scalar value requires YAML quoting to stay parseable
-/// by a strict YAML reader.
-///
-/// Why (issue #3556): `merge_frontmatter` used to emit every scalar field
-/// (`name`, `role`, `description`, `model`, `resource_tier`) as a bare plain
-/// scalar regardless of content, even though `parse_kv_line` had already
-/// stripped any quotes the SOURCE file used. `split_frontmatter`'s own
-/// lenient parser (first-colon-only split) tolerates a colon anywhere in the
-/// value, so a source template quoting `description: 'Rust 2024 edition
-/// specialist: memory-safe systems...'` composed to the exact same UNQUOTED
-/// `description: Rust 2024 edition specialist: memory-safe systems...` line
-/// regardless of the source's quoting style — invalid YAML a strict parser
-/// (`serde_yaml`, used by `trusty-agents::agents::registry::md_agent::parse_md_agent`)
-/// rejects with "mapping values are not allowed in this context". Because
-/// compose output was invariant to source quoting, re-provisioning alone
-/// could never have fixed the 11 affected agents — recomposing reproduced
-/// byte-identical broken output. Quoting-on-emit whenever a value is unsafe
-/// as a plain scalar fixes it at the one place all consumers share.
-/// What: `true` when `value` is empty, opens with a YAML indicator
-/// character, has leading/trailing whitespace, contains an embedded newline,
-/// is one of the YAML core-schema null tokens (`null`/`Null`/`NULL`/`~`,
-/// which would otherwise round-trip through `Option<String>` as `None`
-/// instead of the literal string), or contains a `": "` / trailing `:` / a
-/// mid-string `" #"` sequence a plain scalar cannot represent. The `" #"`
-/// check exists because a space followed by `#` starts a YAML comment
-/// ANYWHERE in a plain scalar, not just at the start of the line — the
-/// leading-character check above only catches `#` as the very first
-/// character, so a value like `Model context protocol #1 tool for
-/// delegating` silently truncated to `Model context protocol` at the first
-/// `" #"` with no error anywhere in the pipeline (code-critic review of
-/// #3556's PR #3565): `compose_agent` succeeds, `validate_frontmatter`
-/// accepts it (truncated-but-still-valid YAML is syntactically fine), and
-/// the real consumer (`trusty-agents`' `.md` loader) silently drops
-/// everything from the `#` onward. Same blind spot as the #3556 root cause
-/// (trusty-mpm's own lenient `parse_kv_line` only treats `#` as a comment
-/// marker at the start of the trimmed line, so it never notices either) —
-/// just a different trigger character.
-/// Test: `needs_quoting_true_for_colon_space`, `needs_quoting_true_for_empty`,
-/// `needs_quoting_false_for_plain_value`, `needs_quoting_true_for_mid_string_hash_comment`,
-/// `needs_quoting_true_for_embedded_newline`, `needs_quoting_true_for_null_tokens`,
-/// `needs_quoting_indicator_characters` (table-driven) in builder_tests.rs.
-fn needs_quoting(value: &str) -> bool {
-    if value.is_empty() {
-        return true;
-    }
-    if matches!(value, "null" | "Null" | "NULL" | "~") {
-        return true;
-    }
-    let first = value.chars().next().expect("checked non-empty above");
-    if "!&*-?|>%@`\"'#,[]{}:".contains(first) {
-        return true;
-    }
-    if value.starts_with(' ') || value.ends_with(' ') {
-        return true;
-    }
-    if value.contains('\n') {
-        return true;
-    }
-    value.contains(": ") || value.ends_with(':') || value.contains(" #")
-}
-
-/// Render one frontmatter scalar value, quoting it when [`needs_quoting`]
-/// says a plain scalar would not survive a strict YAML parse.
-///
-/// Why: shared by every scalar field `merge_frontmatter` emits (`name`,
-/// `role`, `description`, `model`, `resource_tier`) so the quote-when-needed
-/// policy is applied uniformly rather than ad hoc per field (issue #3556).
-/// What: returns `value` unchanged when it is safe as a plain scalar;
-/// otherwise a double-quoted, escaped scalar via
-/// [`escape_yaml_double_quoted`] — the same quoting style `initialPrompt`
-/// already used, so `split_frontmatter`'s existing `unescape_yaml_double_quoted`
-/// decode (now applied to these fields too) round-trips it.
-/// Test: `compose_description_with_colon_is_quoted_and_strict_yaml_valid`,
-/// `compose_description_without_colon_is_unquoted` in builder_tests.rs.
-fn render_scalar(value: &str) -> String {
-    if needs_quoting(value) {
-        format!("\"{}\"", escape_yaml_double_quoted(value))
-    } else {
-        value.to_string()
     }
 }
 
@@ -786,6 +691,12 @@ fn merge_frontmatter(chain: &[Frontmatter]) -> String {
         if fm.max_tokens.is_some() {
             merged.max_tokens = fm.max_tokens;
         }
+        // #4698: scalar child-wins. A base that declares nothing leaves the
+        // child's declaration standing, and a child that declares nothing
+        // inherits the base's — the same rule `model:` follows.
+        if fm.provenance.is_some() {
+            merged.provenance = fm.provenance;
+        }
         // #2897: OVERRIDE, not union (contrast with `skills:` above) — a
         // child's `tools:` (whenever the key was present at all, i.e.
         // `Some`) replaces the parent's list entirely, so a restrictive leaf
@@ -822,6 +733,13 @@ fn merge_frontmatter(chain: &[Frontmatter]) -> String {
     }
     if let Some(v) = &merged.role {
         out.push_str(&format!("role: {}\n", render_scalar(v)));
+    }
+    // #4698: emitted right after the identity keys so an operator opening a
+    // deployed file sees who wrote it before anything else. Only when declared
+    // — an absent key is the "not ours, never touch" signal, and emitting a
+    // default would destroy it.
+    if let Some(v) = &merged.provenance {
+        out.push_str(&format!("{PROVENANCE_KEY}: {}\n", v.as_str()));
     }
     if let Some(v) = &merged.description {
         out.push_str(&format!("description: {}\n", render_scalar(v)));
@@ -955,6 +873,40 @@ pub fn compose_agent(name: &str, source_dir: &Path) -> Result<String, AgentBuild
     let sources = build_source_map(source_dir);
     let mut visiting = Vec::new();
     let (frontmatters, bodies) = resolve(name, &sources, &mut visiting)?;
+    Ok(render_composed(&frontmatters, &bodies))
+}
+
+/// [`compose_agent`], stamping the composed output with a `provenance:` value.
+///
+/// Why (#4698): provenance is a property of the WRITE, not of the source. The
+/// same source tree composed by the framework's deploy and by
+/// `tm-agent-manager` produces two files with different authors, so the writer
+/// must supply the value — exactly as it already supplies
+/// [`crate::agents::manifest::ManifestEntry::origin`] rather than reading it
+/// out of the agent. Stamping here rather than declaring the field in each
+/// bundled source asset also means a NEW asset cannot ship un-marked: there is
+/// no per-file declaration to forget.
+/// What: composes `name` as [`compose_agent`] does, then overrides the merged
+/// `provenance:` with `stamp` before rendering. A source-declared value is
+/// replaced, not merged — the writer's claim about its own authorship is the
+/// only one that can be true.
+/// Test: `compose_with_provenance_stamps_the_field`,
+/// `compose_with_provenance_overrides_a_source_declaration`.
+pub fn compose_agent_with_provenance(
+    name: &str,
+    source_dir: &Path,
+    stamp: Provenance,
+) -> Result<String, AgentBuildError> {
+    let sources = build_source_map(source_dir);
+    let mut visiting = Vec::new();
+    let (mut frontmatters, bodies) = resolve(name, &sources, &mut visiting)?;
+    // Push a frontmatter carrying ONLY the stamp: `merge_frontmatter` walks the
+    // chain base-first with scalar child-wins, so a last entry setting just
+    // this one key overrides any source declaration and touches nothing else.
+    frontmatters.push(Frontmatter {
+        provenance: Some(stamp),
+        ..Frontmatter::default()
+    });
     Ok(render_composed(&frontmatters, &bodies))
 }
 

--- a/crates/trusty-agents-common/src/agents/builder_tests.rs
+++ b/crates/trusty-agents-common/src/agents/builder_tests.rs
@@ -12,6 +12,11 @@
 //! Test: run with `cargo test -p trusty-agents-common -- agents::builder`.
 
 use super::*;
+// #4698: the YAML scalar helpers moved to `builder_yaml` when adding
+// `provenance:` pushed `builder.rs` over the SLOC cap. `render_scalar` and the
+// escape pair arrive through `super::*` (the composer imports them);
+// `needs_quoting` has no caller in `builder.rs`, so it is named directly.
+use crate::agents::builder_yaml::needs_quoting;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
@@ -863,7 +868,7 @@ fn compose_agent_with_no_skills_omits_the_key() {
     write_agent(
         tmp.path(),
         "plain",
-        "---\nname: plain\nrole: engineer\n---\n\n# Plain\n\nBODY\n",
+        "---\nname: plain\nrole: base\n---\n\n# Plain\n\nBODY\n",
     );
     let composed = compose_agent("plain", tmp.path()).unwrap();
     assert!(!composed.contains("skills:"));
@@ -1357,4 +1362,142 @@ fn agent_type_is_parsed_but_never_emitted() {
     // ...and compose still drops it, byte-identically to pre-#4511 output.
     let composed = compose_agent("aws-ops", tmp.path()).unwrap();
     assert_eq!(composed, "---\nname: aws-ops\n---\n\n# AWS Ops\n\nBODY\n");
+}
+
+// ---------------------------------------------------------------------------
+// #4698: the `provenance:` frontmatter field.
+// ---------------------------------------------------------------------------
+
+/// The field parses, merges, and is re-emitted, so a composed file stays
+/// self-describing about who wrote it.
+#[test]
+fn provenance_parsed_merged_and_emitted() {
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "qa",
+        "---\nname: qa\nrole: base\nprovenance: tm-agent-manager-built\n---\n\n# QA\n\nBODY\n",
+    );
+
+    let (fm, _body) =
+        split_frontmatter(&fs::read_to_string(tmp.path().join("qa.md")).unwrap()).unwrap();
+    assert_eq!(fm.provenance, Some(Provenance::TmAgentManagerBuilt));
+
+    let composed = compose_agent("qa", tmp.path()).unwrap();
+    assert_eq!(
+        composed,
+        "---\nname: qa\nrole: base\nprovenance: tm-agent-manager-built\n---\n\n# QA\n\nBODY\n"
+    );
+}
+
+/// Absence is the signal #4698 relies on, so an agent that declares nothing
+/// composes to output with no `provenance:` line at all — byte-identical to
+/// what the composer emitted before this field existed.
+#[test]
+fn absent_provenance_emits_no_line() {
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "plain",
+        "---\nname: plain\nrole: base\n---\n\n# Plain\n\nBODY\n",
+    );
+    let composed = compose_agent("plain", tmp.path()).unwrap();
+    assert_eq!(
+        composed,
+        "---\nname: plain\nrole: base\n---\n\n# Plain\n\nBODY\n"
+    );
+    assert!(!composed.contains("provenance"));
+}
+
+/// Scalar child-wins across an `extends` chain, matching `model:`.
+#[test]
+fn provenance_child_wins_across_chain() {
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "base-agent",
+        "---\nname: base-agent\nprovenance: framework-owned\n---\n\nBASE\n",
+    );
+    write_agent(
+        tmp.path(),
+        "child",
+        "---\nname: child\nextends: base-agent\nprovenance: user-authored\n---\n\nCHILD\n",
+    );
+    let composed = compose_agent("child", tmp.path()).unwrap();
+    assert!(composed.contains("provenance: user-authored"));
+    assert!(!composed.contains("framework-owned"));
+
+    // And a child that declares nothing inherits the base's declaration.
+    write_agent(
+        tmp.path(),
+        "quiet",
+        "---\nname: quiet\nextends: base-agent\n---\n\nQUIET\n",
+    );
+    assert!(
+        compose_agent("quiet", tmp.path())
+            .unwrap()
+            .contains("provenance: framework-owned")
+    );
+}
+
+/// An unrecognised value is REJECTED with the typed error, never coerced to
+/// the absent default — coercion would read a typo as user-authored and freeze
+/// a framework file (#4408's shape).
+#[test]
+fn unknown_provenance_value_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "typo",
+        "---\nname: typo\nprovenance: framework_owned\n---\n\nBODY\n",
+    );
+    let err = compose_agent("typo", tmp.path()).unwrap_err();
+    match &err {
+        AgentBuildError::InvalidProvenance(inner) => assert_eq!(inner.value, "framework_owned"),
+        other => panic!("expected InvalidProvenance, got {other:?}"),
+    }
+    assert!(
+        err.to_string().contains("framework_owned"),
+        "the message names the offending value: {err}"
+    );
+    // The typed payload is reachable through `source()` too.
+    assert!(std::error::Error::source(&err).is_some());
+}
+
+/// The deployer supplies the value; the source need not declare one.
+#[test]
+fn compose_with_provenance_stamps_the_field() {
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "plain",
+        "---\nname: plain\nrole: base\n---\n\n# Plain\n\nBODY\n",
+    );
+    let composed =
+        compose_agent_with_provenance("plain", tmp.path(), Provenance::FrameworkOwned).unwrap();
+    assert_eq!(
+        composed,
+        "---\nname: plain\nrole: base\nprovenance: framework-owned\n---\n\n# Plain\n\nBODY\n"
+    );
+    // Removing the stamped line recovers the unstamped composition exactly —
+    // the property the deployer's adoption path depends on.
+    assert_eq!(
+        crate::agents::provenance::without_provenance_line(&composed),
+        compose_agent("plain", tmp.path()).unwrap()
+    );
+}
+
+/// The writer's claim about its own authorship overrides the source's.
+#[test]
+fn compose_with_provenance_overrides_a_source_declaration() {
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "claims",
+        "---\nname: claims\nprovenance: user-authored\n---\n\nBODY\n",
+    );
+    let composed =
+        compose_agent_with_provenance("claims", tmp.path(), Provenance::FrameworkOwned).unwrap();
+    assert!(composed.contains("provenance: framework-owned"));
+    assert!(!composed.contains("user-authored"));
 }

--- a/crates/trusty-agents-common/src/agents/builder_yaml.rs
+++ b/crates/trusty-agents-common/src/agents/builder_yaml.rs
@@ -1,0 +1,165 @@
+//! YAML scalar encoding for the composed frontmatter block.
+//!
+//! Why: `builder.rs` reached the 500-SLOC production cap while `provenance:`
+//! (#4698) was being added to it. These four functions are the one cohesive
+//! group in that file that nothing outside the composer calls and that carries
+//! no knowledge of agents, inheritance, or `Frontmatter` — they take a `&str`
+//! and return a `String`. Splitting them out is the smallest cut that leaves
+//! both halves whole.
+//! What: [`escape_yaml_double_quoted`] and [`unescape_yaml_double_quoted`] are
+//! exact inverses, so a compose -> deploy -> re-compose cycle round-trips a
+//! value verbatim; [`needs_quoting`] decides whether a scalar must be quoted at
+//! all, and [`render_scalar`] applies that decision. Every item is
+//! `pub(crate)` — this is the composer's private encoding, not a public API.
+//! Test: the round-trip and quoting tests live with the composer they serve, in
+//! `builder_tests.rs`: `initial_prompt_with_embedded_quote_round_trips`,
+//! `initial_prompt_with_backslash_round_trips`,
+//! `description_with_embedded_newline_round_trips`,
+//! `compose_description_with_colon_is_quoted_and_strict_yaml_valid`,
+//! `compose_description_without_colon_is_unquoted`.
+
+/// Escape a string for emission inside a YAML double-quoted scalar.
+///
+/// Why: `merge_frontmatter` wraps the `initialPrompt` value — and, since
+/// issue #3556, any other scalar [`render_scalar`] decided needs quoting —
+/// in double-quotes. A raw `"` or `\` in the value would otherwise terminate
+/// the quote early or be misread as an escape, and a raw embedded newline
+/// would break the single-line frontmatter grammar entirely; either produces
+/// malformed YAML. claude-mpm parity requires the emitted frontmatter always
+/// be parseable.
+/// What: a single pass over `value`'s characters that escapes `\` → `\\`,
+/// `"` → `\"`, and a literal newline → the two-character sequence `\n` (so a
+/// multi-line description/model/etc. value still composes to one physical
+/// frontmatter line). Every other character passes through unchanged. The
+/// exact inverse of [`unescape_yaml_double_quoted`].
+/// Test: `initial_prompt_with_embedded_quote_round_trips`,
+/// `initial_prompt_with_backslash_round_trips`,
+/// `description_with_embedded_newline_round_trips` in builder_tests.rs.
+pub(crate) fn escape_yaml_double_quoted(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Reverse [`escape_yaml_double_quoted`] on a parsed scalar value.
+///
+/// Why: a value parsed back from emitted frontmatter still carries the `\"`
+/// and `\\` escapes after [`parse_kv_line`] strips the single outer quote pair.
+/// Decoding them here makes a compose→deploy→re-compose round-trip yield the
+/// original `initialPrompt` string unchanged.
+/// What: collapses `\\` → `\`, `\"` → `"`, and `\n` (the two-character
+/// escape sequence) → a literal newline; any other `\x` sequence (and a
+/// trailing lone `\`) is left verbatim so non-escaped backslashes survive.
+/// Test: `initial_prompt_with_embedded_quote_round_trips`,
+/// `initial_prompt_with_backslash_round_trips`,
+/// `description_with_embedded_newline_round_trips` in builder_tests.rs.
+pub(crate) fn unescape_yaml_double_quoted(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('\\') => out.push('\\'),
+                Some('"') => out.push('"'),
+                Some('n') => out.push('\n'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Whether a frontmatter scalar value requires YAML quoting to stay parseable
+/// by a strict YAML reader.
+///
+/// Why (issue #3556): `merge_frontmatter` used to emit every scalar field
+/// (`name`, `role`, `description`, `model`, `resource_tier`) as a bare plain
+/// scalar regardless of content, even though `parse_kv_line` had already
+/// stripped any quotes the SOURCE file used. `split_frontmatter`'s own
+/// lenient parser (first-colon-only split) tolerates a colon anywhere in the
+/// value, so a source template quoting `description: 'Rust 2024 edition
+/// specialist: memory-safe systems...'` composed to the exact same UNQUOTED
+/// `description: Rust 2024 edition specialist: memory-safe systems...` line
+/// regardless of the source's quoting style — invalid YAML a strict parser
+/// (`serde_yaml`, used by `trusty-agents::agents::registry::md_agent::parse_md_agent`)
+/// rejects with "mapping values are not allowed in this context". Because
+/// compose output was invariant to source quoting, re-provisioning alone
+/// could never have fixed the 11 affected agents — recomposing reproduced
+/// byte-identical broken output. Quoting-on-emit whenever a value is unsafe
+/// as a plain scalar fixes it at the one place all consumers share.
+/// What: `true` when `value` is empty, opens with a YAML indicator
+/// character, has leading/trailing whitespace, contains an embedded newline,
+/// is one of the YAML core-schema null tokens (`null`/`Null`/`NULL`/`~`,
+/// which would otherwise round-trip through `Option<String>` as `None`
+/// instead of the literal string), or contains a `": "` / trailing `:` / a
+/// mid-string `" #"` sequence a plain scalar cannot represent. The `" #"`
+/// check exists because a space followed by `#` starts a YAML comment
+/// ANYWHERE in a plain scalar, not just at the start of the line — the
+/// leading-character check above only catches `#` as the very first
+/// character, so a value like `Model context protocol #1 tool for
+/// delegating` silently truncated to `Model context protocol` at the first
+/// `" #"` with no error anywhere in the pipeline (code-critic review of
+/// #3556's PR #3565): `compose_agent` succeeds, `validate_frontmatter`
+/// accepts it (truncated-but-still-valid YAML is syntactically fine), and
+/// the real consumer (`trusty-agents`' `.md` loader) silently drops
+/// everything from the `#` onward. Same blind spot as the #3556 root cause
+/// (trusty-mpm's own lenient `parse_kv_line` only treats `#` as a comment
+/// marker at the start of the trimmed line, so it never notices either) —
+/// just a different trigger character.
+/// Test: `needs_quoting_true_for_colon_space`, `needs_quoting_true_for_empty`,
+/// `needs_quoting_false_for_plain_value`, `needs_quoting_true_for_mid_string_hash_comment`,
+/// `needs_quoting_true_for_embedded_newline`, `needs_quoting_true_for_null_tokens`,
+/// `needs_quoting_indicator_characters` (table-driven) in builder_tests.rs.
+pub(crate) fn needs_quoting(value: &str) -> bool {
+    if value.is_empty() {
+        return true;
+    }
+    if matches!(value, "null" | "Null" | "NULL" | "~") {
+        return true;
+    }
+    let first = value.chars().next().expect("checked non-empty above");
+    if "!&*-?|>%@`\"'#,[]{}:".contains(first) {
+        return true;
+    }
+    if value.starts_with(' ') || value.ends_with(' ') {
+        return true;
+    }
+    if value.contains('\n') {
+        return true;
+    }
+    value.contains(": ") || value.ends_with(':') || value.contains(" #")
+}
+
+/// Render one frontmatter scalar value, quoting it when [`needs_quoting`]
+/// says a plain scalar would not survive a strict YAML parse.
+///
+/// Why: shared by every scalar field `merge_frontmatter` emits (`name`,
+/// `role`, `description`, `model`, `resource_tier`) so the quote-when-needed
+/// policy is applied uniformly rather than ad hoc per field (issue #3556).
+/// What: returns `value` unchanged when it is safe as a plain scalar;
+/// otherwise a double-quoted, escaped scalar via
+/// [`escape_yaml_double_quoted`] — the same quoting style `initialPrompt`
+/// already used, so `split_frontmatter`'s existing `unescape_yaml_double_quoted`
+/// decode (now applied to these fields too) round-trips it.
+/// Test: `compose_description_with_colon_is_quoted_and_strict_yaml_valid`,
+/// `compose_description_without_colon_is_unquoted` in builder_tests.rs.
+pub(crate) fn render_scalar(value: &str) -> String {
+    if needs_quoting(value) {
+        format!("\"{}\"", escape_yaml_double_quoted(value))
+    } else {
+        value.to_string()
+    }
+}

--- a/crates/trusty-agents-common/src/agents/deployer.rs
+++ b/crates/trusty-agents-common/src/agents/deployer.rs
@@ -46,13 +46,15 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::agents::builder::{AgentBuildError, compose_agent, source_chain};
+use crate::agents::builder::{AgentBuildError, compose_agent_with_provenance, source_chain};
 use crate::agents::frontmatter::validate_frontmatter;
 use crate::agents::manifest::{
     AgentManifest, MANIFEST_FILE, ManifestEntry, ManifestError, ManifestLoad, Origin, atomic_write,
     checksum, manifest_lock_path, with_agent_manifest_lock,
 };
 use crate::agents::metadata::agent_metadata_from_str;
+// #4698: every file this deployer writes is stamped framework-owned.
+use crate::agents::provenance::{Provenance, without_provenance_line};
 
 /// Summary of one [`deploy_agents`] run.
 ///
@@ -107,7 +109,7 @@ pub struct DeployResult {
     /// agent still needs to land, and the caller (`tm install`, session
     /// launch) needs to know WHICH agent(s) were skipped and why, rather than
     /// the whole operation failing with no roster deployed at all.
-    /// What: one entry per source agent whose [`compose_agent`] call
+    /// What: one entry per source agent whose [`compose_agent_with_provenance`] call
     /// returned `Err`; that agent is neither composed nor written, and
     /// processing continues with the next agent.
     /// Test: `deploy_isolates_single_malformed_agent_failure`.
@@ -220,6 +222,23 @@ pub fn deploy_agents_filtered(
 /// [`deploy_agents_filtered`]. Never call it directly; it is unsafe against
 /// concurrent writers by construction.
 /// Test: covered by every `deploy_*` test through the public wrapper.
+/// May an UNTRACKED target file be adopted as content this deployer wrote?
+///
+/// Why (#4698): adoption's test was byte equality with the fresh composition
+/// (#2504). Stamping `provenance:` changed those bytes, so every file deployed
+/// before the stamp existed would have failed the test and been permanently
+/// skipped — refused adoption, refused refresh. The pre-stamp spelling has to
+/// stay adoptable.
+/// What: `true` when `current` equals `composed`, or equals `composed` with its
+/// `provenance:` line removed. Nothing else is accepted — a file differing in
+/// any other byte is still treated as possibly the operator's.
+/// Test: `deploy_adopts_untracked_byte_identical_file`,
+/// `deploy_adopts_an_untracked_file_written_before_the_provenance_stamp`.
+fn is_adoptable(current: &str, composed: &str) -> bool {
+    checksum(current) == checksum(composed)
+        || checksum(current) == checksum(&without_provenance_line(composed))
+}
+
 fn deploy_agents_locked(
     source_dir: &Path,
     target_dir: &Path,
@@ -266,18 +285,24 @@ fn deploy_agents_locked(
         // failure instead of propagating it with `?` — one malformed asset
         // (e.g. unterminated frontmatter) must not abort the entire roster
         // deploy. Log loudly, record it, and move on to the next agent.
-        let composed = match compose_agent(&name, source_dir) {
-            Ok(c) => c,
-            Err(err) => {
-                tracing::error!(
-                    agent = %name,
-                    "agent compose FAILED — skipping this agent, roster deploy \
-                     continues for the rest of the roster: {err}"
-                );
-                result.failed.push(format!("{name}: {err}"));
-                continue;
-            }
-        };
+        // #4698: stamp `provenance: framework-owned` into the composed output
+        // before it is validated, checksummed, or written. Stamping at compose
+        // time (rather than editing the string afterwards) keeps ONE frontmatter
+        // grammar in play, and keeps the checksum the manifest records the
+        // checksum of the exact bytes on disk.
+        let composed =
+            match compose_agent_with_provenance(&name, source_dir, Provenance::FrameworkOwned) {
+                Ok(c) => c,
+                Err(err) => {
+                    tracing::error!(
+                        agent = %name,
+                        "agent compose FAILED — skipping this agent, roster deploy \
+                         continues for the rest of the roster: {err}"
+                    );
+                    result.failed.push(format!("{name}: {err}"));
+                    continue;
+                }
+            };
 
         // Issue #3556: `compose_agent`'s success only means trusty-mpm's own
         // LENIENT frontmatter reader could parse the result — it tolerates a
@@ -323,12 +348,21 @@ fn deploy_agents_locked(
                 // Otherwise keep the conservative skip (it may be genuinely
                 // user-owned) but flag it for the `--reset-agents` warning.
                 let current = std::fs::read_to_string(&target_path)?;
-                if checksum(&current) == checksum(&composed) {
+                if is_adoptable(&current, &composed) {
                     manifest.managed.insert(
                         filename.clone(),
                         ManifestEntry {
                             source_chain: source_chain(&name, source_dir)?,
-                            checksum: checksum(&composed),
+                            // #4698: the checksum of what is ON DISK, not of the
+                            // fresh composition. Adoption registers without
+                            // rewriting, so recording the composition's checksum
+                            // would make an adopted pre-#4698 file (which carries
+                            // no `provenance:` line) mismatch its own ledger row
+                            // the instant it was written. Recording the disk
+                            // content keeps the row true; the next deploy sees a
+                            // matching checksum, a differing composition, and
+                            // refreshes the file into the stamped form.
+                            checksum: checksum(&current),
                             deployed_at: now.clone(),
                             origin: Origin::Bundled,
                         },

--- a/crates/trusty-agents-common/src/agents/deployer_tests.rs
+++ b/crates/trusty-agents-common/src/agents/deployer_tests.rs
@@ -772,3 +772,116 @@ fn retract_refuses_on_corrupt_manifest() {
         "no file may be removed when the ledger is unreadable"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #4698: every deployed agent carries `provenance: framework-owned`.
+// ---------------------------------------------------------------------------
+
+/// The deployer stamps the field on every file it writes, and the manifest
+/// round-trip still holds: the recorded checksum is the checksum of the bytes
+/// actually on disk, so a second run reports the file unchanged.
+#[test]
+fn deploy_stamps_provenance_and_the_manifest_still_round_trips() {
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_sources(src.path());
+
+    let result = deploy_agents(src.path(), tgt.path()).unwrap();
+    assert_eq!(result.deployed.len(), 2, "both agents written: {result:?}");
+
+    for filename in ["base-agent.md", "engineer.md"] {
+        let on_disk = fs::read_to_string(tgt.path().join(filename)).unwrap();
+        assert!(
+            on_disk.contains("provenance: framework-owned"),
+            "{filename} carries the stamp:\n{on_disk}"
+        );
+        // The declaration and the ledger's `Origin` agree — the invariant
+        // `provenance::reconcile_with_ledger` exists to police.
+        let declared = crate::agents::metadata::agent_metadata_from_str(&on_disk).provenance;
+        assert_eq!(declared, Some(Provenance::FrameworkOwned));
+        let manifest = AgentManifest::load(tgt.path());
+        let entry = manifest.managed.get(filename).expect("tracked");
+        assert!(entry.origin.is_framework_owned());
+        assert_eq!(
+            declared.map(Provenance::is_framework_owned),
+            Some(entry.origin.is_framework_owned()),
+            "{filename}: frontmatter and ledger agree"
+        );
+        assert!(
+            manifest.checksum_matches(filename, &on_disk),
+            "{filename}: the recorded checksum is the on-disk content's"
+        );
+    }
+
+    // A second run sees everything current — no churn from the new field.
+    let again = deploy_agents(src.path(), tgt.path()).unwrap();
+    assert_eq!(again.unchanged.len(), 2, "idempotent: {again:?}");
+    assert!(again.deployed.is_empty());
+}
+
+/// A file deployed BEFORE the stamp existed is still adopted, then upgraded on
+/// the next run. Without this, every pre-#4698 untracked file would be refused
+/// adoption AND refused refresh — frozen, which is #4408's failure.
+#[test]
+fn deploy_adopts_an_untracked_file_written_before_the_provenance_stamp() {
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_sources(src.path());
+
+    // The pre-#4698 spelling: what `compose_agent` alone emits, no stamp.
+    let unstamped = crate::agents::builder::compose_agent("engineer", src.path()).unwrap();
+    assert!(!unstamped.contains("provenance"));
+    fs::write(tgt.path().join("engineer.md"), &unstamped).unwrap();
+
+    let result = deploy_agents(src.path(), tgt.path()).unwrap();
+    assert!(
+        result.adopted.contains(&"engineer.md".to_string()),
+        "adopted, not skipped: {result:?}"
+    );
+    assert!(
+        !result
+            .untracked_modified
+            .contains(&"engineer.md".to_string())
+    );
+    // Adoption is registration-only, so the file is still the unstamped bytes
+    // and the ledger records THOSE bytes.
+    let after_adopt = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
+    assert_eq!(after_adopt, unstamped);
+    assert!(AgentManifest::load(tgt.path()).checksum_matches("engineer.md", &after_adopt));
+
+    // The next run finds a matching checksum and a differing composition, so it
+    // refreshes into the stamped form.
+    let second = deploy_agents(src.path(), tgt.path()).unwrap();
+    assert!(
+        second.deployed.contains(&"engineer.md".to_string()),
+        "upgraded on the next run: {second:?}"
+    );
+    let upgraded = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
+    assert!(upgraded.contains("provenance: framework-owned"));
+    assert!(AgentManifest::load(tgt.path()).checksum_matches("engineer.md", &upgraded));
+}
+
+/// A source asset that declares nothing still deploys stamped — there is no
+/// per-file declaration for a new bundled agent to forget.
+#[test]
+fn deploy_stamps_an_agent_whose_source_declares_no_provenance() {
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    fs::write(
+        src.path().join("solo.md"),
+        "---\nname: solo\nrole: engineer\n---\n\n# Solo\n\nBODY\n",
+    )
+    .unwrap();
+    assert!(
+        !fs::read_to_string(src.path().join("solo.md"))
+            .unwrap()
+            .contains("provenance")
+    );
+
+    deploy_agents(src.path(), tgt.path()).unwrap();
+    assert!(
+        fs::read_to_string(tgt.path().join("solo.md"))
+            .unwrap()
+            .contains("provenance: framework-owned")
+    );
+}

--- a/crates/trusty-agents-common/src/agents/metadata.rs
+++ b/crates/trusty-agents-common/src/agents/metadata.rs
@@ -33,6 +33,7 @@
 use std::path::Path;
 
 use super::builder::{Frontmatter, split_frontmatter};
+use super::provenance::Provenance;
 
 /// A deployed agent's parsed frontmatter, projected for display/diagnostics.
 ///
@@ -93,6 +94,24 @@ pub struct AgentMetadata {
     /// OVERRIDE-merged across an `extends` chain rather than unioned (see
     /// `builder::merge_frontmatter`).
     pub tools: Option<Vec<String>>,
+    /// The `provenance:` field — who wrote this file (#4698).
+    ///
+    /// Why: the read-only surfaces that already report a file's recorded
+    /// [`crate::agents::manifest::Origin`] need the frontmatter's own claim
+    /// beside it, because the two are independent records and a file with no
+    /// ledger entry has ONLY this one.
+    /// What: `None` when the key is absent, which
+    /// [`crate::agents::provenance::declared_or_default`] resolves to
+    /// [`Provenance::UserAuthored`]. `None` ALSO when the document failed to
+    /// parse at all — including the case where `provenance:` itself carried an
+    /// unrecognised value, since this projection degrades a parse failure to
+    /// [`AgentMetadata::default`] rather than propagating it. A caller that
+    /// must distinguish "absent" from "malformed" parses with
+    /// [`crate::agents::builder::compose_agent`] instead, which rejects.
+    /// Test: `metadata_from_str_reads_provenance`,
+    /// `metadata_from_str_provenance_absent_is_none`,
+    /// `metadata_from_str_unknown_provenance_is_default`.
+    pub provenance: Option<Provenance>,
 }
 
 impl From<Frontmatter> for AgentMetadata {
@@ -107,6 +126,7 @@ impl From<Frontmatter> for AgentMetadata {
             skills: fm.skills,
             max_tokens: fm.max_tokens,
             tools: fm.tools,
+            provenance: fm.provenance,
         }
     }
 }
@@ -195,6 +215,42 @@ mod tests {
         let meta = agent_metadata_from_str("---\nname: plain\nrole: engineer\n---\n\nBody.\n");
         assert_eq!(meta.role.as_deref(), Some("engineer"));
         assert_eq!(meta.agent_type, None);
+    }
+
+    /// #4698: the field a deployed framework agent now carries.
+    #[test]
+    fn metadata_from_str_reads_provenance() {
+        let doc = "---\nname: qa\nrole: qa\nprovenance: framework-owned\n---\n\nBody.\n";
+        assert_eq!(
+            agent_metadata_from_str(doc).provenance,
+            Some(Provenance::FrameworkOwned)
+        );
+        let doc = "---\nname: helper\nprovenance: tm-agent-manager-built\n---\n\nBody.\n";
+        assert_eq!(
+            agent_metadata_from_str(doc).provenance,
+            Some(Provenance::TmAgentManagerBuilt)
+        );
+    }
+
+    /// #4698: absence is the "not ours, never touch" signal, so it projects as
+    /// `None` here and is resolved by `provenance::declared_or_default`.
+    #[test]
+    fn metadata_from_str_provenance_absent_is_none() {
+        let meta = agent_metadata_from_str("---\nname: plain\nrole: engineer\n---\n\nBody.\n");
+        assert_eq!(meta.provenance, None);
+        assert_eq!(
+            super::super::provenance::declared_or_default(meta.provenance),
+            Provenance::UserAuthored
+        );
+    }
+
+    /// #4698: an unknown value hard-errors in the composer; this best-effort
+    /// projection degrades the whole document to a default rather than
+    /// propagating, exactly as it already does for malformed frontmatter.
+    #[test]
+    fn metadata_from_str_unknown_provenance_is_default() {
+        let doc = "---\nname: broken\nprovenance: framework_owned\n---\n\nBody.\n";
+        assert_eq!(agent_metadata_from_str(doc), AgentMetadata::default());
     }
 
     #[test]

--- a/crates/trusty-agents-common/src/agents/mod.rs
+++ b/crates/trusty-agents-common/src/agents/mod.rs
@@ -35,6 +35,9 @@
 
 pub mod builder;
 pub mod builder_in_memory;
+// #4698: `builder`'s YAML scalar encoding, split out when adding `provenance:`
+// pushed `builder.rs` over the 500-SLOC production cap.
+mod builder_yaml;
 pub mod deployer;
 pub mod frontmatter;
 pub mod manifest;
@@ -48,6 +51,10 @@ pub mod tier_audit;
 // could not supply: `agent_schema` (is this trusty-mpm's artifact or another
 // project's?) and `vcs_claim` (does the repository claim this file?).
 pub mod agent_schema;
+// #4698: the `provenance:` frontmatter field — which of the three writers
+// (framework deploy, tm-agent-manager, the operator's own editor) produced a
+// given agent file. Additive: it records authorship, never a tier.
+pub mod provenance;
 pub mod quarantine;
 pub mod quarantine_receipt;
 pub mod vcs_claim;

--- a/crates/trusty-agents-common/src/agents/provenance.rs
+++ b/crates/trusty-agents-common/src/agents/provenance.rs
@@ -1,0 +1,406 @@
+//! Who wrote this agent file? The `provenance:` frontmatter field (#4698).
+//!
+//! Why: an agent file on disk carried no marker saying which of three writers
+//! produced it — the framework's own deploy, `tm-agent-manager` composing one
+//! on request, or a human hand-writing one through Claude Code's `/agents`.
+//! The never-clobber-what-we-did-not-write rule needs that distinction, and
+//! [`crate::agents::manifest::Origin::is_framework_owned`] cannot supply it:
+//! it answers only from the ledger, so a file with no ledger entry — every
+//! hand-written agent, and every stale leftover — reads identically. Issue
+//! #4698 records the owner's ruling of 2026-08-03 verbatim: "We use
+//! frontmatter to track this."
+//!
+//! What: [`Provenance`], the three declared values, plus the parse
+//! ([`Provenance::from_str`], rejecting anything else with the typed
+//! [`UnknownProvenance`]) and the absence rule. Issue #4698's design note
+//! fixes that rule: "ABSENCE of the field is itself the signal for 'not ours,
+//! never touch.'" — so an absent field resolves to
+//! [`Provenance::UserAuthored`], never to a framework-owned default.
+//! [`reconcile_with_ledger`] settles the one case where a file's declaration
+//! and the ownership ledger can disagree.
+//!
+//! This field is ADDITIVE. It records who wrote a file; it is not a tier, and
+//! nothing here participates in tier resolution — the owner's 2026-08-01
+//! ruling collapsed the agent tiers to a single deploy target fed by
+//! prioritised sources, and no code in this module may be extended into a
+//! second tier mechanism.
+//!
+//! Test: `provenance_round_trips_every_value`,
+//! `provenance_rejects_an_unknown_value`, `absent_provenance_is_user_authored`,
+//! `only_framework_owned_is_framework_owned`,
+//! `reconcile_agreeing_declaration_is_silent`,
+//! `reconcile_disagreement_lets_the_ledger_win_and_names_the_file`,
+//! `reconcile_without_a_declaration_is_silent`.
+
+use std::fmt;
+use std::str::FromStr;
+
+use thiserror::Error;
+
+/// The frontmatter key this module owns.
+pub const PROVENANCE_KEY: &str = "provenance";
+
+/// Who wrote an agent file.
+///
+/// Why: the three writers of a `.claude/agents/*.md` file need to stay
+/// distinguishable on disk, independently of any ledger — see the module doc.
+/// What: a closed enum whose wire spellings are exactly the three the issue
+/// title names: `framework-owned`, `tm-agent-manager-built`, `user-authored`.
+/// The spelling is the contract — it appears in deployed files an operator
+/// reads, so it is written out by hand in [`Provenance::as_str`] rather than
+/// derived from the variant name.
+/// Test: `provenance_round_trips_every_value`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Provenance {
+    /// Written by the framework's own agent deploy — the `Overwrite` tier.
+    FrameworkOwned,
+    /// Composed on request by `tm-agent-manager`.
+    TmAgentManagerBuilt,
+    /// Hand-authored by the operator (Claude Code's `/agents`, or any editor).
+    UserAuthored,
+}
+
+impl Provenance {
+    /// Every accepted value, in declaration order.
+    ///
+    /// Why: [`UnknownProvenance`]'s message lists what WAS accepted, and the
+    /// round-trip test iterates the same list, so neither can drift from the
+    /// match arms below.
+    pub const ALL: [Provenance; 3] = [
+        Provenance::FrameworkOwned,
+        Provenance::TmAgentManagerBuilt,
+        Provenance::UserAuthored,
+    ];
+
+    /// The wire spelling written into and read from frontmatter.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Provenance::FrameworkOwned => "framework-owned",
+            Provenance::TmAgentManagerBuilt => "tm-agent-manager-built",
+            Provenance::UserAuthored => "user-authored",
+        }
+    }
+
+    /// Whether this declaration marks a FRAMEWORK-owned file.
+    ///
+    /// Why: the frontmatter counterpart of
+    /// [`crate::agents::manifest::Origin::is_framework_owned`], and it must
+    /// agree with it wherever both exist — [`reconcile_with_ledger`] is what
+    /// checks that.
+    /// What: `true` only for [`Provenance::FrameworkOwned`].
+    /// [`Provenance::TmAgentManagerBuilt`] is deliberately NOT framework-owned:
+    /// the operator asked for that file, so it keeps the preserve-on-mismatch
+    /// treatment [`crate::agents::manifest::Origin::Registry`] gets for the
+    /// same reason.
+    /// Test: `only_framework_owned_is_framework_owned`.
+    pub fn is_framework_owned(self) -> bool {
+        matches!(self, Provenance::FrameworkOwned)
+    }
+}
+
+impl fmt::Display for Provenance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A `provenance:` value that is not one of the three accepted spellings.
+///
+/// Why: #4698 requires an unknown value be REJECTED, not silently coerced to a
+/// default — coercing would let a typo (`provenance: framework_owned`) read as
+/// user-authored and freeze a framework file forever, which is #4408's failure
+/// shape reached through a new door. A typed error keeps that decision at the
+/// call site instead of inside a `String`.
+/// What: carries the offending value verbatim and names what was accepted.
+/// Test: `provenance_rejects_an_unknown_value`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error(
+    "unknown `provenance:` value `{value}` — expected one of \
+     framework-owned, tm-agent-manager-built, user-authored"
+)]
+pub struct UnknownProvenance {
+    /// The value as it appeared in the frontmatter, trimmed.
+    pub value: String,
+}
+
+impl FromStr for Provenance {
+    type Err = UnknownProvenance;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        Provenance::ALL
+            .into_iter()
+            .find(|p| p.as_str() == trimmed)
+            .ok_or_else(|| UnknownProvenance {
+                value: trimmed.to_string(),
+            })
+    }
+}
+
+/// Resolve a declaration that may be absent.
+///
+/// Why: #4698's design note, verbatim — "ABSENCE of the field is itself the
+/// signal for 'not ours, never touch.'" That makes the default the SAFE one,
+/// and stating it in one function keeps a caller from choosing a different
+/// default and quietly reclassifying every pre-#4698 file as the framework's.
+/// What: the declaration when present, else [`Provenance::UserAuthored`].
+/// Test: `absent_provenance_is_user_authored`.
+pub fn declared_or_default(declared: Option<Provenance>) -> Provenance {
+    declared.unwrap_or(Provenance::UserAuthored)
+}
+
+/// The same document with its `provenance:` frontmatter line removed.
+///
+/// Why: the ADOPTION path (#2504) registers an untracked target file when its
+/// bytes already equal what the deployer would write. Every file deployed
+/// BEFORE #4698 lacks the stamped line, so a naive byte comparison stopped
+/// matching the moment the deployer began stamping — and a file that fails
+/// adoption is skipped, warned about, and never refreshed again. That is
+/// #4408's freeze reached through a new door, so adoption compares against
+/// both spellings.
+/// What: drops the first line whose key is `provenance` from the leading
+/// frontmatter block, leaving everything else — the body included — byte-exact.
+/// A document with no such line is returned unchanged. Only the frontmatter
+/// block is scanned, so a `provenance:` line in prose survives.
+/// Test: `without_provenance_line_drops_only_that_line`,
+/// `without_provenance_line_is_a_no_op_when_absent`,
+/// `without_provenance_line_ignores_a_body_line`.
+pub fn without_provenance_line(doc: &str) -> String {
+    let mut out = String::with_capacity(doc.len());
+    let mut in_frontmatter = false;
+    let mut dropped = false;
+    for (idx, line) in doc.split_inclusive('\n').enumerate() {
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if idx == 0 && trimmed == "---" {
+            in_frontmatter = true;
+            out.push_str(line);
+            continue;
+        }
+        if in_frontmatter && trimmed == "---" {
+            in_frontmatter = false;
+            out.push_str(line);
+            continue;
+        }
+        let is_provenance = in_frontmatter
+            && !dropped
+            && trimmed
+                .split_once(':')
+                .is_some_and(|(key, _)| key.trim() == PROVENANCE_KEY);
+        if is_provenance {
+            dropped = true;
+            continue;
+        }
+        out.push_str(line);
+    }
+    out
+}
+
+/// The outcome of checking a file's declaration against the ownership ledger.
+///
+/// Why: the disagreement must be both LOGGED and testable. Returning the
+/// message as data — as well as emitting it through `tracing` — lets a test
+/// assert that the file is named without standing up a subscriber.
+/// What: the ledger's verdict (always — the ledger wins), plus the
+/// disagreement message when there was one.
+/// Test: `reconcile_disagreement_lets_the_ledger_win_and_names_the_file`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reconciled {
+    /// Whether the file is framework-owned. Always the LEDGER's answer.
+    pub framework_owned: bool,
+    /// `Some` only when a declaration existed and contradicted the ledger.
+    pub disagreement: Option<String>,
+}
+
+/// Reconcile a file's declared `provenance:` against its ledger entry.
+///
+/// Why: #4698 adds a second, independent record of the same fact, and two
+/// records can disagree — a hand-edited deployed file is exactly how. The
+/// ledger wins, because it is the record the deployer itself wrote under a
+/// lock and checksummed; the frontmatter is the copy anyone with an editor can
+/// change. Silently preferring the file would hand an operator (or a corrupted
+/// write) a way to flip a bundled agent to user-owned and freeze it.
+/// What: returns the ledger's `framework_owned` unchanged in every case. When
+/// a declaration exists and contradicts it, also emits a `tracing::warn!`
+/// naming `file_name`, both spellings, and returns that message in
+/// [`Reconciled::disagreement`]. A file with NO declaration is silent — that
+/// is every file written before this field existed, which is not an anomaly.
+///
+/// This never runs where there is no ledger entry: an absent entry is not a
+/// disagreement, and letting a declaration stand in for one would manufacture
+/// a user-owned exemption out of a field anybody can type (see
+/// [`crate::agents::tier_audit`]'s invariant 2).
+/// Test: `reconcile_agreeing_declaration_is_silent`,
+/// `reconcile_disagreement_lets_the_ledger_win_and_names_the_file`,
+/// `reconcile_without_a_declaration_is_silent`.
+pub fn reconcile_with_ledger(
+    file_name: &str,
+    ledger_framework_owned: bool,
+    declared: Option<Provenance>,
+) -> Reconciled {
+    let Some(declared) = declared else {
+        return Reconciled {
+            framework_owned: ledger_framework_owned,
+            disagreement: None,
+        };
+    };
+    if declared.is_framework_owned() == ledger_framework_owned {
+        return Reconciled {
+            framework_owned: ledger_framework_owned,
+            disagreement: None,
+        };
+    }
+    let ledger_spelling = if ledger_framework_owned {
+        Provenance::FrameworkOwned.as_str()
+    } else {
+        "not framework-owned"
+    };
+    let message = format!(
+        "'{file_name}' declares `provenance: {}` but the deployed-agent manifest records it as \
+         {ledger_spelling}; the manifest wins (#4698)",
+        declared.as_str()
+    );
+    tracing::warn!(
+        file = %file_name,
+        declared = %declared.as_str(),
+        ledger_framework_owned,
+        "agent `provenance:` disagrees with the deployed-agent manifest — the manifest wins"
+    );
+    Reconciled {
+        framework_owned: ledger_framework_owned,
+        disagreement: Some(message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provenance_round_trips_every_value() {
+        for p in Provenance::ALL {
+            assert_eq!(p.as_str().parse::<Provenance>(), Ok(p), "{p} round-trips");
+        }
+        // The exact spellings #4698's title names, pinned literally so a
+        // variant rename cannot silently change the on-disk contract.
+        assert_eq!(Provenance::FrameworkOwned.as_str(), "framework-owned");
+        assert_eq!(
+            Provenance::TmAgentManagerBuilt.as_str(),
+            "tm-agent-manager-built"
+        );
+        assert_eq!(Provenance::UserAuthored.as_str(), "user-authored");
+    }
+
+    #[test]
+    fn provenance_parse_trims_surrounding_whitespace() {
+        assert_eq!(
+            "  framework-owned ".parse::<Provenance>(),
+            Ok(Provenance::FrameworkOwned)
+        );
+    }
+
+    #[test]
+    fn provenance_rejects_an_unknown_value() {
+        // An underscore typo of the real spelling: the exact mistake that must
+        // NOT coerce to a default.
+        let err = "framework_owned".parse::<Provenance>().unwrap_err();
+        assert_eq!(err.value, "framework_owned");
+        assert!(
+            err.to_string().contains("framework-owned"),
+            "the error lists the accepted spellings: {err}"
+        );
+        assert!("".parse::<Provenance>().is_err(), "empty is not a value");
+        assert!(
+            "Framework-Owned".parse::<Provenance>().is_err(),
+            "the spelling is case-sensitive"
+        );
+    }
+
+    #[test]
+    fn absent_provenance_is_user_authored() {
+        // #4698: "ABSENCE of the field is itself the signal for 'not ours,
+        // never touch.'"
+        assert_eq!(declared_or_default(None), Provenance::UserAuthored);
+        assert!(!declared_or_default(None).is_framework_owned());
+        assert_eq!(
+            declared_or_default(Some(Provenance::FrameworkOwned)),
+            Provenance::FrameworkOwned
+        );
+    }
+
+    #[test]
+    fn only_framework_owned_is_framework_owned() {
+        assert!(Provenance::FrameworkOwned.is_framework_owned());
+        assert!(!Provenance::TmAgentManagerBuilt.is_framework_owned());
+        assert!(!Provenance::UserAuthored.is_framework_owned());
+    }
+
+    #[test]
+    fn without_provenance_line_drops_only_that_line() {
+        let doc = "---\nname: qa\nprovenance: framework-owned\nrole: qa\n---\n\nBody.\n";
+        assert_eq!(
+            without_provenance_line(doc),
+            "---\nname: qa\nrole: qa\n---\n\nBody.\n"
+        );
+    }
+
+    #[test]
+    fn without_provenance_line_is_a_no_op_when_absent() {
+        let doc = "---\nname: qa\nrole: qa\n---\n\nBody.\n";
+        assert_eq!(without_provenance_line(doc), doc);
+        // No frontmatter at all is equally untouched.
+        assert_eq!(without_provenance_line("just prose\n"), "just prose\n");
+    }
+
+    #[test]
+    fn without_provenance_line_ignores_a_body_line() {
+        // Prose that happens to mention the key must survive byte-exact —
+        // agent bodies document this field.
+        let doc = "---\nname: qa\n---\n\nSet provenance: framework-owned in frontmatter.\n";
+        assert_eq!(without_provenance_line(doc), doc);
+    }
+
+    #[test]
+    fn reconcile_agreeing_declaration_is_silent() {
+        let r = reconcile_with_ledger("qa.md", true, Some(Provenance::FrameworkOwned));
+        assert!(r.framework_owned);
+        assert_eq!(r.disagreement, None);
+
+        let r = reconcile_with_ledger("mine.md", false, Some(Provenance::UserAuthored));
+        assert!(!r.framework_owned);
+        assert_eq!(r.disagreement, None);
+
+        // tm-agent-manager-built agrees with a non-framework-owned ledger row.
+        let r = reconcile_with_ledger("built.md", false, Some(Provenance::TmAgentManagerBuilt));
+        assert_eq!(r.disagreement, None);
+    }
+
+    #[test]
+    fn reconcile_disagreement_lets_the_ledger_win_and_names_the_file() {
+        // A hand-edited deployed file claiming to be the operator's while the
+        // ledger still records the framework as its author.
+        let r = reconcile_with_ledger("rust-engineer.md", true, Some(Provenance::UserAuthored));
+        assert!(r.framework_owned, "the manifest wins");
+        let msg = r.disagreement.expect("a disagreement is reported");
+        assert!(msg.contains("rust-engineer.md"), "names the file: {msg}");
+        assert!(
+            msg.contains("user-authored"),
+            "names the declaration: {msg}"
+        );
+
+        // And the mirror: a declaration claiming the framework wrote a file the
+        // ledger records as the operator's.
+        let r = reconcile_with_ledger("mine.md", false, Some(Provenance::FrameworkOwned));
+        assert!(!r.framework_owned, "the manifest wins in both directions");
+        assert!(r.disagreement.is_some_and(|m| m.contains("mine.md")));
+    }
+
+    #[test]
+    fn reconcile_without_a_declaration_is_silent() {
+        // Every file written before #4698 lands here; it is not an anomaly.
+        for owned in [true, false] {
+            let r = reconcile_with_ledger("legacy.md", owned, None);
+            assert_eq!(r.framework_owned, owned);
+            assert_eq!(r.disagreement, None);
+        }
+    }
+}

--- a/crates/trusty-agents-common/src/agents/tier_audit.rs
+++ b/crates/trusty-agents-common/src/agents/tier_audit.rs
@@ -84,6 +84,8 @@ use thiserror::Error;
 use crate::agents::deployer::is_agent_file;
 use crate::agents::manifest::{AgentManifest, ManifestLoad};
 use crate::agents::metadata::agent_metadata_from_str;
+// #4698: the file's own authorship claim, reconciled against the ledger.
+use crate::agents::provenance::{Provenance, reconcile_with_ledger};
 
 /// Why [`audit_agent_tier`] could not answer for a directory.
 ///
@@ -271,6 +273,43 @@ pub fn ownership_of(manifest: &AgentManifest, file_name: &str) -> TierOwnership 
     }
 }
 
+/// [`ownership_of`], additionally checking the file's own `provenance:` claim
+/// against the ledger (#4698).
+///
+/// Why: #4698 adds a SECOND record of who wrote a file, and two records can
+/// disagree once anybody edits the deployed copy. The ledger has to win — it is
+/// the record the deployer wrote under a lock and checksummed — but a
+/// disagreement is still worth an operator seeing, so it is warned rather than
+/// swallowed.
+/// What: the verdict is byte-for-byte [`ownership_of`]'s in every case; the
+/// only added behaviour is the warning
+/// [`crate::agents::provenance::reconcile_with_ledger`] emits. Deliberately a
+/// no-op for [`TierOwnership::Untracked`]: an absent ledger entry is not a
+/// disagreement, and letting `provenance: user-authored` stand in for one would
+/// manufacture the user-owned exemption out of a field anybody can type —
+/// exactly the proof invariant 2 above says only a ledger entry supplies.
+/// Test: `ownership_declared_agreeing_matches_ownership_of`,
+/// `ownership_declared_disagreement_keeps_the_ledger_verdict`,
+/// `ownership_declared_never_exempts_an_untracked_file`.
+pub fn ownership_of_declared(
+    manifest: &AgentManifest,
+    file_name: &str,
+    declared: Option<Provenance>,
+) -> TierOwnership {
+    let ownership = ownership_of(manifest, file_name);
+    match ownership {
+        TierOwnership::Untracked => ownership,
+        TierOwnership::FrameworkOwned | TierOwnership::UserOwned => {
+            reconcile_with_ledger(
+                file_name,
+                ownership == TierOwnership::FrameworkOwned,
+                declared,
+            );
+            ownership
+        }
+    }
+}
+
 /// Classify one file in a non-canonical tier. Pure — no I/O.
 ///
 /// Why: the verdict is the shared contract between #4442 and #4448, so it is
@@ -369,7 +408,12 @@ pub fn audit_agent_tier(
             }
             let content = std::fs::read_to_string(entry.path()).unwrap_or_default();
             let name = agent_identity(&content, &file_name);
-            let class = classify_tier_resident(&name, ownership_of(&manifest, &file_name), bundled);
+            // #4698: read the file's own `provenance:` claim so a disagreement
+            // with the ledger is reported. The verdict is unchanged — the
+            // ledger wins — so this scan's classification is identical.
+            let declared = agent_metadata_from_str(&content).provenance;
+            let ownership = ownership_of_declared(&manifest, &file_name, declared);
+            let class = classify_tier_resident(&name, ownership, bundled);
             class.is_tm_owned().then(|| MisplacedAgent {
                 path: entry.path(),
                 name,

--- a/crates/trusty-agents-common/src/agents/tier_audit.rs
+++ b/crates/trusty-agents-common/src/agents/tier_audit.rs
@@ -273,43 +273,6 @@ pub fn ownership_of(manifest: &AgentManifest, file_name: &str) -> TierOwnership 
     }
 }
 
-/// [`ownership_of`], additionally checking the file's own `provenance:` claim
-/// against the ledger (#4698).
-///
-/// Why: #4698 adds a SECOND record of who wrote a file, and two records can
-/// disagree once anybody edits the deployed copy. The ledger has to win — it is
-/// the record the deployer wrote under a lock and checksummed — but a
-/// disagreement is still worth an operator seeing, so it is warned rather than
-/// swallowed.
-/// What: the verdict is byte-for-byte [`ownership_of`]'s in every case; the
-/// only added behaviour is the warning
-/// [`crate::agents::provenance::reconcile_with_ledger`] emits. Deliberately a
-/// no-op for [`TierOwnership::Untracked`]: an absent ledger entry is not a
-/// disagreement, and letting `provenance: user-authored` stand in for one would
-/// manufacture the user-owned exemption out of a field anybody can type —
-/// exactly the proof invariant 2 above says only a ledger entry supplies.
-/// Test: `ownership_declared_agreeing_matches_ownership_of`,
-/// `ownership_declared_disagreement_keeps_the_ledger_verdict`,
-/// `ownership_declared_never_exempts_an_untracked_file`.
-pub fn ownership_of_declared(
-    manifest: &AgentManifest,
-    file_name: &str,
-    declared: Option<Provenance>,
-) -> TierOwnership {
-    let ownership = ownership_of(manifest, file_name);
-    match ownership {
-        TierOwnership::Untracked => ownership,
-        TierOwnership::FrameworkOwned | TierOwnership::UserOwned => {
-            reconcile_with_ledger(
-                file_name,
-                ownership == TierOwnership::FrameworkOwned,
-                declared,
-            );
-            ownership
-        }
-    }
-}
-
 /// Classify one file in a non-canonical tier. Pure — no I/O.
 ///
 /// Why: the verdict is the shared contract between #4442 and #4448, so it is
@@ -408,12 +371,7 @@ pub fn audit_agent_tier(
             }
             let content = std::fs::read_to_string(entry.path()).unwrap_or_default();
             let name = agent_identity(&content, &file_name);
-            // #4698: read the file's own `provenance:` claim so a disagreement
-            // with the ledger is reported. The verdict is unchanged — the
-            // ledger wins — so this scan's classification is identical.
-            let declared = agent_metadata_from_str(&content).provenance;
-            let ownership = ownership_of_declared(&manifest, &file_name, declared);
-            let class = classify_tier_resident(&name, ownership, bundled);
+            let class = classify_tier_resident(&name, ownership_of(&manifest, &file_name), bundled);
             class.is_tm_owned().then(|| MisplacedAgent {
                 path: entry.path(),
                 name,
@@ -422,6 +380,100 @@ pub fn audit_agent_tier(
         })
         .collect();
     found.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(found)
+}
+
+/// One file whose declared `provenance:` contradicts its ledger entry (#4698).
+///
+/// Why: `provenance:` and the ownership ledger are two independent records of
+/// the same fact, so they can disagree once anybody edits a deployed file. The
+/// ledger wins for every OWNERSHIP decision — see
+/// [`crate::agents::provenance::reconcile_with_ledger`] — but the operator
+/// still needs to be told, and a `tracing::warn!` alone reaches no `tm doctor`
+/// report. This is the value that travels to one.
+/// What: the file, both records, and the rendered explanation. `detail` is
+/// [`crate::agents::provenance::Reconciled::disagreement`] verbatim, so the log
+/// line and the doctor finding cannot drift apart.
+/// Test: `audit_provenance_reports_a_contradicting_declaration`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvenanceDisagreement {
+    /// Full path of the file whose declaration contradicts the ledger.
+    pub path: PathBuf,
+    /// What the file declares about its own author.
+    pub declared: Provenance,
+    /// What the ledger records — the value that WINS.
+    pub ledger_framework_owned: bool,
+    /// The rendered explanation, naming the file and both records.
+    pub detail: String,
+}
+
+/// Scan any agent directory for files whose `provenance:` contradicts the
+/// ledger (#4698).
+///
+/// Why: deliberately NOT folded into [`audit_agent_tier`], for two reasons that
+/// both point the same way. [`audit_agent_tier`] answers "is this file
+/// MISPLACED?", and a disagreement is a different question about a file that
+/// may be perfectly placed — folding them would put an unrelated fact inside
+/// [`MisplacedAgent`], which every consumer reads as "move or delete this".
+/// More decisively, [`audit_agent_tier`] must never run on the canonical deploy
+/// directory (every file there is tm-owned, correctly and uselessly), and the
+/// canonical directory is exactly where a hand-edited DEPLOYED agent lives.
+/// A disagreement check that could not look there would miss the case it exists
+/// for.
+/// What: READ-ONLY. Lists `.md` files directly under `dir`, reads this
+/// directory's ownership manifest, and returns one entry per file whose
+/// declaration contradicts its ledger row, sorted by path for stable output.
+/// A file with NO ledger entry yields nothing: an absent entry is not a
+/// disagreement, and a declaration cannot stand in for one (invariant 2 above).
+/// A file declaring nothing yields nothing — that is every file written before
+/// #4698. An ABSENT `dir` returns an empty vec; a `dir` that exists but cannot
+/// be enumerated returns [`TierAuditError::Unscannable`], matching
+/// [`audit_agent_tier`]. A corrupt or unreadable ledger yields nothing: with no
+/// second record to read, no contradiction can be established.
+/// Test: `audit_provenance_reports_a_contradicting_declaration`,
+/// `audit_provenance_is_silent_when_records_agree`,
+/// `audit_provenance_ignores_an_untracked_file`,
+/// `audit_provenance_ignores_a_file_declaring_nothing`,
+/// `audit_provenance_missing_dir_is_empty`,
+/// `audit_provenance_unscannable_dir_is_an_error`.
+pub fn audit_provenance(dir: &Path) -> Result<Vec<ProvenanceDisagreement>, TierAuditError> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(TierAuditError::Unscannable {
+                path: dir.to_path_buf(),
+                source,
+            });
+        }
+    };
+    let manifest = match AgentManifest::load_checked(dir) {
+        ManifestLoad::Ok(m) => m,
+        ManifestLoad::Corrupt(_) => return Ok(Vec::new()),
+    };
+
+    let mut found: Vec<ProvenanceDisagreement> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let file_name = entry.file_name().to_str()?.to_owned();
+            if !is_agent_file(&file_name) || !entry.path().is_file() {
+                return None;
+            }
+            let ledger = manifest.managed.get(&file_name)?;
+            let content = std::fs::read_to_string(entry.path()).ok()?;
+            let declared = agent_metadata_from_str(&content).provenance?;
+            let ledger_framework_owned = ledger.origin.is_framework_owned();
+            let detail = reconcile_with_ledger(&file_name, ledger_framework_owned, Some(declared))
+                .disagreement?;
+            Some(ProvenanceDisagreement {
+                path: entry.path(),
+                declared,
+                ledger_framework_owned,
+                detail,
+            })
+        })
+        .collect();
+    found.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(found)
 }
 

--- a/crates/trusty-agents-common/src/agents/tier_audit_tests.rs
+++ b/crates/trusty-agents-common/src/agents/tier_audit_tests.rs
@@ -15,6 +15,8 @@ use std::collections::BTreeSet;
 
 use super::*;
 use crate::agents::manifest::{AgentManifest, ManifestEntry, Origin, checksum};
+// #4698: the frontmatter authorship claim reconciled against the ledger.
+use crate::agents::provenance::Provenance;
 
 /// Build a name set from string literals.
 fn roster(names: &[&str]) -> BTreeSet<String> {
@@ -371,4 +373,89 @@ fn audit_is_sorted_by_name() {
         audit_agent_tier(tmp.path(), &roster(&["qa", "engineer", "rust-engineer"])).unwrap();
     let names: Vec<&str> = found.iter().map(|f| f.name.as_str()).collect();
     assert_eq!(names, vec!["engineer", "qa", "rust-engineer"]);
+}
+
+// ---------------------------------------------------------------------------
+// #4698: reading the file's own `provenance:` claim beside the ledger.
+// ---------------------------------------------------------------------------
+
+/// A declaration that agrees with the ledger changes nothing.
+#[test]
+fn ownership_declared_agreeing_matches_ownership_of() {
+    let tmp = tempfile::tempdir().unwrap();
+    track(tmp.path(), "qa.md", Origin::Bundled);
+    let manifest = AgentManifest::load(tmp.path());
+    assert_eq!(
+        ownership_of_declared(&manifest, "qa.md", Some(Provenance::FrameworkOwned)),
+        ownership_of(&manifest, "qa.md")
+    );
+    assert_eq!(
+        ownership_of_declared(&manifest, "qa.md", Some(Provenance::FrameworkOwned)),
+        TierOwnership::FrameworkOwned
+    );
+}
+
+/// A declaration that CONTRADICTS the ledger loses. Anyone with an editor can
+/// change the frontmatter; only the deployer writes the ledger.
+#[test]
+fn ownership_declared_disagreement_keeps_the_ledger_verdict() {
+    // `track` rewrites the whole ledger, so each row needs its own directory.
+    let bundled_dir = tempfile::tempdir().unwrap();
+    track(bundled_dir.path(), "qa.md", Origin::Bundled);
+    let user_dir = tempfile::tempdir().unwrap();
+    track(user_dir.path(), "mine.md", Origin::User);
+
+    // A bundled file claiming to be the operator's stays framework-owned.
+    assert_eq!(
+        ownership_of_declared(
+            &AgentManifest::load(bundled_dir.path()),
+            "qa.md",
+            Some(Provenance::UserAuthored)
+        ),
+        TierOwnership::FrameworkOwned
+    );
+    // And the mirror.
+    assert_eq!(
+        ownership_of_declared(
+            &AgentManifest::load(user_dir.path()),
+            "mine.md",
+            Some(Provenance::FrameworkOwned)
+        ),
+        TierOwnership::UserOwned
+    );
+}
+
+/// The declaration never manufactures a ledger entry. An untracked file on a
+/// bundled name is still `Untracked` — the quarantine's whole target set — no
+/// matter what it declares about itself (invariant 2 in this module's docs).
+#[test]
+fn ownership_declared_never_exempts_an_untracked_file() {
+    let manifest = AgentManifest::default();
+    for declared in [
+        None,
+        Some(Provenance::UserAuthored),
+        Some(Provenance::FrameworkOwned),
+        Some(Provenance::TmAgentManagerBuilt),
+    ] {
+        assert_eq!(
+            ownership_of_declared(&manifest, "qa.md", declared),
+            TierOwnership::Untracked,
+            "declared {declared:?} must not stand in for a ledger entry"
+        );
+    }
+}
+
+/// End to end: the scan reads the declaration and still returns the ledger's
+/// classification, so #4698 adds a signal without moving any verdict.
+#[test]
+fn audit_verdict_is_unchanged_by_a_contradicting_declaration() {
+    let tmp = tempfile::tempdir().unwrap();
+    let body = "---\nname: qa\nrole: qa\nprovenance: user-authored\n---\n\nBODY\n";
+    std::fs::write(tmp.path().join("qa.md"), body).unwrap();
+    track(tmp.path(), "qa.md", Origin::Bundled);
+
+    let bundled: BTreeSet<String> = ["qa".to_string()].into_iter().collect();
+    let found = audit_agent_tier(tmp.path(), &bundled).unwrap();
+    assert_eq!(found.len(), 1, "still reported: {found:?}");
+    assert_eq!(found[0].class, TierResidentClass::ShadowsBundled);
 }

--- a/crates/trusty-agents-common/src/agents/tier_audit_tests.rs
+++ b/crates/trusty-agents-common/src/agents/tier_audit_tests.rs
@@ -376,83 +376,132 @@ fn audit_is_sorted_by_name() {
 }
 
 // ---------------------------------------------------------------------------
-// #4698: reading the file's own `provenance:` claim beside the ledger.
+// #4698: `provenance:` that contradicts the ledger, reported not swallowed.
 // ---------------------------------------------------------------------------
 
-/// A declaration that agrees with the ledger changes nothing.
+/// Write `<dir>/<file_name>` declaring `provenance: <declared>` and track it in
+/// the ledger under `origin`.
+fn staged(dir: &std::path::Path, file_name: &str, declared: Option<&str>, origin: Origin) {
+    let line = declared
+        .map(|d| format!("provenance: {d}\n"))
+        .unwrap_or_default();
+    std::fs::write(
+        dir.join(file_name),
+        format!("---\nname: qa\nrole: qa\n{line}---\n\nBODY\n"),
+    )
+    .unwrap();
+    track(dir, file_name, origin);
+}
+
+/// The finding names the file and BOTH records — the whole point of carrying it
+/// out of `reconcile_with_ledger` instead of only logging it.
 #[test]
-fn ownership_declared_agreeing_matches_ownership_of() {
+fn audit_provenance_reports_a_contradicting_declaration() {
     let tmp = tempfile::tempdir().unwrap();
-    track(tmp.path(), "qa.md", Origin::Bundled);
-    let manifest = AgentManifest::load(tmp.path());
-    assert_eq!(
-        ownership_of_declared(&manifest, "qa.md", Some(Provenance::FrameworkOwned)),
-        ownership_of(&manifest, "qa.md")
+    staged(tmp.path(), "qa.md", Some("user-authored"), Origin::Bundled);
+
+    let found = audit_provenance(tmp.path()).unwrap();
+    assert_eq!(found.len(), 1, "one disagreement: {found:?}");
+    assert_eq!(found[0].path, tmp.path().join("qa.md"));
+    assert_eq!(found[0].declared, Provenance::UserAuthored);
+    assert!(
+        found[0].ledger_framework_owned,
+        "the ledger's value travels too"
     );
-    assert_eq!(
-        ownership_of_declared(&manifest, "qa.md", Some(Provenance::FrameworkOwned)),
-        TierOwnership::FrameworkOwned
+    assert!(
+        found[0].detail.contains("qa.md"),
+        "names the file: {}",
+        found[0].detail
+    );
+    assert!(
+        found[0].detail.contains("user-authored"),
+        "names the declaration: {}",
+        found[0].detail
+    );
+    assert!(
+        found[0].detail.contains("framework-owned"),
+        "names the ledger's record: {}",
+        found[0].detail
     );
 }
 
-/// A declaration that CONTRADICTS the ledger loses. Anyone with an editor can
-/// change the frontmatter; only the deployer writes the ledger.
+/// The mirror: a file claiming the framework wrote it while the ledger records
+/// the operator as its author.
 #[test]
-fn ownership_declared_disagreement_keeps_the_ledger_verdict() {
-    // `track` rewrites the whole ledger, so each row needs its own directory.
-    let bundled_dir = tempfile::tempdir().unwrap();
-    track(bundled_dir.path(), "qa.md", Origin::Bundled);
-    let user_dir = tempfile::tempdir().unwrap();
-    track(user_dir.path(), "mine.md", Origin::User);
+fn audit_provenance_reports_the_mirrored_contradiction() {
+    let tmp = tempfile::tempdir().unwrap();
+    staged(tmp.path(), "mine.md", Some("framework-owned"), Origin::User);
 
-    // A bundled file claiming to be the operator's stays framework-owned.
-    assert_eq!(
-        ownership_of_declared(
-            &AgentManifest::load(bundled_dir.path()),
-            "qa.md",
-            Some(Provenance::UserAuthored)
-        ),
-        TierOwnership::FrameworkOwned
-    );
-    // And the mirror.
-    assert_eq!(
-        ownership_of_declared(
-            &AgentManifest::load(user_dir.path()),
-            "mine.md",
-            Some(Provenance::FrameworkOwned)
-        ),
-        TierOwnership::UserOwned
-    );
+    let found = audit_provenance(tmp.path()).unwrap();
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(found[0].declared, Provenance::FrameworkOwned);
+    assert!(!found[0].ledger_framework_owned);
 }
 
-/// The declaration never manufactures a ledger entry. An untracked file on a
-/// bundled name is still `Untracked` — the quarantine's whole target set — no
-/// matter what it declares about itself (invariant 2 in this module's docs).
 #[test]
-fn ownership_declared_never_exempts_an_untracked_file() {
-    let manifest = AgentManifest::default();
-    for declared in [
-        None,
-        Some(Provenance::UserAuthored),
-        Some(Provenance::FrameworkOwned),
-        Some(Provenance::TmAgentManagerBuilt),
-    ] {
-        assert_eq!(
-            ownership_of_declared(&manifest, "qa.md", declared),
-            TierOwnership::Untracked,
-            "declared {declared:?} must not stand in for a ledger entry"
-        );
-    }
+fn audit_provenance_is_silent_when_records_agree() {
+    let tmp = tempfile::tempdir().unwrap();
+    staged(
+        tmp.path(),
+        "qa.md",
+        Some("framework-owned"),
+        Origin::Bundled,
+    );
+    assert!(audit_provenance(tmp.path()).unwrap().is_empty());
 }
 
-/// End to end: the scan reads the declaration and still returns the ledger's
-/// classification, so #4698 adds a signal without moving any verdict.
+/// An absent ledger entry is not a disagreement — a declaration anybody can
+/// type must never stand in for one (invariant 2).
+#[test]
+fn audit_provenance_ignores_an_untracked_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("qa.md"),
+        "---\nname: qa\nprovenance: framework-owned\n---\n\nBODY\n",
+    )
+    .unwrap();
+    assert!(audit_provenance(tmp.path()).unwrap().is_empty());
+}
+
+/// Every file written before #4698 declares nothing; that is not an anomaly.
+#[test]
+fn audit_provenance_ignores_a_file_declaring_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    staged(tmp.path(), "qa.md", None, Origin::Bundled);
+    assert!(audit_provenance(tmp.path()).unwrap().is_empty());
+}
+
+#[test]
+fn audit_provenance_missing_dir_is_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let absent = tmp.path().join("nope");
+    assert!(audit_provenance(&absent).unwrap().is_empty());
+}
+
+/// #5626's rule, applied to this scan too: a directory that exists but cannot
+/// be read has established nothing, and must not read as "found nothing".
+#[test]
+#[cfg(unix)]
+fn audit_provenance_unscannable_dir_is_an_error() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::tempdir().unwrap();
+    let locked = tmp.path().join("locked");
+    std::fs::create_dir(&locked).unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let result = audit_provenance(&locked);
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        matches!(result, Err(TierAuditError::Unscannable { .. })),
+        "{result:?}"
+    );
+}
+
+/// The placement verdict is untouched by a declaration — the ledger still wins
+/// for ownership, so a contradicting file classifies exactly as before.
 #[test]
 fn audit_verdict_is_unchanged_by_a_contradicting_declaration() {
     let tmp = tempfile::tempdir().unwrap();
-    let body = "---\nname: qa\nrole: qa\nprovenance: user-authored\n---\n\nBODY\n";
-    std::fs::write(tmp.path().join("qa.md"), body).unwrap();
-    track(tmp.path(), "qa.md", Origin::Bundled);
+    staged(tmp.path(), "qa.md", Some("user-authored"), Origin::Bundled);
 
     let bundled: BTreeSet<String> = ["qa".to_string()].into_iter().collect();
     let found = audit_agent_tier(tmp.path(), &bundled).unwrap();

--- a/crates/trusty-code/changelog.d/4698-declared-provenance-in-describe.md
+++ b/crates/trusty-code/changelog.d/4698-declared-provenance-in-describe.md
@@ -1,0 +1,9 @@
+Added
+
+- `agents.describe`'s provenance object gained a `declared_provenance` key
+  carrying what the agent FILE says about its own author (#4698), beside the
+  `origin` and `framework_owned` the deployed-agent ledger records. The two are
+  independent records: a hand-edit that strips the field shows a null
+  declaration against a still-framework-owned ledger row, which the checksum
+  alone does not explain. The ledger stays authoritative. The key is always
+  present and goes null when absent, matching the other keys' contract.

--- a/crates/trusty-code/src/agents/describe.rs
+++ b/crates/trusty-code/src/agents/describe.rs
@@ -34,6 +34,9 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{Value, json};
 use trusty_agents_common::agents::manifest::{AgentManifest, MANIFEST_FILE, ManifestLoad, Origin};
+// #4698: the file's own `provenance:` claim, reported beside the ledger's origin.
+use trusty_agents_common::agents::metadata::agent_metadata_from_str;
+use trusty_agents_common::agents::provenance::Provenance;
 
 use crate::jsonrpc::RpcError;
 use crate::paths::TRUSTY_CODE_DIRNAME;
@@ -104,6 +107,10 @@ struct DiskProvenance {
     deployed_at: Option<String>,
     /// The resolved `extends:` chain the deploy composed, base-first.
     source_chain: Vec<String>,
+    /// The `provenance:` the FILE declares about itself (#4698), independent of
+    /// the ledger. `None` when the file declares none or could not be read — an
+    /// absent field means user-authored, per #4698's design note.
+    declared_provenance: Option<Provenance>,
     /// Everything an operator should know that is not simply "this is fine".
     warnings: Vec<String>,
 }
@@ -114,7 +121,7 @@ impl DiskProvenance {
     /// Why: a client reading `provenance.origin` must be able to tell "not
     /// recorded" from "key missing because the server is older" — so the keys
     /// are always present and it is the VALUES that go null.
-    /// What: a fixed six-key object. `warnings` is not included here; the
+    /// What: a fixed seven-key object. `warnings` is not included here; the
     /// caller merges them into the response's single top-level `warnings` list
     /// so a client has one place to look.
     fn to_json(&self) -> Value {
@@ -125,6 +132,10 @@ impl DiskProvenance {
             "checksum": self.checksum,
             "deployed_at": self.deployed_at,
             "source_chain": self.source_chain,
+            // #4698: the file's own claim, beside the ledger's. A client
+            // comparing the two sees a hand-edit the checksum alone would not
+            // explain; the ledger stays authoritative either way.
+            "declared_provenance": self.declared_provenance.map(Provenance::as_str),
         })
     }
 }
@@ -149,7 +160,7 @@ fn origin_token(origin: Origin) -> &'static str {
 /// Why: an embedded or plugin agent has no ledger entry and never will, which
 /// is not the same condition as a missing ledger. Naming it keeps a client from
 /// reading `"absent"` as "something is wrong".
-/// What: the same six keys [`DiskProvenance::to_json`] emits, with
+/// What: the same seven keys [`DiskProvenance::to_json`] emits, with
 /// `manifest: "not-applicable"`.
 /// Test: `embedded_agent_has_no_disk_path_and_no_warnings`.
 fn not_applicable_provenance() -> Value {
@@ -160,6 +171,7 @@ fn not_applicable_provenance() -> Value {
         "checksum": Value::Null,
         "deployed_at": Value::Null,
         "source_chain": [],
+        "declared_provenance": Value::Null,
     })
 }
 
@@ -208,6 +220,7 @@ fn provenance_for(dir: &Path, ledger: &LedgerState, name: &str) -> DiskProvenanc
         checksum: None,
         deployed_at: None,
         source_chain: Vec::new(),
+        declared_provenance: None,
         warnings: Vec::new(),
     };
 
@@ -252,9 +265,13 @@ fn provenance_for(dir: &Path, ledger: &LedgerState, name: &str) -> DiskProvenanc
 
     match std::fs::read_to_string(dir.join(&filename)) {
         Ok(current) if manifest.checksum_matches(&filename, &current) => {
+            // #4698: report what the file says about its own author beside what
+            // the ledger recorded, so a client sees both records.
+            provenance.declared_provenance = agent_metadata_from_str(&current).provenance;
             provenance.checksum = Some("match");
         }
-        Ok(_) => {
+        Ok(current) => {
+            provenance.declared_provenance = agent_metadata_from_str(&current).provenance;
             provenance.checksum = Some("mismatch");
             provenance.warnings.push(format!(
                 "the disk copy of '{name}' diverges from the bundled roster: its content no \

--- a/crates/trusty-code/src/agents/describe_tests.rs
+++ b/crates/trusty-code/src/agents/describe_tests.rs
@@ -351,3 +351,89 @@ fn native_roster_dir_is_recognised_only_by_both_path_components() {
         &root.join(TRUSTY_CODE_DIRNAME).join("skills")
     ));
 }
+
+// ---------------------------------------------------------------------------
+// #4698: the file's own `provenance:` claim, reported beside the ledger origin.
+// ---------------------------------------------------------------------------
+
+/// EVERY bundled agent lands on disk carrying `provenance: framework-owned`
+/// after a real roster deploy — the guarantee #4698 asks for, asserted against
+/// the actual bundled assets rather than a fixture.
+#[test]
+fn every_deployed_bundled_agent_carries_the_framework_owned_stamp() {
+    let (_project, target) = deployed_project();
+
+    let mut checked = 0usize;
+    for entry in std::fs::read_dir(&target).expect("read the deployed roster") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().is_none_or(|e| e != "md") {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path).expect("read a deployed agent");
+        assert!(
+            content.contains("provenance: framework-owned"),
+            "{} is missing the stamp:\n{content}",
+            path.display()
+        );
+        checked += 1;
+    }
+    assert!(checked > 0, "the roster deployed at least one agent");
+}
+
+/// The payload reports the declaration beside the ledger's origin, and the two
+/// agree on a pristine deployed file.
+#[test]
+fn deployed_agent_reports_its_declared_provenance() {
+    let (_project, target) = deployed_project();
+
+    let payload = describe_agent(&target, "project", "engineer", false).expect("describe");
+    assert_eq!(payload["provenance"]["origin"], "bundled");
+    assert_eq!(payload["provenance"]["framework_owned"], true);
+    assert_eq!(
+        payload["provenance"]["declared_provenance"], "framework-owned",
+        "the file's own claim agrees with the ledger: {payload:?}"
+    );
+}
+
+/// A hand-edit that strips the field is visible as a null declaration against a
+/// still-framework-owned ledger row — the disagreement the checksum alone does
+/// not explain. The ledger stays authoritative.
+#[test]
+fn hand_edited_agent_reports_a_null_declared_provenance() {
+    let (_project, target) = deployed_project();
+    std::fs::write(
+        target.join("engineer.md"),
+        "---\nname: engineer\nmodel: marker/hand-edited\n---\n\nMine now.\n",
+    )
+    .expect("hand-edit the deployed agent");
+
+    let payload = describe_agent(&target, "project", "engineer", false).expect("describe");
+    assert_eq!(payload["provenance"]["checksum"], "mismatch");
+    assert_eq!(payload["provenance"]["framework_owned"], true);
+    assert!(
+        payload["provenance"]["declared_provenance"].is_null(),
+        "the edit dropped the field: {payload:?}"
+    );
+}
+
+/// The key is always present, so a client can tell "not declared" from "this
+/// server predates the field" — the same contract the other provenance keys hold.
+#[test]
+fn declared_provenance_key_is_present_even_with_no_ledger() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("solo.md"),
+        "---\nname: solo\n---\n\nHand-written.\n",
+    )
+    .expect("write an agent");
+
+    let payload = describe_agent(dir.path(), "project", "solo", false).expect("describe");
+    assert!(
+        payload["provenance"]
+            .as_object()
+            .expect("provenance object")
+            .contains_key("declared_provenance"),
+        "the key is always emitted: {payload:?}"
+    );
+    assert!(payload["provenance"]["declared_provenance"].is_null());
+}

--- a/crates/trusty-mpm/changelog.d/4698-doctor-reports-provenance-disagreement.md
+++ b/crates/trusty-mpm/changelog.d/4698-doctor-reports-provenance-disagreement.md
@@ -1,0 +1,12 @@
+Added
+
+- `tm doctor`'s `asset_tier` probe reports an agent file whose `provenance:`
+  contradicts the deployed-agent manifest, naming the file and both records. It
+  scans the CANONICAL deploy directory for this, which the probe's shadowing
+  scan deliberately skips — that directory is where a hand-edited deployed agent
+  lives, so a check that could not look there would miss the case it exists for.
+  A disagreement alone is `Warn`, not `Ok`: the manifest still wins for
+  ownership so agent resolution is unaffected, but the file was changed by
+  something other than a deploy and an operator who is never told has no way to
+  find out. It never demotes a shadowing `Fail`, which stays the more actionable
+  finding (#4698).

--- a/crates/trusty-mpm/changelog.d/4698-stamp-provenance-on-framework-writes.md
+++ b/crates/trusty-mpm/changelog.d/4698-stamp-provenance-on-framework-writes.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `update_check::compute_agent_catalog_hashes` and `agent_reset::reset_agents`
+  now compose with `compose_agent_with_provenance(…, FrameworkOwned)`, the same
+  call the agent deployer makes. Both hash or write what the deployer writes;
+  composing unstamped would have differed from every deployed file by the
+  `provenance:` line alone and reported the whole roster permanently stale
+  (#4698).

--- a/crates/trusty-mpm/src/core/agent_reset.rs
+++ b/crates/trusty-mpm/src/core/agent_reset.rs
@@ -34,12 +34,14 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::core::agent_builder::{AgentBuildError, compose_agent, source_chain};
+use crate::core::agent_builder::{AgentBuildError, compose_agent_with_provenance, source_chain};
+// #4698: a reset writes framework-owned files, stamped like the deployer's.
 use crate::core::agent_deployer::is_agent_file;
 use crate::core::agent_manifest::{
     AgentManifest, ManifestEntry, ManifestError, ManifestLoad, Origin, atomic_write, checksum,
     with_agent_manifest_lock,
 };
+use trusty_agents_common::agents::provenance::Provenance;
 
 /// Summary of one [`reset_agents`] run.
 ///
@@ -213,7 +215,12 @@ fn reset_agents_locked(
 
     for name in targets {
         let filename = format!("{name}.md");
-        let composed = compose_agent(&name, source_dir)?;
+        // #4698: a reset is the framework rewriting its own file, so it stamps
+        // exactly what `agents::deployer` stamps. Composing unstamped here would
+        // write a file that differs from the deployer's output by the
+        // `provenance:` line and read as stale until the next deploy.
+        let composed =
+            compose_agent_with_provenance(&name, source_dir, Provenance::FrameworkOwned)?;
         let target_path = target_dir.join(&filename);
         let fresh_checksum = checksum(&composed);
 
@@ -376,7 +383,11 @@ mod tests {
         let src = TempDir::new().unwrap();
         let tgt = TempDir::new().unwrap();
         write_sources(src.path());
-        let composed = compose_agent("engineer", src.path()).unwrap();
+        // #4698: the deployer and `reset_agents` both stamp, so the file
+        // that must be adopted without a rewrite is the STAMPED spelling.
+        let composed =
+            compose_agent_with_provenance("engineer", src.path(), Provenance::FrameworkOwned)
+                .unwrap();
         fs::write(tgt.path().join("engineer.md"), &composed).unwrap();
         let before = fs::metadata(tgt.path().join("engineer.md"))
             .unwrap()

--- a/crates/trusty-mpm/src/core/update_check/mod.rs
+++ b/crates/trusty-mpm/src/core/update_check/mod.rs
@@ -20,9 +20,10 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::core::agent_builder::compose_agent;
+use crate::core::agent_builder::compose_agent_with_provenance;
 use crate::core::agent_manifest::{AgentManifest, checksum};
 use crate::core::skill_manifest::SkillManifest;
+use trusty_agents_common::agents::provenance::Provenance;
 
 mod apply;
 pub use apply::{ApplyError, ApplyReport, apply_catalog};
@@ -309,7 +310,13 @@ pub fn compute_agent_catalog_hashes(catalog_agents: &Path) -> HashMap<String, St
     md_stems(catalog_agents)
         .into_iter()
         .filter_map(|stem| {
-            let composed = compose_agent(&stem, catalog_agents).ok()?;
+            // #4698: hash what the DEPLOYER would write, stamp included. A bare
+            // `compose_agent` here would differ from every deployed file by the
+            // `provenance:` line alone and report the whole roster permanently
+            // stale.
+            let composed =
+                compose_agent_with_provenance(&stem, catalog_agents, Provenance::FrameworkOwned)
+                    .ok()?;
             let hash = checksum(&composed);
             Some((stem, hash))
         })

--- a/crates/trusty-mpm/src/core/update_check/tests.rs
+++ b/crates/trusty-mpm/src/core/update_check/tests.rs
@@ -39,7 +39,9 @@ fn write_skill(dir: &Path, stem: &str, body: &str) {
 /// Build a deployed agent manifest whose entry matches the COMPOSED catalog
 /// agent (i.e. as if it had just been deployed from this exact catalog).
 fn deployed_agent_matching(catalog_agents: &Path, stem: &str) -> AgentManifest {
-    let composed = compose_agent(stem, catalog_agents).unwrap();
+    // #4698: the ledger records what the DEPLOYER wrote, stamp included.
+    let composed =
+        compose_agent_with_provenance(stem, catalog_agents, Provenance::FrameworkOwned).unwrap();
     let mut m = AgentManifest::default();
     m.managed.insert(
         format!("{stem}.md"),
@@ -385,7 +387,9 @@ fn detect_unknown_when_only_one_tree_missing_is_not_unknown() {
 /// Write the COMPOSED catalog agent to a deployment dir, simulating a file tm
 /// deployed WITHOUT recording a manifest entry (the #1940 root-cause scenario).
 fn deploy_agent_on_disk(catalog_agents: &Path, deployed_dir: &Path, stem: &str) {
-    let composed = compose_agent(stem, catalog_agents).unwrap();
+    // #4698: simulate the deployer's bytes, stamp included.
+    let composed =
+        compose_agent_with_provenance(stem, catalog_agents, Provenance::FrameworkOwned).unwrap();
     fs::create_dir_all(deployed_dir).unwrap();
     fs::write(deployed_dir.join(format!("{stem}.md")), composed).unwrap();
 }

--- a/crates/trusty-mpm/src/daemon/doctor_asset_tier.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_asset_tier.rs
@@ -19,13 +19,22 @@
 //! neither side re-derives the predicate. READ-ONLY: this probe never deletes,
 //! moves, or rewrites anything.
 //!
+//! It also reports a second, independent fault (#4698): an agent file whose
+//! `provenance:` frontmatter contradicts what the deployed-agent manifest
+//! recorded for it. That check runs over the CANONICAL deploy directory as well
+//! as the two non-canonical tiers — the shadowing scan above skips the
+//! canonical one by construction, and it is precisely where a hand-edited
+//! DEPLOYED agent lives.
+//!
 //! Test: `crates/trusty-mpm/src/daemon/doctor_asset_tier_tests.rs`.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use trusty_agents_common::agents::tier_audit::TierAuditError;
-use trusty_agents_common::agents::tier_audit::{MisplacedAgent, audit_agent_tier};
+use trusty_agents_common::agents::tier_audit::{
+    MisplacedAgent, ProvenanceDisagreement, audit_agent_tier, audit_provenance,
+};
 
 // #4448: the roster moved to `core::bundled_roster` so the quarantine in
 // `session_launch` shares this exact one — report and repair must agree.
@@ -86,11 +95,14 @@ impl TierScan {
 /// is never empty and the probe can never fall back to a false "nothing is
 /// bundled" green), then scans `<project_dir>/.claude/agents/` and
 /// `<home>/.claude/agents/`, skipping the canonical
-/// [`FrameworkPaths::agent_deploy_dir`] itself and any duplicate path. Verdict
-/// per [`verdict`].
+/// [`FrameworkPaths::agent_deploy_dir`] itself and any duplicate path. It then
+/// runs [`audit_provenance`] over those tiers AND the canonical one (#4698) —
+/// which the shadowing scan skips, and which is where a hand-edited deployed
+/// agent lives. Verdict per [`verdict`].
 /// Test: `project_tier_stub_on_a_bundled_name_fails`,
 /// `clean_project_tier_is_ok`, `custom_project_agent_does_not_fire`,
-/// `user_owned_project_agent_on_a_bundled_name_does_not_fire`.
+/// `user_owned_project_agent_on_a_bundled_name_does_not_fire`,
+/// `check_asset_tier_reports_a_hand_edited_deployed_agent`.
 pub(super) fn check_asset_tier(
     paths: &FrameworkPaths,
     project_dir: Option<&Path>,
@@ -100,6 +112,8 @@ pub(super) fn check_asset_tier(
     let canonical = paths.agent_deploy_dir();
 
     let mut scans: Vec<TierScan> = Vec::new();
+    // #4698: `provenance:` claims that contradict the ledger, from every tier.
+    let mut disagreements: Vec<ProvenanceDisagreement> = Vec::new();
     let mut seen: BTreeSet<PathBuf> = BTreeSet::new();
     seen.insert(canonical.clone());
     for (label, dir) in [
@@ -119,6 +133,9 @@ pub(super) fn check_asset_tier(
             Ok(found) => TierOutcome::Scanned(found),
             Err(e @ TierAuditError::Unscannable { .. }) => TierOutcome::Unscannable(e.to_string()),
         };
+        // #4698: a hand-edited `provenance:` is a fact about a file wherever it
+        // sits, so the same directory is checked for one.
+        disagreements.extend(audit_provenance(&dir).unwrap_or_default());
         scans.push(TierScan {
             label,
             dir,
@@ -126,7 +143,14 @@ pub(super) fn check_asset_tier(
         });
     }
 
-    verdict(&scans, &canonical)
+    // #4698: and the CANONICAL tier above all — it is skipped by the shadowing
+    // scan above (every file there is tm-owned, correctly and uselessly), yet it
+    // is exactly where a hand-edited DEPLOYED agent lives. A disagreement check
+    // that could not look there would miss the case it exists for.
+    disagreements.extend(audit_provenance(&canonical).unwrap_or_default());
+    disagreements.sort_by(|a, b| a.path.cmp(&b.path));
+
+    verdict(&scans, &canonical, &disagreements)
 }
 
 /// The `.claude/agents` tier under `base`.
@@ -158,11 +182,24 @@ fn agent_tier_of(base: &Path) -> PathBuf {
 /// list, and an otherwise-clean run holding one is `Warn`, not `Ok` — the
 /// question is open, not answered. A real hit still outranks it, since a
 /// confirmed shadowing is the more actionable finding.
+///
+/// #4698: `disagreements` never changes the severity a placement hit produced —
+/// shadowing stays the more actionable finding — but it is always named in the
+/// message, and it alone raises an otherwise-clean run from `Ok` to `Warn`. The
+/// manifest still wins for ownership, so nothing resolves wrongly; what the
+/// operator needs to know is that something other than a deploy edited the file.
 /// Test: `verdict_project_hit_is_fail`, `verdict_home_only_is_warn`,
 /// `verdict_clean_is_ok`, `verdict_names_the_files_and_both_tiers`,
 /// `verdict_unscannable_tier_is_warn`,
-/// `verdict_unscannable_tier_is_not_reported_as_scanned`.
-fn verdict(scans: &[TierScan], canonical: &Path) -> DoctorCheck {
+/// `verdict_unscannable_tier_is_not_reported_as_scanned`,
+/// `verdict_disagreement_alone_is_warn_not_ok`,
+/// `verdict_reports_a_provenance_disagreement_alongside_shadowing`,
+/// `verdict_clean_run_says_nothing_about_provenance`.
+fn verdict(
+    scans: &[TierScan],
+    canonical: &Path,
+    disagreements: &[ProvenanceDisagreement],
+) -> DoctorCheck {
     let unscannable: Vec<String> = scans
         .iter()
         .filter_map(|s| match &s.outcome {
@@ -196,6 +233,26 @@ fn verdict(scans: &[TierScan], canonical: &Path) -> DoctorCheck {
                 ),
             );
         }
+        // #4698: nothing is misplaced, but a file's own `provenance:` still
+        // contradicts what the deployer recorded for it. The ledger wins for
+        // ownership, so nothing is broken — but the file was edited by
+        // something, and an operator who never hears that has no way to find
+        // out. Not `Ok`.
+        if !disagreements.is_empty() {
+            return DoctorCheck::new(
+                CHECK_NAME,
+                CheckStatus::Warn,
+                format!(
+                    "no tm-owned agent files outside the canonical tier {}, but {}. The \
+                     deployed-agent manifest wins for ownership, so agent resolution is \
+                     unaffected — but the file's frontmatter was changed by something other \
+                     than a deploy. Re-run `tm install` to restore it, or delete the file if \
+                     it is yours (issue #4698).",
+                    canonical.display(),
+                    disagreement_list(disagreements)
+                ),
+            );
+        }
         return DoctorCheck::new(
             CHECK_NAME,
             CheckStatus::Ok,
@@ -224,6 +281,11 @@ fn verdict(scans: &[TierScan], canonical: &Path) -> DoctorCheck {
         })
         .collect();
     detail.extend(unscannable.iter().map(|u| format!("{u} (UNDETERMINED)")));
+    // #4698: a disagreement never changes the severity below — shadowing is the
+    // more actionable finding — but it is still reported rather than dropped.
+    if !disagreements.is_empty() {
+        detail.push(disagreement_list(disagreements));
+    }
 
     if shadowing {
         return DoctorCheck::new(
@@ -253,6 +315,38 @@ fn verdict(scans: &[TierScan], canonical: &Path) -> DoctorCheck {
             detail.join("; "),
             canonical.display()
         ),
+    )
+}
+
+/// Render the `provenance:` disagreements, naming both records per file.
+///
+/// Why (#4698): the finding is only useful if it says WHICH file and WHAT the
+/// two records disagree about — "a provenance mismatch was found" sends an
+/// operator hunting. Each entry's `detail` already names the file, the
+/// declaration, and the ledger's value, so this joins them rather than
+/// re-deriving the wording and letting the two spellings drift.
+/// What: up to [`MAX_NAMED`] entries, then a `(+N more)` tail, matching
+/// [`name_list`]'s bound so one pathological directory cannot flood the report.
+/// Test: `verdict_reports_a_provenance_disagreement_alongside_shadowing`,
+/// `verdict_disagreement_alone_is_warn_not_ok`.
+fn disagreement_list(disagreements: &[ProvenanceDisagreement]) -> String {
+    let named: Vec<&str> = disagreements
+        .iter()
+        .take(MAX_NAMED)
+        .map(|d| d.detail.as_str())
+        .collect();
+    let rest = disagreements.len().saturating_sub(named.len());
+    let body = named.join("; ");
+    let plural = if disagreements.len() == 1 { "" } else { "s" };
+    if rest == 0 {
+        return format!(
+            "{} agent file{plural} declare a `provenance:` that contradicts the deployed-agent manifest: {body}",
+            disagreements.len()
+        );
+    }
+    format!(
+        "{} agent file{plural} declare a `provenance:` that contradicts the deployed-agent manifest: {body} (+{rest} more)",
+        disagreements.len()
     )
 }
 

--- a/crates/trusty-mpm/src/daemon/doctor_asset_tier_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_asset_tier_tests.rs
@@ -12,6 +12,7 @@
 
 use super::*;
 use trusty_agents_common::agents::manifest::{AgentManifest, ManifestEntry, Origin, checksum};
+use trusty_agents_common::agents::provenance::Provenance;
 use trusty_agents_common::agents::tier_audit::TierResidentClass;
 
 /// A hermetic `FrameworkPaths` whose agent SOURCE dir is inside `base`.
@@ -275,7 +276,7 @@ fn roster_includes_on_disk_source_names() {
 fn verdict_project_hit_is_fail() {
     let dir = PathBuf::from("/w/.claude/agents");
     let canonical = PathBuf::from("/c/agents");
-    let check = verdict(&[scan("project", &dir, &["qa"])], &canonical);
+    let check = verdict(&[scan("project", &dir, &["qa"])], &canonical, &[]);
     assert_eq!(check.status, CheckStatus::Fail);
 }
 
@@ -283,7 +284,7 @@ fn verdict_project_hit_is_fail() {
 fn verdict_home_only_is_warn() {
     let dir = PathBuf::from("/h/.claude/agents");
     let canonical = PathBuf::from("/c/agents");
-    let check = verdict(&[scan("operator home", &dir, &["qa"])], &canonical);
+    let check = verdict(&[scan("operator home", &dir, &["qa"])], &canonical, &[]);
     assert_eq!(check.status, CheckStatus::Warn);
 }
 
@@ -291,7 +292,7 @@ fn verdict_home_only_is_warn() {
 fn verdict_clean_is_ok() {
     let dir = PathBuf::from("/w/.claude/agents");
     let canonical = PathBuf::from("/c/agents");
-    let check = verdict(&[scan("project", &dir, &[])], &canonical);
+    let check = verdict(&[scan("project", &dir, &[])], &canonical, &[]);
     assert_eq!(check.status, CheckStatus::Ok);
     assert!(check.message.contains("/c/agents"), "{}", check.message);
 }
@@ -302,7 +303,7 @@ fn verdict_unscannable_tier_is_warn() {
     // nothing. Pre-fix the same input produced `Ok` with "(scanned: <dir>)".
     let dir = PathBuf::from("/w/.claude/agents");
     let canonical = PathBuf::from("/c/agents");
-    let check = verdict(&[unscannable("project", &dir)], &canonical);
+    let check = verdict(&[unscannable("project", &dir)], &canonical, &[]);
     assert_eq!(check.status, CheckStatus::Warn, "{}", check.message);
     assert!(check.message.contains("UNDETERMINED"), "{}", check.message);
 }
@@ -320,6 +321,7 @@ fn verdict_unscannable_tier_is_not_reported_as_scanned() {
             unscannable("project", &failed_dir),
         ],
         &canonical,
+        &[],
     );
     let scanned_clause = check
         .message
@@ -351,6 +353,7 @@ fn verdict_names_the_files_and_both_tiers() {
             scan("operator home", &home, &["engineer"]),
         ],
         &canonical,
+        &[],
     );
     assert_eq!(check.status, CheckStatus::Fail);
     for needle in [
@@ -375,6 +378,152 @@ fn verdict_summarises_a_long_list() {
     let dir = PathBuf::from("/w/.claude/agents");
     let canonical = PathBuf::from("/c/agents");
     let names = ["a", "b", "c", "d", "e", "f"];
-    let check = verdict(&[scan("project", &dir, &names)], &canonical);
+    let check = verdict(&[scan("project", &dir, &names)], &canonical, &[]);
     assert!(check.message.contains("(+1 more)"), "{}", check.message);
+}
+
+// ---------------------------------------------------------------------------
+// #4698: a `provenance:` that contradicts the ledger reaches the operator.
+// ---------------------------------------------------------------------------
+
+/// One disagreement, as `audit_provenance` would return it.
+fn disagreement(
+    path: &str,
+    declared: Provenance,
+    ledger_framework_owned: bool,
+) -> ProvenanceDisagreement {
+    ProvenanceDisagreement {
+        path: PathBuf::from(path),
+        declared,
+        ledger_framework_owned,
+        detail: format!(
+            "'{}' declares `provenance: {}` but the deployed-agent manifest records it as {}; \
+             the manifest wins (#4698)",
+            path,
+            declared.as_str(),
+            if ledger_framework_owned {
+                "framework-owned"
+            } else {
+                "not framework-owned"
+            }
+        ),
+    }
+}
+
+/// THE regression this exists for: nothing is misplaced, but a deployed file's
+/// frontmatter contradicts its ledger row. Dropping the disagreement returns
+/// this to `Ok` with no mention of the file, which is what shipped before the
+/// critic caught it.
+#[test]
+fn verdict_disagreement_alone_is_warn_not_ok() {
+    let dir = PathBuf::from("/w/.claude/agents");
+    let canonical = PathBuf::from("/c/agents");
+    let check = verdict(
+        &[scan("project", &dir, &[])],
+        &canonical,
+        &[disagreement(
+            "/c/agents/rust-engineer.md",
+            Provenance::UserAuthored,
+            true,
+        )],
+    );
+    assert_eq!(
+        check.status,
+        CheckStatus::Warn,
+        "a clean placement scan with a contradicting declaration is not Ok: {}",
+        check.message
+    );
+    for needle in [
+        "/c/agents/rust-engineer.md",
+        "user-authored",
+        "framework-owned",
+        "#4698",
+    ] {
+        assert!(
+            check.message.contains(needle),
+            "message must carry `{needle}`: {}",
+            check.message
+        );
+    }
+}
+
+/// A disagreement never demotes a shadowing `Fail` — shadowing is the more
+/// actionable finding — but it is still named in the same message.
+#[test]
+fn verdict_reports_a_provenance_disagreement_alongside_shadowing() {
+    let dir = PathBuf::from("/w/.claude/agents");
+    let canonical = PathBuf::from("/c/agents");
+    let check = verdict(
+        &[scan("project", &dir, &["qa"])],
+        &canonical,
+        &[disagreement(
+            "/c/agents/qa.md",
+            Provenance::FrameworkOwned,
+            false,
+        )],
+    );
+    assert_eq!(check.status, CheckStatus::Fail, "{}", check.message);
+    assert!(
+        check.message.contains("/c/agents/qa.md"),
+        "the disagreement is not dropped when shadowing also fires: {}",
+        check.message
+    );
+}
+
+/// No disagreements means the message says nothing about provenance — this
+/// finding must not add noise to an otherwise clean run.
+#[test]
+fn verdict_clean_run_says_nothing_about_provenance() {
+    let dir = PathBuf::from("/w/.claude/agents");
+    let canonical = PathBuf::from("/c/agents");
+    let check = verdict(&[scan("project", &dir, &[])], &canonical, &[]);
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(
+        !check.message.contains("provenance"),
+        "no finding, no mention: {}",
+        check.message
+    );
+}
+
+/// End to end through the real probe: a hand-edited file in the CANONICAL tier
+/// — the directory the shadowing scan deliberately skips — still produces a
+/// finding. This is the case a `MisplacedAgent` field could never reach.
+#[test]
+fn check_asset_tier_reports_a_hand_edited_deployed_agent() {
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let paths = FrameworkPaths::for_managed_project(home.path(), project.path());
+    let canonical = paths.agent_deploy_dir();
+    std::fs::create_dir_all(&canonical).unwrap();
+
+    // A deployed agent whose ledger row says the framework wrote it, but whose
+    // frontmatter now claims otherwise.
+    let body = "---\nname: qa\nrole: qa\nprovenance: user-authored\n---\n\nMine now.\n";
+    std::fs::write(canonical.join("qa.md"), body).unwrap();
+    // `track` appends `.claude/agents` to a base; the canonical deploy dir is
+    // already a full path, so the ledger is written directly into it.
+    let mut manifest = AgentManifest::default();
+    manifest.managed.insert(
+        "qa.md".to_owned(),
+        ManifestEntry {
+            source_chain: vec![],
+            checksum: checksum(body),
+            deployed_at: "2026-07-31T00:00:00Z".to_owned(),
+            origin: Origin::Bundled,
+        },
+    );
+    manifest.save(&canonical).unwrap();
+
+    let check = check_asset_tier(&paths, Some(project.path()), home.path());
+    assert_eq!(
+        check.status,
+        CheckStatus::Warn,
+        "the canonical tier is scanned for disagreements: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("qa.md") && check.message.contains("user-authored"),
+        "names the file and the declaration: {}",
+        check.message
+    );
 }


### PR DESCRIPTION
Refs #4698

An agent file on disk carried no marker saying which of three writers produced
it — the framework's own deploy, `tm-agent-manager` composing one on request, or
a human hand-writing one through Claude Code's `/agents`. The
never-clobber-what-we-did-not-write rule needs that distinction, and
`Origin::is_framework_owned` cannot supply it: it answers only from the ownership
ledger, so every file with no ledger entry reads identically.

Owner ruling on the issue, 2026-08-03, verbatim: "We use frontmatter to track
this." The field is additive — it records authorship and takes no part in tier
resolution, per the 2026-08-01 ruling that collapsed the agent tiers to a single
deploy target fed by prioritised sources.

## What lands

**The three values are the issue title's exact spellings** — `framework-owned`,
`tm-agent-manager-built`, `user-authored`. `agents::provenance` owns them, the
parse, and the absence rule. An unrecognised value is rejected with the typed
`UnknownProvenance`, surfaced as a new `AgentBuildError::InvalidProvenance`
variant rather than a stringly `FrontmatterParse` — degrading a typo'd
`framework_owned` to the absent default would read it as user-authored and freeze
a framework file permanently, which is #4408's unrecoverable shape.

**Absence quotes the issue's design note verbatim**: "ABSENCE of the field is
itself the signal for 'not ours, never touch.'" So `declared_or_default(None)` is
`UserAuthored`, never a framework-owned default.

**Provenance is a property of the WRITE, not the source.** The same source tree
composed by the framework and by `tm-agent-manager` yields two files with
different authors, so the writer supplies the value — exactly as it already
supplies `ManifestEntry::origin`. `compose_agent_with_provenance` stamps at
compose time, and the deployer calls it with `framework-owned`. Stamping rather
than declaring the field per bundled asset also means a new asset has no
declaration to forget.

## Precedence decision

**The ledger wins, in both directions.** The issue does not rule on this. The
ledger is the record the deployer wrote under a lock and checksummed; the
frontmatter is the copy anyone with an editor can change. Preferring the file
would let a hand-edit flip a bundled agent to user-owned and freeze it.

**The check runs only where a ledger entry exists.** An untracked file stays
`Untracked` no matter what it declares. Letting `provenance: user-authored` stand
in for a ledger entry would manufacture the user-owned quarantine exemption out
of a field anybody can type — the proof `tier_audit`'s invariant 2 says only a
ledger entry supplies.

**The disagreement is surfaced, not swallowed.**
`tier_audit::audit_provenance` returns one `ProvenanceDisagreement` per
contradicting file, and `tm doctor`'s `asset_tier` probe reports it, naming the
file and both records. That scan runs over the CANONICAL deploy directory as well
as the two non-canonical tiers — the probe's shadowing scan skips the canonical
one by construction, and it is exactly where a hand-edited *deployed* agent
lives. A disagreement alone raises `Ok` to `Warn`; it never demotes a shadowing
`Fail`, which stays the more actionable finding.

## Two regressions found and fixed here

**Adoption would have frozen every pre-#4698 file.**
`deploy_adopts_untracked_byte_identical_file` went red immediately: adoption
tested byte equality with the fresh composition, and the stamp broke that for
every file deployed before it existed — refused adoption *and* refused refresh.
`without_provenance_line` lets adoption accept the pre-stamp spelling, and the
ledger now records the checksum of the bytes on disk rather than of the
composition, so an adopted file matches its own row and the next deploy upgrades
it into the stamped form.

**trusty-mpm reported the whole roster permanently stale.**
`update_check::compute_agent_catalog_hashes` and `agent_reset::reset_agents`
composed unstamped while comparing against stamped deployed files. Both now use
`compose_agent_with_provenance(…, FrameworkOwned)`.

### Fails-on-main evidence

Observed with `update_check/mod.rs` and `agent_reset.rs` still at their
`origin/main` state and the rest of the change in place:

```
test result: FAILED. 6078 passed; 5 failed; 8 ignored
core::session_assets::tests::session_asset_staleness_ok_when_fresh
  panicked at crates/trusty-mpm/src/core/session_assets.rs:366:9:
  freshly deployed session must not be stale
core::update_check::apply::tests::apply_redeploys_and_clears_staleness
  apply must clear staleness: StalenessReport { stale: true, unknown: false,
    changes: [CatalogChange { artifact: "agent", name: "rust-engineer", kind: Changed }] }
```

And for the doctor finding, stubbing out both `disagreements.extend(...)` calls:

```
test daemon::doctor::doctor_asset_tier::tests::check_asset_tier_reports_a_hand_edited_deployed_agent ... FAILED
panicked at crates/trusty-mpm/src/daemon/doctor_asset_tier_tests.rs:510:5:
  left: Ok
 right: Warn
test result: FAILED. 20 passed; 1 failed
```

The `trusty-agents-common` half is a **compile failure**, stated as such:
reverting only `deployer.rs` removes the `Provenance` import its signature change
introduced, so the new tests cannot build (`error[E0433]: failed to resolve: use
of undeclared type 'Provenance'` at `deployer_tests.rs:801:35`).

## SLOC split

Adding `provenance:` pushed `builder.rs` to 520 SLOC. Its YAML scalar encoding
(`escape_yaml_double_quoted`, `unescape_yaml_double_quoted`, `needs_quoting`,
`render_scalar`) moved to `agents/builder_yaml.rs` in this PR, per the
no-standalone-cap-fix rule.

## Review

`code-critic` returned **WARN** on `69c849c12` with one HIGH: `ownership_of_declared`
computed the disagreement and discarded it, so the doc comment and changelog
claim that it was "warned with the file named" was false. The suggested route — a
field on `MisplacedAgent` — could not satisfy the requirement, because
`check_asset_tier` excludes the canonical tier where deployed files live. Fixed
in `e1d7c426b` with a separate `audit_provenance` scan and type;
`ownership_of_declared` is deleted rather than left discarding a value. Delta
verdict: **APPROVE**.

## Gates — rung 4

`trusty-agents-common` is a shared library. Direct dependents, found with
`rg -l 'trusty-agents-common' crates/*/Cargo.toml`: **trusty-agents,
trusty-code, trusty-kb, trusty-mpm** — all four tested.

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-agents-common -p trusty-mpm --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-agents-common --no-fail-fast` | `ok. 556 passed; 0 failed; 0 ignored` |
| `cargo test -p trusty-mpm --no-fail-fast` | EXIT=0, 54/54 targets ok — `ok. 6097 passed; 0 failed; 8 ignored` (lib), `ok. 2221 passed; 0 failed; 1 ignored` (bin trusty-mpm), `ok. 2221 passed; 0 failed; 1 ignored` (bin tm) |
| `cargo test -p trusty-code --no-fail-fast` | 20/20 targets ok — `ok. 1792 passed; 0 failed; 4 ignored` (lib) |
| `cargo test -p trusty-agents --no-fail-fast` | 14/14 targets ok — `ok. 3646 passed; 0 failed; 13 ignored` (lib) |
| `cargo test -p trusty-kb --no-fail-fast` | 5/5 targets ok — `ok. 108 passed; 0 failed` (lib) |
| `cargo check --workspace` | EXIT=0 |
| `check_line_cap.sh` | `4584 files; 4 allowlisted, 0 violations — OK` |
| `check_test_pointers.sh` | `31920 citations — 0 dangling — OK` |
| `check_sld.sh` | `0 errors, 0 warnings` |
| `check_changelog_fragment.sh` | all 3 crates recorded |
| `check-pr-version-bump.sh` | `clear (0 warnings)` — no bump needed |
| `check_rustdoc_links.sh` | `26 crates, 0 broken links` |

`trusty-code`, `trusty-agents` and `trusty-kb` counts are from the pre-rebase
head; their crates are untouched by the rebase.

**Flake observed, not filed.** One `-p trusty-mpm` run hit
`tests_behavior_b::compose_session_instructions_display_matches_live_prompt`
(`2210 passed; 1 failed`). Not this branch:
`git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/bin/ crates/trusty-mpm/src/assets/`
is empty, and the target passes on re-run (`ok. 2211 passed; 0 failed`). Two
subsequent full runs were green at 54/54.

Every bundled agent carrying the field is asserted against the real roster, not a
fixture: `every_deployed_bundled_agent_carries_the_framework_owned_stamp` deploys
the actual bundled roster and checks each `.md`. No golden or snapshot test
needed refreshing — nothing snapshots composed agent output, and `compose_agent`
on a source that declares nothing is byte-identical to before
(`absent_provenance_emits_no_line`).
