### PR TITLE
fix(trusty-mpm): stabilize gh auth timeout and tmux parity test flakes

### DIFF
--- a/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/core_tests.rs
@@ -101,36 +101,66 @@ fn rpc_router(state: &Arc<DaemonState>) -> RpcRouter {
     register(RpcRouter::new(), state)
 }
 
-/// RAII guard restoring `$HOME` on drop, including on a panic-driven unwind —
-/// mirrors `core::session_assets::tests::HomeGuard`.
-struct HomeGuard(Option<std::ffi::OsString>);
+/// RAII guard restoring `$HOME` and the host-state opt-in on drop, including on
+/// a panic-driven unwind — mirrors `core::session_assets::tests::HomeGuard` and
+/// `daemon::services::tmux_service::tests::HostEnvGuard`.
+struct HomeGuard {
+    home: Option<std::ffi::OsString>,
+    opt_in: Option<std::ffi::OsString>,
+}
 
 impl Drop for HomeGuard {
     fn drop(&mut self) {
         // SAFETY: every caller is `#[serial_test::serial]`, so no other test
         // thread reads or writes the environment concurrently.
-        match self.0.take() {
-            Some(v) => unsafe { std::env::set_var("HOME", v) },
-            None => unsafe { std::env::remove_var("HOME") },
+        unsafe {
+            match self.home.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.opt_in.take() {
+                Some(v) => std::env::set_var(crate::core::host_state_gate::ALLOW_HOST_STATE_ENV, v),
+                None => {
+                    std::env::remove_var(crate::core::host_state_gate::ALLOW_HOST_STATE_ENV);
+                }
+            }
         }
     }
 }
 
-/// Pin `$HOME` at a fresh tempdir for the guard's lifetime (#6580).
+/// Pin `$HOME` at a fresh tempdir and clear the host-state opt-in, for the
+/// guard's lifetime (#6580, #7076).
 ///
 /// Why: `core::host_state_gate` embeds the LIVE `$HOME` in the refusal it hands
 /// every tmux route, so a test that reads that refusal twice gets two different
 /// strings whenever a sibling moves `$HOME` between the reads. Pinning makes the
-/// classification — and therefore the message — the same for both reads. Both
-/// returned values must stay alive for the test's body: dropping the `TempDir`
-/// removes the directory `$HOME` names.
+/// classification — and therefore the message — the same for both reads. A
+/// tempdir can never be this uid's password-database home, so the gate
+/// classifies it scratch and refuses on every host.
+///
+/// Why the opt-in is cleared too (#7076): the gate re-reads
+/// [`crate::core::host_state_gate::ALLOW_HOST_STATE_ENV`] on every call and a
+/// truthy value outranks the `$HOME` classification, so a pin alone leaves the
+/// verdict — and every route that reads live tmux behind it — decided by the
+/// operator's ambient environment. Clearing both is what makes the refusal the
+/// same fact on every host, which is the whole reason to pin. Same shape as
+/// `daemon::services::tmux_service::tests::scratch_home` (#6736).
+///
+/// Both returned values must stay alive for the test's body: dropping the
+/// `TempDir` removes the directory `$HOME` names.
 /// Callers MUST be tagged `#[serial_test::serial]`.
 fn pinned_home() -> (TempDir, HomeGuard) {
     let home = tempfile::tempdir().expect("temp dir for a pinned $HOME");
-    let prior = std::env::var_os("HOME");
+    let guard = HomeGuard {
+        home: std::env::var_os("HOME"),
+        opt_in: std::env::var_os(crate::core::host_state_gate::ALLOW_HOST_STATE_ENV),
+    };
     // SAFETY: caller is `#[serial_test::serial]`.
-    unsafe { std::env::set_var("HOME", home.path()) };
-    (home, HomeGuard(prior))
+    unsafe {
+        std::env::set_var("HOME", home.path());
+        std::env::remove_var(crate::core::host_state_gate::ALLOW_HOST_STATE_ENV);
+    }
+    (home, guard)
 }
 
 /// Drive one HTTP request through the real daemon router and decode the answer.
@@ -428,13 +458,44 @@ async fn parity_errors_agrees_across_transports() {
     assert_same("mpm.errors.list", body, result, &[]);
 }
 
+/// Why serial and a pinned `$HOME` (#7076): `list_tmux_sessions` reaches
+/// `TmuxService::list_all`, whose `TmuxDriver::discover` asks
+/// `core::host_state_gate::host_state_access()` — a fresh `$HOME` read on every
+/// call — and answers an EMPTY list when the gate refuses. `parity_doctor_*` and
+/// the other `pinned_home` cases move `$HOME` process-wide, so one landing
+/// between the two calls below made HTTP read the refusal (`{"sessions": []}`)
+/// while the socket read the operator's live six-session list. Reproduced 2 of
+/// 10 runs of `cargo test -p trusty-mpm --lib --no-fail-fast parity_` at
+/// f954009cb, both times empty-over-HTTP against a populated socket answer.
+///
+/// Pinning does more than order the reads: with the gate refusing, neither call
+/// consults tmux at all, so the machine's live session list — which any agent on
+/// the host adds to and removes from while the test runs — stops being an input.
+/// `#[serial]` is what holds under `cargo test`, where the `$HOME`-moving
+/// siblings share this process; the pin is what holds under nextest, where every
+/// test gets its own process and `#[serial]` orders nothing (#4162). Same
+/// reason and the same shared default group as
+/// [`rpc_tmux_snapshot_unknown_session_reports_a_coded_error`] and
+/// [`parity_tmux_adopt_unknown_session_agrees_across_transports`] below.
 /// Test: this function IS the test.
+// #7076: $HOME is process-global and gates the tmux read; both calls must see one value.
+#[serial_test::serial]
 #[tokio::test]
 async fn parity_tmux_sessions_agrees_across_transports() {
+    // #7076: pinned BEFORE the two calls, and held across both.
+    let (_home, _home_guard) = pinned_home();
     let (state, _dir) = hermetic();
     let (status, body) = http(&state, "GET", "/tmux/sessions", None).await;
     assert_eq!(status, StatusCode::OK);
     let result = rpc_ok(&rpc_router(&state), "mpm.tmux.sessions", Value::Null).await;
+    // The refused gate's answer, pinned rather than merely compared: a route
+    // that started reporting the host's real sessions under a scratch `$HOME`
+    // would be the #5784 leak, and this is where it would surface.
+    assert_eq!(
+        body["sessions"],
+        json!([]),
+        "a scratch $HOME must reach no host tmux session: {body}"
+    );
     assert_same("mpm.tmux.sessions", body, result, &[]);
 }
 

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -2326,20 +2326,39 @@ fn build_inplace_resume_command_carries_oauth_token_when_available() {
 // ─── issue #4206: the trust seed must stay inside the redirected $HOME ────
 
 /// RAII guard that prepends `dir` to `PATH` and restores it on drop.
+///
+/// Why it also holds `env_test_lock` (#7059): this binary had TWO disjoint
+/// mutual-exclusion regimes over the process-global `PATH`. This guard relied on
+/// `#[serial]` alone, while `core::gh_account_enforce` and `core::git_identity`
+/// plant a fake `gh` on `PATH` under `core::trusty_tools_config::env_test_lock`
+/// and take no `#[serial]`. Neither regime excludes the other, so this guard's
+/// `Drop` restored the `PATH` it captured on ENTRY — erasing the fake-`gh`
+/// directory a concurrent gh test had prepended after it. `Command::new("gh")`
+/// then found the operator's real `gh`, and `gh auth status` either hit the
+/// network past the 5 s `GH_ENFORCE_TIMEOUT` or answered "not logged in to
+/// github.com account bobmatnyc". Taking BOTH the lock and `#[serial]` makes
+/// `PATH` one regime, so no gh test can run while this guard is alive.
+/// Test: `spawn_resume_trust_seed_stays_within_redirected_home` (this guard's
+/// only caller) beside
+/// `core::gh_account::enforce::tests::ensure_gh_account_in_dir_accepts_the_api_answer_over_a_stale_transcript`.
 struct PathGuard {
     prev: Option<std::ffi::OsString>,
+    /// Held for the guard's whole lifetime — see the type doc.
+    _env: std::sync::MutexGuard<'static, ()>,
 }
 impl PathGuard {
     fn prepend(dir: &Path) -> Self {
+        // #7059: one regime for PATH — the crate-wide env lock, not #[serial] alone.
+        let env = crate::core::trusty_tools_config::env_test_lock();
         let prev = std::env::var_os("PATH");
         let mut entries = vec![dir.to_path_buf()];
         if let Some(ref p) = prev {
             entries.extend(std::env::split_paths(p));
         }
         let joined = std::env::join_paths(entries).expect("join PATH");
-        // SAFETY: callers are #[serial].
+        // SAFETY: callers are #[serial] AND hold `env_test_lock` via `_env`.
         unsafe { std::env::set_var("PATH", joined) };
-        Self { prev }
+        Self { prev, _env: env }
     }
 }
 impl Drop for PathGuard {


### PR DESCRIPTION
Refs [#7059](https://github.com/bobmatnyc/trusty-tools/issues/7059), Refs [#7076](https://github.com/bobmatnyc/trusty-tools/issues/7076).

## Summary

#7076: `parity_tmux_sessions_agrees_across_transports` raced a sibling test moving `$HOME` process-wide; the gate refused and HTTP answered an empty list while the socket read the live list. Fix: `#[serial_test::serial]` plus `pinned_home()` (which now also clears `ALLOW_HOST_STATE_ENV`), and a new assertion pinning the empty answer under a scratch `$HOME`. 

#7059: `PathGuard` in `runtime/claude_code_tests.rs` now holds `env_test_lock()` so `PATH` has one regime in the lib binary; that fixes `ensure_gh_account_in_dir_accepts_the_api_answer_over_a_stale_transcript`. The second #7059 test (`resolve_project_aware_enforces_paired_account`, `tm` bin target) did not reproduce in 15 loaded runs and is unchanged.

## Test Ladder: Rung 2 (test-only stabilization)

Pre-fix: `cargo test -p trusty-mpm --lib --no-fail-fast parity_` failed 2 of 10 at f954009cb; the gh filter failed 8 of 10. Post-fix: both loops 10 of 10 green. Full gate: `cargo test -p trusty-mpm --no-fail-fast` all 55 targets ok (lib 6103 passed, 0 failed, 8 ignored; tm bin 2241 passed); `cargo fmt --check`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings` exit 0; line-cap, test-pointers, changelog-fragment gates OK (test-only, no fragment owed).

## Security

Credential scan over `git diff origin/main...HEAD` CLEAN.

## Review

Not run (rung 2, Low risk).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
