### PR TITLE
fix(trusty-review): TestCoverage alone no longer drives BLOCK under severity_floor

### DIFF
--- a/crates/trusty-review/changelog.d/7036-severity-floor-test-coverage.md
+++ b/crates/trusty-review/changelog.d/7036-severity-floor-test-coverage.md
@@ -1,0 +1,4 @@
+Fixed
+
+- A `test-coverage` finding on its own no longer drives REQUEST_CHANGES or BLOCK. `FindingCategory::TestCoverage` has been documented as advisory since #1418, but the severity floor partitioned only `method-conformance` out of the correctness bucket, so a high-effort coverage gap floored exactly like a correctness bug. `TestCoverage` now reports `is_informational`, joining `Style` under the advisory ceiling (#7036).
+- A coverage-gap finding's inline PR comment now carries a coverage-specific "does not block" label instead of the style/preference one (#7036).

--- a/crates/trusty-review/src/integrations/github/inline.rs
+++ b/crates/trusty-review/src/integrations/github/inline.rs
@@ -30,7 +30,7 @@
 
 use std::collections::HashSet;
 
-use crate::models::{Effort, Finding, VerifyOutcome};
+use crate::models::{Effort, Finding, FindingCategory, VerifyOutcome};
 
 // ─── Tuning constants ─────────────────────────────────────────────────────────
 
@@ -50,11 +50,23 @@ const VERIFICATION_CAVEAT_PREFIX: &str = "> **Verification:**";
 /// verdict, but a reader meeting the comment on the diff cannot see that. Saying
 /// it on the comment itself is what stops an author treating a taste note as a
 /// change request.
-/// What: prefixes the lead line of any finding whose category reports
-/// [`crate::models::FindingCategory::is_informational`].
+/// What: prefixes the lead line of a [`crate::models::FindingCategory::Style`]
+/// finding.
 /// Test: `render_marks_style_finding_informational`,
 /// `render_leaves_correctness_finding_unlabelled`.
 const INFORMATIONAL_PREFIX: &str = "> **Informational (style / preference) — does not block.**";
+
+/// Lead-in marking a coverage-gap finding as informational (#7036).
+///
+/// Why: `TestCoverage` became advisory in #7036, so it now earns the same
+/// reader-facing label — but calling a missing test a "style / preference" nit
+/// would misdescribe it, and the author would discount a note they should still
+/// act on.  A distinct parenthetical keeps the "does not block" promise honest
+/// without flattening why.
+/// What: prefixes the lead line of a
+/// [`crate::models::FindingCategory::TestCoverage`] finding.
+/// Test: `render_marks_test_coverage_finding_informational`.
+const COVERAGE_INFORMATIONAL_PREFIX: &str = "> **Informational (test coverage) — does not block.**";
 
 /// Confidence below which a finding is hedged rather than asserted (#1416).
 ///
@@ -374,14 +386,21 @@ pub fn build_inline_plan(findings: &[Finding], commentable: &CommentableLines) -
 /// `render_marks_refuted_finding`, `render_marks_error_refuted_as_unverified`,
 /// `render_leaves_confirmed_and_unjudged_findings_unmarked`,
 /// `render_marks_style_finding_informational` (#3474),
+/// `render_marks_test_coverage_finding_informational` (#7036),
 /// `render_leaves_correctness_finding_unlabelled` (#3474).
 pub fn render_finding_comment(finding: &Finding) -> String {
     let mut out = String::with_capacity(256);
 
-    // #3474: say up front that a style nit is advisory, so the reader is never
-    // left inferring severity from a comment the verdict already discounted.
+    // #3474: say up front that an advisory finding is advisory, so the reader is
+    // never left inferring severity from a comment the verdict already
+    // discounted.  #7036: name WHICH kind of advisory, so a coverage gap is not
+    // mislabelled a taste note.
     if finding.category.is_informational() {
-        out.push_str(INFORMATIONAL_PREFIX);
+        out.push_str(if finding.category == FindingCategory::TestCoverage {
+            COVERAGE_INFORMATIONAL_PREFIX
+        } else {
+            INFORMATIONAL_PREFIX
+        });
         out.push_str("\n\n");
     }
 

--- a/crates/trusty-review/src/integrations/github/inline_tests.rs
+++ b/crates/trusty-review/src/integrations/github/inline_tests.rs
@@ -210,6 +210,32 @@ fn render_marks_style_finding_informational() {
     );
 }
 
+/// A coverage-gap finding is labelled informational, but not as a style nit.
+///
+/// Why: #7036 made `TestCoverage` advisory, so it earns the same "does not
+/// block" promise — but calling a missing test a "style / preference" nit would
+/// misdescribe it and invite the author to discount a note worth acting on.
+/// What: renders a `FindingCategory::TestCoverage` finding, asserts the
+/// coverage-specific lead-in and the absence of the style wording.
+#[test]
+fn render_marks_test_coverage_finding_informational() {
+    let f = finding_at("src/db.rs", Some(11))
+        .with_category(crate::models::FindingCategory::TestCoverage);
+    let body = render_finding_comment(&f);
+    assert!(
+        body.starts_with("> **Informational (test coverage) — does not block.**"),
+        "a coverage gap must lead with the coverage-specific label (#7036): {body}"
+    );
+    assert!(
+        !body.contains("style / preference"),
+        "a coverage gap must not be labelled a taste note (#7036): {body}"
+    );
+    assert!(
+        body.contains("**security**"),
+        "the ordinary lead line still renders: {body}"
+    );
+}
+
 /// An ordinary correctness finding gains no informational label.
 ///
 /// Why: the label must be a signal, not decoration — if every comment carried it

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -314,7 +314,8 @@ pub enum FindingCategory {
     MethodConformance,
     /// An unmet test-plan / acceptance-criteria item: the diff lacks evidence of
     /// test coverage for an AC item from the linked ticket or PR test-plan section
-    /// (#1418).  Informational — never drives BLOCK or REQUEST_CHANGES alone.
+    /// (#1418).  Informational — see [`FindingCategory::is_informational`]; it
+    /// never drives BLOCK or REQUEST_CHANGES alone (#7036).
     TestCoverage,
     /// A style / preference / taste nit: naming, formatting, idiom choice, or an
     /// "I would have written it differently" observation with no correctness,
@@ -333,14 +334,19 @@ impl FindingCategory {
     /// `grade::derive_verdict_with` (the verdict ceiling) and
     /// `github::inline::render_finding_comment` (the reader-facing label) from
     /// disagreeing about which categories are advisory.
-    /// What: returns `true` for [`FindingCategory::Style`] only.  `TestCoverage`
-    /// is deliberately NOT included: its floor treatment predates #3474 and
-    /// changing it is a separate calibration decision, not this one.
-    /// Test: `style_category_is_informational`,
-    /// `only_style_findings_never_block`.
+    /// What: returns `true` for [`FindingCategory::Style`] and
+    /// [`FindingCategory::TestCoverage`].  #7036 added `TestCoverage`: its own
+    /// doc comment had claimed since #1418 that a coverage gap never drives
+    /// BLOCK or REQUEST_CHANGES alone, but `grade::severity_floor` ran it
+    /// through the uncapped correctness floor, so the code contradicted the
+    /// contract.  A missing test is a request for more evidence, not evidence of
+    /// a defect — it belongs beside `Style` on the advisory side.
+    /// Test: `advisory_categories_are_informational`,
+    /// `only_style_findings_never_block`, `only_test_coverage_findings_never_block`.
     #[must_use]
     pub fn is_informational(self) -> bool {
-        matches!(self, FindingCategory::Style)
+        // #7036: TestCoverage joins Style — the doc contract already said it is advisory.
+        matches!(self, FindingCategory::Style | FindingCategory::TestCoverage)
     }
 }
 

--- a/crates/trusty-review/src/models/tests.rs
+++ b/crates/trusty-review/src/models/tests.rs
@@ -152,21 +152,22 @@ fn finding_category_serde_roundtrip() {
     assert_eq!(FindingCategory::default(), FindingCategory::Correctness);
 }
 
-/// `Style` is the only informational category (#3474).
+/// `Style` (#3474) and `TestCoverage` (#7036) are the informational categories.
 ///
 /// Why: `grade::derive_verdict_with` and `github::inline::render_finding_comment`
 /// both key off `is_informational`, so the set it reports is the contract
-/// between the verdict ceiling and the reader-facing label.  `TestCoverage` is
-/// asserted OUT deliberately: its floor treatment predates #3474 and changing it
-/// is a separate calibration decision.
+/// between the verdict ceiling and the reader-facing label.  `TestCoverage` was
+/// asserted OUT until #7036, which is exactly the state the `TestCoverage` doc
+/// comment contradicted — a coverage gap it called advisory could still floor to
+/// BLOCK.
 /// What: asserts the predicate over all four variants.
 /// Test: this test itself.
 #[test]
-fn style_category_is_informational() {
+fn advisory_categories_are_informational() {
     assert!(FindingCategory::Style.is_informational());
+    assert!(FindingCategory::TestCoverage.is_informational());
     assert!(!FindingCategory::Correctness.is_informational());
     assert!(!FindingCategory::MethodConformance.is_informational());
-    assert!(!FindingCategory::TestCoverage.is_informational());
 }
 
 /// A `Finding` constructed via `new` defaults to the `Correctness` category.

--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -516,14 +516,15 @@ pub(crate) fn floor_min_confidence() -> f32 {
 ///    floor, regardless of the model's own proposed verdict.  EXCEPTION (#1897):
 ///    see the reconciliation cap below.
 ///
-/// 0. STYLE CEILING (#3474), applied BEFORE both of the above: a
-///    `FindingCategory::Style` finding is a taste note, so it contributes
-///    nothing to any floor, and a batch whose substantive findings are ALL
-///    style nits returns APPROVE outright.  A ceiling rather than a floor
-///    adjustment because `stricter_of` can only raise a verdict — a floor of
-///    APPROVE would still let a model-proposed BLOCK through.  The ceiling
-///    lifts the moment ONE non-style substantive finding is present: the
-///    style nits drop out and the remaining findings floor exactly as before.
+/// 0. ADVISORY CEILING (#3474; widened by #7036), applied BEFORE both of the
+///    above: a finding whose category reports `FindingCategory::is_informational`
+///    — `Style`, and `TestCoverage` since #7036 — is a taste note or a request
+///    for more evidence, so it contributes nothing to any floor, and a batch
+///    whose substantive findings are ALL advisory returns APPROVE outright.  A
+///    ceiling rather than a floor adjustment because `stricter_of` can only raise
+///    a verdict — a floor of APPROVE would still let a model-proposed BLOCK
+///    through.  The ceiling lifts the moment ONE non-advisory substantive finding
+///    is present: the advisory findings drop out and the rest floor as before.
 ///
 /// Special case: `Verdict::Unknown` is always returned as-is — the model has
 /// determined the diff was unassessable and no floor or override applies.
@@ -597,26 +598,27 @@ fn derive_verdict_with(
         .filter(|f| is_substantive(f, thresholds))
         .collect();
 
-    // #3474: style/preference ceiling. A batch whose ONLY substantive findings
-    // are style nits is a taste report, not a quality signal — return APPROVE
-    // outright rather than merely lowering the floor, because the floor is a
-    // MINIMUM and `stricter_of` below could never pull a model-proposed
-    // REQUEST_CHANGES/BLOCK back down. This is the same ceiling shape as the
-    // low-confidence override immediately below.
+    // #3474: advisory ceiling. A batch whose ONLY substantive findings are
+    // advisory (style nits, and coverage gaps since #7036) is a taste or
+    // wish-list report, not a quality signal — return APPROVE outright rather
+    // than merely lowering the floor, because the floor is a MINIMUM and
+    // `stricter_of` below could never pull a model-proposed REQUEST_CHANGES/BLOCK
+    // back down. This is the same ceiling shape as the low-confidence override
+    // immediately below.
     if !substantive.is_empty() && substantive.iter().all(|f| f.category.is_informational()) {
         debug!(
             model_verdict = %model_proposed,
             count = substantive.len(),
-            "style ceiling: every substantive finding is a style/preference nit → APPROVE (#3474)"
+            "advisory ceiling: every substantive finding is informational → APPROVE (#3474, #7036)"
         );
         return Verdict::Approve;
     }
 
-    // #3474: a style nit alongside real findings contributes nothing to the
-    // floor either — otherwise a High-effort, cited style finding would drive
-    // BLOCK through `correctness_floor` Tier 1. Dropping them here (rather than
-    // inside `severity_floor`) keeps `has_high`, `all_low_confidence` and the
-    // #PR84 gates below reading the same style-free set.
+    // #3474: an advisory finding alongside real findings contributes nothing to
+    // the floor either — otherwise a High-effort, cited style nit or coverage gap
+    // would drive BLOCK through `correctness_floor` Tier 1. Dropping them here
+    // (rather than inside `severity_floor`) keeps `has_high`, `all_low_confidence`
+    // and the #PR84 gates below reading the same advisory-free set.
     let substantive: Vec<&Finding> = substantive
         .into_iter()
         .filter(|f| !f.category.is_informational())
@@ -967,6 +969,10 @@ fn severity_floor(findings: &[&Finding], thresholds: &Thresholds) -> FloorResult
     // REQUEST_CHANGES — it must never drive BLOCK (reserved for correctness /
     // safety).  Run the standard floor over the CORRECTNESS findings only, then
     // combine with the conformance floor via `stricter_of`.
+    //
+    // #7036: informational categories (`Style`, `TestCoverage`) never reach here
+    // — `derive_verdict_with` filters them out of `substantive` before calling —
+    // so this two-way split partitions correctness against conformance only.
     let (conformance, correctness): (Vec<&&Finding>, Vec<&&Finding>) = findings
         .iter()
         .partition(|f| f.category == FindingCategory::MethodConformance);

--- a/crates/trusty-review/src/pipeline/grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_tests.rs
@@ -2027,3 +2027,116 @@ fn style_ceiling_holds_through_derive_verdict_with_grade() {
         "an F grade implies BLOCK — it must be reconciled down alongside the verdict"
     );
 }
+
+// ── #7036: the coverage-gap floor ────────────────────────────────────────────
+
+/// A `TestCoverage` finding, otherwise identical to [`finding`] (#7036).
+fn test_coverage_finding(effort: Effort, confidence: f32) -> Finding {
+    finding(effort, confidence).with_category(FindingCategory::TestCoverage)
+}
+
+/// A batch of nothing but coverage gaps can never block or request changes,
+/// however severe the model or the findings claim to be (#7036).
+///
+/// Why: `FindingCategory::TestCoverage` has documented since #1418 that a
+/// coverage gap "never drives BLOCK or REQUEST_CHANGES alone", but
+/// `severity_floor` partitioned only `MethodConformance` out of the correctness
+/// bucket — so a High-effort, diff-provable coverage finding ran
+/// `correctness_floor` Tier 1 and floored to BLOCK exactly like a real bug.
+/// This test fails on the pre-#7036 code.
+/// What: two coverage findings at 0.95 confidence with the model proposing
+/// BLOCK → APPROVE, then a single High-effort one against every non-UNKNOWN
+/// model proposal.
+#[test]
+fn only_test_coverage_findings_never_block() {
+    let findings = vec![
+        test_coverage_finding(Effort::High, 0.95),
+        test_coverage_finding(Effort::Medium, 0.95),
+    ];
+    assert_eq!(
+        derive_verdict(Verdict::Block, &findings),
+        Verdict::Approve,
+        "a batch whose only substantive findings are coverage gaps must grade \
+         APPROVE — never BLOCK (#7036)"
+    );
+
+    let solo = vec![test_coverage_finding(Effort::High, 0.99)];
+    for proposed in [
+        Verdict::Approve,
+        Verdict::ApproveWithReservations,
+        Verdict::RequestChanges,
+        Verdict::Block,
+    ] {
+        assert_eq!(
+            derive_verdict(proposed.clone(), &solo),
+            Verdict::Approve,
+            "coverage-only batch with model proposal {proposed} must grade APPROVE (#7036)"
+        );
+    }
+}
+
+/// A coverage gap alongside a real blocker still blocks (#7036).
+///
+/// Why: the ceiling must lift the moment ONE non-advisory substantive finding is
+/// present, or attaching a coverage note to a review would launder a genuine
+/// critical bug into an APPROVE.
+/// What: one High-effort escalation-eligible correctness finding plus a coverage
+/// gap → BLOCK, exactly as the correctness finding alone would.
+#[test]
+fn test_coverage_finding_alongside_blocker_still_blocks() {
+    let findings = vec![
+        test_coverage_finding(Effort::High, 0.95),
+        finding(Effort::High, 0.9),
+    ];
+    assert_eq!(
+        derive_verdict(Verdict::Approve, &findings),
+        Verdict::Block,
+        "a coverage gap must not disarm a co-occurring correctness blocker (#7036)"
+    );
+}
+
+/// A coverage gap contributes nothing to the floor when the ceiling has lifted.
+///
+/// Why: dropping coverage findings from the floor set is a separate rule from
+/// the ceiling, and only this shape distinguishes them.  A High-effort,
+/// diff-provable coverage finding paired with a merely Low-effort correctness
+/// finding would reach `correctness_floor` Tier 1 and BLOCK if it were still
+/// counted — the ceiling does not fire here, because a correctness finding is
+/// present.
+/// What: one Low-effort correctness finding plus a High-effort coverage gap →
+/// no BLOCK.
+#[test]
+fn test_coverage_finding_does_not_drive_the_floor() {
+    let findings = vec![
+        finding(Effort::Low, 0.9),
+        test_coverage_finding(Effort::High, 0.95),
+    ];
+    assert_ne!(
+        derive_verdict(Verdict::Approve, &findings),
+        Verdict::Block,
+        "a High-effort coverage gap must never reach the BLOCK floor (#7036)"
+    );
+}
+
+/// The coverage ceiling routes through `derive_verdict_with_grade` too (#7036).
+///
+/// Why: the production entry point folds the model's letter grade into an
+/// `effective_model` proposal BEFORE the floor, so a grade of "F" is a second,
+/// independent way a coverage-only review could have blocked.
+/// What: grade F + model BLOCK over a coverage-only batch → APPROVE, with a
+/// grade no longer implying a blocking verdict.
+#[test]
+fn test_coverage_ceiling_holds_through_derive_verdict_with_grade() {
+    let findings = vec![test_coverage_finding(Effort::High, 0.95)];
+    let (verdict, grade) = derive_verdict_with_grade(Verdict::Block, Grade::F, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Approve,
+        "the coverage ceiling must survive the grade-aware entry point (#7036)"
+    );
+    assert_ne!(
+        grade,
+        Some(Grade::F),
+        "an F grade implies BLOCK — it must be reconciled down alongside the verdict"
+    );
+}


### PR DESCRIPTION
## Outcome

Refs #7036

`severity_floor` carved only `MethodConformance` out of the correctness bucket, so a coverage-gap finding alone could grade BLOCK, contradicting the `TestCoverage` doc contract ("never drives BLOCK or REQUEST_CHANGES alone", since #1418). `TestCoverage` now joins `Style` under `is_informational`, the advisory ceiling #3474 built.

## Changes

- `TestCoverage` grading moved from correctness to `is_informational` bucket
- Inline GitHub render now labels it "Informational (test coverage) — does not block"
- Code changed, not the doc: the code-review-standards taxonomy treats a missing test as a request for evidence, not a defect

## Risk

Low — pure grading logic change within existing severity-floor architecture; no public API changes. Fixes an invariant violation where coverage-only findings incorrectly blocked.

## Tests

Test ladder rung 3. Gates run with `--no-fail-fast`:
- `cargo test -p trusty-review --no-fail-fast` — lib 2224 passed, 0 failed, 5 ignored; every other target ok
- Four new grade regression tests added:
  - coverage-only never blocks
  - coverage beside a real blocker still blocks
  - High-effort coverage gap never drives the floor
  - ceiling survives derive_verdict_with_grade
- fmt/check/clippy clean

## Baseline

All tests pass on the branch; no pre-existing failures.

## Docs

- line-cap OK
- changelog-fragment ✓
- test-pointers OK

## Review

No review findings; gates clean.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
