### PR TITLE
test(trusty-mpm): serialize the sessions.discover parity case against $HOME moves (#7047)

### DIFF
--- a/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/sessions_legacy_tests.rs
@@ -637,7 +637,19 @@ async fn parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_trans
     }
 }
 
+/// Why serial (#7047): `discover_all` recomputes
+/// `host_state_gate::host_state_access_for_root` per call, reading the process
+/// `$HOME` each time, and returns the verdict's sentence in the response's
+/// `skipped` field. This case calls it twice; ~24 other test modules in this
+/// binary reassign `$HOME` process-wide. One landing between the two calls
+/// makes the socket answer the #5784 scratch-`$HOME` sentence while HTTP
+/// answered the #6348 scratch-data-root one — a comparison that fails on the
+/// environment moving, not on the transports differing. Same reason, and the
+/// same shared default group, as
+/// [`parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_transports`].
 /// Test: this function IS the test.
+// #7047: $HOME is process-global; both calls must read one value.
+#[serial_test::serial]
 #[tokio::test]
 async fn parity_sessions_discover_agrees_across_transports() {
     let (state, _dir) = hermetic();


### PR DESCRIPTION
Refs #7047

Rung 2 (test-only stabilization). One attribute and a doc comment in one
`*_tests.rs` file; no crate source changed, so no changelog fragment is owed —
`check_changelog_fragment.sh` agrees.

## Root cause

The shared state is the process-global `HOME` environment variable. The two
readers are one function reached twice.

`daemon/discovery.rs:501` — `discover_all` calls
`host_state_gate::host_state_access_for_root(state.framework_root())` on every
invocation and puts the verdict's sentence into `DiscoverResponse.skipped`
(`daemon/api/types.rs:211`). That gate reads `$HOME` fresh each call
(`core/host_state_gate.rs:313`), deliberately uncached.
`parity_sessions_discover_agrees_across_transports` calls it once over HTTP and
once over the socket, then compares the whole body.

`classify_with_data_root` reaches the #6348 `ScratchDataRoot` arm only when the
`$HOME` check first returns `RealEnvironment`. So with a real `$HOME` the
response says #6348; with a reassigned `$HOME` it says #5784. Both refuse — only
the sentence differs.

24 test modules in the `--lib` binary reassign `$HOME` process-wide (52
`set_var("HOME", …)` sites). Every one of them is `#[serial_test::serial]`; this
parity case was not, so it ran free alongside them. Its sibling
`parity_sessions_reap_removes_the_dead_and_spares_the_live_on_both_transports`
already carries `#[serial]` for exactly this reason, documented at
`sessions_legacy_tests.rs:570`.

**No production ordering bug.** Both transports run identical code through one
`discover_all`, and recomputing the guard per call is correct.

## The fix

`#[serial_test::serial]` on the test, plus a doc block naming the mechanism and
a `// #7047:` line at the change site. Joins the crate-wide default group every
`$HOME` mutator already uses. The assertion is untouched — nothing ignored,
cfg-gated, or deleted.

## Deterministic reproduction

A scratch test (since removed) that moved `$HOME` between the two calls produced
the reported failure byte-for-byte, at the same assertion:

```
thread '...tmp7047_repro_home_moved_between_the_two_calls' panicked at crates/trusty-mpm/src/daemon/rpc/sessions_legacy_tests.rs:216:5:
assertion `left == right` failed: mpm.sessions.discover must answer identically over HTTP and the socket
  left: Object {"discovered": Number(0), "sessions": Array [], "skipped": String("this daemon's data root is /var/folders/.../.tmpUc6nBE/.trusty-mpm but this user's framework root is /Users/masa/.trusty-mpm — tmux and the host process table are shared system state that a scratch data root does not isolate, so reaching them would adopt the operator's live sessions, and each adopted record carries a real project directory (#6348). Set TRUSTY_MPM_ALLOW_HOST_STATE=1 to allow it.")}
 right: Object {"discovered": Number(0), "sessions": Array [], "skipped": String("$HOME is /var/folders/.../.tmphOsuBL but this user's real home is /Users/masa — tmux and the host process table are shared system state that $HOME does not isolate, so reaching them would touch the operator's real sessions and project directories (#5784). Set TRUSTY_MPM_ALLOW_HOST_STATE=1 to allow it.")}
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 6105 filtered out
```

**The natural interleaving did not reproduce.** 30 iterations of the discover
test run alongside all 989 tests from the `$HOME`-mutating modules gave
`FAILED_ITERATIONS=0 of 30`. The window between the two calls is microseconds.
The forced-interleaving repro above is the causal proof; a flake count is not.

## Stress evidence

20 consecutive `cargo test -p trusty-mpm --lib --no-fail-fast` runs post-fix:
`FAILED_RUNS=0 of 20`, every run
`test result: ok. 6097 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out`.
Run times spanned 55.92s–203.70s, so the later runs were under real concurrent
load — the condition #7047 names.

## Gates

- `cargo fmt --check` — EXIT=0
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — EXIT=0
- `scripts/check_line_cap.sh` — `measured 4592 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.`
- `scripts/check_test_pointers.sh` — `resolved 32029 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.`
- `scripts/check_changelog_fragment.sh` — `scanned 1 changed path(s); attributed 0 crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK.`
- `cargo test -p trusty-mpm --no-fail-fast` — EXIT=0, all 45 targets green:

```
Running unittests src/lib.rs                      → ok. 6097 passed; 0 failed; 8 ignored
Running unittests src/bin/tm/main.rs (tm)         → ok. 2221 passed; 0 failed; 1 ignored
Running unittests src/bin/tm/main.rs (trusty_mpm) → ok. 2221 passed; 0 failed; 1 ignored
tests/auth_cost.rs                     → ok. 4 passed;   tests/catalog_sync_idempotent.rs       → ok. 3 passed
tests/config_mount.rs                  → ok. 2 passed;   tests/conformance_cross_gate.rs        → ok. 3 passed
tests/daemon_dual_serve.rs             → ok. 1 passed;   tests/e2e/main.rs                      → ok. 34 passed
tests/inproject_cold_start.rs          → ok. 2 passed;   tests/inproject_git_failure.rs         → ok. 1 passed; 1 ignored
tests/inproject_hygiene_test.rs        → ok. 8 passed;   tests/local_spawn.rs                   → ok. 13 passed
tests/manager_cli_client.rs            → ok. 10 passed;  tests/manager_inference.rs             → ok. 8 passed; 1 ignored
tests/manager_routes.rs                → ok. 3 passed;   tests/manager_routing.rs               → ok. 17 passed
tests/mcp_spawn_gate.rs                → ok. 5 passed;   tests/meta_demo_e2e.rs                 → ok. 0 passed; 1 ignored
tests/orphan_gc_sweep.rs               → ok. 9 passed;   tests/pid_registry_sweep.rs            → ok. 4 passed
tests/project_registry_routes.rs       → ok. 20 passed;  tests/project_status_route.rs          → ok. 3 passed
tests/projects_json_concurrency.rs     → ok. 2 passed; 2 ignored (5 sub-runs)
tests/proxy_routes.rs                  → ok. 3 passed;   tests/push_guard_hook.rs               → ok. 8 passed
tests/relocated_interactive_config_4181.rs → ok. 5 passed
tests/resume_unresumable_mapping.rs    → ok. 6 passed;   tests/scratch_home_tmux_gate.rs        → ok. 1 passed
tests/scratch_root_tmux_gate.rs        → ok. 1 passed;   tests/services_integration.rs          → ok. 0 passed; 2 ignored
tests/session_control_api.rs           → ok. 10 passed;  tests/session_lifecycle.rs             → ok. 4 passed
tests/session_manager_mvp.rs           → ok. 28 passed; 2 ignored
tests/session_manager_slots.rs         → ok. 2 passed;   tests/sm_e2e_smoke.rs                  → ok. 1 passed
tests/standalone_isolation.rs          → ok. 11 passed;  tests/test_session_lifecycle.rs        → ok. 1 passed
tests/tm_compress_pipe.rs              → ok. 3 passed;   tests/tm_doctor_standalone.rs          → ok. 3 passed
tests/tm_guided_default_explicit_url.rs → ok. 1 passed;  tests/tm_hook_delegation_payload.rs    → ok. 4 passed
tests/tm_hook_idle_parking.rs          → ok. 5 passed;   tests/tm_hook_pm_guard.rs              → ok. 132 passed
tests/tm_hook_pretooluse_rewrite.rs    → ok. 6 passed;   tests/tm_sessions_alias_notice.rs      → ok. 3 passed
tests/tm_sessions_instructions_diagnostics.rs → ok. 3 passed
tests/worktree_request_fail_closed.rs  → ok. 1 passed
Doc-tests trusty_mpm                   → ok. 1 passed / ok. 3 passed
```

## After the rebase onto 788e61e81

`fmt --check` EXIT=0, `clippy -p trusty-mpm --all-targets -- -D warnings`
EXIT=0. The first `--lib` run on the moved base failed one unrelated test,
`core::gh_account::enforce::tests::ensure_gh_account_in_dir_accepts_the_api_answer_over_a_stale_transcript`,
on `` `gh auth status` did not respond within 5s `` — a subprocess timeout, in a
file this branch does not touch (the branch is one commit changing only
`sessions_legacy_tests.rs`). It passed in isolation in 1.34s, and the re-run of
the full suite was green:

```
test result: ok. 6108 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out; finished in 239.63s
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
