### PR TITLE
ci: mechanically resolve backtick path citations in live docs (#5147)

### DIFF
--- a/.github/workflows/doc-paths.yml
+++ b/.github/workflows/doc-paths.yml
@@ -1,0 +1,60 @@
+# Backtick path-citation gate for the trusty-tools workspace (issue #5147).
+#
+# A doc that cites `crates/…/src/mcp/tools.rs` makes a checkable claim, and
+# nothing checked it. The doc/code consistency sweep found 18 broken citations
+# outside the archival trees, five of them in crates/trusty-search/CLAUDE.md,
+# all left behind when a 500-SLOC split turned a module file into a directory.
+# This job resolves every backtick-quoted `crates/`, `src/`, `scripts/`, `docs/`
+# and `.github/` token in the live Markdown set against the checkout.
+#
+# NO `paths:` FILTER, on purpose. Every sibling doc gate can name the corpus it
+# reads, so it filters on it. This one cannot: the citation lives in a doc and
+# the file it names lives in the code, so DELETING OR MOVING A SOURCE FILE is
+# what breaks it, and a filter over Markdown would miss exactly that. Filtering
+# on the union — crates/**, docs/**, scripts/**, .github/** — is every path in
+# the repository, so the filter would buy nothing but a way to be wrong. The job
+# is pure shell with no toolchain and finishes in seconds.
+#
+# Pure text scanning — no Rust toolchain or build needed, so this runs as its
+# own lightweight job (matches line-cap.yml / doc-numbers.yml checkout style).
+name: Doc paths
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
+
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
+concurrency:
+  group: doc-paths-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
+
+jobs:
+  doc-paths:
+    name: Backtick path-citation lint
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Full history is not needed — the gate resolves paths in the working
+      # tree, never against a base ref.
+      - uses: actions/checkout@v5
+
+      # Gate on the fixtures first. The token extraction and the seven exclusion
+      # rules are the part that can silently rot into "0 findings", and an
+      # exclusion that over-matches makes the real run's green meaningless.
+      # Mirrors line-cap.yml's selftest-then-gate ordering.
+      - name: Path-citation gate selftest (fixtures)
+        run: bash scripts/check_doc_paths_selftest.sh
+
+      - name: Resolve backtick path citations against the checkout
+        run: bash scripts/check_doc_paths.sh

--- a/.github/workflows/red-main-notify.yml
+++ b/.github/workflows/red-main-notify.yml
@@ -53,7 +53,7 @@
 #     completion recurses (GitHub caps the chain at three levels).
 #   - Every watched completion creates a run of this workflow, green or not. The
 #     job is skipped on a green one and consumes no runner, but the Actions list
-#     shows the entry. That noise buys a signal for all 18 siblings at once.
+#     shows the entry. That noise buys a signal for all 19 siblings at once.
 name: Red main notifier
 
 on:
@@ -66,6 +66,7 @@ on:
       - "build.rs sync" # buildrs-sync.yml
       - "Capabilities drift" # capabilities-drift.yml
       - "Doc numbers" # doc-numbers.yml
+      - "Doc paths" # doc-paths.yml
       - "Generation artifact lint" # generation-artifact-lint.yml
       - "Homebrew formula" # homebrew-formula.yml
       - "Line cap" # line-cap.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -151,6 +151,25 @@ repos:
         pass_filenames: false
         always_run: true
 
+  # Backtick path-citation gate (issue #5147). Fails the commit when a
+  # backtick-quoted `crates/`, `src/`, `scripts/`, `docs/` or `.github/` token
+  # in the live Markdown set (repo-root CLAUDE.md/README.md, docs/reference/**,
+  # docs/architecture/**, crates/*/{CLAUDE,README}.md) names a file that is not
+  # in the checkout — the shape a 500-SLOC split leaves behind when `foo.rs`
+  # becomes `foo/` and the docs stay put. Placeholders, globs, elisions and Rust
+  # module paths are excluded by documented rule; see the script's header.
+  # Runs against the whole tracked tree (pass_filenames: false), because the
+  # citation lives in a doc and the file it names lives in the code, so a
+  # staged-file subset cannot answer the question.
+  - repo: local
+    hooks:
+      - id: doc-paths
+        name: "Backtick path-citation lint"
+        entry: scripts/check_doc_paths.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+
   # Leaked AI-generation / tool-call artifact lint (issue #3579). Fails the
   # commit when a raw `</content>`/`</invoke>`/`</parameter>`/
   # `<function_calls>`/`</function_calls>` fragment is found bare on a line

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,9 +574,10 @@ already deployed in `trusty-console/ui-search`, `trusty-analyze/ui`,
 
 Most references are linked from the rule they serve, above. Not linked elsewhere:
 
-- [ci-scripts.md](docs/reference/ci-scripts.md) — the eight `scripts/` checks that run only in a workflow: where each runs, what it gates, and which have a self-test
+- [ci-scripts.md](docs/reference/ci-scripts.md) — the nine `scripts/` checks that run only in a workflow: where each runs, what it gates, and which have a self-test
 - [documentation-layout.md](docs/reference/documentation-layout.md) — docs layout conventions
 - [DOC-38](docs/specs/spec-linked-documentation.md) — SLD policy, enforced by `scripts/check_sld.sh`
 - [threat-model.md](docs/reference/threat-model.md) — per-daemon bind/guard/proxy inventory ([ADR-0018](docs/adr/0018-loopback-only-doctrine.md))
 - [generated-doc-regions.md](docs/reference/generated-doc-regions.md) — the `<!-- BEGIN GENERATED: … -->` contract and `UPDATE_DOCS=1 cargo test -p <crate> --test generated_docs`; a crate with no markers is not checked
 - [public-manifest.tsv](docs/public-manifest.tsv) — ALLOWLIST of publishable `docs/` pages (absent = never public), enforced by `scripts/check_public_docs.sh`; the internal mdBook is unaffected
+- `scripts/check_doc_paths.sh` (#5147) — resolves backtick-quoted `crates/`, `src/`, `scripts/`, `docs/` and `.github/` citations in this file, the crate `CLAUDE.md`/`README.md` set, `docs/reference/` and `docs/architecture/` against the checkout. Write a non-literal path in one of the shapes its header's EXCLUDED TOKENS list covers — a placeholder, a glob, an elision — rather than widening the gate

--- a/crates/trusty-agents/README.md
+++ b/crates/trusty-agents/README.md
@@ -135,8 +135,8 @@ cargo run -- --version
 | `src/memory`      | Local redb + usearch + fastembed vector store.             |
 | `src/search`      | Code indexer and file watcher (tree-sitter).               |
 | `src/init`        | Project self-initialization and auto-index seeding.        |
-| `src/build_info`  | Persistent build counter + version string.                 |
-| `src/session`     | Per-run session directory management.                      |
+| `src/build_info.rs` | Persistent build counter + version string.               |
+| `src/session.rs`  | Per-run session directory management.                      |
 | `src/subprocess`  | Spawn and NDJSON-interact with sub-agent processes.        |
 | `src/perf`        | Performance telemetry stamps.                              |
 | `src/cli`         | `memory search` / `code search` sub-commands.              |

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -158,7 +158,8 @@ The same `trusty-memory start` daemon serves the embedded Svelte admin UI
 at the bound address (printed by `trusty-memory monitor web` once the
 daemon is running) and a REST API under `/api/v1/`.
 
-Key REST API field names (verified against `src/web.rs` and `src/service.rs`):
+Key REST API field names (verified against `src/transport/methods/palaces.rs`
+and `src/service/core.rs`):
 - Recall endpoints (`GET /api/v1/palaces/{id}/recall` and `GET /api/v1/recall`) accept
   the query string as **`q`** (not `query`): `?q=my+search+term&top_k=5`.
 - Drawer-create body (`POST /api/v1/palaces/{id}/drawers`) expects a **`content`** field

--- a/crates/trusty-mpm-gui/README.md
+++ b/crates/trusty-mpm-gui/README.md
@@ -245,25 +245,29 @@ Optimization:
 
 ```
 crates/trusty-mpm-gui/
-├── src-tauri/              # Rust/Tauri backend
+├── src/                    # Rust/Tauri backend
 │   ├── main.rs
-│   ├── handlers/           # HTTP request handlers
-│   └── config.rs
-├── src/                    # Svelte frontend
-│   ├── App.svelte
-│   ├── routes/
-│   ├── components/
-│   └── lib/
-├── tailwind.config.js
-└── package.json
+│   ├── lib.rs
+│   ├── commands.rs         # Tauri command handlers
+│   └── state.rs
+├── ui/                     # Svelte frontend
+│   ├── src/
+│   │   ├── App.svelte
+│   │   ├── components/
+│   │   ├── lib/
+│   │   └── stores/
+│   ├── tailwind.config.js
+│   └── package.json
+├── build.rs
+└── tauri.conf.json
 ```
 
 ### Adding a New Page
 
-1. Create Svelte component in `src/routes/+page.svelte`
-2. Add navigation link in `src/App.svelte`
+1. Create the Svelte component under `ui/src/components/`
+2. Add navigation link in `ui/src/App.svelte`
 3. Implement HTTP API calls using `fetch()`
-4. Add state management in `src/lib/store.ts`
+4. Add state management in `ui/src/stores/app.ts`
 
 ### Testing
 

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -791,7 +791,7 @@ this table is generated from it, not maintained by hand.
 - **HTTP**: axum 0.7 + tower-http (CORS, trace, gzip), HTTP/2
 - **Vector store**: usearch 2.25 (HNSW), wrapped in `Arc<RwLock<>>` for concurrent reads
 - **Embeddings**: fastembed 5.x (ONNX, all-MiniLM-L6-v2, 384-dim, SIMD/AVX2/NEON)
-- **Lexical**: BM25 (zero-dep port from trusty-agents `src/context/bm25.rs`)
+- **Lexical**: BM25 (zero-dep port from `crates/trusty-agents/src/context/bm25.rs`)
 - **KV store**: redb 2.6 (chunk metadata, file→chunks mapping, `_meta` schema version)
 - **File watching**: notify 6 + notify-debouncer-mini 0.4 (500ms debounce, fsevent)
 - **Code parsing**: tree-sitter 0.24 (rust, python, js, ts, go, java, c, cpp)
@@ -833,7 +833,7 @@ Set `TRUSTY_DISABLE_MIGRATIONS=1` to skip auto-migrations.
 
 ### Adding a new migration
 
-1. Create `src/core/migration/m00N.rs` implementing `Migration` (`source_version`,
+1. Create `src/core/migration/m00<N>.rs` implementing `Migration` (`source_version`,
    `target_version`, `description`, `apply`). The `apply` method must be
    idempotent.
 2. Register it in `MigrationRegistry::new()` in `src/core/migration/mod.rs`.
@@ -1192,7 +1192,7 @@ the `pnpm install --frozen-lockfile && pnpm build`) and then mirrors
 `crates/trusty-console/ui-search-dist/` into the crate-root `ui-dist/`.
 
 🔴 **The `ui-dist-check` job this section used to cite was real, and it never
-ran once.** It lived in `crates/trusty-search/.github/workflows/ci.yml` — a
+ran once.** It lived in this crate's own `<crate>/.github/workflows/ci.yml` — a
 pre-monorepo leftover carried in by the initial import (`13f9fa2c0`,
 2026-05-19) — and did exactly the rebuild-then-diff the old text described.
 GitHub Actions only discovers workflows in the REPO-ROOT

--- a/docs/reference/changelog-fragments.md
+++ b/docs/reference/changelog-fragments.md
@@ -156,7 +156,7 @@ still not a record, and the fragment is still the rule.
 
 ## git-cliff No Longer Touches `CHANGELOG.md`
 
-`scripts/generate-changelog.sh` is deleted; it ran `git cliff --unreleased
+The old `generate-changelog.sh` is deleted; it ran `git cliff --unreleased
 --prepend`, which blindly stacked a fresh `## [Unreleased]` on top of the
 hand-written one — the defect #2793 tracks and the reason `bump-version.sh` used
 to carry a duplicate-heading stopgap. Both are gone: there is exactly ONE

--- a/docs/reference/ci-scripts.md
+++ b/docs/reference/ci-scripts.md
@@ -49,6 +49,31 @@ gate that cannot fail makes its own green meaningless:
 own. Both carry a frozen baseline or a fetch that can fail open, which is the
 shape a self-test exists to pin, so both are candidates if either is edited.
 
+## Gated in a workflow, but not CI-only
+
+`scripts/check_doc_paths.sh` (issue #5147) is deliberately NOT in the table
+above: it runs in `.github/workflows/doc-paths.yml` **and** in the pre-commit
+hook, so it fails the definition this page is scoped to. It is named here
+because `scripts/` is where a reader looks, and the gate is new enough that
+nobody has yet met it by having a commit rejected.
+
+It resolves every backtick-quoted `crates/`, `src/`, `scripts/`, `docs/` and
+`.github/` token in the live Markdown set — repo-root `CLAUDE.md` and
+`README.md`, `docs/reference/`, `docs/architecture/`, and depth-1
+`crates/*/CLAUDE.md` and `crates/*/README.md` — against the checkout, and fails
+on any that names nothing. Its self-test is
+`scripts/check_doc_paths_selftest.sh`, which the workflow runs as the step
+before the gate: seven documented rules exclude placeholders, globs, elisions
+and Rust module paths, and each of those is a rule that could also suppress a
+real finding, so each is pinned to a fixture line under
+`scripts/test-data/doc-paths/`.
+
+Its workflow carries no `paths:` filter, which is the one thing that looks like
+an oversight and is not. The citation lives in a doc and the file it names lives
+in the code, so deleting or moving a source file is what breaks it — a filter
+over Markdown would miss exactly that case, and filtering on the union of every
+tree it can reach is every path in the repository.
+
 ## Which of these block a merge
 
 One does: `check_workspace_dep_versions.sh` runs as a step of `version-parity.yml`'s

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -514,7 +514,7 @@ both the FDA (search) and App Data (mpm) categories.
 ### Single Source of Truth (#2558)
 
 The identifier scheme, signing flags, and guidance text live in exactly one
-place: `crates/trusty-installer/src/commands/macos_signing.rs`. Both
+place: `crates/trusty-installer/src/commands/macos_signing/mod.rs`. Both
 `tctl install` (automatic, fail-soft post-install hook) and the standalone
 `tctl sign <target>` command (hard-failing, for local-source builds or
 re-signing) call into it — there is no second, independently-maintained

--- a/scripts/check_doc_paths.sh
+++ b/scripts/check_doc_paths.sh
@@ -112,7 +112,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -h | --help)
-      sed -n '2,105p' "$0" >&2
+      sed -n '2,92p' "$0" >&2
       exit 0
       ;;
     *)

--- a/scripts/check_doc_paths.sh
+++ b/scripts/check_doc_paths.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+#
+# check_doc_paths.sh — backtick path-citation gate (issue #5147).
+#
+# Why: a doc that cites `crates/trusty-search/src/mcp/tools.rs` is making a
+#   checkable claim, and nothing checked it. The doc/code consistency sweep
+#   (#5136 / PR #5137) found 18 broken backtick path citations outside the
+#   archival trees — five of them in crates/trusty-search/CLAUDE.md, a file
+#   agents read every session, all of them left behind when a 500-SLOC split
+#   turned a module file into a directory. A reader who opens the cited path
+#   gets nothing, and an agent that greps for it concludes the code is missing.
+#   Resolving a backtick-quoted path against the filesystem needs no human
+#   judgment, so it belongs in a gate for the same reason the SLOC cap does
+#   (scripts/check_line_cap.sh, #610): advice without a gate loses.
+#
+#   This is the path half of what scripts/check_public_docs.sh --stale does for
+#   retired names (#5125 / PR #5128). That check proves a published page IS
+#   THERE; neither proves the other, and both are needed.
+#
+# What: scans a fixed set of LIVE, actively-maintained Markdown files for
+#   backtick-quoted tokens beginning `crates/`, `src/`, `scripts/`, `docs/` or
+#   `.github/`, and fails on any that does not resolve in the checkout.
+#
+#   Findings, one line each on stderr:
+#     FAIL BROKEN <file>:<line>: <token> — …   the path does not exist
+#     WARN LINE   <file>:<line>: <token> — …   the file exists but the `:N`
+#                                              suffix is past its last line
+#
+#   The WARN is deliberately not a failure. A stale line number still lands the
+#   reader in the right file, which is most of the citation's value, and line
+#   numbers drift on every edit to the cited file — failing on drift would make
+#   the gate fire constantly for the smallest possible payoff. A missing FILE is
+#   categorically different: there is nothing to land in.
+#
+# SCOPE — what is scanned, and why the rest is not:
+#     CLAUDE.md, README.md                 repo root
+#     docs/reference/**/*.md               the current-state reference set
+#     docs/architecture/**/*.md            the current-state architecture set
+#     crates/*/CLAUDE.md                   per-crate agent instructions
+#     crates/*/README.md                   per-crate entry points
+#
+#   Everything else under docs/ is excluded ON PURPOSE, not for convenience. An
+#   ADR, a spec, a research note, a release readiness doc and a session log all
+#   RECORD A PAST STATE: docs/adr/0013 must keep saying `crates/trusty-controller/`
+#   because that is what the crate was called when the decision was taken.
+#   "Fixing" those citations would falsify the record. Same reasoning as
+#   check_public_docs.sh's excluded trees — historical names belong in
+#   historical documents.
+#
+#   The crate globs are depth-1 by design. crates/*/*/README.md reaches into
+#   bundled asset trees (crates/trusty-agents/.trusty-agents/skills/**) whose
+#   READMEs describe a payload shipped elsewhere, so their paths are not this
+#   checkout's paths.
+#
+# EXCLUDED TOKENS — a path-SHAPED token is not always a path citation. Each rule
+#   below is a class the sweep flagged, or would have flagged, as a false
+#   positive (issue #5147 names the constructed-name class explicitly). A token
+#   is skipped when it contains any of:
+#     <  >        a placeholder            `crates/<crate>/changelog.d/`
+#     $           shell/env interpolation  `docs/$CRATE/README.md`
+#     {  }        brace expansion, or a Rust/format template
+#                                          `crates/{a,b}/Cargo.toml`
+#     *  ?        a glob                   `crates/*/Cargo.toml`
+#     ...  …      an elision               `crates/trusty-search/src/…`
+#     ::          a Rust module path, not a filesystem path
+#                                          `crates/tc-services::cto_db`
+#     |           an alternation, or a markdown table cell escape
+#   …and one structural rule:
+#     a bare `src/…` token in a file that is not inside a crate. `src/` is
+#     crate-relative by convention, so docs/architecture/harnesses.md naming
+#     `src/tools/` in a per-crate table has no single crate to resolve against.
+#     Inside a crate there is exactly one, and the token IS checkable — which is
+#     the case the issue is actually about.
+#
+#   A `:LINE` or `:LINE-LINE` suffix and a `#anchor` suffix are stripped before
+#   the existence check; `:LINE` is then re-checked against the file's length.
+#
+# Usage:
+#   bash scripts/check_doc_paths.sh              # scan the checkout
+#   bash scripts/check_doc_paths.sh --root <dir> # scan a fixture tree (self-test)
+#   bash scripts/check_doc_paths.sh --help
+#
+# Exit: 0 when every citation resolves (warnings do not fail); 1 on any BROKEN
+#   finding or on an empty scan; 2 on a usage error.
+#
+# Test: scripts/check_doc_paths_selftest.sh — fixture trees under
+#   scripts/test-data/doc-paths/ cover a broken citation, a clean file, every
+#   excluded-token class, the crate-relative `src/` resolution, and the
+#   line-overrun warning. It also asserts the committed tree passes.
+#
+# Portability: bash 3.2 (macOS system bash) and bash 5 (Linux CI). POSIX tools
+#   only — no associative arrays, no jq.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$REPO_ROOT"
+FIXTURE_MODE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root)
+      [[ $# -lt 2 ]] && {
+        echo "ERROR: --root needs a path" >&2
+        exit 2
+      }
+      ROOT="$(cd "$2" 2>/dev/null && pwd)" || {
+        echo "ERROR: --root '$2' is not a directory" >&2
+        exit 2
+      }
+      FIXTURE_MODE=1
+      shift 2
+      ;;
+    -h | --help)
+      sed -n '2,105p' "$0" >&2
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+[[ "$ROOT" == "$REPO_ROOT" ]] && FIXTURE_MODE=0
+
+fail=0
+broken=0
+warned=0
+scanned=0
+
+# Why: the real run must scan what is COMMITTED, so an untracked scratch file
+#   cannot fail someone else's commit. A fixture tree cannot use that rule — a
+#   fixture is untracked while it is being written, `git ls-files` would return
+#   nothing, and the scan floor would then fire on the self-test instead of on
+#   the thing it is meant to catch.
+# What: prints the in-scope Markdown paths, relative to $ROOT, one per line.
+# Test: scripts/check_doc_paths_selftest.sh — every case runs in fixture mode,
+#   and the final case runs the tracked-file path over the real checkout.
+list_scanned_files() {
+  if [[ "$FIXTURE_MODE" -eq 1 ]]; then
+    (cd "$ROOT" && find . -name '*.md' -type f | sed 's|^\./||' | sort) | in_scope_filter
+  else
+    (cd "$ROOT" && git ls-files '*.md') | in_scope_filter
+  fi
+}
+
+# Why: `case`'s `*` matches `/` as well, so a `crates/*/README.md` glob would
+#   also admit crates/trusty-agents/.trusty-agents/skills/cto-db/python/README.md
+#   — a bundled asset payload, five levels down, whose paths are not this
+#   checkout's paths. The depth-1 rule needs a pattern that cannot cross `/`.
+# What: prints only the in-scope paths from stdin. See SCOPE in the header.
+in_scope_filter() {
+  local f
+  while IFS= read -r f; do
+    if [[ "$f" =~ ^(CLAUDE|README)\.md$ ]] ||
+      [[ "$f" =~ ^docs/reference/.*\.md$ ]] ||
+      [[ "$f" =~ ^docs/architecture/.*\.md$ ]] ||
+      [[ "$f" =~ ^crates/[^/]+/(CLAUDE|README)\.md$ ]]; then
+      printf '%s\n' "$f"
+    fi
+  done
+}
+
+# Prints the crate root (relative to $ROOT) containing $1, or nothing.
+crate_root_of() {
+  local d
+  d="$(dirname "$1")"
+  while [[ "$d" != "." && "$d" != "/" ]]; do
+    if [[ -f "${ROOT}/${d}/Cargo.toml" ]]; then
+      printf '%s' "$d"
+      return 0
+    fi
+    d="$(dirname "$d")"
+  done
+  return 1
+}
+
+report_broken() {
+  echo "FAIL BROKEN $1:$2: $3 — no such file or directory in this checkout" >&2
+  broken=$((broken + 1))
+  fail=1
+}
+
+report_warn() {
+  echo "WARN LINE $1:$2: $3 — $4 has only $5 line(s)" >&2
+  warned=$((warned + 1))
+}
+
+# Extracts backtick-quoted, path-prefixed tokens from one file as
+# "<line><TAB><token>". Fenced code blocks are skipped: inside a fence there are
+# no inline code spans to quote a citation, and a fence's own delimiter line
+# would otherwise be parsed as one.
+extract_tokens() {
+  awk '
+    /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
+    fence { next }
+    {
+      line = $0
+      while (match(line, /`[^`]+`/)) {
+        span = substr(line, RSTART + 1, RLENGTH - 2)
+        line = substr(line, RSTART + RLENGTH)
+        n = split(span, words, /[[:space:]]+/)
+        for (i = 1; i <= n; i++) {
+          w = words[i]
+          # Trailing prose punctuation a citation picks up inside a span. A
+          # trailing `.` is stripped one at a time and never off a token already
+          # ending `..`, so an ASCII elision (`crates/…/core/...`) survives to
+          # reach the exclusion rules instead of being silently repaired into a
+          # directory path that does not exist.
+          do {
+            prev = w
+            sub(/[,;)\]]$/, "", w)
+            if (w !~ /\.\.$/) sub(/\.$/, "", w)
+          } while (w != prev)
+          if (w ~ /^(crates|src|scripts|docs|\.github)\//)
+            printf "%d\t%s\n", NR, w
+        }
+      }
+    }
+  ' "$1"
+}
+
+while IFS= read -r doc; do
+  [[ -n "$doc" ]] || continue
+  scanned=$((scanned + 1))
+
+  while IFS=$'\t' read -r lineno token; do
+    [[ -n "$token" ]] || continue
+
+    # See EXCLUDED TOKENS in the header. Each pattern is one documented class.
+    case "$token" in
+      *'<'* | *'>'* | *'$'* | *'{'* | *'}'* | *'*'* | *'?'* | \
+        *'...'* | *'…'* | *'::'* | *'|'*) continue ;;
+    esac
+
+    path="$token"
+    path="${path%%#*}" # `docs/specs/foo.md#SPEC-X` → docs/specs/foo.md
+    want_line=""
+    case "$path" in
+      *:[0-9]*)
+        want_line="${path#*:}"
+        want_line="${want_line%%-*}" # `…:81-104` → 81
+        path="${path%%:*}"
+        ;;
+    esac
+    [[ -n "$path" ]] || continue
+
+    base=""
+    case "$path" in
+      src/*)
+        # Crate-relative by convention — see EXCLUDED TOKENS. No crate, no claim.
+        base="$(crate_root_of "$doc")" || continue
+        base="${base}/"
+        ;;
+    esac
+
+    if [[ ! -e "${ROOT}/${base}${path}" ]]; then
+      report_broken "$doc" "$lineno" "$token"
+      continue
+    fi
+
+    if [[ -n "$want_line" && -f "${ROOT}/${base}${path}" ]]; then
+      total="$(grep -c '' "${ROOT}/${base}${path}" | tr -d ' ')"
+      if [[ "$want_line" -gt "$total" ]]; then
+        report_warn "$doc" "$lineno" "$token" "${base}${path}" "$total"
+      fi
+    fi
+  done < <(extract_tokens "${ROOT}/${doc}")
+done < <(list_scanned_files)
+
+# Scan floor, same premise as check_public_docs.sh's and
+# check_changelog_fragment.sh's (#4618): "nothing was scanned" and "everything
+# scanned was clean" produce the same exit status, and only one of them is a
+# passing gate. An empty scan means a bad --root or a broken file list.
+if [[ "$scanned" -lt 1 ]]; then
+  echo "FAIL: SCAN FLOOR — no in-scope Markdown file was scanned under ${ROOT}." >&2
+  echo "      Nothing was examined, so this gate could not have failed." >&2
+  exit 1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  cat >&2 <<'EOF'
+
+A backtick-quoted path citation names a file that is not in this checkout.
+Fix the CITATION — a reader who opens it gets nothing, and an agent that greps
+for it concludes the code was deleted. The usual cause is a 500-SLOC split that
+turned `foo.rs` into `foo/` and left the docs behind.
+
+Never widen this gate to make it green. If a token is genuinely not a literal
+path (a placeholder, a glob, a Rust module path), write it in one of the shapes
+the header's EXCLUDED TOKENS list already covers.
+EOF
+  exit 1
+fi
+
+summary="doc-paths gate: ${scanned} file(s) scanned — every backtick path citation resolves"
+if [[ "$warned" -gt 0 ]]; then
+  summary="${summary} (${warned} stale line-number warning(s) above)"
+fi
+echo "${summary}."

--- a/scripts/check_doc_paths_selftest.sh
+++ b/scripts/check_doc_paths_selftest.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# check_doc_paths_selftest.sh — fixture cases for the backtick path-citation
+# gate, scripts/check_doc_paths.sh (issue #5147).
+#
+# Why: the gate's whole value is what it REJECTS, and a path checker that has
+#   only ever been observed passing is indistinguishable from one that returns 0
+#   unconditionally. Its exclusion rules carry the same risk in the other
+#   direction: every rule that suppresses a false positive is also a rule that
+#   can suppress a real finding, so each one is pinned to a fixture line rather
+#   than left to a reader's confidence. The issue names the false-positive class
+#   explicitly (a doc that CONSTRUCTS a name instead of quoting one), which is
+#   what excluded/ exists to hold.
+#
+# What: points the gate at each fixture tree under scripts/test-data/doc-paths/
+#   via --root and asserts the exit status plus the exact substrings the run must
+#   produce. Asserting the substrings, not just non-zero, is what stops a fixture
+#   from passing for the wrong reason — crate-relative/ must report the ONE
+#   missing `src/…` path and stay silent about the one that resolves, and a
+#   fixture that reported both would look identical on exit status alone.
+#
+# Test: this IS the test. Run directly:
+#   bash scripts/check_doc_paths_selftest.sh
+#
+# Portability: same constraints as check_doc_paths.sh — POSIX tools only,
+#   bash 3.2 (macOS) and bash 5 (Linux CI).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$SCRIPT_DIR/check_doc_paths.sh"
+FIXTURE_DIR="$SCRIPT_DIR/test-data/doc-paths"
+
+TAB="$(printf '\t')"
+
+# tree<TAB>expected_exit<TAB>required substrings (comma-separated; "-" for none)
+CASES="broken${TAB}1${TAB}FAIL BROKEN,broken.md:3: crates/trusty-installer/src/commands/gone.rs
+clean${TAB}0${TAB}-
+excluded${TAB}0${TAB}-
+crate-relative${TAB}1${TAB}src/core/migration/m001.rs
+line-overrun${TAB}0${TAB}WARN LINE,target.md:900
+out-of-scope${TAB}1${TAB}SCAN FLOOR"
+
+# Substrings that must NOT appear. A gate can satisfy every positive assertion
+# above and still be wrong by ALSO reporting something it was told to ignore:
+# the fenced sample in clean/, the resolving half of crate-relative/, or any of
+# excluded/'s ten classes.
+NEGATIVE="clean${TAB}nowhere.rs
+crate-relative${TAB}src/lib.rs
+excluded${TAB}FAIL BROKEN
+line-overrun${TAB}FAIL BROKEN"
+
+fail=0
+
+run_gate() { # $1 = fixture tree, $2 = output file; prints exit status
+  local rc=0
+  bash "$GATE" --root "$FIXTURE_DIR/$1" >"$2" 2>&1 || rc=$?
+  printf '%s' "$rc"
+}
+
+while IFS="$TAB" read -r tree expected_exit expected_subs; do
+  [ -n "$tree" ] || continue
+  if [ ! -d "$FIXTURE_DIR/$tree" ]; then
+    echo "FAIL: fixture tree missing: $FIXTURE_DIR/$tree" >&2
+    fail=1
+    continue
+  fi
+
+  out="$(mktemp "${TMPDIR:-/tmp}/doc-paths-selftest.XXXXXX")"
+  rc="$(run_gate "$tree" "$out")"
+
+  if [ "$rc" -ne "$expected_exit" ]; then
+    echo "FAIL: $tree -> exit $rc (expected $expected_exit)" >&2
+    sed 's/^/       /' "$out" >&2
+    fail=1
+    rm -f "$out"
+    continue
+  fi
+
+  missing=""
+  if [ "$expected_subs" != "-" ]; then
+    # Comma-split without arrays, so this stays bash 3.2 clean.
+    rest="$expected_subs"
+    while [ -n "$rest" ]; do
+      case "$rest" in
+        *,*)
+          sub="${rest%%,*}"
+          rest="${rest#*,}"
+          ;;
+        *)
+          sub="$rest"
+          rest=""
+          ;;
+      esac
+      grep -qF -- "$sub" "$out" || missing="${missing}'${sub}' "
+    done
+  fi
+
+  if [ -n "$missing" ]; then
+    echo "FAIL: $tree -> exit $rc but output never mentions ${missing}" >&2
+    sed 's/^/       /' "$out" >&2
+    fail=1
+    rm -f "$out"
+    continue
+  fi
+
+  if [ "$expected_subs" = "-" ]; then
+    echo "PASS: $tree -> exit $rc (clean)"
+  else
+    echo "PASS: $tree -> exit $rc, reported ${expected_subs}"
+  fi
+  rm -f "$out"
+done <<EOF
+$CASES
+EOF
+
+while IFS="$TAB" read -r tree forbidden; do
+  [ -n "$tree" ] || continue
+  out="$(mktemp "${TMPDIR:-/tmp}/doc-paths-selftest.XXXXXX")"
+  run_gate "$tree" "$out" >/dev/null
+  if grep -qF -- "$forbidden" "$out"; then
+    echo "FAIL: $tree -> output mentions '$forbidden', which it must not" >&2
+    sed 's/^/       /' "$out" >&2
+    fail=1
+  else
+    echo "PASS: $tree -> silent about '$forbidden'"
+  fi
+  rm -f "$out"
+done <<EOF
+$NEGATIVE
+EOF
+
+# The committed tree must pass. A green fixture suite over a red checkout is the
+# failure this catches — and it is the only case that exercises the tracked-file
+# enumeration, which fixture mode replaces with `find`.
+out="$(mktemp "${TMPDIR:-/tmp}/doc-paths-selftest.XXXXXX")"
+if bash "$GATE" >"$out" 2>&1; then
+  echo "PASS: committed tree -> exit 0 (clean)"
+else
+  echo "FAIL: the committed tree does not pass the gate" >&2
+  sed 's/^/       /' "$out" >&2
+  fail=1
+fi
+rm -f "$out"
+
+if [ "$fail" -ne 0 ]; then
+  echo "check_doc_paths_selftest: one or more cases FAILED." >&2
+  exit 1
+fi
+
+echo "check_doc_paths_selftest: all cases passed."
+exit 0

--- a/scripts/test-data/doc-paths/README.md
+++ b/scripts/test-data/doc-paths/README.md
@@ -1,0 +1,23 @@
+# doc-paths fixtures
+
+Fixture trees for `scripts/check_doc_paths.sh`, driven by
+`scripts/check_doc_paths_selftest.sh`. Each subdirectory is a whole `--root`:
+the gate is pointed at it and scans it exactly as it scans the checkout, so the
+scope rules, the exclusion rules and the scan floor are all exercised for real
+rather than mocked.
+
+This file sits at the fixture root, not inside any tree, so it is never itself
+one of the scanned roots.
+
+| Tree | What it pins |
+|---|---|
+| `broken/` | a citation naming a file that does not exist — exit 1, `FAIL BROKEN` |
+| `clean/` | citations that all resolve — exit 0 |
+| `excluded/` | one line per EXCLUDED TOKENS class, none of which resolves as a literal path — exit 0 |
+| `crate-relative/` | a bare `src/…` token in a crate README, resolved against that crate's root: one hit, one miss |
+| `line-overrun/` | a `:LINE` past the cited file's last line — exit 0 with `WARN LINE` |
+| `out-of-scope/` | a broken citation in `docs/adr/`, which the scope excludes — the gate scans nothing and refuses with `SCAN FLOOR` |
+
+`crate-relative/crates/demo-crate/Cargo.toml` is a marker, not a package: the
+gate finds a crate root by walking up for a `Cargo.toml`, and the workspace's
+`crates/*` glob never reaches under `scripts/`.

--- a/scripts/test-data/doc-paths/broken/docs/reference/broken.md
+++ b/scripts/test-data/doc-paths/broken/docs/reference/broken.md
@@ -1,0 +1,9 @@
+# broken
+
+The signing helper lives in `crates/trusty-installer/src/commands/gone.rs`,
+which is exactly the shape issue #5147 names: a module file a 500-SLOC split
+turned into a directory, with the citation left behind.
+
+For contrast, this page cites itself at `docs/reference/broken.md`, which does
+resolve — so a fixture that reported one finding rather than two would be
+failing for the wrong reason.

--- a/scripts/test-data/doc-paths/clean/docs/reference/clean.md
+++ b/scripts/test-data/doc-paths/clean/docs/reference/clean.md
@@ -1,0 +1,14 @@
+# clean
+
+Every citation here resolves inside this fixture root: `docs/reference/clean.md`
+(this page), `docs/reference/` (a directory), `docs/reference/clean.md:3` (a
+line that exists) and `docs/reference/clean.md#clean` (an anchor the existence
+check strips before resolving).
+
+```
+see `crates/does-not-exist/src/nowhere.rs` for details
+```
+
+The fenced block above is not scanned, and its broken citation must not be
+reported — a fence quotes sample text, and its own delimiter line would
+otherwise parse as an inline code span.

--- a/scripts/test-data/doc-paths/crate-relative/crates/demo-crate/Cargo.toml
+++ b/scripts/test-data/doc-paths/crate-relative/crates/demo-crate/Cargo.toml
@@ -1,0 +1,8 @@
+# Fixture marker, not a package: scripts/check_doc_paths.sh finds a crate root
+# by walking up for a Cargo.toml, and the workspace's `crates/*` member glob
+# never reaches under scripts/. Nothing builds this.
+[package]
+name = "doc-paths-fixture-demo-crate"
+version = "0.0.0"
+edition = "2021"
+publish = false

--- a/scripts/test-data/doc-paths/crate-relative/crates/demo-crate/README.md
+++ b/scripts/test-data/doc-paths/crate-relative/crates/demo-crate/README.md
@@ -1,0 +1,8 @@
+# demo-crate
+
+A bare `src/…` citation in a crate README is crate-relative, so the gate
+resolves it against this directory rather than against the root.
+
+- `src/lib.rs` exists here and must pass.
+- `src/core/migration/m001.rs` does not and must fail — the case issue #5147
+  found five times in the trusty-search agent instructions.

--- a/scripts/test-data/doc-paths/crate-relative/crates/demo-crate/src/lib.rs
+++ b/scripts/test-data/doc-paths/crate-relative/crates/demo-crate/src/lib.rs
@@ -1,0 +1,3 @@
+// Fixture target for scripts/check_doc_paths_selftest.sh. Its README cites
+// `src/lib.rs`; this file is what makes that citation resolve. Nothing compiles
+// it — see the sibling Cargo.toml.

--- a/scripts/test-data/doc-paths/excluded/docs/reference/excluded.md
+++ b/scripts/test-data/doc-paths/excluded/docs/reference/excluded.md
@@ -1,0 +1,21 @@
+# excluded
+
+One line per EXCLUDED TOKENS class in `check_doc_paths.sh`'s header. Not one of
+these tokens resolves as a literal path, and the gate must still exit 0 — that
+is what makes the class an exclusion rather than a bug.
+
+- placeholder: `crates/<crate>/changelog.d/<issue>-<slug>.md`
+- interpolation: `docs/$CRATE/README.md`
+- brace template: `crates/{trusty-common,trusty-search}/Cargo.toml`
+- glob: `crates/*/Cargo.toml` and `docs/**/*.md`
+- single-char glob: `scripts/check_?.sh`
+- ASCII elision: `crates/trusty-search/src/core/...`
+- Unicode elision: `crates/trusty-search/src/core/…`
+- Rust module path: `crates/tc-services::cto_db`
+- alternation: `docs/adr/0044|0048`
+- crate-relative `src/…` with no crate to resolve against: `src/mcp/tools.rs`
+
+The last one is the structural rule, not a character rule: this page lives under
+`docs/`, so no ancestor directory holds a `Cargo.toml` and there is no single
+crate the token could mean. The `crate-relative/` fixture pins the other half —
+inside a crate, the same shape of token IS checked.

--- a/scripts/test-data/doc-paths/line-overrun/docs/reference/overrun.md
+++ b/scripts/test-data/doc-paths/line-overrun/docs/reference/overrun.md
@@ -1,0 +1,7 @@
+# overrun
+
+`docs/reference/target.md:2` names a line that exists.
+
+`docs/reference/target.md:900` names one that does not. The file resolves, so
+the reader still lands somewhere useful — that is a WARN, and the gate still
+exits 0.

--- a/scripts/test-data/doc-paths/line-overrun/docs/reference/target.md
+++ b/scripts/test-data/doc-paths/line-overrun/docs/reference/target.md
@@ -1,0 +1,3 @@
+# target
+
+Three lines, so a `:900` suffix pointing here is past the end.

--- a/scripts/test-data/doc-paths/out-of-scope/docs/adr/0001-example.md
+++ b/scripts/test-data/doc-paths/out-of-scope/docs/adr/0001-example.md
@@ -1,0 +1,8 @@
+# ADR-0001: example
+
+An ADR records a past state, so `crates/trusty-controller/src/main.rs` must keep
+naming the crate as it was called when the decision was taken. The scope
+excludes `docs/adr/` for that reason.
+
+This tree therefore holds no in-scope file at all, and the gate must refuse the
+run with SCAN FLOOR rather than report a clean pass over nothing.


### PR DESCRIPTION
A doc that cites `crates/…/src/mcp/tools.rs` makes a checkable claim, and nothing checked it. The doc/code consistency sweep found 18 broken citations outside the archival trees, five of them in the trusty-search agent instructions, all left behind when a 500-SLOC split turned a module file into a directory.

`scripts/check_doc_paths.sh` resolves every backtick-quoted `crates/`, `src/`, `scripts/`, `docs/` and `.github/` token in the live Markdown set against the checkout and fails on any that names nothing. Fenced code blocks are skipped. `:LINE` / `:LINE-LINE` and `#anchor` suffixes are stripped before the existence check; a `:LINE` past the cited file's last line warns instead of failing, because the reader still lands in the right file and line numbers drift on every edit to it.

Refs #5147

## Scope: 62 files, and why the rest is excluded

Repo-root `CLAUDE.md` and `README.md`, `docs/reference/`, `docs/architecture/`, and depth-1 crate `CLAUDE.md` / `README.md`.

Everything else under `docs/` is excluded on purpose, not for convenience. An ADR, a spec, a research note and a release-readiness doc all RECORD A PAST STATE: `docs/adr/0013` must keep naming the crate `trusty-controller` because that is what it was called when the decision was taken, and repairing that citation would falsify the record. Same reasoning as `check_public_docs.sh`'s excluded trees.

The crate rule is depth-1 and mechanically so. `case`'s `*` matches `/` as well, so a `crates/*/README.md` glob also admitted a bundled asset README five levels down whose paths are not this checkout's paths. The filter uses `=~ ^crates/[^/]+/(CLAUDE|README)\.md$` instead.

## Seven documented exclusions

A path-shaped token is not always a path citation. Each rule is a class the sweep flagged, or would have flagged, and each is pinned to a fixture line rather than left to confidence — every rule that suppresses a false positive can also suppress a real finding.

| Contains | Class | Example |
|---|---|---|
| `<` `>` | placeholder | `crates/<crate>/changelog.d/` |
| `$` | shell/env interpolation | `docs/$CRATE/README.md` |
| `{` `}` | brace expansion or format template | `crates/{a,b}/Cargo.toml` |
| `*` `?` | glob | `crates/*/Cargo.toml` |
| `...` `…` | elision | `crates/trusty-search/src/core/...` |
| `::` | Rust module path, not a filesystem path | `crates/tc-services::cto_db` |
| `\|` | alternation or markdown table-cell escape | |

Plus one structural rule: a bare `src/…` token in a file that is not inside a crate. `src/` is crate-relative by convention, so `docs/architecture/harnesses.md` naming `src/tools/` in a per-crate table has no single crate to resolve against — that rule alone is the difference between 26 false positives and zero there. Inside a crate there is exactly one crate root, the token IS checkable, and that is the case the issue is actually about.

One trap found while building it: the trailing-prose-punctuation strip was eating `...` and silently repairing an elision into a directory path that does not exist. Periods are now stripped one at a time and never off a token already ending `..`.

## The 12 citations the gate found, and their fixes

| File | Was | Now |
|---|---|---|
| `docs/reference/release-workflow.md` | `crates/trusty-installer/src/commands/macos_signing.rs` | `…/macos_signing/mod.rs` — the exact 500-SLOC-split shape the issue names |
| `docs/reference/changelog-fragments.md` | `scripts/generate-changelog.sh` | unbackticked; the sentence says the script is deleted |
| `crates/trusty-search/CLAUDE.md` | `src/context/bm25.rs` | `crates/trusty-agents/src/context/bm25.rs` — the port's source crate, not this one |
| `crates/trusty-search/CLAUDE.md` | `src/core/migration/m00N.rs` | `src/core/migration/m00<N>.rs` — a template, written in a shape the exclusions cover |
| `crates/trusty-search/CLAUDE.md` | `crates/trusty-search/.github/workflows/ci.yml` | `<crate>/.github/workflows/ci.yml` — the directory was deleted; the sentence is about that |
| `crates/trusty-agents/README.md` | `src/build_info`, `src/session` | `src/build_info.rs`, `src/session.rs` |
| `crates/trusty-memory/README.md` | `src/web.rs`, `src/service.rs` | `src/transport/methods/palaces.rs`, `src/service/core.rs` |
| `crates/trusty-mpm-gui/README.md` | `src/routes/+page.svelte`, `src/App.svelte`, `src/lib/store.ts` | `ui/src/components/`, `ui/src/App.svelte`, `ui/src/stores/app.ts` |

The mpm-gui fix also corrects the adjacent Project Structure block, which described a `src-tauri/` layout this crate has never had. It sits inside a fence, so the gate does not read it — leaving a knowingly-wrong tree two lines above the fix would have been worse than the drift.

No allowlist file: 12 is under the ~25 threshold, so the citations are fixed rather than frozen.

## Two wiring decisions

**No `paths:` filter on `doc-paths.yml`**, unlike every sibling doc gate. This is the one thing that looks like an oversight and is not. The citation lives in a doc and the file it names lives in the code, so DELETING OR MOVING A SOURCE FILE is what breaks the gate — a filter over Markdown would miss exactly that case, and filtering on the union of every tree it reads is every path in the repository. The job is pure shell with no toolchain and finishes in seconds.

**A section in `ci-scripts.md`, not a table row.** That page is scoped to scripts that run in a workflow and nowhere else; this one also runs in the pre-commit hook, so a row would falsify the page's opening sentence. The section names the self-test. `CLAUDE.md`'s reference list gains one line, because a rule that exists only inside the gate enforcing it is a trap.

`"Doc paths"` joins `red-main-notify.yml`'s watch list, without which `check-red-main-coverage.sh` fails the `changes` job. The context is deliberately NOT required — promoting it wedges every open PR that predates the workflow (#5962), which is a separate step.

## Testing — rung 1 (docs, scripts and CI only)

No Rust source changed, so no cargo gate and no changelog fragment is owed. `check_changelog_fragment.sh` agrees: `scanned 18 changed path(s); attributed 0 crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK.`

```
$ bash scripts/check_doc_paths_selftest.sh
PASS: broken -> exit 1, reported FAIL BROKEN,broken.md:3: crates/trusty-installer/src/commands/gone.rs
PASS: clean -> exit 0 (clean)
PASS: excluded -> exit 0 (clean)
PASS: crate-relative -> exit 1, reported src/core/migration/m001.rs
PASS: line-overrun -> exit 0, reported WARN LINE,target.md:900
PASS: out-of-scope -> exit 1, reported SCAN FLOOR
PASS: clean -> silent about 'nowhere.rs'
PASS: crate-relative -> silent about 'src/lib.rs'
PASS: excluded -> silent about 'FAIL BROKEN'
PASS: line-overrun -> silent about 'FAIL BROKEN'
PASS: committed tree -> exit 0 (clean)
check_doc_paths_selftest: all cases passed.

$ bash scripts/check_doc_paths.sh
doc-paths gate: 62 file(s) scanned — every backtick path citation resolves.
```

The suite asserts required substrings AND forbidden ones. `crate-relative/` must report the missing `src/…` and stay silent about the one that resolves; `clean/`'s fenced sample must not be reported at all. Exit status alone cannot tell those apart, which is how a fixture passes for the wrong reason.

Portability, since the script claims bash 3.2 and POSIX tools:

```
$ /bin/bash -c 'echo $BASH_VERSION'
3.2.57(1)-release
$ /bin/bash scripts/check_doc_paths_selftest.sh   # exit 0

$ shellcheck -s bash scripts/check_doc_paths.sh scripts/check_doc_paths_selftest.sh   # exit 0
```

Neighbouring gates, all exit 0:

| Gate | Output |
|---|---|
| `check_sld.sh` | `0 error(s), 0 warning(s)` |
| `check_test_pointers.sh` | `resolved 32029 Test: citation(s) — 0 dangling pointers — OK.` |
| `check_public_docs.sh` | `28 page(s) across 5 section(s) — all resolve` |
| `check-red-main-coverage.sh` | `21 push-to-main workflow(s), all covered` |
| `check-ci-helpers-selftest.sh` | exit 0 |
| `check_line_cap.sh` | `measured 4593 tracked .rs file(s); 0 violations — OK.` |
| `check_doc_numbers.sh`, `check_adr.sh`, `check_generation_artifacts.sh` | exit 0 each |
| YAML parse of both workflows + `.pre-commit-config.yaml` | OK |

## Possible follow-up, no ticket

The gate covers 62 of 1,456 tracked `.md` files. Widening to all of non-archival `docs/` surfaces roughly 68 further findings, concentrated in point-in-time documents (`docs/releases/`, `docs/audits/`, per-crate spec trees) where the right answer is another exclusion rather than a repair. Worth revisiting once the current scope has run on main for a while.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
