### PR TITLE
ci(public-docs): run the retired-term check by default, in a real CI job (#5134)

### DIFF
--- a/.github/workflows/public-docs.yml
+++ b/.github/workflows/public-docs.yml
@@ -1,0 +1,77 @@
+# Public documentation gate for the trusty-tools workspace (issue #5096; the
+# retired-term pass #5125, wired on #5134).
+#
+# The website publishes only the pages docs/public-manifest.tsv lists, so that
+# file is an audience boundary. This job holds two properties on it:
+#   - every PAGE row still resolves to an existing .md file inside docs/, out of
+#     the DO-NOT-PUBLISH trees, on a unique route;
+#   - no published page names a binary, crate or clone URL that no longer
+#     exists (docs/public-stale-terms.tsv, count-ratcheted waivers).
+#
+# Until #5134 the gate ran only in a pre-commit hook, which is unenforceable:
+# `--no-verify`, a commit made outside the repo's hook path, or a merge that
+# never runs a hook at all all reach main with nothing checked. The audit on
+# #5134 found no workflow ran it and no workflow ran `pre-commit` either, while
+# two files asserted CI enforcement that did not exist.
+#
+# Pure text scanning — no Rust toolchain and no build, so this is its own
+# lightweight job (matches line-cap.yml / doc-numbers.yml).
+name: Public docs
+
+# Optional and pure shell: run only when something the verdict can observe
+# changes — a published page's content, the manifest, the term list, the gate or
+# its fixtures, or this workflow. A published page can be edited anywhere under
+# docs/, so that path is deliberately broad.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "scripts/check_public_docs.sh"
+      - "scripts/check_public_docs_selftest.sh"
+      - "scripts/test-data/public-docs/**"
+      - ".github/workflows/public-docs.yml"
+  pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "scripts/check_public_docs.sh"
+      - "scripts/check_public_docs_selftest.sh"
+      - "scripts/test-data/public-docs/**"
+      - ".github/workflows/public-docs.yml"
+
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
+concurrency:
+  group: public-docs-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
+
+jobs:
+  public-docs:
+    name: Public documentation allowlist + retired-term gate
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      # Fixtures first: the suite proves the gate still REJECTS — a boundary
+      # check only ever observed passing is indistinguishable from one that
+      # returns 0 unconditionally. It also covers the parts the real run cannot
+      # reach on a healthy tree (FORBIDDEN, MISSING, a page carrying a retired
+      # term). Mirrors line-cap.yml's selftest-then-gate ordering.
+      - name: Public-docs gate selftest (fixtures)
+        run: bash scripts/check_public_docs_selftest.sh
+
+      # No arguments, exactly as the pre-commit hook invokes it. The retired-term
+      # pass is part of this run (#5134); a flag here would be a second place for
+      # the two call sites to drift apart.
+      - name: Enforce the public documentation boundary and retired terms
+        run: bash scripts/check_public_docs.sh

--- a/.github/workflows/red-main-notify.yml
+++ b/.github/workflows/red-main-notify.yml
@@ -53,7 +53,7 @@
 #     completion recurses (GitHub caps the chain at three levels).
 #   - Every watched completion creates a run of this workflow, green or not. The
 #     job is skipped on a green one and consumes no runner, but the Actions list
-#     shows the entry. That noise buys a signal for all 18 siblings at once.
+#     shows the entry. That noise buys a signal for all 19 siblings at once.
 name: Red main notifier
 
 on:
@@ -69,6 +69,7 @@ on:
       - "Generation artifact lint" # generation-artifact-lint.yml
       - "Homebrew formula" # homebrew-formula.yml
       - "Line cap" # line-cap.yml
+      - "Public docs" # public-docs.yml
       - "SLD lint" # sld-lint.yml
       - "Tag/publish parity" # tag-publish-parity.yml
       - "Teardown guard" # teardown-guard.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,10 +142,16 @@ repos:
   # published, so the gate only ever validates what IS listed. Runs against the
   # whole manifest (pass_filenames: false), matching the line-cap hook's
   # holistic scan.
+  #
+  # The same run also checks each published page's CONTENT against the retired
+  # names in docs/public-stale-terms.tsv (#5125, wired on in #5134). That pass
+  # takes NO flag, deliberately: an entry that had to carry `--stale` is an
+  # entry a later edit can drop without the diff looking like a removed gate.
+  # .github/workflows/public-docs.yml runs the identical bare invocation.
   - repo: local
     hooks:
       - id: public-docs
-        name: "Public documentation allowlist gate"
+        name: "Public documentation allowlist + retired-term gate"
         entry: scripts/check_public_docs.sh
         language: system
         pass_filenames: false

--- a/docs/public-manifest.tsv
+++ b/docs/public-manifest.tsv
@@ -36,9 +36,11 @@
 #   SvelteKit build (no YAML/TOML parser).
 #
 # Gate: scripts/check_public_docs.sh — fails when a source is missing, escapes
-#   docs/, lands in a DO-NOT-PUBLISH tree, or when a route is duplicated. With
-#   `--stale` it additionally checks each published page's CONTENT against
-#   docs/public-stale-terms.tsv (see "KEEPING A PUBLISHED PAGE CURRENT" below).
+#   docs/, lands in a DO-NOT-PUBLISH tree, or when a route is duplicated. It
+#   then checks each published page's CONTENT against docs/public-stale-terms.tsv
+#   (see "KEEPING A PUBLISHED PAGE CURRENT" below); that pass needs no flag
+#   (#5134). It runs in the `public-docs` pre-commit hook and in
+#   .github/workflows/public-docs.yml, both with no arguments.
 #   Self-test: scripts/check_public_docs_selftest.sh
 #
 # DO-NOT-PUBLISH trees (owner decision, enforced independently of this file by
@@ -85,11 +87,11 @@
 #   (naming a historical artifact by its recorded name, say), with a reason;
 #   waivers are a count ratchet, so raising one to cover new text fails.
 #
-#   Run it with `bash scripts/check_public_docs.sh --stale`. It is OPT-IN and
-#   wired to nothing while the current repairs are in flight (#5125); the hook
-#   and CI still run the plain gate.
+#   Run it with `bash scripts/check_public_docs.sh` — no flag. The pass is on by
+#   default since #5134, in the pre-commit hook and in CI, so a retired name in
+#   a published page fails the commit and the PR.
 #
-# Issue: #5096 (epic #5092). STALE content check: #5125.
+# Issue: #5096 (epic #5092). STALE content check: #5125, wired on in #5134.
 
 SECTION	getting-started	Getting Started
 PAGE	getting-started	docs/intro.md	/	Introduction

--- a/docs/public-stale-terms.tsv
+++ b/docs/public-stale-terms.tsv
@@ -8,7 +8,9 @@
 #   `cargo install trusty-mpmd` off the public site gets an error, not a daemon.
 #
 # What: two record types, tab-separated, consumed by
-#   `scripts/check_public_docs.sh --stale`:
+#   `scripts/check_public_docs.sh` on every run — the pass needs no flag since
+#   #5134, and both call sites (the `public-docs` pre-commit hook and
+#   .github/workflows/public-docs.yml) invoke the gate with no arguments:
 #
 #     TERM   <ere>                              <remedy>
 #     WAIVE  <source>  <ere>  <count>  <reason>

--- a/docs/reference/ci-scripts.md
+++ b/docs/reference/ci-scripts.md
@@ -8,6 +8,11 @@ for a specific failure and none of them announced itself anywhere a reader
 would look, so a change to one of the workflows below could drop it with
 nothing to notice.
 
+`check_public_docs.sh` is listed as a tenth row for the opposite reason: it ran
+in a pre-commit hook ALONE until #5134, which is unenforceable (`--no-verify`, a
+commit made outside the repo's hook path, a merge that runs no hook), and two
+files asserted a CI job that did not exist.
+
 Scripts that CLAUDE.md or another reference already covers are not repeated
 here: `check_line_cap.sh` ([sloc-cap.md](sloc-cap.md)), `check_semver.sh`
 ([semver-gate.md](semver-gate.md)), `check_changelog_fragment.sh`
@@ -28,11 +33,12 @@ what it stops; the header says why it exists.
 | `ci-create-local-main.sh` | `ci.yml`, `pre-publish.yml` | Creates the local `main` branch the `trusty-agents` git tests need, and fails the step when creation genuinely fails. The `git fetch origin main:main \|\| true` it replaced swallowed a GitHub 500 and produced an unrelated test failure eleven minutes later (#5693). |
 | `detect-embedder-cuda-relevant.sh` | `ci.yml` | Decides whether a change can affect the `trusty-common` `embedder-cuda` build, so the CUDA leg runs when it is relevant and is skipped when it is not. |
 | `check_workspace_dep_versions.sh` | `version-parity.yml` (`pr-version-bump`) | Asserts every internal `[workspace.dependencies]` row's `version` requirement actually accepts the member crate's own version, under Cargo's caret rules. The row's `path` wins in-tree, so no cargo command in the workspace can see the drift — `trusty-console` sat at `^0.9.0` against a 0.11.0 crate and `tga` at `^6.0.1` against 7.1.0, both invisible until `cargo publish` or an external consumer resolved from the registry (#6776, same class as #4088). |
+| `check_public_docs.sh` | `public-docs.yml`, plus the `public-docs` pre-commit hook | Validates `docs/public-manifest.tsv`, the allowlist the website publishes from: every PAGE row must resolve to an existing `.md` under `docs/`, outside the DO-NOT-PUBLISH trees, on a unique route. The STALE content pass runs in the same invocation and needs NO flag (#5134) — every published page is searched for the retired names in `docs/public-stale-terms.tsv`, whose waivers are a count ratchet in both directions. Both call sites invoke the script bare, so neither can drop the content check without deleting the gate outright. A page the gate cannot read fails as `UNREADABLE` rather than passing as clean. |
 | `check_token_drift.mjs` | `token-drift.yml` | Compares each Tailwind app's hand-transcribed `--color-*` RGB triples against the canonical Foundry `tokens.css`. `ci.yml` deliberately does NOT duplicate it (`ci.yml`, `ui-checks` job): `token-drift.yml` already runs it across all seven crates directly rather than through each `package.json`. |
 
 ## Self-tests
 
-Seven of the nine have a companion test that proves the gate can still fail — a
+Eight of the ten have a companion test that proves the gate can still fail — a
 gate that cannot fail makes its own green meaningless:
 
 | Script | Its test |
@@ -44,6 +50,7 @@ gate that cannot fail makes its own green meaningless:
 | `detect-embedder-cuda-relevant.sh` | `scripts/check-ci-helpers-selftest.sh` |
 | `check_token_drift.mjs` | `scripts/check_token_drift.test.mjs`, a `node:test` suite `token-drift.yml` runs before the gate |
 | `check_workspace_dep_versions.sh` | `scripts/check_workspace_dep_versions_selftest.sh`, run as the step before the gate in the same job |
+| `check_public_docs.sh` | `scripts/check_public_docs_selftest.sh`, run as the step before the gate in the same job. Two of its cases pass no `--stale` flag at all, so a change that made the content pass opt-in again fails there rather than going quiet |
 
 `check_deny_duplicates.sh` and `ci-create-local-main.sh` have no test of their
 own. Both carry a frozen baseline or a fetch that can fail open, which is the

--- a/docs/reference/documentation-layout.md
+++ b/docs/reference/documentation-layout.md
@@ -73,8 +73,9 @@ as historical and link to the current replacement.
 The public website publishes only the allowlisted pages in
 [`docs/public-manifest.tsv`](../public-manifest.tsv). The manifest is a security
 and audience boundary, not an inventory of the internal documentation tree.
-`scripts/check_public_docs.sh --stale` validates its paths and retired-term
-ratchet.
+`scripts/check_public_docs.sh` validates its paths and, in the same run, each
+published page's content against the retired-term ratchet in
+`docs/public-stale-terms.tsv` (#5134 — no flag).
 
 ## Keeping documentation mapped to code
 

--- a/scripts/check_public_docs.sh
+++ b/scripts/check_public_docs.sh
@@ -28,9 +28,9 @@
 #     BAD-RECORD    a row whose first field is neither SECTION nor PAGE, or
 #                   whose field count is wrong
 #
-#   With `--stale` it additionally reads docs/public-stale-terms.tsv and fails
-#   on:
+#   It then reads docs/public-stale-terms.tsv and fails on:
 #     STALE         a published page contains a retired name or anti-pattern
+#     UNREADABLE    a published page could not be searched at all
 #     BAD-WAIVER    a waiver row is malformed, unexplained, dead, or off-count
 #     BAD-TERM      a TERM row is malformed, or its ERE cannot be built
 #
@@ -40,11 +40,17 @@
 #   human reading closely. A reader who copies `cargo install trusty-mpmd` off
 #   the public site gets an error, not a daemon.
 #
-#   It is OPT-IN and wired to nothing (issue #5125). The pre-commit hook and CI
-#   run this script with no arguments, which skips the pass entirely, because 10
-#   of the 27 published pages hit today and their repairs are in flight on other
-#   branches. Turning it on is a one-line change once those land; the self-test
-#   proves the logic against fixtures in the meantime.
+#   The pass is ON BY DEFAULT (issue #5134). It landed opt-in behind `--stale`
+#   (issue #5125) because 10 of the 27 published pages hit at the time and their
+#   repairs were in flight; those landed, and a flag every call site must
+#   remember is a gate that runs by accident. Both call sites — the `public-docs`
+#   pre-commit hook and .github/workflows/public-docs.yml — invoke this script
+#   with NO arguments, so neither can drift back into the weakened mode.
+#
+#   `--no-stale` is the one way off, and it is refused unless `--manifest` is
+#   also given. The committed manifest therefore cannot be checked without the
+#   STALE pass at all; only a fixture run (the self-test's manifest-shape cases,
+#   whose expectations are about SECTION/PAGE parsing) may disable it.
 #
 #   Scope is the published set — the sources of PAGE rows that passed every
 #   other check. Excluded trees may hold historical names, and often must.
@@ -64,16 +70,18 @@
 #   rendered because the site enumerates the manifest, never the tree.
 #
 # Usage:
-#   bash scripts/check_public_docs.sh                       # default manifest
+#   bash scripts/check_public_docs.sh                       # manifest + STALE
 #   bash scripts/check_public_docs.sh --manifest <path>     # explicit (self-test)
 #   bash scripts/check_public_docs.sh --root <path>         # resolve sources here
-#   bash scripts/check_public_docs.sh --stale               # add the STALE pass
-#   bash scripts/check_public_docs.sh --stale-terms <path>  # implies --stale
+#   bash scripts/check_public_docs.sh --stale               # explicit; the default
+#   bash scripts/check_public_docs.sh --stale-terms <path>  # override the terms file
+#   bash scripts/check_public_docs.sh --no-stale            # fixture runs ONLY
 #   bash scripts/check_public_docs.sh --help
 #
 # Exit: 0 when every listed page resolves inside the public boundary; 1 on any
 #   finding, with one `FAIL <CODE> line N: …` line per finding on stderr; 2 on a
-#   usage error or an unreadable manifest.
+#   usage error or an unreadable manifest — including `--no-stale` without
+#   `--manifest`, and `--no-stale` alongside `--stale`/`--stale-terms`.
 #
 #   A STALE finding's `line N` is the MANIFEST line that published the page; the
 #   page's own line number is in the message. A BAD-WAIVER or BAD-TERM finding's
@@ -84,7 +92,10 @@
 #   including the two the issue names explicitly (a row pointing into
 #   docs/specs/, and a row pointing at a file that does not exist). The STALE
 #   cases run against scripts/test-data/public-docs/fakeroot/ via --root, so
-#   they never depend on what the real docs/ tree happens to say today.
+#   they never depend on what the real docs/ tree happens to say today. Its
+#   `default invocation` cases pass no --stale flag at all, which is what proves
+#   the wiring rather than the logic, and its `unreadable` case pins the grep
+#   exit-2 path below.
 #
 # Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
 #   only — no associative arrays, no jq, no yq.
@@ -95,13 +106,22 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 MANIFEST=""
 ROOT="$REPO_ROOT"
-STALE_MODE=0
+# On by default (#5134). See the header: a call site that has to remember a flag
+# is a gate that runs by accident.
+STALE_MODE=1
 STALE_TERMS=""
+STALE_ASKED=0 # --stale or --stale-terms was given explicitly
+NO_STALE=0    # --no-stale was given
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --stale)
       STALE_MODE=1
+      STALE_ASKED=1
+      shift
+      ;;
+    --no-stale)
+      NO_STALE=1
       shift
       ;;
     --stale-terms)
@@ -113,6 +133,7 @@ while [[ $# -gt 0 ]]; do
       # searches for none of them is a trap, not a convenience.
       STALE_TERMS="$2"
       STALE_MODE=1
+      STALE_ASKED=1
       shift 2
       ;;
     --manifest)
@@ -132,7 +153,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -h | --help)
-      sed -n '2,90p' "$0" >&2
+      sed -n '2,101p' "$0" >&2
       exit 0
       ;;
     *)
@@ -141,6 +162,23 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# --no-stale exists for the self-test's manifest-shape fixtures and nothing else
+# (#5134). Refusing it on the default manifest is what keeps "run the gate with
+# the content check off" from being reachable at a call site: the two real ones
+# pass no arguments at all, and neither can acquire a --manifest without saying
+# so in a diff.
+if [[ "$NO_STALE" -eq 1 ]]; then
+  if [[ "$STALE_ASKED" -eq 1 ]]; then
+    echo "ERROR: --no-stale contradicts --stale / --stale-terms" >&2
+    exit 2
+  fi
+  if [[ -z "$MANIFEST" ]]; then
+    echo "ERROR: --no-stale requires --manifest — the committed manifest is always checked for retired terms (#5134)." >&2
+    exit 2
+  fi
+  STALE_MODE=0
+fi
 
 [[ -n "$MANIFEST" ]] || MANIFEST="${ROOT}/docs/public-manifest.tsv"
 
@@ -396,14 +434,24 @@ stale_check_dead_waivers() {
 
 # Searches every published page for every term, enforcing the waiver ratchet.
 stale_scan_pages() {
-  local mline msrc tkey tpat tremedy hits mcount waived note pline h wl
+  local mline msrc tkey tpat tremedy hits mcount waived note pline h wl grc
 
   while IFS=$'\t' read -r mline msrc; do
     [[ -n "$mline" ]] || continue
     while IFS=$'\t' read -r tkey tpat tremedy; do
       [[ -n "$tkey" ]] || continue
 
-      hits="$(grep -nE -- "$tpat" "${ROOT}/${msrc}" || true)"
+      # grep exit 1 is "no match"; anything above it is "could not search" — an
+      # unreadable file, most often. `|| true` swallowed both identically and
+      # reported the page clean while it carried every term (#5134). Read the
+      # status instead: a page the gate cannot open is a finding, not a pass.
+      grc=0
+      hits="$(grep -nE -- "$tpat" "${ROOT}/${msrc}")" || grc=$?
+      if [[ "$grc" -gt 1 ]]; then
+        report UNREADABLE "$mline" \
+          "page '${msrc}' could not be searched for '${tkey}' (grep exited ${grc}). An unsearchable page is not a clean page — fix its permissions or its path."
+        continue
+      fi
       if [[ -z "$hits" ]]; then
         mcount=0
       else
@@ -602,8 +650,7 @@ fi
 
 # The STALE pass runs LAST and only over pages that cleared every check above,
 # so it never reports on a source the manifest could not resolve in the first
-# place. It is opt-in (issue #5125) — see the header for why it is wired to
-# nothing yet.
+# place. It runs unless a fixture run disabled it with --no-stale (#5134).
 stale_scanned=0
 manifest_fail="$fail" # findings raised before the STALE pass began
 if [[ "$STALE_MODE" -eq 1 ]]; then

--- a/scripts/check_public_docs_selftest.sh
+++ b/scripts/check_public_docs_selftest.sh
@@ -11,12 +11,25 @@
 #       a dressed-up existence check.
 #     - missing-source.tsv points at a docs/ path that does not exist, which is
 #       what a rename or deletion in docs/ looks like to the manifest.
-#   The STALE cases (issue #5125) carry the whole weight of that check, because
-#   it is opt-in and wired to nothing: no hook and no CI job runs
-#   `--stale` today, so these fixtures are the ONLY place its logic is
-#   ever observed working. They run against scripts/test-data/public-docs/fakeroot/
-#   via --root, so they assert on pages this file controls rather than on
-#   whatever the real docs/ tree says this week.
+#   The STALE cases (issue #5125) run against
+#   scripts/test-data/public-docs/fakeroot/ via --root, so they assert on pages
+#   this file controls rather than on whatever the real docs/ tree says this
+#   week. Since #5134 turned the pass on by default they come in two kinds, and
+#   neither substitutes for the other:
+#     - the `--stale-terms` cases prove the LOGIC — a hit fires, a waiver holds,
+#       an unexplained waiver is refused;
+#     - the DEFAULT-INVOCATION cases prove the WIRING. They pass no --stale flag
+#       of any kind, which is exactly how the pre-commit hook and
+#       public-docs.yml call the gate, so a change that made the pass opt-in
+#       again fails here. A flag-bearing case cannot notice that.
+#   The `--no-stale` cases pin the one escape hatch: it is refused without
+#   --manifest, so the committed manifest can never be checked without the
+#   content pass.
+#
+#   The `unreadable page` case pins the grep-status read the STALE scan gained
+#   in #5134. The `|| true` it replaced swallowed grep exit 2 identically to
+#   exit 1, so a page the gate could not open was reported clean while it
+#   carried every retired term.
 #
 #   forbidden-internal-suffix.tsv covers the third case, which has no tree rule
 #   behind it: docs/reference/ is mixed-audience, so the internal half of a split
@@ -68,7 +81,12 @@ while IFS="$TAB" read -r fixture expected_exit expected_code; do
 
   err="$(mktemp "${TMPDIR:-/tmp}/public-docs-selftest.XXXXXX")"
   rc=0
-  bash "$GATE" --manifest "$path" --root "$REPO_ROOT" >/dev/null 2>"$err" || rc=$?
+  # --no-stale: these fixtures assert on manifest SHAPE, and the real
+  # docs/public-stale-terms.tsv waives a page none of them publishes, so the
+  # STALE pass would report a dead waiver on every one of them. Allowed here
+  # only because --manifest is present; the default-invocation cases below cover
+  # what this one switches off.
+  bash "$GATE" --manifest "$path" --root "$REPO_ROOT" --no-stale >/dev/null 2>"$err" || rc=$?
 
   if [ "$rc" -ne "$expected_exit" ]; then
     echo "FAIL: $fixture -> exit $rc (expected $expected_exit)" >&2
@@ -169,6 +187,97 @@ while IFS="$TAB" read -r fixture terms expected_exit expected_subs; do
 done <<EOF
 $STALE_CASES
 EOF
+
+# --- default invocation: the STALE pass runs with NO flag (issue #5134) -------
+#
+# Every case above names a --stale flag, so all of them would still pass if the
+# pass went back to being opt-in. These two do not, and that is the whole point:
+# they invoke the gate exactly as the pre-commit hook and public-docs.yml do.
+#
+# The FAKEROOT carries its own docs/public-stale-terms.tsv at the default path,
+# so a no-flag run there searches fixture pages for fixture terms.
+run_default_case() {
+  # $1 fixture manifest, $2 expected exit, $3 required substring in stdout+stderr
+  local fixture="$1" expected_exit="$2" needle="$3" out rc=0
+  out="$(mktemp "${TMPDIR:-/tmp}/public-docs-selftest.XXXXXX")"
+  bash "$GATE" --manifest "$FIXTURE_DIR/$fixture" --root "$FAKEROOT" >"$out" 2>&1 || rc=$?
+  if [ "$rc" -ne "$expected_exit" ]; then
+    echo "FAIL: default invocation on $fixture -> exit $rc (expected $expected_exit)" >&2
+    sed 's/^/       /' "$out" >&2
+    fail=1
+  elif ! grep -qF -- "$needle" "$out"; then
+    echo "FAIL: default invocation on $fixture -> exit $rc but output never mentions '$needle'" >&2
+    sed 's/^/       /' "$out" >&2
+    fail=1
+  else
+    echo "PASS: default invocation on $fixture -> exit $rc, reported '$needle' with no --stale flag"
+  fi
+  rm -f "$out"
+}
+
+# A page carrying a retired term makes a no-flag run fail. This is the case that
+# proves the gate BITES where it is wired.
+run_default_case "stale-hit.tsv" 1 "FAIL STALE"
+
+# ... and the mirror: a clean page passes, with the success line naming the term
+# count. Without that assertion an exit-0 case cannot tell "searched and found
+# nothing" from "never searched", which is the failure #5134 removed.
+run_default_case "stale-unpublished.tsv" 0 "retired term(s)"
+
+# --- --no-stale is refused wherever it could weaken a real run ---------------
+run_refusal_case() {
+  # $1 label, then the gate's arguments
+  local label="$1" out rc=0
+  shift
+  out="$(mktemp "${TMPDIR:-/tmp}/public-docs-selftest.XXXXXX")"
+  bash "$GATE" "$@" >"$out" 2>&1 || rc=$?
+  if [ "$rc" -ne 2 ]; then
+    echo "FAIL: $label -> exit $rc (expected 2, a usage refusal)" >&2
+    sed 's/^/       /' "$out" >&2
+    fail=1
+  else
+    echo "PASS: $label -> exit 2 (refused)"
+  fi
+  rm -f "$out"
+}
+
+# Without --manifest, --no-stale would disable the content check on the
+# COMMITTED manifest — the one run that must never be weakened.
+run_refusal_case "--no-stale on the default manifest" --no-stale
+run_refusal_case "--no-stale alongside --stale" --manifest "$FIXTURE_DIR/clean.tsv" --no-stale --stale
+
+# --- an unsearchable page is a finding, not a pass (issue #5134) -------------
+#
+# `hits="$(grep -nE … || true)"` reported grep's exit 2 (unreadable file) as
+# cleanly as its exit 1 (no match), so making the only stale-bearing page
+# unreadable produced exit 0 and a line claiming the page carried none of the
+# terms. Root can read a 000 file, which would make this case pass for the wrong
+# reason, so it is skipped there rather than asserted.
+if [ "$(id -u)" = "0" ]; then
+  echo "SKIP: unreadable page -> running as root, which can read a mode-000 file"
+else
+  UNREADABLE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/public-docs-unreadable.XXXXXX")"
+  cp -R "$FAKEROOT/docs" "$UNREADABLE_ROOT/docs"
+  chmod 000 "$UNREADABLE_ROOT/docs/pages/retired-binary.md"
+  err="$(mktemp "${TMPDIR:-/tmp}/public-docs-selftest.XXXXXX")"
+  rc=0
+  bash "$GATE" --manifest "$FIXTURE_DIR/stale-hit.tsv" --root "$UNREADABLE_ROOT" \
+    >/dev/null 2>"$err" || rc=$?
+  if [ "$rc" -ne 1 ]; then
+    echo "FAIL: unreadable page -> exit $rc (expected 1)" >&2
+    sed 's/^/       /' "$err" >&2
+    fail=1
+  elif ! grep -qF -- "UNREADABLE" "$err"; then
+    echo "FAIL: unreadable page -> exit $rc but stderr never mentions 'UNREADABLE'" >&2
+    sed 's/^/       /' "$err" >&2
+    fail=1
+  else
+    echo "PASS: unreadable page -> exit $rc, reported UNREADABLE"
+  fi
+  rm -f "$err"
+  chmod 644 "$UNREADABLE_ROOT/docs/pages/retired-binary.md"
+  rm -rf "$UNREADABLE_ROOT"
+fi
 
 # The committed manifest itself must pass. A green fixture suite over a red
 # manifest is the failure this catches.

--- a/scripts/test-data/public-docs/fakeroot/docs/public-stale-terms.tsv
+++ b/scripts/test-data/public-docs/fakeroot/docs/public-stale-terms.tsv
@@ -1,0 +1,11 @@
+# STALE fixture terms at the DEFAULT path the gate reads when no --stale-terms
+# is given: <root>/docs/public-stale-terms.tsv (#5134).
+#
+# It exists so the self-test can run the gate the way the pre-commit hook and
+# public-docs.yml run it — no --stale, no --stale-terms, no flag of any kind —
+# against pages this fixture tree controls. Those cases prove the WIRING; the
+# --stale-terms cases beside them prove the LOGIC, and one cannot stand in for
+# the other. Keep it in step with stale-terms.tsv.
+TERM	trusty-mpmd	there is no `trusty-mpmd` binary; use `tm daemon`.
+TERM	open[-_]mpm	renamed to `trusty-agents` (binary `tagent`).
+TERM	@FORMER_REPO_CLONE_URLS@	that repo was folded into `bobmatnyc/trusty-tools`.


### PR DESCRIPTION
The STALE content check landed opt-in behind `--stale` (#5125) because 10 of the 27 published pages hit at the time. Those repairs merged, `bash scripts/check_public_docs.sh --stale` exits 0 on the current tree, and this turns the pass on.

## Shape: unconditional, not `--stale` at the call sites

#5134 lists "make the STALE pass unconditional" first, and the script's own header already said "The pre-commit hook and CI run this script with no arguments" — the defect was the default, not the call sites. So both call sites keep the bare invocation and there is no flag for a later edit to drop.

`--no-stale` is the one way off and exits 2 without `--manifest`, so the committed manifest can never be checked without the content pass. Only the self-test's manifest-shape fixtures use it: the real `docs/public-stale-terms.tsv` waives a page none of those fixtures publishes, so the pass would report a dead waiver on every one of them.

## The CI job did not exist

The audit on #5134 is right. Nothing in `.github/workflows/` ran this script and nothing ran `pre-commit` either, while `check_public_docs.sh`'s own header and `website/src/lib/docs/manifest.ts:12` both asserted CI enforcement. A pre-commit hook alone enforces nothing: `--no-verify`, a commit made outside the repo's hook path, and a merge that runs no hook all reach main unchecked.

`public-docs.yml` runs the fixture self-test and then the bare gate, in that order — modelled on `line-cap.yml` / `doc-numbers.yml`, pure text scanning, no toolchain. Its name goes into `red-main-notify.yml` (#5657).

**`Public docs` is a NEW, NON-REQUIRED context.** Promoting it to required would wedge every open PR that predates it (#5962).

## Fail-open fix: grep exit 2

`hits="$(grep -nE … || true)"` reported grep's exit 2 (unreadable file) exactly as its exit 1 (no match), so a page the gate could not open passed as clean while carrying every retired term. Latent while the pass was opt-in; live the moment it turns on. The scan now reads the status and reports a new `UNREADABLE` code.

## Seed waiver kept

`docs/trusty-search/README.md:17` still carries one `open-mpm` line — the doc-map row naming the baseline CORPUS FILE under `regression-testing/`, not an install instruction. The ratchet holds at exactly 1, so dropping the row would fail the gate as an N-1 drift rather than tidy it.

## Test ladder

Rung 1 — docs/CI/scripts only, no crate `src/**`, so no changelog fragment.

```
bash scripts/check_public_docs.sh            EXIT=0  28 page(s) across 5 section(s), none carries any of the 6 retired term(s)
bash scripts/check_public_docs.sh --stale    EXIT=0  identical line
bash scripts/check_public_docs_selftest.sh   19 cases, all passed
bash scripts/check_sld.sh                    0 error(s), 0 warning(s) over 63 specs + 3720 code files
./scripts/check_test_pointers.sh             32029 Test: citation(s), 0 dangling
./scripts/check-red-main-coverage.sh         21 push-to-main workflow(s), all covered
pre-commit run --files <the 10 changed paths>  EXIT=0, every hook Passed or Skipped
```

Six new self-test cases. The pre-existing STALE cases all name a `--stale` flag and would pass unchanged if the pass went back to opt-in, so two cases invoke the gate with no flag at all — the shape both call sites use:

```
PASS: default invocation on stale-hit.tsv -> exit 1, reported 'FAIL STALE' with no --stale flag
PASS: default invocation on stale-unpublished.tsv -> exit 0, reported 'retired term(s)' with no --stale flag
PASS: --no-stale on the default manifest -> exit 2 (refused)
PASS: --no-stale alongside --stale -> exit 2 (refused)
PASS: unreadable page -> exit 1, reported UNREADABLE
```

The clean mirror asserts the success line names the term count, so exit 0 cannot mean "never searched". The unreadable case is skipped under root, which can read a mode-000 file and would pass for the wrong reason.

**Mutation proof, `--no-stale`** — the same fixture with the pass off is green, so the case above bites rather than passing by construction:

```
$ bash scripts/check_public_docs.sh --manifest scripts/test-data/public-docs/stale-hit.tsv \
    --root scripts/test-data/public-docs/fakeroot --no-stale
public-docs gate: 2 page(s) across 1 section(s) — all resolve inside the public boundary.
EXIT=0
```

**Mutation proof, fail-open** — a copy of the gate with the old `|| true` restored, over a fakeroot whose stale-bearing page is mode 000:

```
--- mutated (pre-#5134) gate:
public-docs gate: 2 page(s) … and none carries any of the 3 retired term(s) …
MUTATED_EXIT=0
--- current gate:
FAIL UNREADABLE line 3: page 'docs/pages/retired-binary.md' could not be searched for 'trusty-mpmd' (grep exited 2) …
CURRENT_EXIT=1
```

## Docs

`docs/public-manifest.tsv` and `docs/public-stale-terms.tsv` headers, the publication-boundary section of `docs/reference/documentation-layout.md`, and a `check_public_docs.sh` row in `docs/reference/ci-scripts.md` saying the STALE check is on by default. `website/src/lib/docs/manifest.ts:12`'s "enforces in CI" becomes true with this PR and needs no edit.

Refs #5134

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
