### PR TITLE
feat(trusty-mpm): ticketing standard requires a project, a milestone, and native relationships on every new issue

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7067-ticketing-project-milestone.md
+++ b/crates/trusty-agents-common/changelog.d/7067-ticketing-project-milestone.md
@@ -1,0 +1,14 @@
+Changed
+
+- The bundled `ticketing` agent no longer leaves the milestone unset by default.
+  Its "Milestones Are Release Slots" section becomes "Milestone, Project,
+  Relationships — Set on Every New Issue": every issue it files carries exactly
+  one milestone (the parent's, else the crate's `Backlog · <crate>`, else the
+  one `tm issue standard` names), at least one GitHub Project, and every
+  relationship the brief names, all set natively on the `gh issue create` call
+  — `--milestone`, `--add-project`, `--parent`, and the `dependencies/blocked_by`
+  API for blocked-by. Titles come from `tm issue standard`, never hand-typed. An
+  issue may carry no milestone only with a `no-milestone: <reason>` comment on
+  it, and the agent verifies its own filing with
+  `gh issue view N --json milestone,projectItems` before reporting it done
+  (#7067).

--- a/crates/trusty-agents-common/src/assets/agents/ticketing.md
+++ b/crates/trusty-agents-common/src/assets/agents/ticketing.md
@@ -159,8 +159,9 @@ family.
 
 🟡 **Read the standard rather than assuming it.** `tm issue standard` prints
 what is in effect — the component labels, the lifecycle labels, the default
-assignee, and whether a claim comment and a closing note are expected. Those
-values come from the `agents.ticketing` block in
+assignee, whether a claim comment and a closing note are expected, and (#7067)
+whether a milestone and a project are required, plus the live lists that satisfy
+them. Those values come from the `agents.ticketing` block in
 `~/.trusty-tools/trusty-mpm/config.yaml`, so a project can add a component
 label, restyle one, name a different assignee, or point at its own
 `issue-state.yaml` (#6918). Two things the block cannot change, and the command
@@ -169,23 +170,59 @@ the deliberate `tm pr open --closes` flag), and `trusty-mpm` stays a component
 label, never a lifecycle one. A block that tries either is refused at load with
 the field named.
 
-## Milestones Are Release Slots, Not a Field to Fill
+## Milestone, Project, Relationships — Set on Every New Issue
 
-🔴 **Leave the milestone UNSET by default.** A milestone is a slot in a named
-release or epic (`tm 1.3.5`, `trusty-agents 0.39`) — not bookkeeping every
-issue receives. Most bugs and enhancements never get one, and even
-`epic`-labelled issues split about evenly between a named milestone and none.
+🔴 **Every issue you file carries exactly one milestone, at least one GitHub
+Project, and every relationship the brief names.** All three are set with the
+call that creates the issue, natively, never in prose and never in a follow-up
+pass. An issue filed with no milestone and no project is a standard violation.
 
-Set one only when deliberately scheduling the issue into a release you have
-confirmed is open:
+🔴 **`tm issue standard` is the source of truth.** It prints
+`milestone_required`, `project_required`, the configured `default_project`, and
+live lists of the repository's open milestones and the owner's open projects.
+Read it before your first filing and take every title from it — a hand-typed
+name is the failure this replaces.
 
 ```bash
-gh api "repos/{owner}/{repo}/milestones" --jq '.[].title'   # gh has no `milestone` subcommand
+gh issue create --title "…" --body "…" \
+  --milestone "Backlog · mpm/core" --add-project "trusty-mpm" --parent 7067 \
+  --assignee @me --label "ws/$WS_NAME" --label bug --label trusty-mpm
+gh issue edit 7070 --milestone "mpm 1.4" --add-project "trusty-mpm"
 ```
 
-Never invent a milestone name, and never put a `ws/<session-name>` value in the
-milestone slot — that is a label. An issue holds many labels and exactly one
-milestone, so a workstream parked there evicts the real release slot.
+Installed `gh` is 2.98 — `--milestone`, `--add-project` and `--parent` all work
+on `issue create` and `issue edit`, and the token carries the `project` scope.
+Blocked-by has no flag; it is the API call in `tm-ticketing`, "Relationships
+(native, never prose)":
+
+```bash
+BLOCKER_ID=$(gh api repos/OWNER/REPO/issues/BLOCKER_NUM --jq .id)
+gh api --method POST repos/OWNER/REPO/issues/ISSUE_NUM/dependencies/blocked_by -F issue_id="$BLOCKER_ID"
+```
+
+**Pick the milestone by rule, in this order:** the parent's milestone when the
+issue is a sub-issue; else the owning crate's `Backlog · <crate>` milestone;
+else the one `tm issue standard` names. Never invent a title, and never put a
+`ws/<session-name>` value in the milestone slot — that is a label. An issue
+holds many labels and exactly one milestone, so a workstream parked there evicts
+the real slot.
+
+**An issue may carry no milestone only with a reason on the record.** When none
+of the three rules yields one, post `no-milestone: <reason>` as a comment on the
+issue in the same dispatch. Without that comment an unset milestone is a defect.
+
+**Verify before you report the filing done:**
+
+```bash
+gh issue view 7070 --json milestone,projectItems
+```
+
+A `null` milestone with no `no-milestone` comment, or an empty `projectItems`,
+is yours to fix now.
+
+If `tm issue standard` reports `milestones: unavailable (…)`, the fetch failed —
+the requirement did not lift. Fix the `gh` error, or say in your report that the
+milestone is unset because the list could not be read.
 
 ## Integration Priority
 
@@ -198,8 +235,10 @@ set, so `gh` is available regardless of which MCP servers are configured.
 **2. GitHub Issues**: When the project's tracker is GitHub (no ticketing MCP,
 a `gh`-authenticated repo — this is the common case), use `gh` directly:
 ```bash
-# full label set per "Label at Creation" above — type + component + optional priority
+# full label set per "Label at Creation" above — type + component + optional
+# priority — plus the milestone and project every new issue carries (#7067)
 gh issue create --title "Title" --body "Details" \
+  --milestone "Backlog · search/core" --add-project "trusty-search" \
   --assignee @me --label "ws/$WS_NAME" --label bug --label trusty-search
 gh issue edit 4069 --add-label refactor --add-label trusty-common
 gh issue list --search "search terms" --state all   # search open AND closed FIRST
@@ -410,14 +449,16 @@ When PM delegates a TODO list for conversion:
 
 Report scope classification, and for anything that could have become a ticket,
 which of the four dispositions you took, what you searched, and — for anything
-created — the labels applied and the milestone (or that you left it unset):
+created — the labels applied, the milestone, the project, and any relationship
+set. An unset milestone is reported with the `no-milestone` reason you posted:
 
 ```
 Searched: "reconcile" / "WatcherManager" / -p trusty-search — open + closed
 REOPEN #3712 (same root cause recurred; commented)
 COMMENT on open #4409
 NEW REGRESSION #5002 — different failure mode after #3990's verified fix
-CREATED #5001 — bug, trusty-search, P1; milestone unset
+CREATED #5001 — bug, trusty-search, P1; milestone "Backlog · search/core";
+              project "trusty-search"; sub-issue of #4990
 NO TICKET (1 item — fixed in the current PR)
 
 status:in-progress -> #5001 (claimed by session ws/search-watcher, 2026-08-31)

--- a/crates/trusty-mpm/changelog.d/7067-ticketing-project-milestone.md
+++ b/crates/trusty-mpm/changelog.d/7067-ticketing-project-milestone.md
@@ -1,0 +1,19 @@
+Added
+
+- The ticketing standard now requires a project and a milestone on every new
+  issue. `agents.ticketing` takes three new keys — `default_project` (a GitHub
+  Project title), `milestone_required` and `project_required`, both defaulting
+  to `true` — and `tm issue standard` prints all three alongside a live section
+  listing the repository's open milestones and the owner's open projects, read
+  through the same `gh` runner the rest of `tm issue` uses. A `gh` failure
+  prints `milestones: unavailable (<error>)` rather than an empty list, so a
+  fetch failure cannot be read as "no milestone needed"; the requirement lines
+  come from config and are unaffected. `tm issue seed-config` now also prints a
+  copy-pasteable `agents.ticketing` starter block carrying the new keys, since
+  the lifecycle model and the standard live in different files. The
+  `tm-ticketing` skill reverses its old "leave the milestone unset by default"
+  rule: every new issue carries exactly one milestone chosen by a stated rule
+  (the parent's, else the crate's `Backlog · <crate>`, else the one
+  `tm issue standard` names), at least one project, and every relationship the
+  brief names — an unset milestone is legitimate only with a
+  `no-milestone: <reason>` comment on the issue (#7067).

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -223,19 +223,71 @@ the deliberate `tm pr open --closes` flag), and `trusty-mpm` stays a component
 label, never a lifecycle one. A block that tries either is refused at load with
 the field named.
 
-## Milestones
+## Every New Issue Carries a Milestone, a Project, and Its Relationships
 
-🔴 **Leave the milestone UNSET by default.** A milestone is a delivery slot in a
-named release or epic — not a field every issue receives. Set one only when the
-issue is one of:
+🔴 **Three things are set at creation, natively, on every issue you file:**
+exactly one milestone, at least one GitHub Project, and every relationship the
+brief names. An issue filed with no milestone and no project is a standard
+violation, not a tidy-up for later. The relationship half is "Relationships
+(native, never prose)" below — parent/child and blocked-by, set with the same
+`gh` call that files the issue.
 
-- deliberately scheduled into a release you have confirmed is open;
-- child work that a release-gating parent already carries into that release;
-- identified as a blocker for a release already in flight.
+`tm issue standard` is the source of truth for all three. It prints
+`milestone_required`, `project_required`, the configured `default_project`, and
+the live lists of open milestones and open projects. Read it before the first
+filing in a repository; never hand-type a title it did not print.
 
-A milestone is not a label and not a project view. An issue holds many labels and
-exactly one milestone, so parking a workstream or a theme there evicts the real
-release slot. `ws/<session-name>` is always a label.
+```bash
+gh issue create --title "…" --body "…" \
+  --milestone "Backlog · mpm/core" --add-project "trusty-mpm" \
+  --label bug --label trusty-mpm
+gh issue edit 7067 --milestone "mpm 1.4" --add-project "trusty-mpm"
+```
+
+Installed `gh` is 2.98; `--milestone`, `--add-project`, and `--parent` are all
+supported on `issue create` and `issue edit`, and the token carries the
+`project` scope.
+
+**Choosing the milestone — a stated rule, in order:**
+
+1. The parent's milestone, when the issue is a sub-issue.
+2. Otherwise the owning crate's backlog milestone — `Backlog · <crate>`.
+3. Otherwise the one `tm issue standard` names for the repository.
+
+Never invent a title. If none of the three yields a milestone, file with none
+and post a `no-milestone: <reason>` comment on the issue in the same dispatch.
+That comment is the only thing that makes an unset milestone legitimate.
+
+An issue holds many labels and exactly one milestone, so a workstream or a theme
+parked there evicts the real slot. `ws/<session-name>` is always a label.
+
+## Projects
+
+🔴 **Every new issue joins at least one project**, chosen by crate/topic fit
+from the list `tm issue standard` prints. `agents.ticketing.default_project`
+names one when the project always applies; when it does not, pick from the live
+list rather than guessing a title.
+
+```bash
+gh project list --owner <owner> --format json   # what `tm issue standard` reads
+gh issue edit 7067 --add-project "trusty-mpm"
+```
+
+A project is a view; a milestone is a delivery slot. An issue can sit in several
+projects and still carry exactly one milestone.
+
+**Checking a filing.** One command says whether both landed:
+
+```bash
+gh issue view 7067 --json milestone,projectItems
+```
+
+A `null` milestone with no `no-milestone` comment, or an empty `projectItems`,
+is the violation to fix — on the issue you just filed, before reporting it done.
+
+**If `tm issue standard` prints `milestones: unavailable (…)`,** the fetch
+failed; the requirement did not lift. Resolve the `gh` error, or file and say in
+your report that the milestone is unset because the list could not be read.
 
 ## Relationships (native, never prose)
 
@@ -251,11 +303,17 @@ used for anything but the literal fix link.
 - "Companion" or "related" in prose is not a relationship. Use sub-issue,
   blocked-by, or nothing.
 
-**Commands.** Both endpoints take the child/blocker's numeric database id, not
-its issue number. `-F` sends a field as an integer; `-f` sends it as a string
-and the call fails.
+**Commands.** For parent/child, `gh issue create --parent <n>` and
+`gh issue edit <n> --parent <p>` take the parent's ISSUE NUMBER and are the
+shortest path (gh 2.98). The API forms below take the child/blocker's numeric
+database id instead, and remain the only route for blocked-by. `-F` sends a
+field as an integer; `-f` sends it as a string and the call fails.
 
 ```bash
+# parent/child, by issue number
+gh issue create --title "…" --body "…" --parent 7067
+gh issue edit 7070 --parent 7067
+
 CHILD_ID=$(gh api repos/OWNER/REPO/issues/CHILD_NUM --jq .id)   # number -> id
 
 # sub-issue: add / remove
@@ -268,9 +326,10 @@ gh api --method POST repos/OWNER/REPO/issues/ISSUE_NUM/dependencies/blocked_by -
 gh api --method DELETE repos/OWNER/REPO/issues/ISSUE_NUM/dependencies/blocked_by/$BLOCKER_ID
 ```
 
-**On filing.** When the brief names a parent or a blocker, set the
-relationship in the same dispatch that files the issue, and report it —
-"filed #N as a sub-issue of #P", or "filed #N, blocked-by #B".
+**On filing.** Every relationship the brief names is set in the same dispatch
+that files the issue — alongside the milestone and the project — and reported:
+"filed #N as a sub-issue of #P", or "filed #N, blocked-by #B". A relationship
+left for a follow-up pass is a relationship that does not exist.
 
 **On closing a parent.** List its open sub-issues first. Refuse to close while
 any are open unless the user explicitly says to close anyway.

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -269,7 +269,8 @@ names one when the project always applies; when it does not, pick from the live
 list rather than guessing a title.
 
 ```bash
-gh project list --owner <owner> --format json   # what `tm issue standard` reads
+# -L is required: gh silently caps the list at 30 without it (#7067)
+gh project list --owner <owner> -L 200 --format json  # what `tm issue standard` reads
 gh issue edit 7067 --add-project "trusty-mpm"
 ```
 

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
@@ -18,6 +18,7 @@
 pub(crate) mod config;
 pub(crate) mod ops;
 pub(crate) mod standard;
+pub(crate) mod standard_live;
 pub(crate) mod state;
 pub(crate) mod validate;
 
@@ -28,13 +29,15 @@ mod project_model_tests;
 use std::path::PathBuf;
 
 use crate::cli::IssueCmd;
-use crate::commands::ticket::runner::RealCommandRunner;
+use crate::commands::ticket::runner::{CommandRunner, RealCommandRunner};
 use crate::commands::ticket::system::{
     GhTicketSystem, TicketSystem, TicketSystemKind, not_yet_supported,
 };
 
 use config::{StateModel, load_model};
-use trusty_mpm::core::trusty_tools_config::{TrustyToolsConfig, resolve_ticketing};
+use trusty_mpm::core::trusty_tools_config::{
+    TICKETING_BLOCK_TEMPLATE, TrustyToolsConfig, resolve_ticketing,
+};
 
 /// `tm issue <subcommand>` dispatcher.
 ///
@@ -47,12 +50,16 @@ pub(crate) fn issue(cmd: IssueCmd, system: TicketSystemKind) -> anyhow::Result<(
     // #1265: bind the active project's GitHub identity to every `gh` call this
     // verb makes (empty binding → ambient gh identity, no regression).
     let gh_env = crate::gh_identity::load_gh_env()?;
+    // #7067: `standard`'s live milestone/project read-back needs a runner of
+    // its own — the backend owns one but does not expose it. Same binding, so
+    // both halves of the verb speak to GitHub as the same identity.
+    let runner = RealCommandRunner::with_gh_env(&gh_env);
     let backend = match system {
         TicketSystemKind::Gh => GhTicketSystem::new(RealCommandRunner::with_gh_env(&gh_env)),
         TicketSystemKind::Jira => return Err(not_yet_supported("jira")),
         TicketSystemKind::Linear => return Err(not_yet_supported("linear")),
     };
-    dispatch(&backend, cmd)
+    dispatch(&backend, &runner, cmd)
 }
 
 /// Dispatch a parsed [`IssueCmd`] against a backend (generic for testability).
@@ -62,7 +69,11 @@ pub(crate) fn issue(cmd: IssueCmd, system: TicketSystemKind) -> anyhow::Result<(
 /// What: matches each verb, loads the model where required, runs the op, and
 /// prints a human summary.
 /// Test: per-verb ops are unit-tested; this is thin glue.
-fn dispatch<S: TicketSystem>(backend: &S, cmd: IssueCmd) -> anyhow::Result<()> {
+fn dispatch<S: TicketSystem>(
+    backend: &S,
+    runner: &dyn CommandRunner,
+    cmd: IssueCmd,
+) -> anyhow::Result<()> {
     // #6918: resolve the operator's ticketing standard ONCE. An absent
     // `agents.ticketing` block yields the built-in defaults; a malformed one is
     // an error here rather than a silent revert to them.
@@ -80,7 +91,7 @@ fn dispatch<S: TicketSystem>(backend: &S, cmd: IssueCmd) -> anyhow::Result<()> {
         }
         IssueCmd::Standard { config } => {
             let model = load_model(config.as_deref(), lifecycle)?;
-            standard::print_standard(&ticketing, &model);
+            standard::print_standard(&ticketing, &model, runner);
         }
         IssueCmd::Transition {
             issue,
@@ -170,8 +181,12 @@ fn print_states(model: &StateModel) {
 /// mirroring `tm services init` (RFC §6).
 /// What: writes [`config::DEFAULT_MODEL_YAML`] to
 /// `~/.trusty-tools/trusty-mpm/issue-state.yaml`, creating parent dirs; refuses
-/// to overwrite an existing file unless `--force`.
-/// Test: side-effect-only (filesystem); covered manually + by the dispatch glue.
+/// to overwrite an existing file unless `--force`. Then prints the
+/// [`TICKETING_BLOCK_TEMPLATE`] starter block (#7067) — the lifecycle half of
+/// the standard lands on disk, and the operator is shown the other half,
+/// including the milestone and project keys, rather than having to find them.
+/// Test: side-effect-only (filesystem/stdout); the template itself is covered by
+/// `the_seed_template_parses_to_the_builtin_defaults`.
 fn seed_config(force: bool) -> anyhow::Result<()> {
     let path: PathBuf = config::user_config_path()
         .ok_or_else(|| anyhow::anyhow!("could not resolve home directory for the user config"))?;
@@ -189,5 +204,15 @@ fn seed_config(force: bool) -> anyhow::Result<()> {
     std::fs::write(&path, config::DEFAULT_MODEL_YAML)
         .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))?;
     println!("wrote default issue-state model to {}", path.display());
+
+    // #7067: the milestone/project keys live in a DIFFERENT file, so name it
+    // and print the block rather than leaving the operator to find both.
+    let config_yaml = path.with_file_name("config.yaml");
+    println!(
+        "\nthe rest of the standard lives in {} — paste this block to state it \
+         explicitly (every value below is already the default):\n",
+        config_yaml.display()
+    );
+    print!("{TICKETING_BLOCK_TEMPLATE}");
     Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/standard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/standard.rs
@@ -5,18 +5,23 @@
 //! of those facts was prose in an asset file, so an operator who configured
 //! `agents.ticketing` had no way to make the agent read the change — the agent
 //! would keep applying what its prompt said. This verb is the read side of the
-//! config block: one command, no `gh`, no mutation, whose output IS the
-//! standard.
-//! What: [`render_standard`] builds the report as a string (pure, so it is
-//! testable), [`print_standard`] writes it to stdout. It reports the resolved
-//! [`ResolvedTicketing`], the component labels
-//! `policy_labels_configured` would seed, and the lifecycle labels the loaded
+//! config block: one command, no mutation, whose output IS the standard. Since
+//! #7067 it also READS from `gh` — the milestones and projects a new issue can
+//! be filed into — because a mandatory field the agent cannot enumerate is a
+//! field it fills by guessing.
+//! What: [`render_standard`] builds the report as a string (testable — its only
+//! I/O is the injected runner), [`print_standard`] writes it to stdout. It
+//! reports the resolved [`ResolvedTicketing`], the component labels
+//! `policy_labels_configured` would seed, the lifecycle labels the loaded
 //! `issue-state.yaml` declares — the two families side by side, which is the
-//! distinction the block cannot blur.
+//! distinction the block cannot blur — and, since #7067, the live milestones
+//! and projects a new issue can be filed into.
 //! Test: `standard_reports_the_builtin_defaults`,
 //! `standard_reports_configured_extra_labels`,
 //! `standard_states_the_two_fixed_rules`,
-//! `standard_lists_the_model_lifecycle_labels`.
+//! `standard_lists_the_model_lifecycle_labels`,
+//! `standard_reports_the_filing_targets`,
+//! `standard_still_requires_a_milestone_when_the_fetch_fails`.
 
 use std::fmt::Write as _;
 
@@ -24,14 +29,20 @@ use trusty_mpm::core::policy_labels::{CONVENTION_LABEL, policy_labels_configured
 use trusty_mpm::core::trusty_tools_config::ResolvedTicketing;
 
 use super::config::StateModel;
+use super::standard_live::render_filing_targets;
+use crate::commands::ticket::runner::CommandRunner;
 
 /// Print the effective ticketing standard to stdout.
 ///
 /// Why: the agent-facing entry point; the render is separate so a test can
 /// assert the text without capturing stdout.
 /// Test: side-effect only — see [`render_standard`]'s tests.
-pub(crate) fn print_standard(ticketing: &ResolvedTicketing, model: &StateModel) {
-    print!("{}", render_standard(ticketing, model));
+pub(crate) fn print_standard(
+    ticketing: &ResolvedTicketing,
+    model: &StateModel,
+    runner: &dyn CommandRunner,
+) {
+    print!("{}", render_standard(ticketing, model, runner));
 }
 
 /// Render the effective ticketing standard.
@@ -40,15 +51,22 @@ pub(crate) fn print_standard(ticketing: &ResolvedTicketing, model: &StateModel) 
 /// block, derived from the same values the code acts on — so the report cannot
 /// drift from the behaviour the way a prose asset can.
 /// What: the config-file location, the two rules configuration cannot relax,
-/// the resolved scalar settings, the component labels
+/// the resolved scalar settings, the #7067 filing requirements and the live
+/// milestones/projects that satisfy them, the component labels
 /// [`policy_labels_configured`] yields, and the lifecycle labels the loaded
 /// model declares. `session` supplies the `ws/<session>` label when known; the
 /// caller passes `None` outside tmux and the line is simply absent.
 /// Test: `standard_reports_the_builtin_defaults`,
 /// `standard_reports_configured_extra_labels`,
 /// `standard_states_the_two_fixed_rules`,
-/// `standard_lists_the_model_lifecycle_labels`.
-pub(crate) fn render_standard(ticketing: &ResolvedTicketing, model: &StateModel) -> String {
+/// `standard_lists_the_model_lifecycle_labels`,
+/// `standard_reports_the_filing_targets`,
+/// `standard_still_requires_a_milestone_when_the_fetch_fails`.
+pub(crate) fn render_standard(
+    ticketing: &ResolvedTicketing,
+    model: &StateModel,
+    runner: &dyn CommandRunner,
+) -> String {
     let session = crate::commands::tmux_attach::current_tmux_session_name();
     let mut out = String::new();
 
@@ -88,6 +106,28 @@ pub(crate) fn render_standard(ticketing: &ResolvedTicketing, model: &StateModel)
             .as_ref()
             .map_or_else(|| "(discovered)".to_string(), |p| p.display().to_string())
     );
+    // #7067: printed from config, so a `gh` outage below cannot make the
+    // requirement look lifted.
+    let _ = writeln!(
+        out,
+        "  default_project:     {}",
+        ticketing
+            .default_project
+            .as_deref()
+            .unwrap_or("(none — pick one from the live list below)")
+    );
+    let _ = writeln!(
+        out,
+        "  milestone_required:  {} (exactly one; unset needs a `no-milestone: <reason>` comment)",
+        ticketing.milestone_required
+    );
+    let _ = writeln!(
+        out,
+        "  project_required:    {} (at least one)",
+        ticketing.project_required
+    );
+
+    out.push_str(&render_filing_targets(runner));
 
     let labels = policy_labels_configured(ticketing, session.as_deref());
     let _ = writeln!(out, "\ncomponent labels ({}):", labels.len());
@@ -124,14 +164,61 @@ pub(crate) fn render_standard(ticketing: &ResolvedTicketing, model: &StateModel)
 mod tests {
     use super::*;
     use crate::commands::issue::config::DEFAULT_MODEL_YAML;
+    use crate::commands::ticket::runner::CommandOutput;
+    use std::cell::RefCell;
 
     fn model() -> StateModel {
         serde_yaml::from_str(DEFAULT_MODEL_YAML).expect("embedded default parses")
     }
 
+    /// A scripted runner standing in for `gh` (#7067).
+    ///
+    /// Why: `render_standard` now fetches; the tests must not.
+    /// What: returns queued outputs in order, then fails.
+    struct FakeRunner(RefCell<Vec<CommandOutput>>);
+
+    impl CommandRunner for FakeRunner {
+        fn run(&self, _program: &str, _args: &[&str]) -> anyhow::Result<CommandOutput> {
+            let mut outs = self.0.borrow_mut();
+            if outs.is_empty() {
+                anyhow::bail!("FakeRunner exhausted")
+            }
+            Ok(outs.remove(0))
+        }
+    }
+
+    fn out(success: bool, stdout: &str, stderr: &str) -> CommandOutput {
+        CommandOutput {
+            success,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+        }
+    }
+
+    /// A runner that answers the milestone, owner, and project calls.
+    fn healthy_gh() -> FakeRunner {
+        FakeRunner(RefCell::new(vec![
+            out(true, "Backlog · mpm/core\n", ""),
+            out(true, "bobmatnyc", ""),
+            out(
+                true,
+                r#"{"projects":[{"number":3,"title":"trusty-mpm"}]}"#,
+                "",
+            ),
+        ]))
+    }
+
+    /// A runner whose every call fails.
+    fn broken_gh() -> FakeRunner {
+        FakeRunner(RefCell::new(vec![
+            out(false, "", "gh auth login required"),
+            out(false, "", "gh auth login required"),
+        ]))
+    }
+
     #[test]
     fn standard_reports_the_builtin_defaults() {
-        let text = render_standard(&ResolvedTicketing::default(), &model());
+        let text = render_standard(&ResolvedTicketing::default(), &model(), &healthy_gh());
         assert!(text.contains("default_assignee:    @me"), "{text}");
         assert!(text.contains("ensure_labels:       true"), "{text}");
         assert!(text.contains("lifecycle_model:     (discovered)"), "{text}");
@@ -142,7 +229,7 @@ mod tests {
     fn standard_states_the_two_fixed_rules() {
         // #6918: both rulings have to be visible to the agent that reads this,
         // or the config block looks like it could relax them.
-        let text = render_standard(&ResolvedTicketing::default(), &model());
+        let text = render_standard(&ResolvedTicketing::default(), &model(), &healthy_gh());
         assert!(text.contains("pr_link_keyword: Refs #N"), "{text}");
         assert!(
             text.contains("component label only, never a lifecycle label"),
@@ -159,7 +246,7 @@ mod tests {
                 "CLI surface",
             )])
             .with_default_assignee("bobmatnyc");
-        let text = render_standard(&cfg, &model());
+        let text = render_standard(&cfg, &model(), &healthy_gh());
         assert!(text.contains("area/cli  #0E8A16  CLI surface"), "{text}");
         assert!(text.contains("default_assignee:    bobmatnyc"), "{text}");
     }
@@ -167,7 +254,7 @@ mod tests {
     #[test]
     fn standard_lists_the_model_lifecycle_labels() {
         let m = model();
-        let text = render_standard(&ResolvedTicketing::default(), &m);
+        let text = render_standard(&ResolvedTicketing::default(), &m, &healthy_gh());
         let first = m
             .states
             .iter()
@@ -177,6 +264,44 @@ mod tests {
         assert!(
             text.contains("from issue-state.yaml, never from this block"),
             "{text}"
+        );
+    }
+
+    #[test]
+    fn standard_reports_the_filing_targets() {
+        // #7067: the configured project, both requirement flags, and the live
+        // milestone list have to be in one read.
+        let cfg = ResolvedTicketing::default().with_default_project("trusty-mpm");
+        let text = render_standard(&cfg, &model(), &healthy_gh());
+        assert!(text.contains("default_project:     trusty-mpm"), "{text}");
+        assert!(text.contains("milestone_required:  true"), "{text}");
+        assert!(text.contains("project_required:    true"), "{text}");
+        assert!(text.contains("open milestones (1):"), "{text}");
+        assert!(text.contains("Backlog · mpm/core"), "{text}");
+        assert!(text.contains("#3  trusty-mpm"), "{text}");
+    }
+
+    #[test]
+    fn standard_still_requires_a_milestone_when_the_fetch_fails() {
+        // #7067: the requirement is rendered from config, so a `gh` outage
+        // cannot be read as "no milestone needed".
+        let text = render_standard(&ResolvedTicketing::default(), &model(), &broken_gh());
+        assert!(text.contains("milestones: unavailable ("), "{text}");
+        assert!(text.contains("gh auth login required"), "{text}");
+        assert!(text.contains("milestone_required:  true"), "{text}");
+        assert!(text.contains("project_required:    true"), "{text}");
+        assert!(!text.contains("open milestones ("), "{text}");
+    }
+
+    #[test]
+    fn a_disabled_requirement_still_prints() {
+        let cfg = ResolvedTicketing::default().with_filing_requirements(false, false);
+        let text = render_standard(&cfg, &model(), &healthy_gh());
+        assert!(text.contains("milestone_required:  false"), "{text}");
+        assert!(text.contains("project_required:    false"), "{text}");
+        assert!(
+            text.contains("default_project:     (none"),
+            "an unset default names itself: {text}"
         );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/standard_live.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/standard_live.rs
@@ -1,0 +1,291 @@
+//! The live half of `tm issue standard` — the milestones and projects a new
+//! issue can actually be filed into (#7067).
+//!
+//! Why: #7067 made a milestone and a project mandatory on every new issue, and
+//! a rule the agent cannot satisfy is a rule it will break. The agent had no
+//! read-back: it either hand-ran `gh api …/milestones` and `gh project list`
+//! every filing, or guessed a title and got a `gh` error. This module is that
+//! read-back, so `tm issue standard` prints the requirement and the choices in
+//! one place.
+//!
+//! What: [`render_filing_targets`] renders the section. Both fetches go through
+//! the injected [`CommandRunner`] — the same seam `tm ticket` uses, which is
+//! where #1265's per-project GitHub identity is bound — so this module spawns
+//! no `gh` of its own.
+//!
+//! # Failing closed
+//!
+//! A `gh` failure prints `milestones: unavailable (<error>)`, never an empty
+//! list. An empty list reads as "this repo has no milestones, so none is
+//! needed", which is the exact misreading that would re-create the #7067 gap;
+//! the requirement lines are rendered from config and are unaffected by a
+//! fetch failure.
+//!
+//! Test: `filing_targets_list_open_milestones_and_projects`,
+//! `filing_targets_report_a_milestone_fetch_failure`,
+//! `filing_targets_report_a_project_fetch_failure`,
+//! `filing_targets_skip_closed_projects`.
+
+use std::fmt::Write as _;
+
+use anyhow::Context as _;
+use serde::Deserialize;
+
+use crate::commands::ticket::runner::CommandRunner;
+
+/// One project row from `gh project list --format json`.
+///
+/// Why: decouples the rendering from gh's wire shape.
+/// What: the fields the section prints, plus `closed` so a finished project is
+/// never offered as a filing target.
+/// Test: `filing_targets_skip_closed_projects`.
+#[derive(Debug, Deserialize)]
+struct GhProject {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    number: u64,
+    #[serde(default)]
+    closed: bool,
+}
+
+/// The `gh project list --format json` envelope.
+#[derive(Debug, Deserialize)]
+struct GhProjectList {
+    #[serde(default)]
+    projects: Vec<GhProject>,
+}
+
+/// Render the live filing-target section.
+///
+/// Why: the agent needs the exact titles it must hand to
+/// `gh issue create --milestone` / `--add-project`, from the repo it is about
+/// to file into — a hand-typed name is the failure this replaces.
+/// What: open milestones (GitHub's list-milestones endpoint defaults to
+/// `state=open`) and the owner's open projects, each rendered as a counted
+/// list, or as an `unavailable (<error>)` line when `gh` failed.
+/// Test: see the module doc.
+pub(crate) fn render_filing_targets(runner: &dyn CommandRunner) -> String {
+    let mut out = String::new();
+    out.push_str("\nfiling targets — live, from gh:\n");
+
+    match fetch_milestones(runner) {
+        Ok(titles) => {
+            let _ = writeln!(out, "  open milestones ({}):", titles.len());
+            for title in &titles {
+                let _ = writeln!(out, "    {title}");
+            }
+        }
+        Err(e) => {
+            let _ = writeln!(out, "  milestones: unavailable ({})", one_line(&e));
+        }
+    }
+
+    match fetch_projects(runner) {
+        Ok(projects) => {
+            let _ = writeln!(out, "  open projects ({}):", projects.len());
+            for (number, title) in &projects {
+                let _ = writeln!(out, "    #{number}  {title}");
+            }
+        }
+        Err(e) => {
+            let _ = writeln!(out, "  projects: unavailable ({})", one_line(&e));
+        }
+    }
+
+    out
+}
+
+/// Collapse an error chain to one line so a multi-line `gh` stderr cannot
+/// break the section's shape.
+fn one_line(err: &anyhow::Error) -> String {
+    err.to_string()
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Fetch the repository's OPEN milestone titles.
+///
+/// Why: the milestone an issue carries is chosen from this list, never invented.
+/// What: `gh api repos/{owner}/{repo}/milestones` — gh expands the `{owner}` /
+/// `{repo}` placeholders from the working directory's remote, so no separate
+/// repository lookup is needed. The endpoint defaults to `state=open`.
+/// Test: `filing_targets_list_open_milestones_and_projects`.
+fn fetch_milestones(runner: &dyn CommandRunner) -> anyhow::Result<Vec<String>> {
+    let out = runner.run(
+        "gh",
+        &[
+            "api",
+            "repos/{owner}/{repo}/milestones",
+            "--paginate",
+            "--jq",
+            ".[].title",
+        ],
+    )?;
+    let text = out.ok_or_stderr("gh api repos/{owner}/{repo}/milestones")?;
+    Ok(text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Fetch the repository owner's OPEN projects as `(number, title)`.
+///
+/// Why: `gh project list` is owner-scoped, not repo-scoped, so the owner has to
+/// be resolved first; asking gh for it keeps the answer tied to the same
+/// working directory the milestone call reads.
+/// What: `gh repo view --json owner`, then
+/// `gh project list --owner <login> --format json`, dropping closed projects.
+/// Test: `filing_targets_skip_closed_projects`.
+fn fetch_projects(runner: &dyn CommandRunner) -> anyhow::Result<Vec<(u64, String)>> {
+    let owner_out = runner.run(
+        "gh",
+        &["repo", "view", "--json", "owner", "--jq", ".owner.login"],
+    )?;
+    let owner = owner_out.ok_or_stderr("gh repo view --json owner")?;
+    if owner.is_empty() {
+        anyhow::bail!("`gh repo view` named no owner — is this a GitHub repository?");
+    }
+
+    let list_out = runner.run(
+        "gh",
+        &["project", "list", "--owner", &owner, "--format", "json"],
+    )?;
+    let text = list_out.ok_or_stderr("gh project list")?;
+    let parsed: GhProjectList = serde_json::from_str(&text)
+        .with_context(|| format!("could not parse `gh project list --owner {owner}` output"))?;
+    Ok(parsed
+        .projects
+        .into_iter()
+        .filter(|p| !p.closed)
+        .map(|p| (p.number, p.title))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::ticket::runner::CommandOutput;
+    use std::cell::RefCell;
+
+    /// A scripted [`CommandRunner`] returning queued outputs in order.
+    struct FakeRunner {
+        outputs: RefCell<Vec<anyhow::Result<CommandOutput>>>,
+        calls: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl FakeRunner {
+        fn new(outputs: Vec<anyhow::Result<CommandOutput>>) -> Self {
+            Self {
+                outputs: RefCell::new(outputs),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(&self, program: &str, args: &[&str]) -> anyhow::Result<CommandOutput> {
+            let mut call = vec![program.to_string()];
+            call.extend(args.iter().map(|a| (*a).to_string()));
+            self.calls.borrow_mut().push(call);
+            let mut outs = self.outputs.borrow_mut();
+            if outs.is_empty() {
+                anyhow::bail!("FakeRunner exhausted")
+            }
+            outs.remove(0)
+        }
+    }
+
+    fn ok_out(stdout: &str) -> anyhow::Result<CommandOutput> {
+        Ok(CommandOutput {
+            success: true,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        })
+    }
+
+    fn fail_out(stderr: &str) -> anyhow::Result<CommandOutput> {
+        Ok(CommandOutput {
+            success: false,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+        })
+    }
+
+    const PROJECTS_JSON: &str = r#"{"projects":[
+        {"number":3,"title":"trusty-mpm","closed":false},
+        {"number":9,"title":"Retired 2025","closed":true}
+    ]}"#;
+
+    #[test]
+    fn filing_targets_list_open_milestones_and_projects() {
+        let runner = FakeRunner::new(vec![
+            ok_out("Backlog · mpm/core\nmpm 1.4\n"),
+            ok_out("bobmatnyc"),
+            ok_out(PROJECTS_JSON),
+        ]);
+        let text = render_filing_targets(&runner);
+        assert!(text.contains("open milestones (2):"), "{text}");
+        assert!(text.contains("Backlog · mpm/core"), "{text}");
+        assert!(text.contains("open projects (1):"), "{text}");
+        assert!(text.contains("#3  trusty-mpm"), "{text}");
+        // The owner reaches `gh project list`, not a hardcoded login.
+        let calls = runner.calls.borrow();
+        assert!(
+            calls[2].contains(&"bobmatnyc".to_string()),
+            "{:?}",
+            calls[2]
+        );
+    }
+
+    #[test]
+    fn filing_targets_skip_closed_projects() {
+        let runner = FakeRunner::new(vec![ok_out(""), ok_out("bobmatnyc"), ok_out(PROJECTS_JSON)]);
+        let text = render_filing_targets(&runner);
+        assert!(!text.contains("Retired 2025"), "{text}");
+    }
+
+    #[test]
+    fn filing_targets_report_a_milestone_fetch_failure() {
+        // #7067: a failed fetch must never render as an empty list — an agent
+        // would read that as "no milestone needed".
+        let runner = FakeRunner::new(vec![
+            fail_out("gh: Not Found (HTTP 404)"),
+            ok_out("bobmatnyc"),
+            ok_out(PROJECTS_JSON),
+        ]);
+        let text = render_filing_targets(&runner);
+        assert!(text.contains("milestones: unavailable ("), "{text}");
+        assert!(text.contains("HTTP 404"), "{text}");
+        assert!(!text.contains("open milestones (0)"), "{text}");
+    }
+
+    #[test]
+    fn filing_targets_report_a_project_fetch_failure() {
+        let runner = FakeRunner::new(vec![
+            ok_out("mpm 1.4\n"),
+            fail_out("gh: your token has not been granted the required scopes: `project`"),
+        ]);
+        let text = render_filing_targets(&runner);
+        assert!(text.contains("projects: unavailable ("), "{text}");
+        assert!(text.contains("project"), "{text}");
+        // The milestone half still rendered.
+        assert!(text.contains("open milestones (1):"), "{text}");
+    }
+
+    #[test]
+    fn a_multi_line_gh_error_stays_one_line() {
+        let runner = FakeRunner::new(vec![fail_out("first\n\nsecond"), fail_out("boom")]);
+        let text = render_filing_targets(&runner);
+        let line = text
+            .lines()
+            .find(|l| l.contains("milestones: unavailable"))
+            .expect("the unavailable line renders");
+        assert!(line.contains("first; second"), "{line}");
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/standard_live.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/standard_live.rs
@@ -134,14 +134,20 @@ fn fetch_milestones(runner: &dyn CommandRunner) -> anyhow::Result<Vec<String>> {
         .collect())
 }
 
+/// Cap passed to `gh project list -L`. gh's own default is 30, which it applies
+/// silently, so a project past position 30 would never reach the agent.
+const PROJECT_LIST_LIMIT: &str = "200";
+
 /// Fetch the repository owner's OPEN projects as `(number, title)`.
 ///
 /// Why: `gh project list` is owner-scoped, not repo-scoped, so the owner has to
 /// be resolved first; asking gh for it keeps the answer tied to the same
 /// working directory the milestone call reads.
 /// What: `gh repo view --json owner`, then
-/// `gh project list --owner <login> --format json`, dropping closed projects.
-/// Test: `filing_targets_skip_closed_projects`.
+/// `gh project list --owner <login> -L 200 --format json`, dropping closed
+/// projects.
+/// Test: `filing_targets_skip_closed_projects`,
+/// `project_list_carries_an_explicit_limit`.
 fn fetch_projects(runner: &dyn CommandRunner) -> anyhow::Result<Vec<(u64, String)>> {
     let owner_out = runner.run(
         "gh",
@@ -152,9 +158,19 @@ fn fetch_projects(runner: &dyn CommandRunner) -> anyhow::Result<Vec<(u64, String
         anyhow::bail!("`gh repo view` named no owner — is this a GitHub repository?");
     }
 
+    // #7067: without -L, gh caps the list at 30 and signals no truncation.
     let list_out = runner.run(
         "gh",
-        &["project", "list", "--owner", &owner, "--format", "json"],
+        &[
+            "project",
+            "list",
+            "--owner",
+            &owner,
+            "-L",
+            PROJECT_LIST_LIMIT,
+            "--format",
+            "json",
+        ],
     )?;
     let text = list_out.ok_or_stderr("gh project list")?;
     let parsed: GhProjectList = serde_json::from_str(&text)
@@ -248,6 +264,29 @@ mod tests {
         let runner = FakeRunner::new(vec![ok_out(""), ok_out("bobmatnyc"), ok_out(PROJECTS_JSON)]);
         let text = render_filing_targets(&runner);
         assert!(!text.contains("Retired 2025"), "{text}");
+    }
+
+    #[test]
+    fn project_list_carries_an_explicit_limit() {
+        // #7067: gh caps `project list` at 30 with no truncation signal, so the
+        // flag and its value must both survive in argv.
+        let runner = FakeRunner::new(vec![ok_out(""), ok_out("bobmatnyc"), ok_out(PROJECTS_JSON)]);
+        let _ = render_filing_targets(&runner);
+        let calls = runner.calls.borrow();
+        let argv = &calls[2];
+        let flag = argv
+            .iter()
+            .position(|a| a == "-L")
+            .unwrap_or_else(|| panic!("`gh project list` carries -L: {argv:?}"));
+        assert_eq!(
+            argv.get(flag + 1).map(String::as_str),
+            Some(PROJECT_LIST_LIMIT),
+            "{argv:?}"
+        );
+        assert!(
+            PROJECT_LIST_LIMIT.parse::<u32>().is_ok_and(|n| n > 30),
+            "the limit must exceed gh's silent default of 30: {PROJECT_LIST_LIMIT}"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -43,7 +43,8 @@ pub use untracked_sync::{
 pub mod agents;
 pub use agents::{
     AgentsConfig, ConfiguredLabel, DEFAULT_ASSIGNEE, LabelRole, REQUIRED_PR_LINK_KEYWORD,
-    ResolvedTicketing, TicketingConfig, TicketingConfigError, resolve_ticketing,
+    ResolvedTicketing, TICKETING_BLOCK_TEMPLATE, TicketingConfig, TicketingConfigError,
+    resolve_ticketing,
 };
 
 /// Cloud log-drain config shape + resolution (#6535), split out for the same

--- a/crates/trusty-mpm/src/core/trusty_tools_config/agents.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/agents.rs
@@ -58,6 +58,38 @@ pub const DEFAULT_ASSIGNEE: &str = "@me";
 /// Test: `closes_pr_link_keyword_is_rejected`, `refs_pr_link_keyword_is_accepted`.
 pub const REQUIRED_PR_LINK_KEYWORD: &str = "Refs";
 
+/// A commented starter `agents.ticketing` block, for `tm issue seed-config`
+/// to hand an operator (#7067).
+///
+/// Why: the verb seeds `issue-state.yaml` — the lifecycle half of the standard.
+/// The other half lives in a different file the operator has to write by hand,
+/// and #7067 added three keys to it, so a seeded lifecycle with no pointer at
+/// the block leaves the milestone and project rules undiscoverable. This is
+/// that pointer, in copy-pasteable form.
+/// What: every key set to its built-in default, so pasting the block changes
+/// nothing until an entry is edited. `default_project` is commented out —
+/// there is no default title to state.
+/// Test: `the_seed_template_parses_to_the_builtin_defaults`.
+pub const TICKETING_BLOCK_TEMPLATE: &str = "\
+# The ticketing standard. Read the resolved values back with `tm issue standard`.
+agents:
+  ticketing:
+    # #7067: every new issue carries exactly one milestone. An issue filed with
+    # none needs a `no-milestone: <reason>` comment on it.
+    milestone_required: true
+    # #7067: every new issue joins at least one GitHub Project.
+    project_required: true
+    # #7067: the Project TITLE new issues join by default. Leave it out to pick
+    # per issue from the live list `tm issue standard` prints.
+    # default_project: trusty-mpm
+    # Whether session launch ensures the component labels exist.
+    ensure_labels: true
+    # Whether claiming an issue posts a comment naming the claiming session.
+    claim_comment: true
+    # Whether closing requires live-verification evidence.
+    close_requires_note: true
+";
+
 /// The `agents:` group of `~/.trusty-tools/trusty-mpm/config.yaml` (#6918).
 ///
 /// Why: settings that belong to ONE bundled agent are grouped under that
@@ -85,7 +117,8 @@ pub struct AgentsConfig {
 /// What: every field is optional so a partial block falls back per-field.
 /// [`resolve_ticketing`] is what turns it into usable values, and is where the
 /// two non-negotiable rules are enforced.
-/// Test: `ticketing_config_yaml_round_trip`, `extra_labels_extend_the_policy_set`.
+/// Test: `ticketing_config_yaml_round_trip`, `extra_labels_extend_the_policy_set`,
+/// `filing_target_keys_round_trip`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct TicketingConfig {
@@ -139,6 +172,31 @@ pub struct TicketingConfig {
     /// model is referenced, never inlined here.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lifecycle_model: Option<PathBuf>,
+
+    // #7067: the milestone/project slice of the standard. Titles, never ids —
+    // an agent reads a title back from `tm issue standard` and hands the same
+    // string to `gh issue create --add-project`.
+    /// GitHub Project (v2) TITLE every new issue joins by default.
+    ///
+    /// `None` → no default; the agent picks a project by crate/topic fit from
+    /// the live list `tm issue standard` prints. Present but blank is refused.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_project: Option<String>,
+
+    /// Whether every new issue must carry exactly one milestone.
+    ///
+    /// `None` → `true`. Setting `false` is how a project that does not use
+    /// milestones says so; it does not make an unset milestone invisible —
+    /// `tm issue standard` still prints the flag.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub milestone_required: Option<bool>,
+
+    /// Whether every new issue must join at least one GitHub Project.
+    ///
+    /// `None` → `true`. Read by the ticketing agent through
+    /// `tm issue standard`; trusty-mpm files no issues itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_required: Option<bool>,
 }
 
 /// What a [`ConfiguredLabel`] is FOR.
@@ -233,6 +291,13 @@ pub enum TicketingConfigError {
     /// `default_assignee` was present but blank.
     #[error("agents.ticketing.default_assignee: cannot be blank (omit the key for `@me`)")]
     BlankAssignee,
+
+    /// `default_project` was present but blank (#7067).
+    #[error(
+        "agents.ticketing.default_project: cannot be blank (omit the key to let the agent pick \
+         a project from the live list `tm issue standard` prints)"
+    )]
+    BlankDefaultProject,
 }
 
 /// The ticketing standard in effect, after applying the block on top of the
@@ -262,6 +327,12 @@ pub struct ResolvedTicketing {
     pub lifecycle_model: Option<PathBuf>,
     /// Component labels the block adds to (or restyles in) the policy table.
     pub extra_labels: Vec<PolicyLabel>,
+    /// GitHub Project title new issues join by default, or `None` (#7067).
+    pub default_project: Option<String>,
+    /// Whether every new issue must carry exactly one milestone (#7067).
+    pub milestone_required: bool,
+    /// Whether every new issue must join at least one project (#7067).
+    pub project_required: bool,
 }
 
 impl ResolvedTicketing {
@@ -292,6 +363,23 @@ impl ResolvedTicketing {
         self.ensure_labels = ensure;
         self
     }
+
+    /// This standard with a `default_project` title (#7067).
+    /// Test: `standard_reports_the_filing_targets`.
+    #[must_use]
+    pub fn with_default_project(mut self, project: impl Into<String>) -> Self {
+        self.default_project = Some(project.into());
+        self
+    }
+
+    /// This standard with the two filing requirements set (#7067).
+    /// Test: `standard_reports_the_filing_targets`.
+    #[must_use]
+    pub fn with_filing_requirements(mut self, milestone: bool, project: bool) -> Self {
+        self.milestone_required = milestone;
+        self.project_required = project;
+        self
+    }
 }
 
 impl Default for ResolvedTicketing {
@@ -305,6 +393,12 @@ impl Default for ResolvedTicketing {
             pr_link_keyword: REQUIRED_PR_LINK_KEYWORD,
             lifecycle_model: None,
             extra_labels: Vec::new(),
+            // #7067: both default ON. A filing that carries neither is a
+            // standard violation the agent can be held to, and an operator who
+            // does not use milestones or projects turns the flag off by hand.
+            default_project: None,
+            milestone_required: true,
+            project_required: true,
         }
     }
 }
@@ -324,7 +418,8 @@ impl Default for ResolvedTicketing {
 /// `closes_pr_link_keyword_is_rejected`,
 /// `lifecycle_role_on_the_convention_label_is_rejected`,
 /// `blank_label_name_is_rejected`, `blank_assignee_is_rejected`,
-/// `extra_labels_extend_the_policy_set`.
+/// `extra_labels_extend_the_policy_set`, `filing_target_keys_round_trip`,
+/// `blank_default_project_is_rejected`.
 pub fn resolve_ticketing(
     config: &TrustyToolsConfig,
 ) -> Result<ResolvedTicketing, TicketingConfigError> {
@@ -346,6 +441,15 @@ pub fn resolve_ticketing(
         Some(a) if a.trim().is_empty() => return Err(TicketingConfigError::BlankAssignee),
         Some(a) => a.trim().to_string(),
         None => DEFAULT_ASSIGNEE.to_string(),
+    };
+
+    // #7067: same shape as `default_assignee` — a present-but-blank title is a
+    // typo, not "no default", and resolving it silently to `None` would leave
+    // the agent picking a project the operator thought they had named.
+    let default_project = match block.default_project.as_deref() {
+        Some(p) if p.trim().is_empty() => return Err(TicketingConfigError::BlankDefaultProject),
+        Some(p) => Some(p.trim().to_string()),
+        None => None,
     };
 
     let mut extra_labels = Vec::with_capacity(block.extra_labels.len());
@@ -375,6 +479,9 @@ pub fn resolve_ticketing(
         pr_link_keyword: REQUIRED_PR_LINK_KEYWORD,
         lifecycle_model: block.lifecycle_model.clone(),
         extra_labels,
+        default_project,
+        milestone_required: block.milestone_required.unwrap_or(true),
+        project_required: block.project_required.unwrap_or(true),
     })
 }
 
@@ -399,6 +506,67 @@ mod tests {
         assert_eq!(resolved.pr_link_keyword, "Refs");
         assert!(resolved.extra_labels.is_empty());
         assert!(resolved.lifecycle_model.is_none());
+        // #7067: an absent block still REQUIRES a milestone and a project.
+        assert!(resolved.default_project.is_none());
+        assert!(resolved.milestone_required);
+        assert!(resolved.project_required);
+    }
+
+    #[test]
+    fn filing_target_keys_round_trip() {
+        // #7067: the three new keys parse where they live, survive a
+        // serialise/re-parse, and resolve to the values written.
+        let cfg = config_from(
+            "agents:\n\
+             \x20 ticketing:\n\
+             \x20   default_project: trusty-mpm\n\
+             \x20   milestone_required: false\n\
+             \x20   project_required: false\n",
+        );
+        let back = serde_yaml::to_string(&cfg).expect("serialises");
+        let again: TrustyToolsConfig = serde_yaml::from_str(&back).expect("re-parses");
+        assert_eq!(cfg, again);
+
+        let resolved = resolve_ticketing(&cfg).expect("resolves");
+        assert_eq!(resolved.default_project.as_deref(), Some("trusty-mpm"));
+        assert!(!resolved.milestone_required);
+        assert!(!resolved.project_required);
+    }
+
+    #[test]
+    fn the_seed_template_parses_to_the_builtin_defaults() {
+        // #7067: pasting the seeded block must be a no-op until an entry is
+        // edited — otherwise seeding it silently changes the standard.
+        let cfg = config_from(TICKETING_BLOCK_TEMPLATE);
+        assert_eq!(
+            resolve_ticketing(&cfg).expect("the template resolves"),
+            ResolvedTicketing::default()
+        );
+        // Every #7067 key is named, so the template cannot drift from the schema.
+        for key in ["milestone_required", "project_required", "default_project"] {
+            assert!(TICKETING_BLOCK_TEMPLATE.contains(key), "missing {key}");
+        }
+    }
+
+    #[test]
+    fn blank_default_project_is_rejected() {
+        let cfg = config_from("agents:\n  ticketing:\n    default_project: \"  \"\n");
+        let err = resolve_ticketing(&cfg).expect_err("blank project title");
+        assert_eq!(err, TicketingConfigError::BlankDefaultProject);
+        assert!(
+            err.to_string().contains("agents.ticketing.default_project"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_filing_key_is_dropped_not_fatal() {
+        // #7067: the surrounding parse stays LENIENT — a misspelt key must not
+        // take the whole config down, which is why the three real keys are
+        // declared rather than left to the warn-and-drop path.
+        let cfg = config_from("agents:\n  ticketing:\n    default_projects: trusty-mpm\n");
+        let resolved = resolve_ticketing(&cfg).expect("resolves");
+        assert!(resolved.default_project.is_none());
     }
 
     #[test]


### PR DESCRIPTION
The universal ticketing standard now requires every new issue to carry exactly one milestone, at least one GitHub Project, and every relationship the brief names, set natively at filing. `agents.ticketing` in config.yaml gains `default_project`, `milestone_required`, `project_required` (both flags default true; a blank project title is refused). `tm issue standard` prints the trio and a live filing-targets section (open milestones, open projects with an explicit limit) through the existing gh seam, failing closed to `unavailable (<error>)`. The tm-ticketing skill and the ticketing agent asset replace "leave the milestone unset" with the mandatory trio and a `no-milestone: <reason>` escape. `tm issue seed-config` prints a commented starter block naming config.yaml rather than writing it.

Refs #7067

Sub-issue of #6918.

**Test ladder:** Rung 4 (cross-crate: trusty-mpm, trusty-agents-common): cargo fmt --check, clippy --all-targets -D warnings on both, test -p trusty-mpm --no-fail-fast (54 targets, 10974 passed, 0 failed, 19 ignored), test -p trusty-agents-common --no-fail-fast (556 passed, 0 failed), cargo check --workspace; changelog fragments in both crates; check_capabilities.sh no drift.

**Review:** code-critic APPROVE on b4abd9ccd; MEDIUM (gh project list capped at 30 with no signal) fixed in de43172a2 with a mutation-checked argv test.

**Flake note:** parity_tmux_adopt_unknown_session_agrees_across_transports failed once on a $HOME move from a sibling test (#5784/#7056 family, untouched code), passed alone and in two further full runs.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XAqBLVJbLSXH613FeE6Ucj
