### PR TITLE
fix(trusty-mpm): tm issue seed-config writes the agents.ticketing block into config.yaml

### DIFF
--- a/crates/trusty-common/changelog.d/7067-atomic-raw-config-write.md
+++ b/crates/trusty-common/changelog.d/7067-atomic-raw-config-write.md
@@ -1,0 +1,10 @@
+Added
+
+- `crate_config::save_raw_at` writes caller-supplied bytes to a config path
+  atomically — temp sibling, then rename — for a caller that already holds the
+  exact text to land and cannot go through `save_at`'s serialise-and-header
+  path. `tm issue seed-config` appends its `agents.ticketing` block textually to
+  preserve an operator's comments, and now routes that write here instead of a
+  truncating `std::fs::write`, so an interrupted seed leaves the existing config
+  byte-identical rather than half-written. `save_at` delegates to it, keeping one
+  atomic-config-write implementation in the workspace (#7067).

--- a/crates/trusty-common/src/crate_config.rs
+++ b/crates/trusty-common/src/crate_config.rs
@@ -205,8 +205,31 @@ pub fn save_at<T: Serialize>(path: &Path, value: &T) -> Result<PathBuf, ConfigEr
                   # Managed by the trusty-tools config convention (#1220).\n\
                   # Edit by hand or via the trusty-console Config tab.\n\n";
     let content = format!("{header}{yaml}");
+    save_raw_at(path, &content)
+}
+
+/// Write `contents` verbatim to a config path, atomically.
+///
+/// Why: the atomic half of [`save_at`], reachable by a caller that already holds
+/// the exact bytes to land — `tm issue seed-config` appends a template textually
+/// so it can preserve an operator's comments, which a serialise-and-write cannot
+/// (#7067). Without this seam that caller would reimplement the temp-and-rename
+/// dance, giving the workspace a second atomic-config-write implementation.
+/// What: creates the parent directory, writes a sibling `<stem>.yaml.tmp`, then
+/// renames it over the target. A reader never observes a torn file, and a failed
+/// write leaves the target byte-identical because the target is never opened for
+/// writing. Returns the path written.
+/// Test: `save_then_load_round_trips`, `save_raw_at_leaves_no_tmp_sibling`,
+/// `a_failed_raw_write_leaves_the_target_byte_identical`.
+pub fn save_raw_at(path: &Path, contents: &str) -> Result<PathBuf, ConfigError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ConfigError::Io {
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
     let tmp = path.with_extension("yaml.tmp");
-    std::fs::write(&tmp, &content).map_err(|e| ConfigError::Io {
+    std::fs::write(&tmp, contents).map_err(|e| ConfigError::Io {
         path: tmp.clone(),
         source: e,
     })?;
@@ -291,6 +314,71 @@ mod tests {
         // where it came from.
         let raw = std::fs::read_to_string(&path).unwrap();
         assert!(raw.contains("trusty-tools config convention"));
+    }
+
+    /// Why: the temp-and-rename write must leave nothing behind — a surviving
+    /// `config.yaml.tmp` would be a half-written config sitting next to the real
+    /// one, and the next reader that globs the directory would find two.
+    /// Test: itself.
+    #[test]
+    fn save_raw_at_leaves_no_tmp_sibling() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = crate_config_path_at(tmp.path(), "trusty-mpm");
+
+        let written = save_raw_at(&path, "name: demo\n").unwrap();
+
+        assert_eq!(written, path);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "name: demo\n");
+        let siblings: Vec<PathBuf> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .collect();
+        assert_eq!(siblings, vec![path], "a .tmp sibling survived the write");
+    }
+
+    /// Why: the reason [`save_raw_at`] exists. A plain `std::fs::write` truncates
+    /// the target and then writes into it, so a write that cannot complete costs
+    /// the operator their config. Writing a sibling first means the target is
+    /// never opened for writing at all, so a failure leaves it byte-identical.
+    /// What: a read-only parent directory blocks creating the `.tmp` sibling
+    /// while leaving the existing file readable and (to `write(2)`) writable —
+    /// exactly the case that distinguishes the two writes. Skipped when the
+    /// process can create files in a read-only directory anyway (running as
+    /// root), since the failure being asserted cannot be provoked there.
+    /// Test: itself.
+    #[cfg(unix)]
+    #[test]
+    fn a_failed_raw_write_leaves_the_target_byte_identical() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = crate_config_path_at(tmp.path(), "trusty-mpm");
+        let dir = path.parent().unwrap().to_path_buf();
+        std::fs::create_dir_all(&dir).unwrap();
+        let original = "# hand-written\nname: operator\n";
+        std::fs::write(&path, original).unwrap();
+
+        let restore = std::fs::metadata(&dir).unwrap().permissions();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+        let root_can_still_write = std::fs::write(dir.join("probe"), b"x").is_ok();
+
+        let result = if root_can_still_write {
+            std::fs::remove_file(dir.join("probe")).ok();
+            None
+        } else {
+            Some(save_raw_at(&path, "name: clobbered\n"))
+        };
+
+        std::fs::set_permissions(&dir, restore).unwrap();
+        let Some(result) = result else {
+            return; // running as root: the write cannot be made to fail here.
+        };
+        assert!(result.is_err(), "the write was expected to fail");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            original,
+            "a failed write modified the target"
+        );
     }
 
     /// Why: `load_or_default` must collapse an absent file to `T::default()` so

--- a/crates/trusty-mpm/changelog.d/7067-ticketing-project-milestone.md
+++ b/crates/trusty-mpm/changelog.d/7067-ticketing-project-milestone.md
@@ -8,9 +8,15 @@ Added
   through the same `gh` runner the rest of `tm issue` uses. A `gh` failure
   prints `milestones: unavailable (<error>)` rather than an empty list, so a
   fetch failure cannot be read as "no milestone needed"; the requirement lines
-  come from config and are unaffected. `tm issue seed-config` now also prints a
-  copy-pasteable `agents.ticketing` starter block carrying the new keys, since
-  the lifecycle model and the standard live in different files. The
+  come from config and are unaffected. `tm issue seed-config` now also WRITES
+  the `agents.ticketing` starter block carrying the new keys into
+  `~/.trusty-tools/trusty-mpm/config.yaml` — the same file the runtime loader
+  reads — since the lifecycle model and the standard live in different files.
+  It creates that file if it is absent, appends the block textually if the file
+  exists without one (every prior byte and comment preserved), and leaves an
+  existing `agents.ticketing` exactly as the operator wrote it; it prints the
+  path and which of the three happened. Every key in the written block is at
+  its built-in default, so seeding does not change the standard. The
   `tm-ticketing` skill reverses its old "leave the milestone unset by default"
   rule: every new issue carries exactly one milestone chosen by a stated rule
   (the parent's, else the crate's `Backlog · <crate>`, else the one

--- a/crates/trusty-mpm/changelog.d/7067-ticketing-project-milestone.md
+++ b/crates/trusty-mpm/changelog.d/7067-ticketing-project-milestone.md
@@ -15,8 +15,16 @@ Added
   It creates that file if it is absent, appends the block textually if the file
   exists without one (every prior byte and comment preserved), and leaves an
   existing `agents.ticketing` exactly as the operator wrote it; it prints the
-  path and which of the three happened. Every key in the written block is at
-  its built-in default, so seeding does not change the standard. The
+  path and which of the four outcomes happened. The fourth is a refusal: a file
+  that already declares `agents:` without `ticketing:` is left untouched, since
+  a second top-level `agents:` key would make it unparseable and discard every
+  other setting in it — the block is printed for a manual paste under the
+  existing key and the command exits nonzero, so a provisioning script cannot
+  read a seed that did not happen as one that did. Writes go through the
+  workspace's atomic config write (temp sibling, then rename), so an
+  interrupted seed can never leave a half-written config. Every key in the
+  written block is at its built-in default, so seeding does not change the
+  standard. The
   `tm-ticketing` skill reverses its old "leave the milestone unset by default"
   rule: every new issue carries exactly one milestone chosen by a stated rule
   (the parent's, else the crate's `Backlog · <crate>`, else the one

--- a/crates/trusty-mpm/help.yaml
+++ b/crates/trusty-mpm/help.yaml
@@ -225,7 +225,7 @@ commands:
           - name: config
             description: Explicit path to an issue-state YAML (overrides discovery)
       seed-config:
-        description: Write the embedded default model to ~/.trusty-tools/trusty-mpm/issue-state.yaml
+        description: Write the default model to ~/.trusty-tools/trusty-mpm/issue-state.yaml and the agents.ticketing block to config.yaml
         flags:
           - name: force
             description: Overwrite an existing user config file

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -46,7 +46,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
 - `issue` — YAML-configurable issue state-management (labels/transitions/assignee)
   - `current` — Report an issue's current state, derived from its labels
   - `repair` — Resolve a mid-transition issue carrying multiple state labels
-  - `seed-config` — Write the embedded default model to the user config path
+  - `seed-config` — Write the default lifecycle model and the `agents.ticketing` block to the user config path
   - `seed-labels` — Create any missing labels (states + extra families) in the repo
   - `standard` — Print the ticketing standard in effect (#6918; reads config, no `gh`)
   - `states` — List the configured states and transitions (reads YAML only)

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -146,7 +146,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `ls` — List managed sessions (session-manager MVP). Auto-prunes dead records; pass `--no-prune` for a read that changes nothing
   - `managed-resume` — \[DEPRECATED\] Resume a stopped managed session — use `resume` instead
   - `managed-stop` — \[DEPRECATED\] Stop a managed session's runtime — use `stop` instead
-  - `new` — Spawn a new managed session from a repo + ref (session-manager MVP)
+  - `new` — Spawn a new managed session in an existing local checkout
   - `output` — Capture the current output of a session's tmux pane
   - `pause` — Pause a running session, saving state for later resume
   - `prune` — Prune managed sessions by state + compact tombstones (#1508)
@@ -180,7 +180,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `ls` — List managed sessions (session-manager MVP). Auto-prunes dead records; pass `--no-prune` for a read that changes nothing
   - `managed-resume` — \[DEPRECATED\] Resume a stopped managed session — use `resume` instead
   - `managed-stop` — \[DEPRECATED\] Stop a managed session's runtime — use `stop` instead
-  - `new` — Spawn a new managed session from a repo + ref (session-manager MVP)
+  - `new` — Spawn a new managed session in an existing local checkout
   - `output` — Capture the current output of a session's tmux pane
   - `pause` — Pause a running session, saving state for later resume
   - `prune` — Prune managed sessions by state + compact tombstones (#1508)

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -220,6 +220,11 @@ label, restyle one, name a different assignee, or point at its own
 `issue-state.yaml` (#6918). `tm issue seed-config` WRITES that block into
 `config.yaml` — it creates the file, or appends the block to an existing one,
 leaving every prior byte and an existing `agents.ticketing` untouched (#7067).
+One case it refuses: a file that already declares `agents:` without
+`ticketing:`, since a second top-level `agents:` key would make the whole file
+unparseable and cost the operator every other setting in it. There it writes
+nothing, prints the block, and **exits nonzero** — paste the block under the
+existing `agents:` key by hand, then re-run to confirm.
 Two things the block cannot change, and the command prints both: the PR
 issue-link keyword stays `Refs #N` (a one-off `Closes` is the deliberate
 `tm pr open --closes` flag), and `trusty-mpm` stays a component label, never a

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -217,11 +217,14 @@ lifecycle labels, the default assignee, and whether a claim comment and a
 closing note are expected. Those values come from the `agents.ticketing` block
 in `~/.trusty-tools/trusty-mpm/config.yaml`, so a project can add a component
 label, restyle one, name a different assignee, or point at its own
-`issue-state.yaml` (#6918). Two things the block cannot change, and the command
-prints both: the PR issue-link keyword stays `Refs #N` (a one-off `Closes` is
-the deliberate `tm pr open --closes` flag), and `trusty-mpm` stays a component
-label, never a lifecycle one. A block that tries either is refused at load with
-the field named.
+`issue-state.yaml` (#6918). `tm issue seed-config` WRITES that block into
+`config.yaml` — it creates the file, or appends the block to an existing one,
+leaving every prior byte and an existing `agents.ticketing` untouched (#7067).
+Two things the block cannot change, and the command prints both: the PR
+issue-link keyword stays `Refs #N` (a one-off `Closes` is the deliberate
+`tm pr open --closes` flag), and `trusty-mpm` stays a component label, never a
+lifecycle one. A block that tries either is refused at load with the field
+named.
 
 ## Every New Issue Carries a Milestone, a Project, and Its Relationships
 

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/issue.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/issue.rs
@@ -16,8 +16,8 @@ use clap::Subcommand;
 /// What: `SeedLabels` (idempotent create-missing), `Transition` (validated
 /// atomic state change), `Current` (read state from labels), `States` (list the
 /// model), `Standard` (print the effective ticketing standard, #6918),
-/// `SeedConfig` (write the default YAML to disk), `Repair` (resolve a
-/// multi-state issue).
+/// `SeedConfig` (write the default lifecycle YAML plus the `agents.ticketing`
+/// block, #7067), `Repair` (resolve a multi-state issue).
 /// Test: `cli_parses_issue_*` in `tests.rs`.
 #[derive(Debug, Subcommand)]
 pub(crate) enum IssueCmd {
@@ -63,7 +63,7 @@ pub(crate) enum IssueCmd {
         #[arg(long)]
         config: Option<std::path::PathBuf>,
     },
-    /// Write the embedded default model to the user config path.
+    /// Write the default lifecycle model and the `agents.ticketing` block to the user config path.
     SeedConfig {
         /// Overwrite an existing user config file.
         #[arg(long)]

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
@@ -17,6 +17,7 @@
 
 pub(crate) mod config;
 pub(crate) mod ops;
+pub(crate) mod seed_ticketing;
 pub(crate) mod standard;
 pub(crate) mod standard_live;
 pub(crate) mod state;
@@ -35,6 +36,7 @@ use crate::commands::ticket::system::{
 };
 
 use config::{StateModel, load_model};
+use seed_ticketing::{TicketingSeedOutcome, seed_ticketing_block, ticketing_config_path};
 use trusty_mpm::core::trusty_tools_config::{
     TICKETING_BLOCK_TEMPLATE, TrustyToolsConfig, resolve_ticketing,
 };
@@ -175,17 +177,21 @@ fn print_states(model: &StateModel) {
     }
 }
 
-/// `tm issue seed-config [--force]` — write the embedded default to user config.
+/// `tm issue seed-config [--force]` — write both halves of the standard.
 ///
 /// Why: lets operators start from a copy of the default model and edit it,
 /// mirroring `tm services init` (RFC §6).
 /// What: writes [`config::DEFAULT_MODEL_YAML`] to
 /// `~/.trusty-tools/trusty-mpm/issue-state.yaml`, creating parent dirs; refuses
-/// to overwrite an existing file unless `--force`. Then prints the
-/// [`TICKETING_BLOCK_TEMPLATE`] starter block (#7067) — the lifecycle half of
-/// the standard lands on disk, and the operator is shown the other half,
-/// including the milestone and project keys, rather than having to find them.
-/// Test: side-effect-only (filesystem/stdout); the template itself is covered by
+/// to overwrite an existing file unless `--force`. Then seeds the
+/// [`TICKETING_BLOCK_TEMPLATE`] into `config.yaml` — the file
+/// [`TrustyToolsConfig::load`] reads — via
+/// [`seed_ticketing_block`] (#7067), so the milestone and project half of the
+/// standard lands on disk rather than being printed for the operator to paste.
+/// That half is never overwritten: an existing `agents.ticketing` is left as
+/// the operator wrote it.
+/// Test: side-effect-only (filesystem/stdout); the write itself is covered by
+/// the `seed_ticketing` tests, the template by
 /// `the_seed_template_parses_to_the_builtin_defaults`.
 fn seed_config(force: bool) -> anyhow::Result<()> {
     let path: PathBuf = config::user_config_path()
@@ -205,14 +211,29 @@ fn seed_config(force: bool) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))?;
     println!("wrote default issue-state model to {}", path.display());
 
-    // #7067: the milestone/project keys live in a DIFFERENT file, so name it
-    // and print the block rather than leaving the operator to find both.
-    let config_yaml = path.with_file_name("config.yaml");
-    println!(
-        "\nthe rest of the standard lives in {} — paste this block to state it \
-         explicitly (every value below is already the default):\n",
-        config_yaml.display()
-    );
-    print!("{TICKETING_BLOCK_TEMPLATE}");
+    // #7067: the milestone/project keys live in a DIFFERENT file, so write
+    // them there too rather than leaving the operator to paste a block.
+    let config_yaml = ticketing_config_path()
+        .ok_or_else(|| anyhow::anyhow!("could not resolve home directory for the user config"))?;
+    let shown = config_yaml.display();
+    match seed_ticketing_block(&config_yaml)? {
+        TicketingSeedOutcome::Created => {
+            println!("created {shown} with the agents.ticketing block");
+        }
+        TicketingSeedOutcome::Appended => {
+            println!("appended the agents.ticketing block to {shown}");
+        }
+        TicketingSeedOutcome::AlreadyPresent => {
+            println!("{shown} already declares agents.ticketing — left unchanged");
+        }
+        TicketingSeedOutcome::AgentsBlockPresent => {
+            println!(
+                "{shown} declares `agents:` without `ticketing:` — left unchanged, \
+                 since a second `agents:` key would make the file unreadable. \
+                 Add this entry under the `agents:` block by hand:\n"
+            );
+            print!("{TICKETING_BLOCK_TEMPLATE}");
+        }
+    }
     Ok(())
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
@@ -36,7 +36,9 @@ use crate::commands::ticket::system::{
 };
 
 use config::{StateModel, load_model};
-use seed_ticketing::{TicketingSeedOutcome, seed_ticketing_block, ticketing_config_path};
+use seed_ticketing::{
+    TicketingSeedOutcome, seed_outcome_result, seed_ticketing_block, ticketing_config_path,
+};
 use trusty_mpm::core::trusty_tools_config::{
     TICKETING_BLOCK_TEMPLATE, TrustyToolsConfig, resolve_ticketing,
 };
@@ -189,9 +191,12 @@ fn print_states(model: &StateModel) {
 /// [`seed_ticketing_block`] (#7067), so the milestone and project half of the
 /// standard lands on disk rather than being printed for the operator to paste.
 /// That half is never overwritten: an existing `agents.ticketing` is left as
-/// the operator wrote it.
+/// the operator wrote it. One outcome exits NONZERO — an `agents:` key with no
+/// `ticketing:` cannot be appended to, so the block is printed for a manual
+/// paste and the command fails rather than reporting a seed it did not do.
 /// Test: side-effect-only (filesystem/stdout); the write itself is covered by
-/// the `seed_ticketing` tests, the template by
+/// the `seed_ticketing` tests, the exit split by
+/// `only_the_refusal_outcome_exits_nonzero`, the template by
 /// `the_seed_template_parses_to_the_builtin_defaults`.
 fn seed_config(force: bool) -> anyhow::Result<()> {
     let path: PathBuf = config::user_config_path()
@@ -216,7 +221,8 @@ fn seed_config(force: bool) -> anyhow::Result<()> {
     let config_yaml = ticketing_config_path()
         .ok_or_else(|| anyhow::anyhow!("could not resolve home directory for the user config"))?;
     let shown = config_yaml.display();
-    match seed_ticketing_block(&config_yaml)? {
+    let outcome = seed_ticketing_block(&config_yaml)?;
+    match outcome {
         TicketingSeedOutcome::Created => {
             println!("created {shown} with the agents.ticketing block");
         }
@@ -235,5 +241,7 @@ fn seed_config(force: bool) -> anyhow::Result<()> {
             print!("{TICKETING_BLOCK_TEMPLATE}");
         }
     }
-    Ok(())
+    // #7067: the refusal arm exits nonzero — the standard is half-applied and a
+    // script must not read that as a completed seed.
+    seed_outcome_result(outcome, &config_yaml)
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/seed_ticketing.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/seed_ticketing.rs
@@ -1,0 +1,279 @@
+//! Seeding the `agents.ticketing` block into the runtime config (#7067).
+//!
+//! Why: `tm issue seed-config` writes the lifecycle half of the ticketing
+//! standard (`issue-state.yaml`). The other half — the milestone and project
+//! rules #7067 added — lives in `~/.trusty-tools/trusty-mpm/config.yaml`, a
+//! DIFFERENT file. Printing a block for the operator to paste left the seeded
+//! standard half-applied; this module writes it.
+//!
+//! What: [`ticketing_config_path`] resolves the same path
+//! [`trusty_mpm::core::trusty_tools_config::TrustyToolsConfig::load`] reads,
+//! by calling the loader's own `trusty_common::crate_config` resolver rather
+//! than rebuilding the path. [`seed_ticketing_block`] then creates that file
+//! with [`TICKETING_BLOCK_TEMPLATE`], appends the template textually, or
+//! leaves the file alone — reporting which as a [`TicketingSeedOutcome`]. The
+//! append is textual on purpose: parsing and re-serialising would reorder keys
+//! and strip every comment the operator wrote.
+//!
+//! Test: `seed_creates_the_config_file_with_the_ticketing_block`,
+//! `seed_appends_and_preserves_every_existing_byte`,
+//! `seed_leaves_an_existing_ticketing_block_untouched`,
+//! `seed_refuses_to_append_under_an_existing_agents_block`,
+//! `a_seeded_file_resolves_to_the_builtin_ticketing_defaults`,
+//! `the_seeded_path_is_the_one_the_loader_reads`.
+
+use std::path::{Path, PathBuf};
+
+use trusty_mpm::core::trusty_tools_config::{CRATE_NAME, TICKETING_BLOCK_TEMPLATE};
+
+/// What [`seed_ticketing_block`] did to the config file.
+///
+/// Why: the caller prints what happened, and "already present" must be
+/// distinguishable from "written" — an operator who has tuned the standard
+/// needs to be told their values were left alone, not that a seed succeeded.
+/// What: the three write outcomes plus [`Self::AgentsBlockPresent`], the
+/// refusal case (see [`seed_ticketing_block`] for why it cannot append).
+/// Test: asserted by every test in this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TicketingSeedOutcome {
+    /// The file did not exist; it was created holding only the block.
+    Created,
+    /// The file existed with no `agents:` key; the block was appended to it.
+    Appended,
+    /// The file already declares `agents.ticketing`; nothing was written.
+    AlreadyPresent,
+    /// The file declares `agents:` WITHOUT `ticketing:`; nothing was written.
+    AgentsBlockPresent,
+}
+
+/// Resolve the config file `TrustyToolsConfig::load` actually reads.
+///
+/// Why: the block is only useful in the file the runtime loads. Deriving the
+/// path here a second time would let the two drift; delegating to the
+/// loader's own resolver cannot.
+/// What: `trusty_common::crate_config::crate_config_path(CRATE_NAME)` —
+/// `~/.trusty-tools/trusty-mpm/config.yaml`. `None` only when the home
+/// directory cannot be resolved.
+/// Test: `the_seeded_path_is_the_one_the_loader_reads`.
+pub(crate) fn ticketing_config_path() -> Option<PathBuf> {
+    trusty_common::crate_config::crate_config_path(CRATE_NAME)
+}
+
+/// Write [`TICKETING_BLOCK_TEMPLATE`] into `path`, without clobbering it.
+///
+/// Why: seeding must be safe to re-run and must never overwrite a value an
+/// operator set. Everything already on disk is preserved byte for byte.
+/// What: absent file → create it holding the template. Present file with no
+/// `agents:` key → append the template after a blank line, leaving every
+/// prior byte intact. Present `agents.ticketing` → no write. Present
+/// `agents:` without `ticketing:` → no write either: appending would put a
+/// SECOND top-level `agents:` key in the file, and `serde_yaml` rejects a
+/// duplicate mapping key, so `load_or_default` would discard the operator's
+/// whole config back to defaults. The presence check is a read-only
+/// `serde_yaml::Value` parse; a file that does not parse is an error, never a
+/// blind append.
+/// Test: the five write/refusal tests named in the module doc.
+pub(crate) fn seed_ticketing_block(path: &Path) -> anyhow::Result<TicketingSeedOutcome> {
+    let existing = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    anyhow::anyhow!("failed to create config dir {}: {e}", parent.display())
+                })?;
+            }
+            write_config(path, TICKETING_BLOCK_TEMPLATE)?;
+            return Ok(TicketingSeedOutcome::Created);
+        }
+        Err(e) => return Err(anyhow::anyhow!("failed to read {}: {e}", path.display())),
+    };
+
+    let doc: serde_yaml::Value = serde_yaml::from_str(&existing).map_err(|e| {
+        anyhow::anyhow!(
+            "{} is not valid YAML ({e}) — fix it, then re-run `tm issue seed-config`",
+            path.display()
+        )
+    })?;
+    match doc.get("agents") {
+        Some(agents) if agents.get("ticketing").is_some() => {
+            return Ok(TicketingSeedOutcome::AlreadyPresent);
+        }
+        Some(_) => return Ok(TicketingSeedOutcome::AgentsBlockPresent),
+        None => {}
+    }
+
+    let mut appended = existing;
+    if !appended.is_empty() {
+        if !appended.ends_with('\n') {
+            appended.push('\n');
+        }
+        appended.push('\n');
+    }
+    appended.push_str(TICKETING_BLOCK_TEMPLATE);
+    write_config(path, &appended)?;
+    Ok(TicketingSeedOutcome::Appended)
+}
+
+/// Write `contents` to `path`, naming the path on failure.
+fn write_config(path: &Path, contents: &str) -> anyhow::Result<()> {
+    std::fs::write(path, contents)
+        .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use trusty_mpm::core::trusty_tools_config::{
+        ResolvedTicketing, TrustyToolsConfig, resolve_ticketing,
+    };
+
+    /// A config file with comments and a hand-set key — the bytes an append
+    /// must leave untouched.
+    const OPERATOR_CONFIG: &str = "\
+# my notes, which a parse-and-reserialize would delete
+auto_resume: true
+
+workspace_root_template: ~/work
+";
+
+    fn config_at(dir: &tempfile::TempDir) -> PathBuf {
+        dir.path().join(".trusty-tools/trusty-mpm/config.yaml")
+    }
+
+    #[test]
+    fn seed_creates_the_config_file_with_the_ticketing_block() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = config_at(&tmp);
+        assert!(!path.exists());
+
+        let outcome = seed_ticketing_block(&path).expect("seeds");
+
+        assert_eq!(outcome, TicketingSeedOutcome::Created);
+        let written = std::fs::read_to_string(&path).expect("reads back");
+        assert_eq!(written, TICKETING_BLOCK_TEMPLATE);
+    }
+
+    #[test]
+    fn seed_appends_and_preserves_every_existing_byte() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = config_at(&tmp);
+        std::fs::create_dir_all(path.parent().expect("has a parent")).expect("mkdir");
+        std::fs::write(&path, OPERATOR_CONFIG).expect("seed file");
+
+        let outcome = seed_ticketing_block(&path).expect("seeds");
+
+        assert_eq!(outcome, TicketingSeedOutcome::Appended);
+        let written = std::fs::read_to_string(&path).expect("reads back");
+        // Byte-for-byte: the original prefix survives, comments included.
+        assert!(
+            written.starts_with(OPERATOR_CONFIG),
+            "existing bytes were rewritten:\n{written}"
+        );
+        assert!(written.ends_with(TICKETING_BLOCK_TEMPLATE), "{written}");
+        // The result is still one valid config, with both halves readable.
+        let cfg: TrustyToolsConfig = serde_yaml::from_str(&written).expect("parses");
+        assert_eq!(cfg.auto_resume, Some(true));
+        assert_eq!(
+            resolve_ticketing(&cfg).expect("resolves"),
+            ResolvedTicketing::default()
+        );
+    }
+
+    #[test]
+    fn seed_leaves_an_existing_ticketing_block_untouched() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = config_at(&tmp);
+        std::fs::create_dir_all(path.parent().expect("has a parent")).expect("mkdir");
+        let tuned = "agents:\n  ticketing:\n    milestone_required: false\n";
+        std::fs::write(&path, tuned).expect("seed file");
+
+        let outcome = seed_ticketing_block(&path).expect("seeds");
+
+        assert_eq!(outcome, TicketingSeedOutcome::AlreadyPresent);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("reads back"),
+            tuned,
+            "an operator's tuned value was overwritten"
+        );
+    }
+
+    #[test]
+    fn seed_refuses_to_append_under_an_existing_agents_block() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = config_at(&tmp);
+        std::fs::create_dir_all(path.parent().expect("has a parent")).expect("mkdir");
+        // `agents:` present, `ticketing:` absent. Appending here would make a
+        // duplicate top-level key and cost the operator the whole file.
+        let other_agent = "agents:\n  someday: {}\n";
+        std::fs::write(&path, other_agent).expect("seed file");
+
+        let outcome = seed_ticketing_block(&path).expect("seeds");
+
+        assert_eq!(outcome, TicketingSeedOutcome::AgentsBlockPresent);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("reads back"),
+            other_agent
+        );
+    }
+
+    #[test]
+    fn a_seeded_file_resolves_to_the_builtin_ticketing_defaults() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = config_at(&tmp);
+        seed_ticketing_block(&path).expect("seeds");
+
+        let raw = std::fs::read_to_string(&path).expect("reads back");
+        let cfg: TrustyToolsConfig = serde_yaml::from_str(&raw).expect("parses");
+        assert_eq!(
+            resolve_ticketing(&cfg).expect("resolves"),
+            ResolvedTicketing::default(),
+            "seeding must not change the standard"
+        );
+    }
+
+    /// The whole point of #7067's fix: the file we write is the file the
+    /// runtime loader reads. A path derived independently would pass every
+    /// other test in this module and still seed the wrong file.
+    ///
+    /// The home directory is INJECTED as `crate_config_path_at`'s `base`
+    /// rather than repointed via `$HOME` — #5544 hard-bans a `$HOME` write in
+    /// this bin target, and `env_isolation_tests.rs` fails the build on one.
+    /// `crate_config_path_at` and `load_at` are the hermetic cores
+    /// `crate_config_path` and `TrustyToolsConfig::load` delegate to, so this
+    /// exercises the production layout and the production parse.
+    #[test]
+    fn the_seeded_path_is_the_one_the_loader_reads() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = trusty_common::crate_config::crate_config_path_at(tmp.path(), CRATE_NAME);
+        // The layout the loader computes is the layout we seed into.
+        assert_eq!(path, config_at(&tmp));
+        // And the production accessor is that resolver, not a hand-built path.
+        assert_eq!(
+            ticketing_config_path(),
+            trusty_common::crate_config::crate_config_path(CRATE_NAME)
+        );
+
+        assert_eq!(
+            seed_ticketing_block(&path).expect("seeds"),
+            TicketingSeedOutcome::Created
+        );
+
+        // Read it back through the loader's own parse, not a local one.
+        let loaded: TrustyToolsConfig = trusty_common::crate_config::load_at(&path)
+            .expect("the loader reads it")
+            .expect("the file is there");
+        assert!(
+            loaded
+                .agents
+                .as_ref()
+                .and_then(|a| a.ticketing.as_ref())
+                .is_some(),
+            "the loader did not see the seeded block"
+        );
+        assert_eq!(
+            resolve_ticketing(&loaded).expect("resolves"),
+            ResolvedTicketing::default()
+        );
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/seed_ticketing.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/seed_ticketing.rs
@@ -20,7 +20,9 @@
 //! `seed_leaves_an_existing_ticketing_block_untouched`,
 //! `seed_refuses_to_append_under_an_existing_agents_block`,
 //! `a_seeded_file_resolves_to_the_builtin_ticketing_defaults`,
-//! `the_seeded_path_is_the_one_the_loader_reads`.
+//! `the_seeded_path_is_the_one_the_loader_reads`,
+//! `seed_writes_atomically_and_never_in_place`,
+//! `only_the_refusal_outcome_exits_nonzero`.
 
 use std::path::{Path, PathBuf};
 
@@ -114,10 +116,49 @@ pub(crate) fn seed_ticketing_block(path: &Path) -> anyhow::Result<TicketingSeedO
     Ok(TicketingSeedOutcome::Appended)
 }
 
-/// Write `contents` to `path`, naming the path on failure.
+/// Write `contents` to `path` atomically, naming the path on failure.
+///
+/// Why: this is the operator's real config. A `std::fs::write` truncates the
+/// target and then fills it, so a kill or a full disk mid-write leaves a
+/// half-file where a working config was — the exact loss the whole
+/// never-clobber design above exists to prevent.
+/// What: delegates to the workspace's one atomic config write, which lands a
+/// sibling temp file and renames it over the target, so the target is never
+/// opened for writing and a failed write leaves it byte-identical.
+/// Test: `seed_writes_atomically_and_never_in_place`.
 fn write_config(path: &Path, contents: &str) -> anyhow::Result<()> {
-    std::fs::write(path, contents)
+    // #7067: temp-and-rename, never a truncating in-place write.
+    trusty_common::crate_config::save_raw_at(path, contents)
+        .map(|_| ())
         .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))
+}
+
+/// The process exit disposition for a [`TicketingSeedOutcome`].
+///
+/// Why: three of the four outcomes end with the block on disk; the fourth
+/// leaves the standard half-applied and needs the operator to paste it by
+/// hand. Returning `Ok(())` for all four made those cases indistinguishable to
+/// a script — a provisioning run that seeded nothing looked like one that
+/// seeded everything.
+/// What: `Created` / `Appended` / `AlreadyPresent` → `Ok`, so `tm issue
+/// seed-config` exits 0. `AgentsBlockPresent` → `Err`, so it exits nonzero,
+/// carrying the one-line reason. The printing is the caller's; this is only
+/// the disposition, so the two cannot disagree about which arm exits.
+/// Test: `only_the_refusal_outcome_exits_nonzero`.
+pub(crate) fn seed_outcome_result(
+    outcome: TicketingSeedOutcome,
+    path: &Path,
+) -> anyhow::Result<()> {
+    match outcome {
+        TicketingSeedOutcome::Created
+        | TicketingSeedOutcome::Appended
+        | TicketingSeedOutcome::AlreadyPresent => Ok(()),
+        TicketingSeedOutcome::AgentsBlockPresent => Err(anyhow::anyhow!(
+            "the agents.ticketing block was NOT written to {} — add the block above \
+             under the existing `agents:` key by hand",
+            path.display()
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -230,6 +271,86 @@ workspace_root_template: ~/work
             ResolvedTicketing::default(),
             "seeding must not change the standard"
         );
+    }
+
+    /// The write must never truncate the operator's config in place.
+    ///
+    /// Phase 1 pins the visible half: after a successful append the sibling
+    /// temp file is gone, so nothing is left for a directory reader to mistake
+    /// for a config. Phase 2 pins the half that matters: a read-only parent
+    /// directory blocks creating that sibling while leaving the existing file
+    /// writable via `write(2)`, so a truncating in-place write SUCCEEDS there
+    /// and an atomic one fails — the seed must fail and leave every byte.
+    /// Skipped when the process can create files in a read-only directory
+    /// anyway (running as root), since the failure cannot be provoked there.
+    #[cfg(unix)]
+    #[test]
+    fn seed_writes_atomically_and_never_in_place() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = config_at(&tmp);
+        let dir = path.parent().expect("has a parent").to_path_buf();
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(&path, OPERATOR_CONFIG).expect("seed file");
+
+        assert_eq!(
+            seed_ticketing_block(&path).expect("seeds"),
+            TicketingSeedOutcome::Appended
+        );
+        let siblings: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .expect("reads dir")
+            .map(|e| e.expect("entry").path())
+            .collect();
+        assert_eq!(siblings, vec![path.clone()], "a .tmp sibling survived");
+
+        // Phase 2: the same file, now with an `agents:`-free body the seed
+        // would append to again, under a directory that refuses new files.
+        std::fs::write(&path, OPERATOR_CONFIG).expect("reset");
+        let restore = std::fs::metadata(&dir).expect("stat").permissions();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).expect("chmod");
+        let root_can_still_write = std::fs::write(dir.join("probe"), b"x").is_ok();
+        let result = if root_can_still_write {
+            std::fs::remove_file(dir.join("probe")).ok();
+            None
+        } else {
+            Some(seed_ticketing_block(&path))
+        };
+        std::fs::set_permissions(&dir, restore).expect("restore");
+
+        let Some(result) = result else {
+            return; // running as root: the write cannot be made to fail here.
+        };
+        assert!(result.is_err(), "the write was expected to fail");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("reads back"),
+            OPERATOR_CONFIG,
+            "a failed write modified the operator's config in place"
+        );
+    }
+
+    /// The refusal outcome is the only one that exits nonzero, so a script can
+    /// tell "nothing was written" from "the block is on disk".
+    #[test]
+    fn only_the_refusal_outcome_exits_nonzero() {
+        let path = Path::new("/home/bob/.trusty-tools/trusty-mpm/config.yaml");
+
+        for ok in [
+            TicketingSeedOutcome::Created,
+            TicketingSeedOutcome::Appended,
+            TicketingSeedOutcome::AlreadyPresent,
+        ] {
+            assert!(
+                seed_outcome_result(ok, path).is_ok(),
+                "{ok:?} must exit 0 — the block is on disk"
+            );
+        }
+
+        let err = seed_outcome_result(TicketingSeedOutcome::AgentsBlockPresent, path)
+            .expect_err("the refusal must exit nonzero");
+        let msg = err.to_string();
+        assert!(msg.contains("NOT written"), "{msg}");
+        assert!(msg.contains(&path.display().to_string()), "{msg}");
     }
 
     /// The whole point of #7067's fix: the file we write is the file the

--- a/crates/trusty-mpm/src/core/trusty_tools_config/agents.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/agents.rs
@@ -58,14 +58,16 @@ pub const DEFAULT_ASSIGNEE: &str = "@me";
 /// Test: `closes_pr_link_keyword_is_rejected`, `refs_pr_link_keyword_is_accepted`.
 pub const REQUIRED_PR_LINK_KEYWORD: &str = "Refs";
 
-/// A commented starter `agents.ticketing` block, for `tm issue seed-config`
-/// to hand an operator (#7067).
+/// The commented starter `agents.ticketing` block `tm issue seed-config`
+/// writes into `config.yaml` (#7067).
 ///
 /// Why: the verb seeds `issue-state.yaml` — the lifecycle half of the standard.
-/// The other half lives in a different file the operator has to write by hand,
-/// and #7067 added three keys to it, so a seeded lifecycle with no pointer at
-/// the block leaves the milestone and project rules undiscoverable. This is
-/// that pointer, in copy-pasteable form.
+/// The other half lives in a different file, and #7067 added three keys to it,
+/// so a seeded lifecycle with no block leaves the milestone and project rules
+/// undiscoverable. `seed_ticketing_block` lands this text in that file in three
+/// of its four outcomes; only the refusal case — an `agents:` key already
+/// present without `ticketing:`, where a second top-level `agents:` would make
+/// the file unparseable — prints it for the operator to paste by hand.
 /// What: every key set to its built-in default, so pasting the block changes
 /// nothing until an entry is edited. `default_project` is commented out —
 /// there is no default title to state.


### PR DESCRIPTION
`tm issue seed-config` now writes the `agents.ticketing` starter block into the config.yaml that `TrustyToolsConfig::load()` reads, resolved through the loader's own `crate_config_path`. Four outcomes: create, append (textual, every existing byte preserved), already present (no-op), and refuse with the block printed for manual paste when an `agents:` key exists without `ticketing:` (appending a second top-level key would make serde_yaml reject the whole file). The write is atomic via a new shared `crate_config::save_raw_at` (temp file + rename), which `save_at` now delegates to. The refusal outcome exits nonzero.

Refs #7067. Follow-up to #7073.

**Test ladder (Rung 4):**
cargo fmt --check, clippy --all-targets -D warnings on trusty-mpm and trusty-common (crate-config lane), cargo check --workspace --all-targets, cargo test -p trusty-mpm --no-fail-fast (55 targets, all ok, largest 6103 passed 0 failed), scripts/test_trusty_common_lanes.sh (4 lanes pass); the atomicity test fails against the pre-fix in-place write, which succeeds in overwriting a config whose parent dir is read-only.

**Code-critic review (accd63ed3):**
WARN on accd63ed3 with three findings: HIGH (in-place std::fs::write), MEDIUM (refusal arm exited 0), MEDIUM (docs named three of four outcomes), LOW (stale template doc comment). All four fixed in d9eb8a218.

**Flake note:**
One cold-compile run of the trusty-common core lane exited 101 with truncated output and did not reproduce in two full lane runs and 20 targeted runs of the two new tests.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XAqBLVJbLSXH613FeE6Ucj
