### PR TITLE
feat(tga): send the profiling schema through ChatRequest.response_schema

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/5588-tga-response-schema.md
+++ b/crates/trusty-git-analytics/changelog.d/5588-tga-response-schema.md
@@ -1,0 +1,10 @@
+Changed
+
+- Both contributor-profiling model passes — the per-period review and the
+  narrative synthesis — now send their JSON Schema on
+  `trusty_common::inference::ChatRequest.response_schema`, so a provider that
+  supports structured output constrains the answer instead of being asked in
+  prose to follow the schema. On a provider that cannot honour it (Bedrock's
+  Converse API has no such parameter), the schema is still rendered into the
+  system turn as before, so `tga profile --model bedrock/…` keeps working
+  (#5588).

--- a/crates/trusty-git-analytics/src/classify/tiers/llm.rs
+++ b/crates/trusty-git-analytics/src/classify/tiers/llm.rs
@@ -620,6 +620,12 @@ impl LlmClassifier {
 
 // ---- request / response DTOs (private) ----
 
+// #5588: this `response_format` is JSON MODE (`{"type":"json_object"}`), not the
+// schema-constrained output `trusty_common::inference::StructuredOutput` renders
+// — the commons has no dialect for it, so this is not a second copy of that
+// translation. Folding the whole tier onto `trusty_common::inference` would move
+// its credential model (`LlmConfig::api_key_env`, `CredentialSource`) and its
+// configurable endpoint, and is a separate change from #5588.
 #[derive(Serialize)]
 struct ChatRequest<'a> {
     model: &'a str,

--- a/crates/trusty-git-analytics/src/profile/batch_reviewer.rs
+++ b/crates/trusty-git-analytics/src/profile/batch_reviewer.rs
@@ -29,6 +29,7 @@ use trusty_common::inference::{
     InferenceError,
 };
 
+use super::schema_delivery::deliver_schema;
 use super::types::{Effort, Finding, LongitudinalFinding, PeriodBatch, TokenCostSummary};
 
 // ─── Request parameters ───────────────────────────────────────────────────────
@@ -45,6 +46,12 @@ pub const PERIOD_REVIEWER_MAX_TOKENS: u32 = 2048;
 const MAX_DIFFS_IN_PROMPT: usize = 10;
 
 // ─── Prompt construction ──────────────────────────────────────────────────────
+
+/// The name OpenAI-dialect providers attach to the period-findings schema.
+///
+/// #5588: `StructuredOutput` requires one; it is a label on the wire, not a
+/// field the model fills in.
+pub const PERIOD_FINDINGS_SCHEMA_NAME: &str = "period_findings";
 
 /// JSON Schema for the period-findings response.
 ///
@@ -184,25 +191,33 @@ pub fn build_period_user_message(batch: &PeriodBatch) -> String {
 
 /// Assemble the shared-inference request for one period.
 ///
-/// Why: [`trusty_common::inference::ChatRequest`] carries no structured-output
-/// field, so the schema only reaches the model if the system turn spells it
-/// out. Stating it there keeps [`parse_period_findings`]'s direct-JSON path —
+/// Why: the schema is what keeps [`parse_period_findings`]'s direct-JSON path —
 /// the one that needs no fence — the likely outcome rather than the lucky one.
-/// What: system turn = the reviewer role plus [`period_findings_schema`]
-/// rendered as JSON; user turn = [`build_period_user_message`]. `model` is
-/// passed through UNCHANGED: a `bedrock/` or `openrouter/` prefix is what
-/// `provider_for` routes on, and the adapter strips it for the wire in
-/// `ProviderId::wire_model_id`.
+/// #5588 gave [`trusty_common::inference::ChatRequest`] a `response_schema`
+/// field, so on a provider that honours it the schema now constrains the
+/// completion instead of asking for it in prose.
+/// What: system turn = the reviewer role, plus [`period_findings_schema`]
+/// rendered as JSON only when `structured_output` is false; user turn =
+/// [`build_period_user_message`]. `structured_output` is the sending adapter's
+/// [`InferenceAdapter::supports_structured_output`] — see
+/// [`super::schema_delivery::deliver_schema`] for why the fallback exists rather
+/// than a refusal. `model` is passed through UNCHANGED: a `bedrock/` or
+/// `openrouter/` prefix is what `provider_for` routes on, and the adapter strips
+/// it for the wire in `ProviderId::wire_model_id`.
 /// Test: `period_request_preserves_routing_prefix`,
-/// `period_request_carries_schema_and_sampling`.
-pub fn build_period_request(batch: &PeriodBatch, model: &str) -> ChatRequest {
-    // `to_string_pretty` over a `Value` this module built cannot fail; an empty
-    // string would still leave the prose instructions in the system turn.
-    let schema = serde_json::to_string_pretty(&period_findings_schema()).unwrap_or_default();
-    let system = format!(
-        "{}\n\n## Response schema\nReturn ONLY a JSON object conforming to this schema:\n\
-         ```json\n{schema}\n```",
-        period_reviewer_system_prompt()
+/// `period_request_sends_the_schema_through_response_schema`,
+/// `period_request_falls_back_to_prose_without_the_capability`.
+pub fn build_period_request(
+    batch: &PeriodBatch,
+    model: &str,
+    structured_output: bool,
+) -> ChatRequest {
+    // #5588: one delivery or the other, never both.
+    let (system, response_schema) = deliver_schema(
+        period_reviewer_system_prompt(),
+        PERIOD_FINDINGS_SCHEMA_NAME,
+        period_findings_schema(),
+        structured_output,
     );
 
     let mut req = ChatRequest::new(
@@ -214,6 +229,7 @@ pub fn build_period_request(batch: &PeriodBatch, model: &str) -> ChatRequest {
     );
     req.temperature = Some(PERIOD_REVIEWER_TEMPERATURE);
     req.max_tokens = Some(PERIOD_REVIEWER_MAX_TOKENS);
+    req.response_schema = response_schema;
     req
 }
 
@@ -477,7 +493,13 @@ impl PeriodReviewer {
         cost_out: &mut TokenCostSummary,
     ) -> PeriodReview {
         let period = &batch.stats.period_label;
-        let request = build_period_request(batch, &self.model);
+        // #5588: the adapter's own capability decides the delivery — asking it
+        // is what keeps a `bedrock/…` run from failing before the socket opens.
+        let request = build_period_request(
+            batch,
+            &self.model,
+            self.adapter.supports_structured_output(),
+        );
         let start = Instant::now();
 
         let response = match self.adapter.chat(&request).await {

--- a/crates/trusty-git-analytics/src/profile/batch_reviewer_tests.rs
+++ b/crates/trusty-git-analytics/src/profile/batch_reviewer_tests.rs
@@ -25,10 +25,13 @@ use trusty_common::inference::{
     UsageBlock,
 };
 
+use crate::profile::test_support::RecordingAdapter;
+
 use super::{
     build_period_request, build_period_user_message, parse_period_findings, period_findings_schema,
     period_reviewer_system_prompt, severity_to_effort, PeriodReview, PeriodReviewer,
-    PeriodRunSummary, PERIOD_REVIEWER_MAX_TOKENS, PERIOD_REVIEWER_TEMPERATURE,
+    PeriodRunSummary, PERIOD_FINDINGS_SCHEMA_NAME, PERIOD_REVIEWER_MAX_TOKENS,
+    PERIOD_REVIEWER_TEMPERATURE,
 };
 use crate::profile::types::{
     AuthorPeriodSummary, Effort, PeriodBatch, SampledDiff, TokenCostSummary,
@@ -282,25 +285,38 @@ fn scripted_response(body: &str, prompt_tokens: u32, completion_tokens: u32) -> 
 /// Test: this test itself.
 #[test]
 fn period_request_preserves_routing_prefix() {
-    let req = build_period_request(&make_batch(), "bedrock/us.anthropic.claude-sonnet-4-5-v1:0");
+    let req = build_period_request(
+        &make_batch(),
+        "bedrock/us.anthropic.claude-sonnet-4-5-v1:0",
+        false,
+    );
     assert_eq!(
         req.model, "bedrock/us.anthropic.claude-sonnet-4-5-v1:0",
         "the routing prefix is trusty_common's to consume, not tga's to strip"
     );
 
-    let req = build_period_request(&make_batch(), "openrouter/openai/gpt-5.4-mini");
+    let req = build_period_request(&make_batch(), "openrouter/openai/gpt-5.4-mini", true);
     assert_eq!(req.model, "openrouter/openai/gpt-5.4-mini");
 }
 
-/// Why: `ChatRequest` carries no structured-output field, so the schema only
-/// reaches the model if the system turn spells it out — and low temperature is
+/// Why: this is #5588's closure condition for the period pass — a schema
+/// described in prose is a suggestion the model may drift from, and the drift is
+/// what leaves `parse_period_findings` with nothing to parse. Low temperature is
 /// what keeps the answer extraction rather than prose.
-/// What: asserts the two-turn shape, the schema text in the system turn, the
-/// period label in the user turn, and both sampling parameters.
+/// What: asserts the schema travels on `ChatRequest.response_schema` verbatim,
+/// that no copy of it is left in the system turn, and that the two-turn shape,
+/// the period label, and both sampling parameters survive.
 /// Test: this test itself.
 #[test]
-fn period_request_carries_schema_and_sampling() {
-    let req = build_period_request(&make_batch(), "openai/gpt-5.4-mini");
+fn period_request_sends_the_schema_through_response_schema() {
+    let req = build_period_request(&make_batch(), "openai/gpt-5.4-mini", true);
+
+    let directive = req
+        .response_schema
+        .as_ref()
+        .expect("a structured-output provider gets the real field, not prose");
+    assert_eq!(directive.name, PERIOD_FINDINGS_SCHEMA_NAME);
+    assert_eq!(directive.schema, period_findings_schema());
 
     assert_eq!(req.messages.len(), 2, "one system turn, one user turn");
     assert_eq!(req.messages[0].role, "system");
@@ -308,14 +324,36 @@ fn period_request_carries_schema_and_sampling() {
 
     let system = req.messages[0].content.clone().unwrap_or_default();
     assert!(
-        system.contains("\"findings\""),
-        "the schema must reach the system turn: {system}"
+        !system.contains("## Response schema"),
+        "the schema must not also be pasted into the prompt: {system}"
     );
     let user = req.messages[1].content.clone().unwrap_or_default();
     assert!(user.contains("2026-Q1"), "the user turn carries the period");
 
     assert_eq!(req.temperature, Some(PERIOD_REVIEWER_TEMPERATURE));
     assert_eq!(req.max_tokens, Some(PERIOD_REVIEWER_MAX_TOKENS));
+}
+
+/// Why: Bedrock's Converse API cannot honour `response_schema`, and
+/// `tga profile --model bedrock/…` is a documented invocation — sending the
+/// field there is `UnsupportedCapability` before any network call, which would
+/// turn every period of that run into a skip.
+/// What: asserts the field is absent and the schema reaches the system turn
+/// instead, so a zero-capability provider still produces findings.
+/// Test: this test itself.
+#[test]
+fn period_request_falls_back_to_prose_without_the_capability() {
+    let req = build_period_request(&make_batch(), "bedrock/us.anthropic.claude", false);
+
+    assert!(
+        req.response_schema.is_none(),
+        "a provider without the capability must not be sent the field"
+    );
+    let system = req.messages[0].content.clone().unwrap_or_default();
+    assert!(
+        system.contains("\"findings\""),
+        "the schema must still reach the model: {system}"
+    );
 }
 
 /// Build a reviewer over a strict `ScriptedAdapter` serving `body` once.
@@ -352,6 +390,55 @@ async fn period_reviewer_routes_through_shared_inference() {
 
     assert_eq!(cost.input_tokens, 1200, "adapter usage must be accumulated");
     assert_eq!(cost.output_tokens, 340);
+}
+
+/// Why: the builder can be given either delivery, so the closure condition of
+/// #5588 for tga is that the TRANSPORT asks the adapter rather than hard-coding
+/// one — a hard-coded `true` breaks every `bedrock/…` run, a hard-coded `false`
+/// leaves the schema in prose forever.
+/// What: reviews the same period against two `RecordingAdapter`s differing only
+/// in their capability seed, and asserts the OpenRouter one received
+/// `response_schema` with no prose copy while the Bedrock one received the
+/// reverse.
+/// Test: this test itself.
+#[tokio::test]
+async fn period_reviewer_picks_the_delivery_the_adapter_supports() {
+    let structured = Arc::new(RecordingAdapter::new(
+        capabilities(ProviderId::OpenRouter),
+        scripted_response(JSON_RESPONSE, 10, 5),
+    ));
+    let mut cost = TokenCostSummary::default();
+    PeriodReviewer::with_adapter(structured.clone(), "openrouter/openai/gpt-5.4-mini")
+        .review_period(&make_batch(), &mut cost)
+        .await;
+
+    let directive = structured
+        .only_request()
+        .response_schema
+        .expect("openrouter honours the field, so the transport must send it");
+    assert_eq!(directive.schema, period_findings_schema());
+    assert!(
+        !structured.only_system_turn().contains("## Response schema"),
+        "no prose copy alongside the field"
+    );
+
+    let prose = Arc::new(RecordingAdapter::new(
+        capabilities(ProviderId::Bedrock),
+        scripted_response(JSON_RESPONSE, 10, 5),
+    ));
+    let mut cost = TokenCostSummary::default();
+    PeriodReviewer::with_adapter(prose.clone(), "bedrock/us.anthropic.claude")
+        .review_period(&make_batch(), &mut cost)
+        .await;
+
+    assert!(
+        prose.only_request().response_schema.is_none(),
+        "bedrock cannot honour the field, and sending it fails the call outright"
+    );
+    assert!(
+        prose.only_system_turn().contains("\"findings\""),
+        "the schema must still reach the model"
+    );
 }
 
 /// Why: a provider outage and a genuinely clean period both produce zero

--- a/crates/trusty-git-analytics/src/profile/mod.rs
+++ b/crates/trusty-git-analytics/src/profile/mod.rs
@@ -23,6 +23,12 @@
 //! with a fallback narrative; a run where SOME periods failed reports that in
 //! [`PeriodRunSummary`] rather than presenting them as clean (#5465).
 //!
+//! Stages 4 and 5 both constrain their answer with a JSON Schema, and since
+//! #5588 both hand it over through
+//! [`trusty_common::inference::ChatRequest::response_schema`] where the provider
+//! can enforce it — [`schema_delivery`] owns that fork, and the prose fallback
+//! behind it.
+//!
 //! [`reporter_github`] publishes the rendered report to a per-contributor
 //! GitHub issue thread, and `tga profile` drives the whole pipeline from the
 //! command line (both #5465).
@@ -39,13 +45,17 @@ pub mod diff_sampler;
 pub mod error;
 pub mod reporter;
 pub mod reporter_github;
+pub mod schema_delivery;
 pub mod selector;
 pub mod synthesizer;
+#[cfg(test)]
+pub mod test_support;
 pub mod types;
 
 pub use batch::{assemble_period_batches, Window};
 pub use batch_reviewer::{
     build_period_request, PeriodReview, PeriodReviewer, PeriodRunSummary, SkippedPeriod,
+    PERIOD_FINDINGS_SCHEMA_NAME,
 };
 pub use diff_sampler::{sample_diffs_for_batches, DiffSamplerConfig, MAX_DIFF_CHARS};
 pub use error::{ProfileError, Result};
@@ -53,12 +63,13 @@ pub use reporter::{render_markdown, ReportFormat, Reporter};
 pub use reporter_github::{
     issue_title, upsert_profile_issue, GithubIssueConfig, PROFILE_ISSUE_LABEL,
 };
+pub use schema_delivery::deliver_schema;
 pub use selector::{
     resolve_contributor, resolve_db_path, ContributorSelector, ResolvedIdentity, ENV_TGA_DB,
 };
 pub use synthesizer::{
     apply_deterministic_synthesis, assign_trend_tags, build_synthesis_request, derive_trajectory,
-    Synthesizer,
+    Synthesizer, SYNTHESIS_OUTPUT_SCHEMA_NAME,
 };
 pub use types::{
     AuthorPeriodSummary, ContributorProfile, Effort, Finding, LongitudinalFinding, PeriodBatch,

--- a/crates/trusty-git-analytics/src/profile/schema_delivery.rs
+++ b/crates/trusty-git-analytics/src/profile/schema_delivery.rs
@@ -1,0 +1,64 @@
+//! How a profiling pass hands its JSON Schema to the model (#5588).
+//!
+//! Why: a schema rendered as prose in the system turn is a request the model may
+//! decline — #5588 was filed because the drift is observable as unparseable
+//! output. `trusty_common::inference::ChatRequest::response_schema` constrains
+//! the completion instead, but only where the provider can honour it: Bedrock's
+//! Converse API has no schema parameter, and `tga profile --model bedrock/…` is
+//! a documented invocation. Sending the field there would be
+//! `InferenceError::UnsupportedCapability` before the socket opens, turning
+//! every period of a Bedrock run into a skip.
+//! What: [`deliver_schema`] picks one delivery per call — the real field when
+//! the adapter supports structured output, the prose fallback when it does not
+//! — so exactly one copy of the schema reaches the model either way.
+//! Test: `schema_delivery_tests.rs`.
+
+use serde_json::Value;
+use trusty_common::inference::StructuredOutput;
+
+/// Choose how one pass's schema reaches the model.
+///
+/// Why: both profiling passes (period review and narrative synthesis) face the
+/// same fork, and a second copy of it would be the duplication #5588 is about.
+/// The fallback rather than a refusal is tga's fail-open precedent: a provider
+/// failure already leaves a period skipped or the narrative deterministic
+/// (`PeriodReview::skipped`, `apply_fallback_narrative`) rather than aborting
+/// the run, and a schema the provider cannot enforce is still a schema the model
+/// can be asked to follow.
+/// What: with `structured_output` true, returns `base_system` unchanged plus
+/// `Some(StructuredOutput)` for the caller to put on
+/// [`trusty_common::inference::ChatRequest::response_schema`]. With it false,
+/// returns `base_system` with the schema appended as a fenced JSON block and
+/// `None`. `strict` is left at [`StructuredOutput::new`]'s default — the passes
+/// want the constraint, not best-effort JSON.
+/// Test: `structured_provider_gets_the_field_and_a_clean_system_turn`,
+/// `unsupported_provider_gets_the_prose_fallback`,
+/// `the_schema_is_delivered_exactly_once`.
+pub fn deliver_schema(
+    base_system: &str,
+    name: &str,
+    schema: Value,
+    structured_output: bool,
+) -> (String, Option<StructuredOutput>) {
+    if structured_output {
+        return (
+            base_system.to_string(),
+            Some(StructuredOutput::new(name, schema)),
+        );
+    }
+
+    // `to_string_pretty` over a `Value` the caller built cannot fail; an empty
+    // string would still leave the prose instructions in the system turn.
+    let rendered = serde_json::to_string_pretty(&schema).unwrap_or_default();
+    let system = format!(
+        "{base_system}\n\n## Response schema\nReturn ONLY a JSON object conforming to this \
+         schema:\n```json\n{rendered}\n```"
+    );
+    (system, None)
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[path = "schema_delivery_tests.rs"]
+mod tests;

--- a/crates/trusty-git-analytics/src/profile/schema_delivery_tests.rs
+++ b/crates/trusty-git-analytics/src/profile/schema_delivery_tests.rs
@@ -1,0 +1,75 @@
+//! Tests for [`super::deliver_schema`] (#5588).
+//!
+//! Why: the fork this module owns decides whether the model is constrained by a
+//! schema or merely asked to follow one, and both arms are reachable from the
+//! command line (`--model openrouter/…` vs `--model bedrock/…`).
+//! What: covers both arms and the once-only property that keeps the two from
+//! overlapping.
+//! Test: included as `#[cfg(test)] mod tests` from `schema_delivery.rs`.
+
+use serde_json::json;
+
+use super::deliver_schema;
+
+fn schema() -> serde_json::Value {
+    json!({"type": "object", "properties": {"findings": {"type": "array"}}})
+}
+
+/// Why: this is #5588's closure condition for tga — the schema travels in the
+/// request field, not in the prompt, wherever the provider can enforce it.
+/// What: asserts the directive carries the name and the schema verbatim, and
+/// that the system turn is the base prompt untouched.
+/// Test: this test itself.
+#[test]
+fn structured_provider_gets_the_field_and_a_clean_system_turn() {
+    let (system, directive) = deliver_schema("BASE", "period_findings", schema(), true);
+
+    let directive = directive.expect("a structured-output provider gets the real field");
+    assert_eq!(directive.name, "period_findings");
+    assert_eq!(directive.schema, schema());
+    assert!(
+        directive.strict,
+        "the passes want the constraint, not best-effort JSON"
+    );
+    assert_eq!(
+        system, "BASE",
+        "the schema must not also be pasted into the prompt: {system}"
+    );
+}
+
+/// Why: Bedrock's Converse API cannot honour `response_schema`, and sending it
+/// there fails the request before any network call — every period of a
+/// `--model bedrock/…` run would be skipped.
+/// What: asserts the directive is absent and the schema is rendered into the
+/// system turn instead.
+/// Test: this test itself.
+#[test]
+fn unsupported_provider_gets_the_prose_fallback() {
+    let (system, directive) = deliver_schema("BASE", "period_findings", schema(), false);
+
+    assert!(
+        directive.is_none(),
+        "a provider without the capability must not be sent the field"
+    );
+    assert!(system.starts_with("BASE"), "{system}");
+    assert!(
+        system.contains("\"findings\""),
+        "the schema must still reach the model: {system}"
+    );
+}
+
+/// Why: delivering both would spend prompt budget restating a constraint the
+/// provider already enforces, and would let the two copies drift.
+/// What: asserts exactly one of the two carries the schema, in both arms.
+/// Test: this test itself.
+#[test]
+fn the_schema_is_delivered_exactly_once() {
+    for structured_output in [true, false] {
+        let (system, directive) = deliver_schema("BASE", "n", schema(), structured_output);
+        assert_eq!(
+            system.contains("\"findings\""),
+            directive.is_none(),
+            "exactly one delivery for structured_output={structured_output}: {system}"
+        );
+    }
+}

--- a/crates/trusty-git-analytics/src/profile/synthesizer.rs
+++ b/crates/trusty-git-analytics/src/profile/synthesizer.rs
@@ -30,6 +30,7 @@ use trusty_common::inference::{
     InferenceError,
 };
 
+use super::schema_delivery::deliver_schema;
 use super::types::{
     ContributorProfile, LongitudinalFinding, PeriodBatch, TokenCostSummary, Trajectory, TrendTag,
 };
@@ -266,6 +267,12 @@ pub fn derive_trajectory(quality_trend: &[(String, f64)]) -> Trajectory {
 
 // ─── Narrative request ────────────────────────────────────────────────────────
 
+/// The name OpenAI-dialect providers attach to the narrative schema.
+///
+/// #5588: `StructuredOutput` requires one; it is a label on the wire, not a
+/// field the model fills in.
+pub const SYNTHESIS_OUTPUT_SCHEMA_NAME: &str = "contributor_synthesis";
+
 /// JSON Schema for the narrative response.
 ///
 /// Test: `synthesis_output_schema_has_expected_properties`.
@@ -397,20 +404,31 @@ pub fn build_synthesizer_user_message(profile: &ContributorProfile) -> String {
 
 /// Assemble the narrative request.
 ///
-/// Why: like the period request, [`ChatRequest`] carries no structured-output
-/// field, so the schema only reaches the model if the system turn states it.
-/// What: system turn = [`synthesizer_system_prompt`] plus
-/// [`synthesis_output_schema`] as JSON; user turn =
-/// [`build_synthesizer_user_message`]. `model` passes through unchanged so the
-/// commons' prefix routing keeps working.
-/// Test: `synthesis_request_preserves_routing_prefix_and_sampling`.
-pub fn build_synthesis_request(profile: &ContributorProfile, model: &str) -> ChatRequest {
-    // `to_string_pretty` over a `Value` this module built cannot fail.
-    let schema = serde_json::to_string_pretty(&synthesis_output_schema()).unwrap_or_default();
-    let system = format!(
-        "{}\n\n## Response schema\nReturn ONLY a JSON object conforming to this schema:\n\
-         ```json\n{schema}\n```",
-        synthesizer_system_prompt()
+/// Why: like the period request, the schema is what makes
+/// [`apply_synthesis_json`]'s parse succeed rather than fall back. #5588 gave
+/// [`ChatRequest`] a `response_schema` field, so on a provider that honours it
+/// the schema constrains the completion instead of asking for it in prose.
+/// What: system turn = [`synthesizer_system_prompt`], plus
+/// [`synthesis_output_schema`] as JSON only when `structured_output` is false;
+/// user turn = [`build_synthesizer_user_message`]. `structured_output` is the
+/// sending adapter's `supports_structured_output` — see
+/// [`super::schema_delivery::deliver_schema`] for why the fallback exists rather
+/// than a refusal. `model` passes through unchanged so the commons' prefix
+/// routing keeps working.
+/// Test: `synthesis_request_preserves_routing_prefix_and_sampling`,
+/// `synthesis_request_sends_the_schema_through_response_schema`,
+/// `synthesis_request_falls_back_to_prose_without_the_capability`.
+pub fn build_synthesis_request(
+    profile: &ContributorProfile,
+    model: &str,
+    structured_output: bool,
+) -> ChatRequest {
+    // #5588: one delivery or the other, never both.
+    let (system, response_schema) = deliver_schema(
+        synthesizer_system_prompt(),
+        SYNTHESIS_OUTPUT_SCHEMA_NAME,
+        synthesis_output_schema(),
+        structured_output,
     );
 
     let mut req = ChatRequest::new(
@@ -422,6 +440,7 @@ pub fn build_synthesis_request(profile: &ContributorProfile, model: &str) -> Cha
     );
     req.temperature = Some(SYNTHESIZER_TEMPERATURE);
     req.max_tokens = Some(SYNTHESIZER_MAX_TOKENS);
+    req.response_schema = response_schema;
     req
 }
 
@@ -501,9 +520,16 @@ impl Synthesizer {
     /// [`apply_fallback_narrative`] and RETURNS the error, so a caller can say
     /// the narrative is a fallback rather than presenting it as the model's.
     /// Test: `synthesizer_transport_applies_the_models_narrative`,
-    /// `synthesizer_transport_falls_back_and_reports_the_failure`.
+    /// `synthesizer_transport_falls_back_and_reports_the_failure`,
+    /// `synthesizer_picks_the_delivery_the_adapter_supports`.
     pub async fn synthesize(&self, profile: &mut ContributorProfile) -> Option<InferenceError> {
-        let request = build_synthesis_request(profile, &self.model);
+        // #5588: the adapter's own capability decides the delivery — asking it
+        // is what keeps a `bedrock/…` run from failing before the socket opens.
+        let request = build_synthesis_request(
+            profile,
+            &self.model,
+            self.adapter.supports_structured_output(),
+        );
         let start = Instant::now();
 
         let response = match self.adapter.chat(&request).await {

--- a/crates/trusty-git-analytics/src/profile/synthesizer_tests.rs
+++ b/crates/trusty-git-analytics/src/profile/synthesizer_tests.rs
@@ -541,8 +541,10 @@ use trusty_common::inference::{
 };
 
 use super::{
-    build_synthesis_request, Synthesizer, SYNTHESIZER_MAX_TOKENS, SYNTHESIZER_TEMPERATURE,
+    build_synthesis_request, Synthesizer, SYNTHESIS_OUTPUT_SCHEMA_NAME, SYNTHESIZER_MAX_TOKENS,
+    SYNTHESIZER_TEMPERATURE,
 };
+use crate::profile::test_support::RecordingAdapter;
 
 /// A scripted response carrying `body` and a usage block.
 fn scripted_response(body: &str) -> ChatResponse {
@@ -646,9 +648,110 @@ async fn synthesizer_transport_falls_back_and_reports_the_failure() {
 /// Test: this test itself.
 #[test]
 fn synthesis_request_preserves_routing_prefix_and_sampling() {
-    let req = build_synthesis_request(&profile_with_trend(), "bedrock/us.anthropic.claude");
+    let req = build_synthesis_request(&profile_with_trend(), "bedrock/us.anthropic.claude", false);
     assert_eq!(req.model, "bedrock/us.anthropic.claude");
     assert_eq!(req.temperature, Some(SYNTHESIZER_TEMPERATURE));
     assert_eq!(req.max_tokens, Some(SYNTHESIZER_MAX_TOKENS));
     assert_eq!(req.messages.len(), 2, "one system turn and one user turn");
+}
+
+/// Why: the builder can be given either delivery, so what has to be pinned at
+/// this call site is that `Synthesizer::synthesize` ASKS its adapter — a
+/// hard-coded `true` fails every `bedrock/…` narrative before the socket opens,
+/// a hard-coded `false` leaves the schema in prose forever. The period pass has
+/// the same guard in `period_reviewer_picks_the_delivery_the_adapter_supports`.
+/// What: synthesises the same profile against two `RecordingAdapter`s differing
+/// only in their capability seed, and asserts the OpenRouter one received
+/// `response_schema` with no prose copy while the Bedrock one received the
+/// reverse.
+/// Test: this test itself.
+#[tokio::test]
+async fn synthesizer_picks_the_delivery_the_adapter_supports() {
+    const BODY: &str = r#"{"strengths":["tests first"],"recurring_weaknesses":["broad error types"],
+        "improvement_trajectory":"improving","narrative":"Steady."}"#;
+
+    let structured = Arc::new(RecordingAdapter::new(
+        capabilities(ProviderId::OpenRouter),
+        scripted_response(BODY),
+    ));
+    Synthesizer::with_adapter(structured.clone(), "openrouter/anthropic/x")
+        .synthesize(&mut profile_with_trend())
+        .await;
+
+    let directive = structured
+        .only_request()
+        .response_schema
+        .expect("openrouter honours the field, so the transport must send it");
+    assert_eq!(directive.name, SYNTHESIS_OUTPUT_SCHEMA_NAME);
+    assert_eq!(directive.schema, synthesis_output_schema());
+    assert!(
+        !structured.only_system_turn().contains("## Response schema"),
+        "no prose copy alongside the field"
+    );
+
+    let prose = Arc::new(RecordingAdapter::new(
+        capabilities(ProviderId::Bedrock),
+        scripted_response(BODY),
+    ));
+    Synthesizer::with_adapter(prose.clone(), "bedrock/us.anthropic.claude")
+        .synthesize(&mut profile_with_trend())
+        .await;
+
+    assert!(
+        prose.only_request().response_schema.is_none(),
+        "bedrock cannot honour the field, and sending it fails the call outright"
+    );
+    assert!(
+        prose.only_system_turn().contains("\"narrative\""),
+        "the schema must still reach the model"
+    );
+}
+
+/// Why: #5588's closure condition for the narrative pass — a schema stated in
+/// prose is a suggestion, and a drifting answer sends `apply_synthesis_json`
+/// down the fallback path that presents a computed narrative as the model's.
+/// What: asserts the schema travels on `ChatRequest.response_schema` verbatim
+/// under its wire name, with no copy left in the system turn.
+/// Test: this test itself.
+#[test]
+fn synthesis_request_sends_the_schema_through_response_schema() {
+    let req = build_synthesis_request(&profile_with_trend(), "openrouter/anthropic/x", true);
+
+    let directive = req
+        .response_schema
+        .as_ref()
+        .expect("a structured-output provider gets the real field, not prose");
+    assert_eq!(directive.name, SYNTHESIS_OUTPUT_SCHEMA_NAME);
+    assert_eq!(directive.schema, synthesis_output_schema());
+    assert!(
+        !req.messages[0]
+            .content
+            .clone()
+            .unwrap_or_default()
+            .contains("## Response schema"),
+        "the schema must not also be pasted into the prompt"
+    );
+}
+
+/// Why: Bedrock cannot honour `response_schema`, and sending it there fails the
+/// call before any network I/O — the narrative would be the deterministic
+/// fallback on every `--model bedrock/…` run.
+/// What: asserts the field is absent and the schema reaches the system turn.
+/// Test: this test itself.
+#[test]
+fn synthesis_request_falls_back_to_prose_without_the_capability() {
+    let req = build_synthesis_request(&profile_with_trend(), "bedrock/us.anthropic.claude", false);
+
+    assert!(
+        req.response_schema.is_none(),
+        "a provider without the capability must not be sent the field"
+    );
+    assert!(
+        req.messages[0]
+            .content
+            .clone()
+            .unwrap_or_default()
+            .contains("\"narrative\""),
+        "the schema must still reach the model"
+    );
 }

--- a/crates/trusty-git-analytics/src/profile/test_support.rs
+++ b/crates/trusty-git-analytics/src/profile/test_support.rs
@@ -1,0 +1,89 @@
+//! Test doubles shared across the profiling submodules' test files.
+//!
+//! Why: both model passes decide what to send by asking their adapter
+//! (#5588), and `trusty_common::inference::test_support::ScriptedAdapter`
+//! discards the request — so neither call site can be proven from its response
+//! alone. Both need the same double, and a second copy of it would drift.
+//! What: [`RecordingAdapter`], an [`InferenceAdapter`] that keeps every request
+//! it was handed and answers with one canned [`ChatResponse`].
+//! Test: used by `period_reviewer_picks_the_delivery_the_adapter_supports`
+//! (`batch_reviewer_tests.rs`) and
+//! `synthesizer_picks_the_delivery_the_adapter_supports`
+//! (`synthesizer_tests.rs`).
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use trusty_common::inference::{
+    ChatRequest, ChatResponse, InferenceAdapter, InferenceError, ProviderCapabilities,
+};
+
+/// An adapter that keeps every request it was handed and answers `response`.
+///
+/// Why: the capability an adapter reports is what each profiling pass reads to
+/// choose between `ChatRequest.response_schema` and the prose fallback, so the
+/// only way to prove a call site asked rather than hard-coded one delivery is to
+/// inspect the request it actually sent.
+/// What: constructed with a capability seed and one canned response; `chat`
+/// records the request and returns a clone of that response, however many times
+/// it is called. [`Self::only_request`] reads the single recorded request back.
+/// Test: as the module doc.
+pub struct RecordingAdapter {
+    capabilities: &'static ProviderCapabilities,
+    seen: Mutex<Vec<ChatRequest>>,
+    response: ChatResponse,
+}
+
+impl RecordingAdapter {
+    /// Build a recorder over `capabilities` answering `response` every time.
+    pub fn new(capabilities: &'static ProviderCapabilities, response: ChatResponse) -> Self {
+        Self {
+            capabilities,
+            seen: Mutex::new(Vec::new()),
+            response,
+        }
+    }
+
+    /// The single request this adapter was sent.
+    ///
+    /// Panics when the count is not exactly one — a pass that called twice, or
+    /// not at all, is a different failure than the delivery being wrong, and the
+    /// assertion should say which.
+    pub fn only_request(&self) -> ChatRequest {
+        let seen = self.seen.lock().unwrap_or_else(|p| p.into_inner());
+        assert_eq!(
+            seen.len(),
+            1,
+            "expected exactly one call, got {}",
+            seen.len()
+        );
+        seen[0].clone()
+    }
+
+    /// The system turn of [`Self::only_request`], or an empty string.
+    pub fn only_system_turn(&self) -> String {
+        self.only_request().messages[0]
+            .content
+            .clone()
+            .unwrap_or_default()
+    }
+}
+
+#[async_trait]
+impl InferenceAdapter for RecordingAdapter {
+    fn name(&self) -> &str {
+        "recording"
+    }
+
+    fn capabilities(&self) -> &ProviderCapabilities {
+        self.capabilities
+    }
+
+    async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError> {
+        self.seen
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(request.clone());
+        Ok(self.response.clone())
+    }
+}


### PR DESCRIPTION
Refs [#5588](https://github.com/bobmatnyc/trusty-tools/issues/5588)

## Summary

`profile/schema_delivery.rs::deliver_schema` puts the JSON schema on `ChatRequest.response_schema` when the adapter reports `supports_structured_output()`, otherwise keeps the byte-identical prose fallback (Bedrock's flag is false since [#7058](https://github.com/bobmatnyc/trusty-tools/pull/7058) and `tga profile --model bedrock/...` is documented). `build_period_request` and `build_synthesis_request` gain a `structured_output: bool`; both call sites pass the adapter's capability. `classify/tiers/llm.rs`'s private request type is deliberately left: it sends JSON mode (`response_format: json_object`), which trusty-common cannot express; a `// #5588:` comment records this. Shared test double `profile/test_support.rs::RecordingAdapter`; eight new tests including end-to-end delivery tests at both call sites.

## Test Ladder

Rung 4 (tga public API changed; sole dependent trusty-analyze references nothing under `profile::` and checks clean). Gates: `cargo fmt --check`, `cargo check -p tga --all-targets`, `cargo clippy -p tga --all-targets -- -D warnings` exit 0; `cargo test -p tga --no-fail-fast` 11 targets all ok (lib 1612 passed, 0 failed, 7 ignored); `SKIP_UI_BUILD=1 cargo check -p trusty-analyze --all-targets` exit 0; line-cap, changelog-fragment (`crates/trusty-git-analytics/changelog.d/5588-tga-response-schema.md`), test-pointers, sld gates OK. Pre-fix probe test failed at origin/main with "the schema must travel on ChatRequest.response_schema, not in the prompt".

## Review & Security

Code-critic APPROVE (one MEDIUM, the synthesizer end-to-end test, addressed in the amend). Security: credential scan CLEAN (full three-dot and the amend delta).

## Release Note

`build_period_request`/`build_synthesis_request` signature change is a 0.x breaking change for tga; the release-time semver gate decides the bump.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
