### PR TITLE
fix(trusty-console): saver honours loginwindow's stop request immediately so Touch ID unlock is not blocked

### DIFF
--- a/crates/trusty-console/changelog.d/6900-saver-honours-stop.md
+++ b/crates/trusty-console/changelog.d/6900-saver-honours-stop.md
@@ -1,0 +1,12 @@
+Fixed
+- `TrustyConsole.saver` now honours `loginwindow`'s stop request immediately, so
+  Touch ID is offered at unlock instead of waiting on a saver that has not
+  stopped. `stopAnimation()` used to set the same `.offline` state the retry
+  timer reads as "keep trying", leave the navigation delegate attached, and
+  navigate to `about:blank` over an in-flight console load — WebKit reported that
+  cancellation, the offline handler re-armed the retry timer the stop had just
+  invalidated, and the saver went on loading the console for four minutes after
+  being told to stop. The stop now enters a terminal state that only
+  `startAnimation()` leaves, cancels the in-flight load, and detaches the
+  delegate before navigating away, so no late callback can restart the loop
+  ([#6900](https://github.com/bobmatnyc/trusty-tools/issues/6900)).

--- a/crates/trusty-console/macos/saver/PaintHarness.swift
+++ b/crates/trusty-console/macos/saver/PaintHarness.swift
@@ -22,6 +22,12 @@
 //               the target frame the way a host that learns the screen late
 //               would; asserts the web view tracks `bounds`, that the page's own
 //               viewport matches, and that the frame is not black at its edges.
+//     stop    — #6900: points the view at the same never-answering listener so a
+//               load is genuinely in flight, then issues `stopAnimation()` the
+//               way `loginwindow` does; asserts the call returns inside the
+//               issue's 500 ms bar and that the listener sees no further
+//               connection, twice — once on an in-flight load and once from
+//               inside a render tick.
 //   Every mode takes the frame it runs at — `--frame WxH`, default 1280x800 —
 //   so the ultrawide geometry #6871 was reported on is reachable.
 // Test: it IS the test. README.md, "Paint harness", has the invocations;
@@ -92,6 +98,29 @@ let retryObservationSeconds: TimeInterval = 34
 /// one connection and waits out `URLRequest`'s 60 s default, so this is the
 /// assertion that fails on the unfixed bundle.
 let minSlowModeAttempts = 3
+
+// MARK: - Stop-path thresholds (#6900)
+
+/// How long `stopAnimation()` itself may take to return. #6900's acceptance
+/// says "under 500 ms"; `loginwindow` waits on the screen-saver host before it
+/// hands the display to the unlock UI, so this is what Touch ID waits behind.
+///
+/// The call does synchronous work only — invalidate four timers, detach a
+/// delegate, cancel a load — so the real number is microseconds and the budget
+/// is not a tight fit. It is here to catch a future change that puts a blocking
+/// wait, a synchronous XPC round trip, or a run-loop spin into the stop path.
+let stopReturnBudget: TimeInterval = 0.5
+/// How long after the stop the listener is watched for traffic that must not
+/// come. The unfixed view's re-armed retry lands about 5 s after the stop
+/// (`about:blank` supersedes the in-flight load, WebKit reports the
+/// cancellation, `enterOffline` re-arms `scheduleRetryTimer`'s 5 s delay), and
+/// each subsequent attempt about 11 s after that, so 20 s holds two or three of
+/// them. Anything above zero in this window is #6900.
+let stopQuietSeconds: TimeInterval = 20
+/// How long to wait for the view to open its first connection before issuing
+/// the stop. The stop has to land on a load that is genuinely IN FLIGHT —
+/// stopping an idle view proves nothing.
+let stopInFlightWait: TimeInterval = 10
 
 /// The Foundry dark background the view fills before drawing anything, from
 /// `docs/design/UI/design-system/tokens.css` (`--trusty-content-bg: #201612`).
@@ -164,8 +193,8 @@ let bundlePath = positional.count > 1
     ? positional[1]
     : NSHomeDirectory() + "/Library/Screen Savers/TrustyConsole.saver"
 
-guard ["offline", "slow", "preview", "resize"].contains(mode) else {
-    note("usage: paintharness <offline|slow|preview|resize> [bundlePath]"
+guard ["offline", "slow", "preview", "resize", "stop"].contains(mode) else {
+    note("usage: paintharness <offline|slow|preview|resize|stop> [bundlePath]"
         + " [--frame WxH] [--start WxH]")
     note("  --frame  the frame to run at (default 1280x800; env SAVER_HARNESS_FRAME)")
     note("  --start  resize mode only: the frame to construct at (default 320x200)")
@@ -416,7 +445,10 @@ var silent: SilentListener?
 switch mode {
 case "offline":
     pointView(atPort: closedPort())
-case "slow":
+case "slow", "stop":
+    // #6900 wants the same endpoint `slow` uses: a load that is in flight and
+    // stays there is the state the stop has to interrupt, and every connection
+    // the view opens is counted.
     guard let listener = SilentListener() else {
         note("could not start the silent listener")
         finish(6)
@@ -611,6 +643,106 @@ case "slow":
         }
     } else {
         failures.append("could not read the view's bitmap after the stall")
+    }
+
+case "stop":
+    guard let listener = silent else { break }
+
+    /// Runs the run loop until `condition` holds or `seconds` elapse. The view's
+    /// timers and WebKit's callbacks all land on the main run loop, so a plain
+    /// sleep would stop the very machinery under test.
+    func pump(_ seconds: TimeInterval, until condition: () -> Bool = { false }) {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline && !condition() {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    /// One stop, measured. Returns the elapsed seconds and how many connections
+    /// the listener saw in the quiet window that follows.
+    ///
+    /// `issue` is the caller's stop — a plain call for the in-flight case, a
+    /// run-loop timer for the mid-render one — and is handed the clock so the
+    /// budget covers `stopAnimation()` and nothing around it.
+    func measureStop(_ label: String, issue: (@escaping () -> Void) -> Void) -> (elapsed: TimeInterval, leaked: Int) {
+        let before = listener.accepted
+        var elapsed: TimeInterval = -1
+        issue {
+            let started = Date()
+            view.stopAnimation()
+            elapsed = Date().timeIntervalSince(started)
+        }
+        pump(5, until: { elapsed >= 0 })
+        note("\(label): stopAnimation() returned in "
+            + String(format: "%.1f", elapsed * 1000) + "ms")
+        if elapsed < 0 {
+            failures.append("\(label): the stop never ran")
+            return (elapsed, 0)
+        }
+        if elapsed > stopReturnBudget {
+            failures.append(String(format: "%@: stopAnimation() took %.3fs, budget %.3fs",
+                                   label, elapsed, stopReturnBudget))
+        }
+        note("\(label): watching for \(Int(stopQuietSeconds))s of traffic that must not come")
+        pump(stopQuietSeconds)
+        let leaked = listener.accepted - before
+        note("\(label): connection attempts after the stop: \(leaked)")
+        if leaked > 0 {
+            failures.append("\(label): kept loading the console after the stop —"
+                + " \(leaked) connection attempt(s), expected 0")
+        }
+        return (elapsed, leaked)
+    }
+
+    // --- the load must be in flight before the stop lands -------------------
+    pump(stopInFlightWait, until: { listener.accepted > 0 })
+    guard listener.accepted > 0 else {
+        failures.append("the view never opened a connection — nothing to interrupt")
+        break
+    }
+    note("load in flight after \(listener.accepted) connection attempt(s)")
+
+    // --- 1: the stop lands on an in-flight load ----------------------------
+    // This is #6900's reported shape: `loginwindow` stops the saver while its
+    // WKWebView is mid-load.
+    _ = measureStop("in-flight stop") { body in body() }
+
+    // --- restart, then 2: the stop lands inside a render tick --------------
+    // Restarting first proves the stopped state is not sticky (a wake that does
+    // not unlock stops and re-arms the saver) and re-arms the loader that the
+    // second stop has to interrupt.
+    view.startAnimation()
+    let afterRestart = listener.accepted
+    pump(stopInFlightWait, until: { listener.accepted > afterRestart })
+    if listener.accepted == afterRestart {
+        failures.append("startAnimation() after a stop did not resume loading:"
+            + " no new connection in \(Int(stopInFlightWait))s")
+    }
+
+    // The failure path #6900 asks for: the stop arrives while the view is
+    // repainting. `animateOneFrame()` marks the view dirty and the stop is
+    // issued in the same turn of the run loop, before that redraw is flushed —
+    // the host's animation tick and `loginwindow`'s stop request landing
+    // together.
+    var midRenderFrame: PaintStats?
+    _ = measureStop("mid-render stop") { body in
+        Timer.scheduledTimer(withTimeInterval: 0.05, repeats: false) { _ in
+            view.animateOneFrame()
+            body()
+            midRenderFrame = capture(view).flatMap(stats(of:))
+        }
+    }
+
+    // #6838 must not regress on the way out: a view told to stop mid-frame
+    // still paints the fallback rather than going black.
+    if let painted = midRenderFrame {
+        note("frame after the mid-render stop: \(painted.summary)")
+        if painted.nonBlackRatio < minNonBlackRatio {
+            failures.append(String(format: "frame went black across the mid-render stop: nonBlack=%.4f",
+                                   painted.nonBlackRatio))
+        }
+    } else {
+        failures.append("could not read the view's bitmap after the mid-render stop")
     }
 
 default:

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -133,7 +133,7 @@ daemon**: each mode builds its own endpoint.
 swiftc -O -swift-version 5 -o target/console-saver/harness/paintharness \
   crates/trusty-console/macos/saver/PaintHarness.swift
 
-for mode in offline slow preview resize; do
+for mode in offline slow preview resize stop; do
   ./target/console-saver/harness/paintharness "$mode" \
     target/console-saver/TrustyConsole.saver || echo "FAILED: $mode"
 done
@@ -148,6 +148,41 @@ unoptimised build spends over a second in it.
 | `slow` | a listener that accepts and never answers | the same, plus ≥3 connection attempts in 34 s — i.e. the load timed out and retried instead of hanging on `URLRequest`'s 60 s default |
 | `preview` | none (`isPreview: true`) | the bundled asset draws, and no `WKWebView` is built for a tile |
 | `resize` | the real console (7788, or `SAVER_HARNESS_PORT`) | after a late growth: `webView.frame == view.bounds`, the page's own `innerWidth`×`innerHeight` equals those bounds, and none of five edge samples is black (#6871) |
+| `stop` | the same never-answering listener | `stopAnimation()` returns inside 500 ms and the listener sees **zero** further connections for 20 s — twice, once with a load in flight and once from inside a render tick (#6900) |
+
+### Stop path (#6900)
+
+`loginwindow` stops the screen-saver host and waits for it before handing the
+display to the unlock UI, so anything the view still does after the stop is time
+the operator spends waiting instead of touching the sensor. The owner's report
+was Touch ID not being offered; the unified log showed the stop request landing
+at 18:35:26 and the saver still loading the console four minutes later.
+
+`stopAnimation()` was never slow — it returns in about 0.2 ms on both the fixed
+and the unfixed bundle. It simply did not stop the view. It set
+`state = .offline`, which is the state `scheduleRetryTimer` reads as "keep
+trying", left the navigation delegate attached, and then navigated to
+`about:blank` over an in-flight console load. WebKit reported that cancellation,
+`enterOffline` re-armed the retry timer the stop had just invalidated, and the
+loop sustained itself from there.
+
+So the mode measures traffic, not latency, and the budget is only a guard
+against a future change putting a blocking wait into the stop path:
+
+```
+# unfixed bundle
+PAINT: in-flight stop: stopAnimation() returned in 0.2ms
+PAINT: in-flight stop: connection attempts after the stop: 2
+PAINT: FAIL — in-flight stop: kept loading the console after the stop — 2 connection attempt(s), expected 0
+
+# fixed bundle
+PAINT: in-flight stop: connection attempts after the stop: 0
+PAINT: PASS — stop
+```
+
+Between the two stops the mode calls `startAnimation()` again and requires a
+fresh connection, so the terminal `.stopped` state cannot be sticky — a wake
+that does not unlock stops and re-arms the saver, and that view has to load.
 
 ### Frame size (#6871)
 

--- a/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
+++ b/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
@@ -16,8 +16,9 @@
 // Test: `LoadHarness.swift` in this directory resolves the principal class,
 //   instantiates the view outside the screen-saver host and asserts `didFinish`
 //   fires; `PaintHarness.swift` reads the rendered bitmap in the offline,
-//   slow-daemon and preview states and tracks the web view's frame across a
-//   late host resize in the `resize` state. The in-host run is manual — see
+//   slow-daemon and preview states, tracks the web view's frame across a late
+//   host resize in the `resize` state, and in the `stop` state asserts the host's
+//   stop request is honoured at once (#6900). The in-host run is manual — see
 //   README.md, "Manual verification".
 //
 // Two constraints below are load-tested spike findings, not preference:
@@ -101,6 +102,12 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         case live
         case offline
         case preview
+        /// #6900: the host has asked the saver to stop. Terminal until the next
+        /// `startAnimation()` — nothing may start a load, arm a retry, or put
+        /// the web view back on screen from here. `.offline` cannot serve this
+        /// purpose because it is the state [`scheduleRetryTimer`] reads as
+        /// "keep trying".
+        case stopped
     }
 
     /// How long one load attempt may run before it counts as a failure.
@@ -214,6 +221,12 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         // already the preview and never an unpainted view.
         needsDisplay = true
         guard state != .preview else { return }
+        // #6900: leaving `.stopped` is this method's job alone. A host that
+        // stops the saver and re-arms it — a wake that does not unlock — has to
+        // get a loading view back, and the navigation delegate `stopAnimation()`
+        // detached on the way out has to come back with it.
+        state = .offline
+        webView?.navigationDelegate = self
         loadConsole()
         scheduleReloadTimer()
     }
@@ -252,7 +265,30 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         needsDisplay = true
     }
 
+    /// Why: `loginwindow` asks the screen-saver host to stop and then waits for
+    ///   it before handing the display to the unlock UI, so whatever this view
+    ///   is still doing after the stop delays Touch ID at unlock (#6900). Before
+    ///   #6900 the stop set `state = .offline` — the exact state
+    ///   [`scheduleRetryTimer`] reads as "keep trying" — while leaving the
+    ///   navigation delegate attached and the in-flight console load running.
+    ///   The `about:blank` navigation below then superseded that load, WebKit
+    ///   delivered the cancellation to [`webView(_:didFailProvisionalNavigation:withError:)`],
+    ///   and [`enterOffline`] re-armed the retry timer the stop had just
+    ///   invalidated. From there the loop sustained itself: retry, load,
+    ///   watchdog, retry. The saver went on loading the console for four
+    ///   minutes after being told to stop.
+    /// What: enters the terminal `.stopped` state, cancels the in-flight load,
+    ///   and detaches the delegate BEFORE navigating away, so a late WebKit
+    ///   callback reaches nothing. Every timer callback and delegate method
+    ///   refuses to act in `.stopped`, and only `startAnimation()` leaves it.
+    ///   Returns synchronously; the elapsed time is logged so a real unlock can
+    ///   be measured against #6900's 500 ms bar without instrumenting the host.
+    /// Test: `PaintHarness.swift`'s `stop` mode asserts the call returns inside
+    ///   that budget and that no connection reaches the console afterwards —
+    ///   both for a stop that lands on an in-flight load and for one that lands
+    ///   inside a render tick.
     public override func stopAnimation() {
+        let startedAt = Date()
         super.stopAnimation()
         retryTimer?.invalidate()
         retryTimer = nil
@@ -262,29 +298,42 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         loadTimer = nil
         offlineSince = nil
         guard state != .preview else { return }
+        // #6900: the state flip comes FIRST. Everything below can hand control
+        // back to WebKit, and every re-entry guard in this file reads `.stopped`.
+        state = .stopped
+        // #6900: detach before cancelling. A superseded provisional navigation
+        // is delivered to the delegate, and on the way out of the saver that
+        // callback must have nothing to re-arm.
+        webView?.navigationDelegate = nil
+        webView?.stopLoading()
+        webView?.isHidden = true
         // about:blank tears down the SPA, which stops its metrics polling. Without
         // this the console keeps being polled by an off-screen saver.
         if let blank = URL(string: "about:blank") {
             webView?.load(URLRequest(url: blank))
         }
-        webView?.isHidden = true
-        state = .offline
-        os_log("stopAnimation — navigated away", log: saverLog, type: .info)
+        // `.default` rather than `.info`: this is the number #6900's acceptance
+        // is stated in, and `log show` has to still carry it after an unlock.
+        os_log("stopAnimation — stopped in %{public}@ms", log: saverLog, type: .default,
+               String(format: "%.1f", Date().timeIntervalSince(startedAt) * 1000))
     }
 
     /// Why: the fallback has to render even when no web view exists (preview) or the
     ///   web view is hidden (offline), and a transparent screen saver is
     ///   indistinguishable from a crashed one.
     /// What: fills the Foundry dark background, then draws the bundled dashboard
-    ///   render unless the live page is on screen — dimmed and banner-stamped
-    ///   while offline, so a photograph of numbers is never mistaken for live
-    ///   ones (#6839). Falls back to the text wordmark if the asset is missing.
-    /// Test: `PaintHarness.swift`, all three modes.
+    ///   render unless the live page is on screen — dimmed while offline, and
+    ///   banner-stamped there, so a photograph of numbers is never mistaken for
+    ///   live ones (#6839). #6900's `.stopped` takes the same dimming for the
+    ///   same reason and NOT the banner, which says "retrying" and would be
+    ///   false after the host's stop. Only the gallery tile draws at full
+    ///   brightness. Falls back to the text wordmark if the asset is missing.
+    /// Test: `PaintHarness.swift`, all modes.
     public override func draw(_ rect: NSRect) {
         Foundry.background.setFill()
         rect.fill()
         guard state != .live else { return }
-        guard drawPreviewAsset(fraction: state == .offline ? Self.offlineAssetFraction : 1) else {
+        guard drawPreviewAsset(fraction: state == .preview ? 1 : Self.offlineAssetFraction) else {
             drawWordmark()
             return
         }
@@ -297,7 +346,9 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     // MARK: - Loading
 
     private func loadConsole() {
-        guard let webView else { return }
+        // #6900: no load is started after the host's stop, whichever timer or
+        // callback got here.
+        guard let webView, state != .stopped else { return }
         os_log("loading %{public}@", log: saverLog, type: .info, config.url.absoluteString)
         var request = URLRequest(url: config.url)
         request.cachePolicy = .reloadIgnoringLocalCacheData
@@ -344,8 +395,12 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     /// What: one-shot rather than repeating, rescheduled per attempt, so the
     ///   cadence can widen: [`fastRetryInterval`] for the first
     ///   [`fastRetryWindow`] of an outage, then [`slowRetryInterval`].
-    ///   Invalidating first makes two stacked timers unreachable.
-    /// Test: `PaintHarness.swift`'s `slow` mode.
+    ///   Invalidating first makes two stacked timers unreachable. The fired
+    ///   closure reloads only in `.offline`, which is what keeps `.stopped`
+    ///   terminal (#6900) — a timer already in flight when the host stops runs
+    ///   out and reloads nothing.
+    /// Test: `PaintHarness.swift`'s `slow` mode; `stop` mode for the `.stopped`
+    ///   half.
     private func scheduleRetryTimer() {
         retryTimer?.invalidate()
         let downFor = offlineSince.map { Date().timeIntervalSince($0) } ?? 0
@@ -359,6 +414,14 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     }
 
     private func enterOffline(_ reason: String) {
+        // #6900: a callback that lands after the host's stop must not put the
+        // view back into the retrying state the stop just left. This is the
+        // exact re-entry that kept the saver loading for four minutes past
+        // `loginwindow`'s stop request.
+        guard state != .stopped else {
+            os_log("ignored after stop — %{public}@", log: saverLog, type: .info, reason)
+            return
+        }
         state = .offline
         webView?.isHidden = true
         loadTimer?.invalidate()
@@ -491,6 +554,9 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     // MARK: - WKNavigationDelegate
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // #6900: a load that finishes after the host's stop must not unhide the
+        // web view or take the view out of `.stopped`.
+        guard state != .stopped else { return }
         // stopAnimation()'s teardown navigation also lands here; treating it as a
         // successful console load would put a blank page on screen.
         guard webView.url?.absoluteString != "about:blank" else { return }


### PR DESCRIPTION
Refs #6900

`stopAnimation()` returned in 0.2 ms but set `state = .offline`, the state the retry machinery reads as "keep trying". The superseded in-flight navigation reached the still-attached delegate → `enterOffline` → `scheduleRetryTimer` → `loadConsole` → watchdog → `enterOffline`, unbounded, so the saver kept loading the console for minutes while loginwindow waited on it. Adds a terminal `.stopped` state that only `startAnimation()` leaves; `stopAnimation()` flips state first, detaches the navigation delegate, calls `stopLoading()`, then navigates away; re-entry guards on `loadConsole`, `enterOffline`, `didFinish`; `draw(_:)` dims in `.stopped`. Matches #6841's log evidence.

Test ladder rung 5. PaintHarness `stop` mode (new): on origin/main 2 connection attempts after the stop (FAIL); after the fix 0 (PASS), both in-flight and mid-render. offline/preview ink numbers byte-identical to #6838/#6839. `cargo test -p trusty-console --no-fail-fast` 428 passed, 0 failed, 4 ignored plus 10 other targets ok; fmt/check/clippy clean; line-cap, changelog-fragment, test-pointers OK.

Live check needs an owner-attended `.saver` install and a Touch ID unlock with `log stream` running; not done in this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
