### PR TITLE
ci: gate the Tauri UI clippy jobs on a per-crate dependency-closure output of the changes job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,8 +375,12 @@ jobs:
             exit 0
           fi
 
+          # #7063: `-z` — without it git C-quotes any path carrying a non-ASCII
+          # byte, a double quote or a backslash, and the quoted string matches
+          # no crate directory, so a change inside the crate answers `false`
+          # and that crate's required clippy job is skipped.
           changed="${RUNNER_TEMP}/ui-changed-paths.txt"
-          if ! git diff --name-only --no-renames "$merge_base" HEAD > "$changed"; then
+          if ! git diff -z --name-only --no-renames "$merge_base" HEAD > "$changed"; then
             fail_closed "git diff against ${merge_base} failed"
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,17 @@ jobs:
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
       embedder_cuda_relevant: ${{ steps.detect-cuda.outputs.embedder_cuda_relevant }}
+      # #7063: one pair per Tauri UI crate — the verdict the four clippy jobs
+      # gate their expensive steps on, and the one-line reason each job echoes
+      # so a skipped run says why in its own log instead of only in this one.
+      trusty_agents_ui_relevant: ${{ steps.detect-ui.outputs.trusty_agents_ui_relevant }}
+      trusty_agents_ui_reason: ${{ steps.detect-ui.outputs.trusty_agents_ui_reason }}
+      trusty_audit_ui_relevant: ${{ steps.detect-ui.outputs.trusty_audit_ui_relevant }}
+      trusty_audit_ui_reason: ${{ steps.detect-ui.outputs.trusty_audit_ui_reason }}
+      trusty_mpm_gui_relevant: ${{ steps.detect-ui.outputs.trusty_mpm_gui_relevant }}
+      trusty_mpm_gui_reason: ${{ steps.detect-ui.outputs.trusty_mpm_gui_reason }}
+      trusty_code_gui_relevant: ${{ steps.detect-ui.outputs.trusty_code_gui_relevant }}
+      trusty_code_gui_reason: ${{ steps.detect-ui.outputs.trusty_code_gui_reason }}
     steps:
       # fetch-depth: 0 — the detector needs `git merge-base` against the base
       # branch, which a shallow checkout cannot resolve.
@@ -229,6 +240,12 @@ jobs:
       # until a human notices main has been red for a day.
       - name: Red-main notifier coverage (#5657)
         run: bash scripts/check-red-main-coverage.sh
+
+      # #7063: the crate-relevance detector decides whether four REQUIRED jobs
+      # do any work, so its own regression fixtures run here — before the step
+      # that consults it — rather than nowhere.
+      - name: Crate-relevance selftest (#7063)
+        run: bash scripts/ci-crate-relevance-selftest.sh
 
       # Refresh the base branch ref (same fix as #4688 in version-parity.yml's
       # pr-version-bump job). `github.event.pull_request.base.sha` is a
@@ -308,6 +325,65 @@ jobs:
             exit 0
           fi
           CUDA_SCOPE_BASE="$before" bash scripts/detect-embedder-cuda-relevant.sh > /dev/null
+
+      # #7063: the four Tauri UI clippy jobs are REQUIRED contexts, so they run
+      # and report on every PR no matter what this step decides — only their
+      # expensive steps consult the booleans written here. Before this, their
+      # sole gate was `docs_only`, so a PR touching one unrelated crate still
+      # paid for a WebKit2GTK apt chain plus a cargo clippy in all four:
+      # trusty-mpm-gui has no workspace dependencies at all and still spent
+      # 1m20s on PR #7062, and trusty-code-gui spent 7m there and has timed out
+      # at 30m before (PR #5992).
+      #
+      # The change set is resolved ONCE here and piped to each crate, so all
+      # four answers and `docs_only` above are decisions about the same diff.
+      # Every failure arm writes `true` for all four: a detector that cannot
+      # answer must cost a full build, never a silent skip — the same rule the
+      # `!cancelled()` job conditions below encode.
+      - name: Classify Tauri UI crate relevance (#7063)
+        id: detect-ui
+        env:
+          UI_CRATES: "trusty-agents-ui trusty-audit-ui trusty-mpm-gui trusty-code-gui"
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -uo pipefail
+
+          fail_closed() {
+            echo "classify-ui: $1 — every Tauri UI job runs (fail closed)"
+            for crate in $UI_CRATES; do
+              key="$(printf '%s' "$crate" | tr - _)"
+              printf '%s_relevant=true\n' "$key" >> "$GITHUB_OUTPUT"
+              printf '%s_reason=fail closed: %s\n' "$key" "$1" >> "$GITHUB_OUTPUT"
+            done
+          }
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base="origin/${BASE_REF}"
+          else
+            base="${PUSH_BEFORE}"
+          fi
+
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            fail_closed "no usable base SHA"
+            exit 0
+          fi
+
+          if ! merge_base="$(git merge-base "$base" HEAD)"; then
+            fail_closed "cannot resolve merge-base against '${base}'"
+            exit 0
+          fi
+
+          changed="${RUNNER_TEMP}/ui-changed-paths.txt"
+          if ! git diff --name-only --no-renames "$merge_base" HEAD > "$changed"; then
+            fail_closed "git diff against ${merge_base} failed"
+            exit 0
+          fi
+
+          for crate in $UI_CRATES; do
+            bash scripts/ci-crate-relevance.sh "$crate" < "$changed" > /dev/null
+          done
 
   # --------------------------------------------------------------------------
   # fmt: enforce cargo fmt --all --check (stable toolchain + rustfmt component)
@@ -1375,10 +1451,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # #7063: one line saying whether this job does real work and why.
+      # Unconditional, so the reason is present on a skipped run too. The
+      # `changes` job's `Classify Tauri UI crate relevance` step logs the
+      # full changed-file list and the derived closure this reason cites.
+      - name: Relevance decision (#7063)
+        env:
+          DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          RELEVANT: ${{ needs.changes.outputs.trusty_agents_ui_relevant }}
+          REASON: ${{ needs.changes.outputs.trusty_agents_ui_reason }}
+        run: |
+          if [ "$DOCS_ONLY" = "true" ]; then
+            echo "trusty-agents-ui: skipped — the change set is Cargo-inert (docs_only=true)"
+          elif [ "$RELEVANT" = "false" ]; then
+            echo "trusty-agents-ui: skipped — ${REASON:-outside the dependency closure}"
+          else
+            echo "trusty-agents-ui: running — ${REASON:-relevance undetermined, failing closed}"
+          fi
+
       - uses: actions/checkout@v5
 
       - name: Install stable toolchain with clippy
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_agents_ui_relevant != 'false'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -1387,7 +1481,7 @@ jobs:
       # mirror the Tauri project's documented Linux prerequisites and are the
       # same reason the headless workspace jobs exclude this crate.
       - name: Install Tauri system dependencies
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_agents_ui_relevant != 'false'
         run: |
           bash scripts/ci-apt-install.sh \
             build-essential \
@@ -1401,7 +1495,7 @@ jobs:
             libjavascriptcoregtk-4.1-dev
 
       - name: Cache cargo artifacts
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_agents_ui_relevant != 'false'
         uses: Swatinem/rust-cache@v2
         with:
           key: agents-ui
@@ -1412,14 +1506,14 @@ jobs:
 
       # Stub the frontendDist so tauri::generate_context!() can embed it.
       - name: Stub frontend dist for generate_context!
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_agents_ui_relevant != 'false'
         run: |
           mkdir -p crates/trusty-agents/ui/dist
           printf '<!doctype html><html><head><meta charset="utf-8"><title>trusty-agents</title></head><body></body></html>\n' \
             > crates/trusty-agents/ui/dist/index.html
 
       - name: cargo clippy -p trusty-agents-ui --all-targets -- -D warnings
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_agents_ui_relevant != 'false'
         run: cargo clippy -p trusty-agents-ui --all-targets -- -D warnings
 
   # --------------------------------------------------------------------------
@@ -1450,16 +1544,34 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # #7063: one line saying whether this job does real work and why.
+      # Unconditional, so the reason is present on a skipped run too. The
+      # `changes` job's `Classify Tauri UI crate relevance` step logs the
+      # full changed-file list and the derived closure this reason cites.
+      - name: Relevance decision (#7063)
+        env:
+          DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          RELEVANT: ${{ needs.changes.outputs.trusty_audit_ui_relevant }}
+          REASON: ${{ needs.changes.outputs.trusty_audit_ui_reason }}
+        run: |
+          if [ "$DOCS_ONLY" = "true" ]; then
+            echo "trusty-audit-ui: skipped — the change set is Cargo-inert (docs_only=true)"
+          elif [ "$RELEVANT" = "false" ]; then
+            echo "trusty-audit-ui: skipped — ${REASON:-outside the dependency closure}"
+          else
+            echo "trusty-audit-ui: running — ${REASON:-relevance undetermined, failing closed}"
+          fi
+
       - uses: actions/checkout@v5
 
       - name: Install stable toolchain with clippy
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_audit_ui_relevant != 'false'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
       - name: Install Tauri system dependencies
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_audit_ui_relevant != 'false'
         run: |
           bash scripts/ci-apt-install.sh \
             build-essential \
@@ -1473,7 +1585,7 @@ jobs:
             libjavascriptcoregtk-4.1-dev
 
       - name: Cache cargo artifacts
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_audit_ui_relevant != 'false'
         uses: Swatinem/rust-cache@v2
         with:
           key: audit-ui
@@ -1484,20 +1596,20 @@ jobs:
       # Stub the frontendDist so tauri::generate_context!() can embed it.
       # SKIP_UI_BUILD=1 below stops build.rs looking for pnpm.
       - name: Stub frontend dist for generate_context!
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_audit_ui_relevant != 'false'
         run: |
           mkdir -p crates/trusty-audit/ui/dist
           printf '<!doctype html><html><head><meta charset="utf-8"><title>trusty-audit</title></head><body></body></html>\n' \
             > crates/trusty-audit/ui/dist/index.html
 
       - name: cargo clippy -p trusty-audit-ui --all-targets -- -D warnings
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_audit_ui_relevant != 'false'
         env:
           SKIP_UI_BUILD: "1"
         run: cargo clippy -p trusty-audit-ui --all-targets -- -D warnings
 
       - name: cargo test -p trusty-audit-ui
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_audit_ui_relevant != 'false'
         env:
           SKIP_UI_BUILD: "1"
         run: cargo test -p trusty-audit-ui
@@ -1532,16 +1644,34 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # #7063: one line saying whether this job does real work and why.
+      # Unconditional, so the reason is present on a skipped run too. The
+      # `changes` job's `Classify Tauri UI crate relevance` step logs the
+      # full changed-file list and the derived closure this reason cites.
+      - name: Relevance decision (#7063)
+        env:
+          DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          RELEVANT: ${{ needs.changes.outputs.trusty_mpm_gui_relevant }}
+          REASON: ${{ needs.changes.outputs.trusty_mpm_gui_reason }}
+        run: |
+          if [ "$DOCS_ONLY" = "true" ]; then
+            echo "trusty-mpm-gui: skipped — the change set is Cargo-inert (docs_only=true)"
+          elif [ "$RELEVANT" = "false" ]; then
+            echo "trusty-mpm-gui: skipped — ${REASON:-outside the dependency closure}"
+          else
+            echo "trusty-mpm-gui: running — ${REASON:-relevance undetermined, failing closed}"
+          fi
+
       - uses: actions/checkout@v5
 
       - name: Install stable toolchain with clippy
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_mpm_gui_relevant != 'false'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
       - name: Install Tauri system dependencies
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_mpm_gui_relevant != 'false'
         run: |
           bash scripts/ci-apt-install.sh \
             build-essential \
@@ -1555,7 +1685,7 @@ jobs:
             libjavascriptcoregtk-4.1-dev
 
       - name: Cache cargo artifacts
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_mpm_gui_relevant != 'false'
         uses: Swatinem/rust-cache@v2
         with:
           key: mpm-gui
@@ -1566,14 +1696,14 @@ jobs:
       # Stub the frontendDist so tauri::generate_context!() can embed it.
       # SKIP_UI_BUILD=1 below stops build.rs looking for pnpm.
       - name: Stub frontend dist for generate_context!
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_mpm_gui_relevant != 'false'
         run: |
           mkdir -p crates/trusty-mpm-gui/ui/dist
           printf '<!doctype html><html><head><meta charset="utf-8"><title>trusty-mpm-gui</title></head><body></body></html>\n' \
             > crates/trusty-mpm-gui/ui/dist/index.html
 
       - name: cargo clippy -p trusty-mpm-gui --all-targets -- -D warnings
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_mpm_gui_relevant != 'false'
         env:
           SKIP_UI_BUILD: "1"
         run: cargo clippy -p trusty-mpm-gui --all-targets -- -D warnings
@@ -1582,7 +1712,7 @@ jobs:
       # that tests added later actually run — clippy --all-targets only compiles
       # the test target, it never executes it.
       - name: cargo test -p trusty-mpm-gui
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_mpm_gui_relevant != 'false'
         env:
           SKIP_UI_BUILD: "1"
         run: cargo test -p trusty-mpm-gui
@@ -1604,16 +1734,34 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # #7063: one line saying whether this job does real work and why.
+      # Unconditional, so the reason is present on a skipped run too. The
+      # `changes` job's `Classify Tauri UI crate relevance` step logs the
+      # full changed-file list and the derived closure this reason cites.
+      - name: Relevance decision (#7063)
+        env:
+          DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          RELEVANT: ${{ needs.changes.outputs.trusty_code_gui_relevant }}
+          REASON: ${{ needs.changes.outputs.trusty_code_gui_reason }}
+        run: |
+          if [ "$DOCS_ONLY" = "true" ]; then
+            echo "trusty-code-gui: skipped — the change set is Cargo-inert (docs_only=true)"
+          elif [ "$RELEVANT" = "false" ]; then
+            echo "trusty-code-gui: skipped — ${REASON:-outside the dependency closure}"
+          else
+            echo "trusty-code-gui: running — ${REASON:-relevance undetermined, failing closed}"
+          fi
+
       - uses: actions/checkout@v5
 
       - name: Install stable toolchain with clippy
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_code_gui_relevant != 'false'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
       - name: Install Tauri system dependencies
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_code_gui_relevant != 'false'
         run: |
           bash scripts/ci-apt-install.sh \
             build-essential \
@@ -1627,7 +1775,7 @@ jobs:
             libjavascriptcoregtk-4.1-dev
 
       - name: Cache cargo artifacts
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_code_gui_relevant != 'false'
         uses: Swatinem/rust-cache@v2
         with:
           key: code-gui
@@ -1638,20 +1786,20 @@ jobs:
       # Stub the frontendDist so tauri::generate_context!() can embed it.
       # SKIP_UI_BUILD=1 below stops build.rs looking for pnpm.
       - name: Stub frontend dist for generate_context!
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_code_gui_relevant != 'false'
         run: |
           mkdir -p crates/trusty-code-gui/ui/dist
           printf '<!doctype html><html><head><meta charset="utf-8"><title>trusty-code-gui</title></head><body></body></html>\n' \
             > crates/trusty-code-gui/ui/dist/index.html
 
       - name: cargo clippy -p trusty-code-gui --all-targets -- -D warnings
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_code_gui_relevant != 'false'
         env:
           SKIP_UI_BUILD: "1"
         run: cargo clippy -p trusty-code-gui --all-targets -- -D warnings
 
       - name: cargo test -p trusty-code-gui
-        if: needs.changes.outputs.docs_only != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.trusty_code_gui_relevant != 'false'
         env:
           SKIP_UI_BUILD: "1"
         run: cargo test -p trusty-code-gui

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,14 @@ change's blast radius. Risk labels map onto the rungs (1–2 Low, 3–4 Normal,
   ```
 
 - Every required job triggers unconditionally (no `paths:` filters) and
-  short-circuits on the `docs_only` boolean from the `changes` job
-  (`ci.yml:166-195`).
+  short-circuits on the `docs_only` boolean from the `changes` job.
+- 🟡 **The four Tauri UI clippy jobs short-circuit on a second boolean (#7063).**
+  The `changes` job also emits `<crate>_relevant` per UI crate, computed by
+  `scripts/ci-crate-relevance.sh` from the crate's transitive workspace
+  dependency closure, so a PR that cannot reach `trusty-mpm-gui` no longer pays
+  for its WebKit2GTK apt chain and cargo clippy. The jobs still run and report —
+  they are required contexts (#5929, #5935) — and every failure arm of the
+  detector answers `true`, so a broken classifier costs a full build.
 - `required_status_checks.strict` is `false`: a PR's head need not be current
   with `main` for its checks to count.
 - 🟡 The required `Clippy` job runs `--workspace --all-targets` but excludes the
@@ -574,7 +580,7 @@ already deployed in `trusty-console/ui-search`, `trusty-analyze/ui`,
 
 Most references are linked from the rule they serve, above. Not linked elsewhere:
 
-- [ci-scripts.md](docs/reference/ci-scripts.md) — the nine `scripts/` checks that run only in a workflow: where each runs, what it gates, and which have a self-test
+- [ci-scripts.md](docs/reference/ci-scripts.md) — the ten `scripts/` checks that run only in a workflow: where each runs, what it gates, and which have a self-test
 - [documentation-layout.md](docs/reference/documentation-layout.md) — docs layout conventions
 - [DOC-38](docs/specs/spec-linked-documentation.md) — SLD policy, enforced by `scripts/check_sld.sh`
 - [threat-model.md](docs/reference/threat-model.md) — per-daemon bind/guard/proxy inventory ([ADR-0018](docs/adr/0018-loopback-only-doctrine.md))

--- a/docs/reference/ci-scripts.md
+++ b/docs/reference/ci-scripts.md
@@ -2,13 +2,13 @@
 
 (Plus two operator scripts no workflow runs at all — see the last section.)
 
-Nine scripts in `scripts/` run in a GitHub Actions workflow and nowhere else —
+Ten scripts in `scripts/` run in a GitHub Actions workflow and nowhere else —
 no pre-commit hook, no `Makefile` target, no other doc page. Each was written
 for a specific failure and none of them announced itself anywhere a reader
 would look, so a change to one of the workflows below could drop it with
 nothing to notice.
 
-`check_public_docs.sh` is listed as a tenth row for the opposite reason: it ran
+`check_public_docs.sh` is listed as an eleventh row for the opposite reason: it ran
 in a pre-commit hook ALONE until #5134, which is unenforceable (`--no-verify`, a
 commit made outside the repo's hook path, a merge that runs no hook), and two
 files asserted a CI job that did not exist.
@@ -32,13 +32,14 @@ what it stops; the header says why it exists.
 | `classify-ci-results.sh` | `ci.yml`, `red-main-notify.yml` | Turns a set of job conclusions into the red-main verdict. `cancelled` is not `failure`, so the previous `contains(needs.*.result, 'failure')` test let an all-cancelled run report main verified (#4179). |
 | `ci-create-local-main.sh` | `ci.yml`, `pre-publish.yml` | Creates the local `main` branch the `trusty-agents` git tests need, and fails the step when creation genuinely fails. The `git fetch origin main:main \|\| true` it replaced swallowed a GitHub 500 and produced an unrelated test failure eleven minutes later (#5693). |
 | `detect-embedder-cuda-relevant.sh` | `ci.yml` | Decides whether a change can affect the `trusty-common` `embedder-cuda` build, so the CUDA leg runs when it is relevant and is skipped when it is not. |
+| `ci-crate-relevance.sh` | `ci.yml` | Decides whether a change can affect ONE crate's build, so the four required Tauri UI clippy jobs skip their expensive steps when the diff cannot reach that crate (#7063). The closure comes from `cargo metadata --no-deps` at run time, dev- and build-dependencies included, and matching is on path segments; every error answers `true`, so a broken detector costs a full build and never a silent skip. The jobs themselves still run and report — a required context that reports nothing wedges the PR BLOCKED (#4468). |
 | `check_workspace_dep_versions.sh` | `version-parity.yml` (`pr-version-bump`) | Asserts every internal `[workspace.dependencies]` row's `version` requirement actually accepts the member crate's own version, under Cargo's caret rules. The row's `path` wins in-tree, so no cargo command in the workspace can see the drift — `trusty-console` sat at `^0.9.0` against a 0.11.0 crate and `tga` at `^6.0.1` against 7.1.0, both invisible until `cargo publish` or an external consumer resolved from the registry (#6776, same class as #4088). |
 | `check_public_docs.sh` | `public-docs.yml`, plus the `public-docs` pre-commit hook | Validates `docs/public-manifest.tsv`, the allowlist the website publishes from: every PAGE row must resolve to an existing `.md` under `docs/`, outside the DO-NOT-PUBLISH trees, on a unique route. The STALE content pass runs in the same invocation and needs NO flag (#5134) — every published page is searched for the retired names in `docs/public-stale-terms.tsv`, whose waivers are a count ratchet in both directions. Both call sites invoke the script bare, so neither can drop the content check without deleting the gate outright. A page the gate cannot read fails as `UNREADABLE` rather than passing as clean. |
 | `check_token_drift.mjs` | `token-drift.yml` | Compares each Tailwind app's hand-transcribed `--color-*` RGB triples against the canonical Foundry `tokens.css`. `ci.yml` deliberately does NOT duplicate it (`ci.yml`, `ui-checks` job): `token-drift.yml` already runs it across all seven crates directly rather than through each `package.json`. |
 
 ## Self-tests
 
-Eight of the ten have a companion test that proves the gate can still fail — a
+Nine of the eleven have a companion test that proves the gate can still fail — a
 gate that cannot fail makes its own green meaningless:
 
 | Script | Its test |
@@ -48,6 +49,7 @@ gate that cannot fail makes its own green meaningless:
 | `generate-homebrew-formula.sh` | `scripts/generate-homebrew-formula-selftest.sh` |
 | `classify-ci-results.sh` | `scripts/check-ci-helpers-selftest.sh` |
 | `detect-embedder-cuda-relevant.sh` | `scripts/check-ci-helpers-selftest.sh` |
+| `ci-crate-relevance.sh` | `scripts/ci-crate-relevance-selftest.sh`, run as a step of `ci.yml`'s `changes` job before the step that consults the detector. Its closure cases run against a throwaway fixture workspace rather than this repo's graph, so an unrelated PR that adds a dependency edge does not turn them red; a short live section holds only #7063's four acceptance pairs |
 | `check_token_drift.mjs` | `scripts/check_token_drift.test.mjs`, a `node:test` suite `token-drift.yml` runs before the gate |
 | `check_workspace_dep_versions.sh` | `scripts/check_workspace_dep_versions_selftest.sh`, run as the step before the gate in the same job |
 | `check_public_docs.sh` | `scripts/check_public_docs_selftest.sh`, run as the step before the gate in the same job. Two of its cases pass no `--stale` flag at all, so a change that made the content pass opt-in again fails there rather than going quiet |

--- a/scripts/ci-crate-relevance-selftest.sh
+++ b/scripts/ci-crate-relevance-selftest.sh
@@ -27,13 +27,16 @@
 #   against an input that answers `false` when cargo works, so it proves the
 #   arm was reached rather than that the answer happened to be true.
 #
-#   One section builds real single-commit git repos and drives the script
-#   through its OWN `git diff` (#7063). Feeding paths on stdin cannot reach
-#   that defect: git C-quotes a path holding a non-ASCII byte, a double quote
-#   or a backslash, and the quoted string matches no crate directory, so a
-#   change INSIDE a crate answered `false` and that crate's required clippy job
-#   was skipped. Its last case is a non-ASCII path OUTSIDE the closure,
-#   asserting `false`, so the section cannot pass by answering `true` always.
+#   One section builds real single-commit git repos and drives the script over
+#   a diff git actually produced (#7063). A hand-fed path list cannot reach that
+#   defect: git C-quotes a path holding a non-ASCII byte, a double quote or a
+#   backslash, and the quoted string matches no crate directory, so a change
+#   INSIDE a crate answered `false` and that crate's required clippy job was
+#   skipped. The section covers BOTH ways a caller supplies the change set —
+#   CRATE_RELEVANCE_BASE, where the script diffs for itself, and stdin, which is
+#   what ci.yml's Classify step uses — because the fix has to hold on each. Two
+#   cases are non-ASCII paths OUTSIDE the closure asserting `false`, one per
+#   route, so neither can pass by answering `true` always.
 #
 # Usage: bash scripts/ci-crate-relevance-selftest.sh
 # Exit: 0 when every case matches; 1 otherwise, printing both sides of each
@@ -151,38 +154,74 @@ live_verdict() {
   (cd "${REPO_ROOT}" && printf '%s\n' "$@" | bash "${SCRIPT}" "${crate}" 2>/dev/null)
 }
 
-# gitfix_verdict <crate> <added path>... — build a throwaway git repo from the
-# pristine fixture, add the named files in a second commit, and let the script
-# resolve the change set with its OWN `git diff` (#7063). A fresh repo per case
+# build_gitfix <added path>... — copy the pristine fixture into a throwaway git
+# repo, commit it, add the named files in a second commit, and print the repo
+# path on line 1 with the base commit's SHA on line 2. A fresh repo per case
 # keeps the cases independent and needs no history rewriting between them.
-gitfix_verdict() {
-  local crate="$1" repo path base
-  shift
-  repo="$(mktemp -d "${WORK}/gitcase.XXXXXX")" || return 1
-  cp -R "${PRISTINE}/." "${repo}/" || return 1
+# Printing nothing means the fixture could not be built; both verdict helpers
+# below turn that into a visible failure rather than letting the script's
+# fail-closed arm answer `true` for a reason unrelated to path quoting.
+build_gitfix() {
+  local repo path base
+  repo="$(mktemp -d "${WORK}/gitcase.XXXXXX")" || return 0
+  cp -R "${PRISTINE}/." "${repo}/" || return 0
   (
-    cd "${repo}" || exit 1
+    cd "${repo}" || exit 0
     git init -q . >/dev/null 2>&1
     git config user.email selftest@example.invalid >/dev/null 2>&1
     git config user.name selftest >/dev/null 2>&1
     git add -A >/dev/null 2>&1
     git commit -qm base >/dev/null 2>&1
     base="$(git rev-parse HEAD 2>/dev/null)"
-    # Without this, a git that could not build the fixture would leave
-    # CRATE_RELEVANCE_BASE empty, the script would read its empty stdin, and
-    # the fail-closed arm would answer `true` — passing five of the six cases
-    # below for a reason that has nothing to do with path quoting.
-    if [ -z "${base}" ]; then
-      echo "git-fixture-setup-failed"
-      exit 0
-    fi
+    [ -n "${base}" ] || exit 0
     for path in "$@"; do
       mkdir -p "$(dirname "${path}")"
       printf 'pub fn x() {}\n' >"${path}"
     done
     git add -A >/dev/null 2>&1
     git commit -qm change >/dev/null 2>&1
-    CRATE_RELEVANCE_BASE="${base}" bash "${SCRIPT}" "${crate}" </dev/null 2>/dev/null
+    printf '%s\n%s\n' "${repo}" "${base}"
+  )
+}
+
+# gitfix_verdict <crate> <added path>... — the CRATE_RELEVANCE_BASE route: the
+# script resolves the change set itself, with its own `git diff -z` (#7063).
+gitfix_verdict() {
+  local crate="$1" fixture repo base
+  shift
+  fixture="$(build_gitfix "$@")"
+  repo="$(printf '%s\n' "${fixture}" | sed -n '1p')"
+  base="$(printf '%s\n' "${fixture}" | sed -n '2p')"
+  if [ -z "${repo}" ] || [ -z "${base}" ]; then
+    echo "git-fixture-setup-failed"
+    return 0
+  fi
+  (cd "${repo}" && CRATE_RELEVANCE_BASE="${base}" bash "${SCRIPT}" "${crate}" </dev/null 2>/dev/null)
+}
+
+# #7063: stdin_gitfix_verdict <crate> <added path>... — the OTHER route, and the
+# one ci.yml's Classify step actually uses: the CALLER runs `git diff -z`, writes
+# the NUL-delimited result to a file, and hands that file to the script on stdin
+# with CRATE_RELEVANCE_BASE unset, so the script takes its `cat` branch instead
+# of diffing anything. The fix has to hold on both routes, and only this one
+# covers the workflow's own call shape.
+stdin_gitfix_verdict() {
+  local crate="$1" fixture repo base changed
+  shift
+  fixture="$(build_gitfix "$@")"
+  repo="$(printf '%s\n' "${fixture}" | sed -n '1p')"
+  base="$(printf '%s\n' "${fixture}" | sed -n '2p')"
+  if [ -z "${repo}" ] || [ -z "${base}" ]; then
+    echo "git-fixture-setup-failed"
+    return 0
+  fi
+  # Beside the repo, not inside it, so the fixture's own diff stays what the
+  # case set up.
+  changed="${repo}.changed-paths"
+  (
+    cd "${repo}" || exit 1
+    git diff -z --name-only --no-renames "${base}" HEAD >"${changed}" 2>/dev/null
+    bash "${SCRIPT}" "${crate}" <"${changed}" 2>/dev/null
   )
 }
 
@@ -255,6 +294,23 @@ assert_eq "top <- crates/unrelated/src/café.rs (non-ASCII, outside)" \
 # did not break the common case.
 assert_eq "top <- crates/top/src/plain.rs (ASCII, own dir)" \
   "true" "$(gitfix_verdict top 'crates/top/src/plain.rs')"
+
+# The cases above take the CRATE_RELEVANCE_BASE route. ci.yml's Classify step
+# takes the other one — it runs `git diff -z` itself and pipes the result in on
+# stdin — so the same two answers are asserted through that call shape too.
+assert_eq "stdin: top <- crates/mid/src/café.rs (non-ASCII, in the closure)" \
+  "true" "$(stdin_gitfix_verdict top 'crates/mid/src/café.rs')"
+assert_eq "stdin: top <- crates/unrelated/src/café.rs (non-ASCII, outside)" \
+  "false" "$(stdin_gitfix_verdict top 'crates/unrelated/src/café.rs')"
+# Two paths, the inert one sorting first, so `git diff -z` writes them as
+# `crates/mid/…\0crates/top-extra/…\0` on a single line. A reader that splits on
+# newlines sees one token beginning `crates/mid/`, which is outside top-extra's
+# closure, and answers `false`; splitting on NUL finds the second path under the
+# crate's own directory. This is the case that separates the two parsers — with
+# one path the trailing NUL lands past the directory prefix and a line-splitting
+# reader gets the right answer by accident.
+assert_eq "stdin: top-extra <- inert path first, then its own café.rs" \
+  "true" "$(stdin_gitfix_verdict top-extra 'crates/mid/src/x.rs' 'crates/top-extra/src/café.rs')"
 
 echo "fixture: fail-closed arms"
 assert_eq "no crate name" \

--- a/scripts/ci-crate-relevance-selftest.sh
+++ b/scripts/ci-crate-relevance-selftest.sh
@@ -27,6 +27,14 @@
 #   against an input that answers `false` when cargo works, so it proves the
 #   arm was reached rather than that the answer happened to be true.
 #
+#   One section builds real single-commit git repos and drives the script
+#   through its OWN `git diff` (#7063). Feeding paths on stdin cannot reach
+#   that defect: git C-quotes a path holding a non-ASCII byte, a double quote
+#   or a backslash, and the quoted string matches no crate directory, so a
+#   change INSIDE a crate answered `false` and that crate's required clippy job
+#   was skipped. Its last case is a non-ASCII path OUTSIDE the closure,
+#   asserting `false`, so the section cannot pass by answering `true` always.
+#
 # Usage: bash scripts/ci-crate-relevance-selftest.sh
 # Exit: 0 when every case matches; 1 otherwise, printing both sides of each
 #   mismatch.
@@ -122,6 +130,13 @@ new_crate crates/nested/ui/src-tauri nested-ui
   echo 'nested = { path = "../.." }'
 } >>"${FIXTURE}/crates/nested/ui/src-tauri/Cargo.toml"
 
+# A pristine copy, taken before any verdict runs so the Cargo.lock that
+# `cargo metadata` writes never reaches a git fixture and never shows up as a
+# changed path (Cargo.lock is a workspace-wide input, which would make every
+# git-fixture case answer `true` for the wrong reason).
+PRISTINE="${WORK}/pristine"
+cp -R "${FIXTURE}" "${PRISTINE}"
+
 # fixture_verdict <crate> <changed path>... — run the script inside the fixture.
 fixture_verdict() {
   local crate="$1"
@@ -134,6 +149,41 @@ live_verdict() {
   local crate="$1"
   shift
   (cd "${REPO_ROOT}" && printf '%s\n' "$@" | bash "${SCRIPT}" "${crate}" 2>/dev/null)
+}
+
+# gitfix_verdict <crate> <added path>... — build a throwaway git repo from the
+# pristine fixture, add the named files in a second commit, and let the script
+# resolve the change set with its OWN `git diff` (#7063). A fresh repo per case
+# keeps the cases independent and needs no history rewriting between them.
+gitfix_verdict() {
+  local crate="$1" repo path base
+  shift
+  repo="$(mktemp -d "${WORK}/gitcase.XXXXXX")" || return 1
+  cp -R "${PRISTINE}/." "${repo}/" || return 1
+  (
+    cd "${repo}" || exit 1
+    git init -q . >/dev/null 2>&1
+    git config user.email selftest@example.invalid >/dev/null 2>&1
+    git config user.name selftest >/dev/null 2>&1
+    git add -A >/dev/null 2>&1
+    git commit -qm base >/dev/null 2>&1
+    base="$(git rev-parse HEAD 2>/dev/null)"
+    # Without this, a git that could not build the fixture would leave
+    # CRATE_RELEVANCE_BASE empty, the script would read its empty stdin, and
+    # the fail-closed arm would answer `true` — passing five of the six cases
+    # below for a reason that has nothing to do with path quoting.
+    if [ -z "${base}" ]; then
+      echo "git-fixture-setup-failed"
+      exit 0
+    fi
+    for path in "$@"; do
+      mkdir -p "$(dirname "${path}")"
+      printf 'pub fn x() {}\n' >"${path}"
+    done
+    git add -A >/dev/null 2>&1
+    git commit -qm change >/dev/null 2>&1
+    CRATE_RELEVANCE_BASE="${base}" bash "${SCRIPT}" "${crate}" </dev/null 2>/dev/null
+  )
 }
 
 echo "fixture: the crate's own directory"
@@ -183,6 +233,28 @@ for path in Cargo.lock Cargo.toml clippy.toml rust-toolchain rust-toolchain.toml
   scripts/ci-crate-relevance-selftest.sh; do
   assert_eq "top <- ${path}" "true" "$(fixture_verdict top "${path}")"
 done
+
+echo "fixture: git-quoted paths reach the matcher (#7063)"
+# Each of these three characters makes git C-quote the path — wrapping it in
+# literal double quotes and escaping the byte — unless the diff is read with
+# `-z`. The quoted string is under no crate directory, so before the fix a
+# change inside the crate answered `false`.
+assert_eq "top <- crates/top/src/café.rs (non-ASCII, own dir)" \
+  "true" "$(gitfix_verdict top 'crates/top/src/café.rs')"
+assert_eq "top <- crates/mid/src/café.rs (non-ASCII, in the closure)" \
+  "true" "$(gitfix_verdict top 'crates/mid/src/café.rs')"
+assert_eq 'top <- crates/top/src/a"b.rs (double quote, own dir)' \
+  "true" "$(gitfix_verdict top 'crates/top/src/a"b.rs')"
+assert_eq 'top <- crates/top/src/back\slash.rs (backslash, own dir)' \
+  "true" "$(gitfix_verdict top 'crates/top/src/back\slash.rs')"
+# The control: a quoted path that is genuinely inert must still answer `false`,
+# so the four above cannot be passing because the fix answers `true` always.
+assert_eq "top <- crates/unrelated/src/café.rs (non-ASCII, outside)" \
+  "false" "$(gitfix_verdict top 'crates/unrelated/src/café.rs')"
+# An ordinary ASCII path through the same git-diff route, pinning that `-z`
+# did not break the common case.
+assert_eq "top <- crates/top/src/plain.rs (ASCII, own dir)" \
+  "true" "$(gitfix_verdict top 'crates/top/src/plain.rs')"
 
 echo "fixture: fail-closed arms"
 assert_eq "no crate name" \

--- a/scripts/ci-crate-relevance-selftest.sh
+++ b/scripts/ci-crate-relevance-selftest.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+#
+# ci-crate-relevance-selftest.sh — regression fixtures for
+#   scripts/ci-crate-relevance.sh (#7063).
+#
+# Why: that script decides whether four REQUIRED Tauri UI clippy jobs do any
+#   real work, and both ways of being wrong are invisible in a diff review. Too
+#   eager and the gate saves nothing; too eager the other way and a crate
+#   reaches main uncompiled, which is the hole #5934 / #5935 closed. The
+#   `false` answers below are the ones that matter: a detector that can only
+#   ever say `true` is one nobody would notice had broken.
+#
+# What: builds a throwaway Cargo workspace with a known dependency shape —
+#   top -> mid -> leaf, top -(dev)-> devonly, an unrelated crate, a sibling
+#   whose name extends top's, and a crate nested inside another crate's
+#   directory — and asserts the verdict for each. Testing the closure walk
+#   against a fixture rather than against this repo's live graph is deliberate:
+#   an unrelated PR that adds a dependency edge must not turn these cases red.
+#
+#   A short LIVE section follows, holding only the four pairs #7063 names as
+#   its acceptance criteria. Those DO track this repo's real graph, and are
+#   expected to change when a Tauri UI crate gains or loses a dependency.
+#
+#   Every fail-closed arm is covered too: no crate name, an unknown crate, an
+#   empty change set, a blank-only change set, an unresolvable base ref, and a
+#   `cargo metadata` that cannot run. The cargo-failure case is asserted
+#   against an input that answers `false` when cargo works, so it proves the
+#   arm was reached rather than that the answer happened to be true.
+#
+# Usage: bash scripts/ci-crate-relevance-selftest.sh
+# Exit: 0 when every case matches; 1 otherwise, printing both sides of each
+#   mismatch.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/ci-crate-relevance.sh"
+
+FAILURES=0
+CASES=0
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $*"
+}
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  CASES=$((CASES + 1))
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %-62s -> %s\n' "$1" "$3"
+  else
+    fail "$1: expected '$2', got '$3'"
+  fi
+}
+
+WORK="$(mktemp -d)" || exit 1
+trap 'rm -rf "${WORK}"' EXIT
+
+FIXTURE="${WORK}/fixture"
+STUB_DIR="${WORK}/stub"
+mkdir -p "${STUB_DIR}"
+
+# ---------------------------------------------------------------------------
+# Fixture workspace
+#
+#   top ──> mid ──> leaf          normal dependencies, one transitive hop
+#   top ──(dev)──> devonly        dev-dependencies are in the closure because
+#                                 clippy --all-targets compiles test targets
+#   unrelated                     no edge to anything
+#   top-extra                     name extends top's, to catch a prefix match
+#   nested, nested/ui/src-tauri   a crate whose directory nests inside another
+#                                 crate's, the trusty-audit-ui / trusty-agents-ui
+#                                 shape
+# ---------------------------------------------------------------------------
+new_crate() {
+  local dir="$1" name="$2"
+  mkdir -p "${FIXTURE}/${dir}/src"
+  : >"${FIXTURE}/${dir}/src/lib.rs"
+  {
+    echo '[package]'
+    echo "name = \"${name}\""
+    echo 'version = "0.1.0"'
+    echo 'edition = "2021"'
+  } >"${FIXTURE}/${dir}/Cargo.toml"
+}
+
+mkdir -p "${FIXTURE}"
+{
+  echo '[workspace]'
+  echo 'resolver = "2"'
+  echo 'members = ["crates/*", "crates/nested/ui/src-tauri"]'
+} >"${FIXTURE}/Cargo.toml"
+
+new_crate crates/leaf leaf
+new_crate crates/mid mid
+new_crate crates/top top
+new_crate crates/devonly devonly
+new_crate crates/unrelated unrelated
+new_crate crates/top-extra top-extra
+new_crate crates/nested nested
+new_crate crates/nested/ui/src-tauri nested-ui
+
+{
+  echo ''
+  echo '[dependencies]'
+  echo 'leaf = { path = "../leaf" }'
+} >>"${FIXTURE}/crates/mid/Cargo.toml"
+
+{
+  echo ''
+  echo '[dependencies]'
+  echo 'mid = { path = "../mid" }'
+  echo ''
+  echo '[dev-dependencies]'
+  echo 'devonly = { path = "../devonly" }'
+} >>"${FIXTURE}/crates/top/Cargo.toml"
+
+{
+  echo ''
+  echo '[dependencies]'
+  echo 'nested = { path = "../.." }'
+} >>"${FIXTURE}/crates/nested/ui/src-tauri/Cargo.toml"
+
+# fixture_verdict <crate> <changed path>... — run the script inside the fixture.
+fixture_verdict() {
+  local crate="$1"
+  shift
+  (cd "${FIXTURE}" && printf '%s\n' "$@" | bash "${SCRIPT}" "${crate}" 2>/dev/null)
+}
+
+# live_verdict <crate> <changed path>... — run it against this repo.
+live_verdict() {
+  local crate="$1"
+  shift
+  (cd "${REPO_ROOT}" && printf '%s\n' "$@" | bash "${SCRIPT}" "${crate}" 2>/dev/null)
+}
+
+echo "fixture: the crate's own directory"
+assert_eq "top <- crates/top/src/lib.rs" \
+  "true" "$(fixture_verdict top crates/top/src/lib.rs)"
+assert_eq "top <- crates/top/Cargo.toml" \
+  "true" "$(fixture_verdict top crates/top/Cargo.toml)"
+assert_eq "nested-ui <- crates/nested/ui/src-tauri/src/lib.rs (nested dir)" \
+  "true" "$(fixture_verdict nested-ui crates/nested/ui/src-tauri/src/lib.rs)"
+
+echo "fixture: the dependency closure"
+assert_eq "top <- crates/mid/src/lib.rs (direct)" \
+  "true" "$(fixture_verdict top crates/mid/src/lib.rs)"
+assert_eq "top <- crates/leaf/src/lib.rs (transitive)" \
+  "true" "$(fixture_verdict top crates/leaf/src/lib.rs)"
+assert_eq "top <- crates/devonly/src/lib.rs (dev-dependency)" \
+  "true" "$(fixture_verdict top crates/devonly/src/lib.rs)"
+assert_eq "nested-ui <- crates/nested/src/lib.rs (parent crate is a dep)" \
+  "true" "$(fixture_verdict nested-ui crates/nested/src/lib.rs)"
+assert_eq "top <- one relevant among three" \
+  "true" "$(fixture_verdict top crates/unrelated/src/lib.rs crates/mid/src/lib.rs docs/x.md)"
+
+echo "fixture: outside the closure"
+assert_eq "top <- crates/unrelated/src/lib.rs" \
+  "false" "$(fixture_verdict top crates/unrelated/src/lib.rs)"
+assert_eq "top <- docs/reference/ci-scripts.md" \
+  "false" "$(fixture_verdict top docs/reference/ci-scripts.md)"
+assert_eq "top <- two unrelated paths" \
+  "false" "$(fixture_verdict top crates/unrelated/src/lib.rs docs/x.md)"
+assert_eq "mid <- crates/top/src/lib.rs (edges are directed)" \
+  "false" "$(fixture_verdict mid crates/top/src/lib.rs)"
+assert_eq "nested-ui <- crates/unrelated/src/lib.rs" \
+  "false" "$(fixture_verdict nested-ui crates/unrelated/src/lib.rs)"
+
+echo "fixture: segment boundaries, not string prefixes"
+# `crates/top` is a string prefix of `crates/top-extra`, and top-extra is in no
+# closure. A `startswith` match with no separator check would answer true here.
+assert_eq "top <- crates/top-extra/src/lib.rs" \
+  "false" "$(fixture_verdict top crates/top-extra/src/lib.rs)"
+assert_eq "top-extra <- crates/top/src/lib.rs" \
+  "false" "$(fixture_verdict top-extra crates/top/src/lib.rs)"
+
+echo "fixture: workspace-wide inputs"
+for path in Cargo.lock Cargo.toml clippy.toml rust-toolchain rust-toolchain.toml \
+  .cargo/config.toml .github/workflows/ci.yml \
+  scripts/ci-apt-install.sh scripts/ci-crate-relevance.sh \
+  scripts/ci-crate-relevance-selftest.sh; do
+  assert_eq "top <- ${path}" "true" "$(fixture_verdict top "${path}")"
+done
+
+echo "fixture: fail-closed arms"
+assert_eq "no crate name" \
+  "true" "$(cd "${FIXTURE}" && echo crates/unrelated/src/lib.rs | bash "${SCRIPT}" 2>/dev/null)"
+assert_eq "unknown crate" \
+  "true" "$(fixture_verdict not-a-workspace-member crates/unrelated/src/lib.rs)"
+assert_eq "empty change set" \
+  "true" "$(cd "${FIXTURE}" && printf '' | bash "${SCRIPT}" top 2>/dev/null)"
+assert_eq "blank-only change set" \
+  "true" "$(cd "${FIXTURE}" && printf '\n\n' | bash "${SCRIPT}" top 2>/dev/null)"
+assert_eq "unresolvable base ref" \
+  "true" "$(cd "${REPO_ROOT}" &&
+    CRATE_RELEVANCE_BASE=refs/heads/definitely-not-a-ref \
+      bash "${SCRIPT}" trusty-mpm-gui </dev/null 2>/dev/null)"
+
+# cargo metadata failure. The same input answers `false` two cases above, so a
+# `true` here can only come from the fail-closed arm.
+printf '#!/bin/sh\nexit 1\n' >"${STUB_DIR}/cargo"
+chmod +x "${STUB_DIR}/cargo"
+assert_eq "cargo metadata failure" \
+  "true" "$(cd "${FIXTURE}" && printf 'crates/unrelated/src/lib.rs\n' |
+    PATH="${STUB_DIR}:${PATH}" bash "${SCRIPT}" top 2>/dev/null)"
+
+echo "fixture: \$GITHUB_OUTPUT contract (read by ci.yml's \`changes\` job)"
+OUT_FILE="${WORK}/github_output"
+: >"${OUT_FILE}"
+(cd "${FIXTURE}" && printf 'crates/unrelated/src/lib.rs\n' |
+  GITHUB_OUTPUT="${OUT_FILE}" bash "${SCRIPT}" top-extra >/dev/null 2>&1)
+assert_eq "hyphens become underscores in the key" \
+  "top_extra_relevant=false" "$(grep '^top_extra_relevant=' "${OUT_FILE}")"
+assert_eq "exactly one reason line" \
+  "1" "$(grep -c '^top_extra_reason=' "${OUT_FILE}")"
+assert_eq "exactly two lines written" \
+  "2" "$(wc -l <"${OUT_FILE}" | tr -d ' ')"
+
+: >"${OUT_FILE}"
+(cd "${FIXTURE}" && printf 'Cargo.lock\n' |
+  GITHUB_OUTPUT="${OUT_FILE}" bash "${SCRIPT}" top >/dev/null 2>&1)
+assert_eq "true verdict is written the same way" \
+  "top_relevant=true" "$(grep '^top_relevant=' "${OUT_FILE}")"
+
+# ---------------------------------------------------------------------------
+# Live workspace — the four acceptance pairs from #7063. These read this
+# repo's real dependency graph, so a PR that adds or removes an edge on a
+# Tauri UI crate is expected to change them.
+# ---------------------------------------------------------------------------
+echo "live: the four #7063 acceptance pairs"
+assert_eq "trusty-mpm-gui  <- crates/trusty-embedderd/src/lib.rs" \
+  "false" "$(live_verdict trusty-mpm-gui crates/trusty-embedderd/src/lib.rs)"
+assert_eq "trusty-code-gui <- crates/trusty-embedderd/src/lib.rs" \
+  "false" "$(live_verdict trusty-code-gui crates/trusty-embedderd/src/lib.rs)"
+assert_eq "trusty-audit-ui <- crates/trusty-common/src/lib.rs" \
+  "true" "$(live_verdict trusty-audit-ui crates/trusty-common/src/lib.rs)"
+for crate in trusty-agents-ui trusty-audit-ui trusty-mpm-gui trusty-code-gui; do
+  assert_eq "${crate} <- Cargo.lock" "true" "$(live_verdict "${crate}" Cargo.lock)"
+done
+
+echo
+if [ "${FAILURES}" -eq 0 ]; then
+  echo "ci-crate-relevance-selftest: ${CASES} cases, all passed"
+  exit 0
+fi
+echo "ci-crate-relevance-selftest: ${CASES} cases, ${FAILURES} FAILED"
+exit 1

--- a/scripts/ci-crate-relevance.sh
+++ b/scripts/ci-crate-relevance.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+#
+# ci-crate-relevance.sh — decide whether a change set can affect one crate's
+#   build (#7063).
+#
+# Why: the four Tauri UI clippy jobs in .github/workflows/ci.yml are required
+#   contexts, so each must run and report a check run on every PR — a job that
+#   never reports leaves the PR BLOCKED rather than fast (#4468). Their only
+#   step gate was `docs_only`, so a PR touching an unrelated crate still paid
+#   for the WebKit2GTK apt chain plus a cargo clippy. On PR #7062
+#   `trusty-mpm-gui`, which has no workspace dependencies at all, spent 1m20s;
+#   `trusty-code-gui` spent 7m and has hit its 30-minute timeout before
+#   (PR #5992).
+#
+# What: prints `true` when any changed path is under the named crate's own
+#   directory, under the directory of any workspace crate in its transitive
+#   dependency closure, or is a workspace-wide input every cargo invocation in
+#   those jobs reads; prints `false` otherwise.
+#
+#   The closure is derived at run time from `cargo metadata --format-version 1
+#   --no-deps`, never a hand-maintained list, so adding or dropping a
+#   dependency edge changes the answer on the PR that does it. `--no-deps`
+#   reads only the workspace member manifests: it needs no registry index and
+#   no network, and it still reports every path dependency, which is the only
+#   kind that can name another crate in this repo.
+#
+#   Dev- and build-dependencies are in the closure, not just normal ones:
+#   `cargo clippy --all-targets` and `cargo test` both compile the test
+#   targets. trusty-code-gui reaches trusty-code exactly that way, through the
+#   `default_daemon_url_matches_tcode_default_http_port` test that pins its
+#   compiled-in DEFAULT_DAEMON_URL against trusty-code's DEFAULT_HTTP_PORT.
+#
+#   Matching is PATH-based and on SEGMENT boundaries, never on crate names and
+#   never on string prefixes: `crates/trusty-mpm` must not match
+#   `crates/trusty-mpm-gui`, and a crate whose directory nests inside another's
+#   (trusty-audit-ui lives at crates/trusty-audit/ui/src-tauri) is matched by
+#   its own directory as well as its parent's.
+#
+#   FAIL CLOSED. Every error — no crate name, a crate cargo does not know, a
+#   `cargo metadata` failure, a missing python3, an unresolvable base ref, an
+#   empty change set — prints `true`, writes a note to stderr, and exits 0, so
+#   the job does the work rather than skipping it. A broken detector costs a
+#   full build; it can never cost a silent skip.
+#
+# Usage:
+#   git diff --name-only --no-renames "$MERGE_BASE" HEAD |
+#     bash scripts/ci-crate-relevance.sh trusty-mpm-gui
+#   CRATE_RELEVANCE_BASE=origin/main bash scripts/ci-crate-relevance.sh trusty-code-gui
+#
+# Output: `true` or `false` alone on stdout. When $GITHUB_OUTPUT is set, also
+#   appends two lines, the crate name with `-` replaced by `_`:
+#     <crate>_relevant=true|false
+#     <crate>_reason=<one line naming the path that decided it, or the closure>
+#
+# Exit: always 0. See FAIL CLOSED above.
+#
+# Test: scripts/ci-crate-relevance-selftest.sh
+
+# No `set -e`: every failure path here has to reach the fail-closed emit
+# rather than abort the script with no verdict written.
+set -uo pipefail
+
+CRATE="${1:-}"
+
+TMPDIR_SELF=""
+
+# emit <true|false> <one-line reason> — write the verdict everywhere and stop.
+emit() {
+  local verdict="$1" reason="$2" key
+  key="$(printf '%s' "${CRATE:-unknown}" | tr '-' '_')"
+  echo "ci-crate-relevance: ${CRATE:-<no crate>} -> ${verdict} (${reason})" >&2
+  echo "${verdict}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s_relevant=%s\n' "$key" "$verdict" >>"${GITHUB_OUTPUT}"
+    printf '%s_reason=%s\n' "$key" "$reason" >>"${GITHUB_OUTPUT}"
+  fi
+  exit 0
+}
+
+fail_closed() { emit true "fail closed: $1"; }
+
+[ -n "$CRATE" ] || fail_closed "no crate name given"
+
+command -v python3 >/dev/null 2>&1 || fail_closed "python3 not on PATH"
+
+TMPDIR_SELF="$(mktemp -d 2>/dev/null)" || fail_closed "cannot create a temp dir"
+# Armed only once the directory exists, so the handler never has an empty path
+# to remove. `emit` exits, so this covers the fail-closed arms too.
+trap 'rm -rf "${TMPDIR_SELF}"' EXIT
+CHANGED_FILE="${TMPDIR_SELF}/changed.txt"
+METADATA_FILE="${TMPDIR_SELF}/metadata.json"
+
+# Resolve the change set: a base ref we diff ourselves, or a list on stdin.
+if [ -n "${CRATE_RELEVANCE_BASE:-}" ]; then
+  if ! merge_base="$(git merge-base "${CRATE_RELEVANCE_BASE}" HEAD 2>/dev/null)"; then
+    fail_closed "cannot resolve merge-base against '${CRATE_RELEVANCE_BASE}'"
+  fi
+  if ! git diff --name-only --no-renames "${merge_base}" HEAD >"${CHANGED_FILE}" 2>/dev/null; then
+    fail_closed "git diff against ${merge_base} failed"
+  fi
+else
+  cat >"${CHANGED_FILE}"
+fi
+
+[ -s "${CHANGED_FILE}" ] || fail_closed "empty change set"
+
+# --offline first so a warm checkout never touches the network; the plain
+# retry covers a checkout where cargo still wants to write its own caches.
+if ! cargo metadata --format-version 1 --no-deps --offline >"${METADATA_FILE}" 2>/dev/null; then
+  if ! cargo metadata --format-version 1 --no-deps >"${METADATA_FILE}" 2>/dev/null; then
+    fail_closed "cargo metadata failed"
+  fi
+fi
+[ -s "${METADATA_FILE}" ] || fail_closed "cargo metadata produced no output"
+
+# The closure walk and the path matching. Prints the verdict on line 1 and the
+# one-line reason on line 2; every per-path decision goes to stderr so the CI
+# log records exactly which files and which closure produced the answer.
+if ! decision="$(
+  CRATE_NAME="$CRATE" \
+    CHANGED_FILE="$CHANGED_FILE" \
+    METADATA_FILE="$METADATA_FILE" \
+    python3 - <<'PY'
+import json
+import os
+import sys
+
+crate = os.environ["CRATE_NAME"]
+
+with open(os.environ["METADATA_FILE"], encoding="utf-8") as fh:
+    meta = json.load(fh)
+with open(os.environ["CHANGED_FILE"], encoding="utf-8") as fh:
+    changed = [line.strip() for line in fh if line.strip()]
+
+root = meta.get("workspace_root")
+packages = meta.get("packages") or []
+if not root or not packages:
+    raise SystemExit("cargo metadata carried no workspace_root or packages")
+
+# The bash side rejects an EMPTY file; a file of nothing but blank lines
+# survives that and arrives here as an empty list. Answering `false` for it
+# would let an unreadable diff turn into a skip, which is the one outcome this
+# script exists to prevent.
+if not changed:
+    print("true")
+    print("fail closed: change set has no usable paths")
+    sys.exit(0)
+
+
+def reldir(manifest_path):
+    """Directory of a manifest, relative to the workspace root, with / separators."""
+    d = os.path.relpath(os.path.dirname(manifest_path), root)
+    return d.replace(os.sep, "/")
+
+
+dir_of_name = {}
+name_of_dir = {}
+for pkg in packages:
+    d = reldir(pkg["manifest_path"])
+    dir_of_name[pkg["name"]] = d
+    name_of_dir[d] = pkg["name"]
+
+if crate not in dir_of_name:
+    print("true")
+    print("fail closed: '%s' is not a workspace member cargo metadata knows" % crate)
+    sys.exit(0)
+
+# Workspace-internal edges, from path dependencies of every kind (normal, dev
+# and build). A path dependency that resolves outside the workspace members
+# still contributes its directory, so an in-repo non-member crate is not lost.
+edges = {}
+extra_dirs = set()
+for pkg in packages:
+    deps = set()
+    for dep in pkg.get("dependencies") or []:
+        dep_path = dep.get("path")
+        if not dep_path:
+            continue
+        d = os.path.relpath(dep_path, root).replace(os.sep, "/")
+        if d in name_of_dir:
+            deps.add(name_of_dir[d])
+        elif not d.startswith(".."):
+            extra_dirs.add(d)
+    edges[pkg["name"]] = deps
+
+closure = {crate}
+stack = [crate]
+while stack:
+    current = stack.pop()
+    for nxt in edges.get(current, ()):
+        if nxt not in closure:
+            closure.add(nxt)
+            stack.append(nxt)
+
+closure_dirs = {dir_of_name[n] for n in closure} | extra_dirs
+closure_names = sorted(closure)
+
+# Inputs no crate directory covers but every cargo invocation in these jobs
+# reads. `.cargo/**` is a prefix rule; the rest are exact paths.
+WORKSPACE_WIDE_EXACT = {
+    "Cargo.toml",
+    "Cargo.lock",
+    "clippy.toml",
+    "rust-toolchain",
+    "rust-toolchain.toml",
+    ".github/workflows/ci.yml",
+    "scripts/ci-apt-install.sh",
+    "scripts/ci-crate-relevance.sh",
+    "scripts/ci-crate-relevance-selftest.sh",
+}
+WORKSPACE_WIDE_PREFIXES = (".cargo/",)
+
+
+def under(path, directory):
+    """True when `path` is `directory` or sits inside it, on segment boundaries."""
+    return path == directory or path.startswith(directory + "/")
+
+
+def workspace_wide(path):
+    if path in WORKSPACE_WIDE_EXACT:
+        return True
+    return any(path.startswith(prefix) for prefix in WORKSPACE_WIDE_PREFIXES)
+
+
+shown = ", ".join(closure_names[:8])
+if len(closure_names) > 8:
+    shown += ", +%d more" % (len(closure_names) - 8)
+print(
+    "ci-crate-relevance: %s closure = %s" % (crate, shown),
+    file=sys.stderr,
+)
+
+reason = None
+for path in changed:
+    if workspace_wide(path):
+        print("  relevant: %s (workspace-wide cargo input)" % path, file=sys.stderr)
+        if reason is None:
+            reason = "%s is a workspace-wide cargo input" % path
+        continue
+    hit = None
+    for directory in closure_dirs:
+        if under(path, directory):
+            # Prefer the most specific directory when crate dirs nest.
+            if hit is None or len(directory) > len(hit):
+                hit = directory
+    if hit is not None:
+        owner = name_of_dir.get(hit, hit)
+        print("  relevant: %s (under %s, %s)" % (path, hit, owner), file=sys.stderr)
+        if reason is None:
+            reason = "%s is under %s (%s), in the %s closure" % (path, hit, owner, crate)
+    else:
+        print("  inert   : %s" % path, file=sys.stderr)
+
+if reason is None:
+    print("false")
+    print(
+        "none of %d changed path(s) touch the %s closure (%s) or a workspace-wide input"
+        % (len(changed), crate, shown)
+    )
+else:
+    print("true")
+    print(reason)
+PY
+)"; then
+  fail_closed "closure computation failed"
+fi
+
+verdict="$(printf '%s\n' "$decision" | sed -n '1p')"
+reason="$(printf '%s\n' "$decision" | sed -n '2p')"
+
+case "$verdict" in
+  true | false) ;;
+  *) fail_closed "closure computation printed an unusable verdict '${verdict}'" ;;
+esac
+[ -n "$reason" ] || reason="no reason recorded"
+
+emit "$verdict" "$reason"

--- a/scripts/ci-crate-relevance.sh
+++ b/scripts/ci-crate-relevance.sh
@@ -36,6 +36,16 @@
 #   (trusty-audit-ui lives at crates/trusty-audit/ui/src-tauri) is matched by
 #   its own directory as well as its parent's.
 #
+#   Paths arrive NUL-delimited, from `git diff -z` (#7063). Without `-z` git
+#   C-quotes any path holding a non-ASCII byte, a double quote or a backslash —
+#   `crates/trusty-mpm/src/caf\303\251.rs`, wrapped in literal double quotes —
+#   and that string matches no directory prefix, so a change INSIDE a crate
+#   answered `false` and the crate's required clippy job was skipped.
+#   `core.quotePath=false` fixes only the non-ASCII third of that; `-z` emits
+#   every byte of every path verbatim. Newline-delimited stdin is still read as
+#   before when the input holds no NUL, which keeps the plain
+#   `git diff --name-only | …` form in Usage working.
+#
 #   FAIL CLOSED. Every error — no crate name, a crate cargo does not know, a
 #   `cargo metadata` failure, a missing python3, an unresolvable base ref, an
 #   empty change set — prints `true`, writes a note to stderr, and exits 0, so
@@ -43,7 +53,7 @@
 #   full build; it can never cost a silent skip.
 #
 # Usage:
-#   git diff --name-only --no-renames "$MERGE_BASE" HEAD |
+#   git diff -z --name-only --no-renames "$MERGE_BASE" HEAD |
 #     bash scripts/ci-crate-relevance.sh trusty-mpm-gui
 #   CRATE_RELEVANCE_BASE=origin/main bash scripts/ci-crate-relevance.sh trusty-code-gui
 #
@@ -95,7 +105,10 @@ if [ -n "${CRATE_RELEVANCE_BASE:-}" ]; then
   if ! merge_base="$(git merge-base "${CRATE_RELEVANCE_BASE}" HEAD 2>/dev/null)"; then
     fail_closed "cannot resolve merge-base against '${CRATE_RELEVANCE_BASE}'"
   fi
-  if ! git diff --name-only --no-renames "${merge_base}" HEAD >"${CHANGED_FILE}" 2>/dev/null; then
+  # #7063: `-z` — without it git C-quotes any path carrying a non-ASCII byte, a
+  # double quote or a backslash, and the quoted string matches no crate
+  # directory, so a change inside the crate answers `false`.
+  if ! git diff -z --name-only --no-renames "${merge_base}" HEAD >"${CHANGED_FILE}" 2>/dev/null; then
     fail_closed "git diff against ${merge_base} failed"
   fi
 else
@@ -129,8 +142,21 @@ crate = os.environ["CRATE_NAME"]
 
 with open(os.environ["METADATA_FILE"], encoding="utf-8") as fh:
     meta = json.load(fh)
-with open(os.environ["CHANGED_FILE"], encoding="utf-8") as fh:
-    changed = [line.strip() for line in fh if line.strip()]
+
+# #7063: `git diff -z` is NUL-delimited and emits every path byte verbatim.
+# A NUL can never occur inside a path, so its presence identifies the format
+# unambiguously; input without one is the newline-delimited form the Usage
+# block still documents, read exactly as before. `surrogateescape` keeps a
+# path that is not valid UTF-8 matchable instead of raising, which would
+# fail closed and cost a full build for a file that is plainly inert.
+with open(
+    os.environ["CHANGED_FILE"], encoding="utf-8", errors="surrogateescape", newline=""
+) as fh:
+    raw = fh.read()
+if "\0" in raw:
+    changed = [path for path in raw.split("\0") if path]
+else:
+    changed = [line.strip() for line in raw.splitlines() if line.strip()]
 
 root = meta.get("workspace_root")
 packages = meta.get("packages") or []


### PR DESCRIPTION
The four Tauri UI clippy jobs (trusty-agents-ui, trusty-audit-ui, trusty-mpm-gui, trusty-code-gui) now run only when the PR touches the crate or a crate in its `cargo metadata` dependency closure, or Cargo.lock; the `changes` job computes a per-crate `<crate>_relevant` output via `scripts/ci-crate-relevance.sh`, which fails closed to `true` on every error arm. The change set is read with `git diff -z` so a path with a non-ASCII byte, quote, or backslash still matches (the round-1 critic BLOCK).

Refs #7063

**Test ladder:** Rung 1 (CI-only): actionlint, shellcheck, scripts/check-red-main-coverage.sh, and scripts/ci-crate-relevance-selftest.sh (51 cases, all passed; 5 fail against 823f7a372).

**Review:** code-critic round 1 BLOCK (quotePath C-quoting at two sites), round 2 APPROVE after the -z fix; MEDIUM stdin-route coverage gap folded in as b7f82833a.

**Note:** the issue's acceptance criterion #2 names trusty-agents-ui as a trusty-common dependent; it has no workspace path deps, and the selftest's live pair asserts trusty-audit-ui instead.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XAqBLVJbLSXH613FeE6Ucj
