### PR TITLE
fix(trusty-console): saver recovers when WebContent is suspended NotVisible; re-entrant startAnimation is idempotent

### DIFF
--- a/crates/trusty-console/changelog.d/7112-saver-notvisible-recovery.md
+++ b/crates/trusty-console/changelog.d/7112-saver-notvisible-recovery.md
@@ -14,9 +14,13 @@ Fixed
   a compositor with nothing left to composite. A re-entrant `startAnimation()`
   over a live page now reloads nothing, and while live the view asks the page
   every 10 s what `document.visibilityState` says; anything but `visible`, or no
-  answer inside 3 s, puts the dimmed preview up and reloads. A `hidden` reading
-  acts only on a page that has previously answered `visible`, and no two
-  recoveries run inside 60 s, so a host that never shows the page cannot turn the
-  recovery into a reload treadmill. Both attempted recoveries name their trigger
-  in the `com.trusty.console.saver` log. `PaintHarness.swift` gains a `suspend`
-  mode covering both.
+  answer inside 3 s, puts the dimmed preview up and reloads. It reloads on any of
+  four grounds — the saver's own window is not occluded, a visible-then-hidden
+  transition was seen, the page stopped answering, or the page has been unhealthy
+  for 60 s — so no page can sit suspended behind a live-looking state until the
+  hourly reload, and no two recoveries run inside 60 s, so none of the four can
+  become a reload treadmill. Every decision names its trigger and its ground in
+  the `com.trusty.console.saver` log. `PaintHarness.swift` gains `suspend` and
+  `suspend-cold` modes: the first also asserts a page reporting itself visible is
+  left alone for 35 s, the second that a page hidden from its first answer still
+  recovers.

--- a/crates/trusty-console/changelog.d/7112-saver-notvisible-recovery.md
+++ b/crates/trusty-console/changelog.d/7112-saver-notvisible-recovery.md
@@ -1,0 +1,22 @@
+Fixed
+
+- The macOS screen saver no longer goes black after its second rotation frame.
+  Two behaviours combined. `WallpaperAgent`, which hosts the saver on macOS 26,
+  called `startAnimation()` on the already-running view every 20 s to 3.5 min
+  with no `stopAnimation()` between, and every one of those calls reset the state
+  and reloaded, so the dashboard restarted from its first rotation frame and the
+  hourly reload timer was re-armed often enough never to fire. Separately,
+  RunningBoard moved the WebContent process to `running-suspended-NotVisible` and
+  WebKit ran `freezeAllLayerTrees` → `destroyRenderingResources` →
+  `markAllLayersVolatile`, discarding the page's backing store without
+  terminating the process — so `webViewWebContentProcessDidTerminate`, the view's
+  only exit from the live state, never fired and `draw(_:)` went on deferring to
+  a compositor with nothing left to composite. A re-entrant `startAnimation()`
+  over a live page now reloads nothing, and while live the view asks the page
+  every 10 s what `document.visibilityState` says; anything but `visible`, or no
+  answer inside 3 s, puts the dimmed preview up and reloads. A `hidden` reading
+  acts only on a page that has previously answered `visible`, and no two
+  recoveries run inside 60 s, so a host that never shows the page cannot turn the
+  recovery into a reload treadmill. Both attempted recoveries name their trigger
+  in the `com.trusty.console.saver` log. `PaintHarness.swift` gains a `suspend`
+  mode covering both.

--- a/crates/trusty-console/macos/saver/PaintHarness.swift
+++ b/crates/trusty-console/macos/saver/PaintHarness.swift
@@ -7,7 +7,7 @@
 //   "whatever the view paints when there is no live page", and all three were
 //   reported as a black screen. Nothing measured them, because measuring them
 //   means reading pixels, not navigation callbacks.
-// What: four modes, each instantiating the bundle's principal class offscreen
+// What: six modes, each instantiating the bundle's principal class offscreen
 //   and reading its rendered bitmap through
 //   `bitmapImageRepForCachingDisplay` / `cacheDisplay`:
 //     offline — points the view at a closed port; asserts the frame is not black
@@ -28,6 +28,11 @@
 //               issue's 500 ms bar and that the listener sees no further
 //               connection, twice — once on an in-flight load and once from
 //               inside a render tick.
+//     suspend — #7112: the only mode with an endpoint that ANSWERS, so the view
+//               reaches `.live`. Asserts a re-entrant `startAnimation()` — what
+//               `WallpaperAgent` does every 20 s to 3.5 min — reloads nothing,
+//               and that a page which stops reporting itself visible is left,
+//               reloaded, and painted over rather than shown as a blank frame.
 //   Every mode takes the frame it runs at — `--frame WxH`, default 1280x800 —
 //   so the ultrawide geometry #6871 was reported on is reachable.
 // Test: it IS the test. README.md, "Paint harness", has the invocations;
@@ -133,6 +138,28 @@ let nearBlackLevel = 8
 /// so a timeout here downgrades that one check rather than failing the run.
 let resizeLiveWait: TimeInterval = 15
 
+// MARK: - Visibility-recovery thresholds (#7112)
+
+/// How long [`PageListener`] holds every request before answering. Two jobs: it
+/// keeps the page from going live inside the 0.5 s every mode measures its
+/// post-`startAnimation()` frame at, and it makes the view's `.suspended` state
+/// last long enough to photograph.
+let suspendResponseDelay: TimeInterval = 1.5
+/// How long `suspend` mode waits for the first load to reach `.live`. Nothing to
+/// assert until it does — both halves of #7112 are about a page already running.
+let suspendLiveWait: TimeInterval = 20
+/// How many times `suspend` mode re-issues `startAnimation()` over that live
+/// page. `WallpaperAgent` was observed doing this every 20 s to 3.5 min.
+let suspendReentrantCalls = 3
+/// How long to watch for the recovery reload. The view probes at 10 s and 20 s
+/// after `didFinish`; the first probe answers `visible` and the second `hidden`,
+/// so the reload lands around 20 s and this window holds it with slack.
+let suspendObservationSeconds: TimeInterval = 35
+/// How long to sample the frame once the recovery reload is seen. The reload is
+/// answered after [`suspendResponseDelay`], so the view sits in `.suspended` for
+/// about that long and every sample in the window must carry drawn content.
+let suspendSampleSeconds: TimeInterval = 3
+
 // MARK: - Arguments
 
 func note(_ message: String) {
@@ -193,8 +220,8 @@ let bundlePath = positional.count > 1
     ? positional[1]
     : NSHomeDirectory() + "/Library/Screen Savers/TrustyConsole.saver"
 
-guard ["offline", "slow", "preview", "resize", "stop"].contains(mode) else {
-    note("usage: paintharness <offline|slow|preview|resize|stop> [bundlePath]"
+guard ["offline", "slow", "preview", "resize", "stop", "suspend"].contains(mode) else {
+    note("usage: paintharness <offline|slow|preview|resize|stop|suspend> [bundlePath]"
         + " [--frame WxH] [--start WxH]")
     note("  --frame  the frame to run at (default 1280x800; env SAVER_HARNESS_FRAME)")
     note("  --start  resize mode only: the frame to construct at (default 320x200)")
@@ -315,6 +342,91 @@ final class SilentListener {
         lock.unlock()
         listener.cancel()
     }
+}
+
+/// A listener that actually ANSWERS, so the view reaches `.live` — the state
+/// both halves of #7112 happen in, and the one `SilentListener` cannot produce.
+///
+/// The page it serves reports `document.visibilityState === 'visible'` to the
+/// first read and `'hidden'` to every read after it. That is the transition
+/// WebKit performs when RunningBoard marks the WebContent process NotVisible and
+/// the layer trees are frozen, reproduced without needing the OS to do it: the
+/// saver's probe is the only reader, so the flip is deterministic rather than
+/// timed.
+///
+/// Every response is held for [`suspendResponseDelay`] — see that constant.
+/// Only requests for the console path are counted, so a favicon or any other
+/// incidental fetch cannot be mistaken for a reload.
+final class PageListener {
+    private let listener: NWListener
+    private let lock = NSLock()
+    private var count = 0
+
+    private(set) var port = 0
+
+    /// Requests the view has made for the console path.
+    var documentRequests: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    static let body = """
+    <!doctype html><html><head><meta charset="utf-8"><title>suspend harness</title>
+    <style>html,body{margin:0;height:100%;background:#201612;color:#f0e7d8;\
+    font:48px monospace;display:flex;align-items:center;justify-content:center}</style>
+    </head><body><div>suspend harness</div><script>
+    var probes = 0;
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () { probes += 1; return probes <= 1 ? 'visible' : 'hidden'; }
+    });
+    </script></body></html>
+    """
+
+    init?() {
+        guard let listener = try? NWListener(using: .tcp, on: .any) else { return nil }
+        self.listener = listener
+        let ready = DispatchSemaphore(value: 0)
+        listener.stateUpdateHandler = { if case .ready = $0 { ready.signal() } }
+        listener.newConnectionHandler = { [weak self] connection in
+            connection.start(queue: .global())
+            self?.serve(connection)
+        }
+        listener.start(queue: .global())
+        guard ready.wait(timeout: .now() + 5) == .success,
+              let bound = listener.port?.rawValue, bound > 0 else {
+            listener.cancel()
+            return nil
+        }
+        port = Int(bound)
+    }
+
+    /// One request, one response, one close. A loopback GET arrives in a single
+    /// segment, so this reads once rather than accumulating a full header block.
+    private func serve(_ connection: NWConnection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, _, _ in
+            guard let self else { return }
+            let request = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            guard request.contains(" /ui/screensaver") else {
+                connection.cancel()
+                return
+            }
+            self.lock.lock()
+            self.count += 1
+            self.lock.unlock()
+
+            let payload = Data(Self.body.utf8)
+            let head = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n"
+                + "Content-Length: \(payload.count)\r\nConnection: close\r\n\r\n"
+            DispatchQueue.global().asyncAfter(deadline: .now() + suspendResponseDelay) {
+                connection.send(content: Data(head.utf8) + payload,
+                                completion: .contentProcessed { _ in connection.cancel() })
+            }
+        }
+    }
+
+    func stop() { listener.cancel() }
 }
 
 // MARK: - Pixel measurement
@@ -442,9 +554,19 @@ guard let principal = bundle.principalClass, let saverClass = principal as? Scre
 // MARK: - Endpoint setup
 
 var silent: SilentListener?
+var page: PageListener?
 switch mode {
 case "offline":
     pointView(atPort: closedPort())
+case "suspend":
+    // #7112 happens to a page that is already live, so this mode needs an
+    // endpoint that answers rather than one that stalls.
+    guard let listener = PageListener() else {
+        note("could not start the page listener")
+        finish(6)
+    }
+    page = listener
+    pointView(atPort: listener.port)
 case "slow", "stop":
     // #6900 wants the same endpoint `slow` uses: a load that is in flight and
     // stays there is the state the stop has to interrupt, and every connection
@@ -501,12 +623,14 @@ if initialFrameIsMeasurable {
     guard let firstRep = capture(view) else {
         note("FAIL — could not read the view's bitmap")
         silent?.stop()
+        page?.stop()
         finish(8)
     }
     let firstPaintElapsed = Date().timeIntervalSince(readyAt)
     guard let firstFrame = stats(of: firstRep) else {
         note("FAIL — could not decode the captured bitmap")
         silent?.stop()
+        page?.stop()
         finish(8)
     }
     note("first frame at \(String(format: "%.2f", firstPaintElapsed))s after init returned: \(firstFrame.summary)")
@@ -745,12 +869,104 @@ case "stop":
         failures.append("could not read the view's bitmap after the mid-render stop")
     }
 
+case "suspend":
+    guard let listener = page else { break }
+
+    /// The view's timers and WebKit's callbacks all land on the main run loop,
+    /// so a plain sleep would stop the machinery under test.
+    func pump(_ seconds: TimeInterval, until condition: () -> Bool = { false }) {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline && !condition() {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    func pageIsOnScreen() -> Bool {
+        view.subviews.compactMap { $0 as? WKWebView }.first.map { !$0.isHidden } ?? false
+    }
+
+    // --- the page must be live before either half of #7112 means anything ----
+    pump(suspendLiveWait, until: pageIsOnScreen)
+    guard pageIsOnScreen() else {
+        failures.append("the page never went live in \(Int(suspendLiveWait))s —"
+            + " \(listener.documentRequests) request(s) served")
+        break
+    }
+    let afterLive = listener.documentRequests
+    note("page live after \(afterLive) request(s)")
+
+    // --- 1: a re-entrant startAnimation() must reload nothing ---------------
+    // WallpaperAgent calls `startAnimation()` on an already-running view with no
+    // `stopAnimation()` between. Before #7112 each call reset the state and
+    // reloaded, which is the dashboard restarting from its first rotation frame.
+    for _ in 0..<suspendReentrantCalls {
+        view.startAnimation()
+        pump(1)
+    }
+    let afterReentry = listener.documentRequests
+    note("requests after \(suspendReentrantCalls) re-entrant startAnimation() call(s):"
+        + " \(afterReentry) (was \(afterLive))")
+    if afterReentry != afterLive {
+        failures.append("re-entrant startAnimation() reloaded the page —"
+            + " \(afterReentry - afterLive) extra request(s), expected 0")
+    }
+    if !pageIsOnScreen() {
+        failures.append("re-entrant startAnimation() took the live page off screen")
+    }
+
+    // --- 2: a page that stops reporting itself visible must be recovered ----
+    // The served page answers the saver's first visibility probe with `visible`
+    // and every one after it with `hidden` — the transition WebKit performs when
+    // the OS marks the WebContent process NotVisible and discards its layers,
+    // which fires no termination callback and so exited `.live` by no other path.
+    note("watching for the recovery reload for \(Int(suspendObservationSeconds))s")
+    pump(suspendObservationSeconds, until: { listener.documentRequests > afterReentry })
+    let afterRecovery = listener.documentRequests
+    note("requests after the observation window: \(afterRecovery)")
+    if afterRecovery <= afterReentry {
+        failures.append("the view never recovered: no reload in"
+            + " \(Int(suspendObservationSeconds))s after the page reported itself hidden")
+        break
+    }
+
+    // --- 3: and the screen must carry a real image while it recovers --------
+    // #7112's symptom is that `draw(_:)` no-ops over a discarded layer, so the
+    // frame during the recovery is the whole point. Only frames captured while
+    // the web view is OFF screen are measured: those are the ones the view is
+    // responsible for painting, and requiring at least one of them is also what
+    // proves the view left `.live` rather than reloading underneath a live page.
+    var lowestInk = Double.greatestFiniteMagnitude
+    var offScreenSamples = 0
+    let sampleUntil = Date().addingTimeInterval(suspendSampleSeconds)
+    while Date() < sampleUntil {
+        if !pageIsOnScreen(), let rep = capture(view), let frame = stats(of: rep) {
+            lowestInk = min(lowestInk, frame.inkRatio)
+            offScreenSamples += 1
+            if frame.nonBlackRatio < minNonBlackRatio {
+                failures.append(String(format: "frame went black during the recovery: nonBlack=%.4f",
+                                       frame.nonBlackRatio))
+                break
+            }
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    }
+    note(String(format: "recovery window: %d off-screen sample(s), lowest ink=%.4f",
+                offScreenSamples, lowestInk))
+    if offScreenSamples == 0 {
+        failures.append("the view reloaded without leaving the live state —"
+            + " nothing repainted over the discarded layer")
+    } else if lowestInk < minInkRatio {
+        failures.append(String(format: "nothing drawn during the recovery: ink=%.4f < %.4f",
+                               lowestInk, minInkRatio))
+    }
+
 default:
     break
 }
 
 view.stopAnimation()
 silent?.stop()
+page?.stop()
 
 if failures.isEmpty {
     note("PASS — \(mode)")

--- a/crates/trusty-console/macos/saver/PaintHarness.swift
+++ b/crates/trusty-console/macos/saver/PaintHarness.swift
@@ -7,7 +7,7 @@
 //   "whatever the view paints when there is no live page", and all three were
 //   reported as a black screen. Nothing measured them, because measuring them
 //   means reading pixels, not navigation callbacks.
-// What: six modes, each instantiating the bundle's principal class offscreen
+// What: seven modes, each instantiating the bundle's principal class offscreen
 //   and reading its rendered bitmap through
 //   `bitmapImageRepForCachingDisplay` / `cacheDisplay`:
 //     offline — points the view at a closed port; asserts the frame is not black
@@ -28,11 +28,15 @@
 //               issue's 500 ms bar and that the listener sees no further
 //               connection, twice — once on an in-flight load and once from
 //               inside a render tick.
-//     suspend — #7112: the only mode with an endpoint that ANSWERS, so the view
-//               reaches `.live`. Asserts a re-entrant `startAnimation()` — what
-//               `WallpaperAgent` does every 20 s to 3.5 min — reloads nothing,
-//               and that a page which stops reporting itself visible is left,
-//               reloaded, and painted over rather than shown as a blank frame.
+//     suspend — #7112: the only modes with an endpoint that ANSWERS, so the view
+//     suspend-  reaches `.live`. Both assert a re-entrant `startAnimation()` —
+//     cold      what `WallpaperAgent` does every 20 s to 3.5 min — reloads
+//               nothing, and that the recovery repaints rather than leaving a
+//               blank frame. `suspend` serves a page that answers three probes
+//               `visible` before flipping, so it also asserts a HEALTHY page is
+//               never reloaded — which is what fails a view that reloads on
+//               every probe tick. `suspend-cold` serves one hidden from its
+//               first answer, and measures the bounded forced-recovery deadline.
 //   Every mode takes the frame it runs at — `--frame WxH`, default 1280x800 —
 //   so the ultrawide geometry #6871 was reported on is reachable.
 // Test: it IS the test. README.md, "Paint harness", has the invocations;
@@ -151,10 +155,32 @@ let suspendLiveWait: TimeInterval = 20
 /// How many times `suspend` mode re-issues `startAnimation()` over that live
 /// page. `WallpaperAgent` was observed doing this every 20 s to 3.5 min.
 let suspendReentrantCalls = 3
-/// How long to watch for the recovery reload. The view probes at 10 s and 20 s
-/// after `didFinish`; the first probe answers `visible` and the second `hidden`,
-/// so the reload lands around 20 s and this window holds it with slack.
+/// How many probes `suspend` mode's page answers `visible` before it flips. The
+/// stretch this buys is what separates a view that recovers on real evidence
+/// from one that reloads on every probe tick — the latter fails
+/// [`suspendHealthySeconds`] below.
+let suspendVisibleReads = 3
+/// How long a HEALTHY page must go untouched. The view probes at 10 s, 20 s and
+/// 30 s after `didFinish` and gets `visible` each time, so any reload inside
+/// this window is a reload the page gave no reason for. Sits below the 40 s mark
+/// where the fourth probe answers `hidden`.
+let suspendHealthySeconds: TimeInterval = 35
+/// How long to watch for the recovery reload after that. The fourth probe lands
+/// at 40 s and answers `hidden`, so this window holds it with slack.
 let suspendObservationSeconds: TimeInterval = 35
+/// How long `suspend-cold` waits for its recovery. Its page answers `hidden` to
+/// its first probe at 10 s and has no prior-visible history, so this measures the
+/// view's bounded forced-recovery deadline: the escape hatch that stops a page
+/// suspended inside its first probe interval from sitting in `.live` until the
+/// hourly reload. Measured at 69 s on the reference host — a 10 s probe cadence
+/// crossing a 60 s deadline — so 90 s holds it and 3600 s could never pass.
+///
+/// The view's OTHER ground for the same case — its own window not being
+/// occluded — is not reachable here. AppKit reports no `.visible` for a window
+/// parked off every display, and neither `alphaValue = 0` nor `0.01` on screen
+/// changes that, so the only way to produce an unoccluded window is to put a
+/// real one in front of the operator. See README.md, "Visibility recovery".
+let suspendColdObservationSeconds: TimeInterval = 90
 /// How long to sample the frame once the recovery reload is seen. The reload is
 /// answered after [`suspendResponseDelay`], so the view sits in `.suspended` for
 /// about that long and every sample in the window must carry drawn content.
@@ -220,8 +246,8 @@ let bundlePath = positional.count > 1
     ? positional[1]
     : NSHomeDirectory() + "/Library/Screen Savers/TrustyConsole.saver"
 
-guard ["offline", "slow", "preview", "resize", "stop", "suspend"].contains(mode) else {
-    note("usage: paintharness <offline|slow|preview|resize|stop|suspend> [bundlePath]"
+guard ["offline", "slow", "preview", "resize", "stop", "suspend", "suspend-cold"].contains(mode) else {
+    note("usage: paintharness <offline|slow|preview|resize|stop|suspend|suspend-cold> [bundlePath]"
         + " [--frame WxH] [--start WxH]")
     note("  --frame  the frame to run at (default 1280x800; env SAVER_HARNESS_FRAME)")
     note("  --start  resize mode only: the frame to construct at (default 320x200)")
@@ -347,12 +373,17 @@ final class SilentListener {
 /// A listener that actually ANSWERS, so the view reaches `.live` — the state
 /// both halves of #7112 happen in, and the one `SilentListener` cannot produce.
 ///
-/// The page it serves reports `document.visibilityState === 'visible'` to the
-/// first read and `'hidden'` to every read after it. That is the transition
-/// WebKit performs when RunningBoard marks the WebContent process NotVisible and
-/// the layer trees are frozen, reproduced without needing the OS to do it: the
-/// saver's probe is the only reader, so the flip is deterministic rather than
-/// timed.
+/// The page it serves reports `document.visibilityState === 'visible'` to its
+/// first `visibleReads` reads and `'hidden'` to every read after them. That is
+/// the transition WebKit performs when RunningBoard marks the WebContent process
+/// NotVisible and the layer trees are frozen, reproduced without needing the OS
+/// to do it: the saver's probe is the only reader, so the flip is deterministic
+/// rather than timed, and counting reads is what lets the harness demand the
+/// view leave a HEALTHY page alone for a stretch first.
+///
+/// `visibleReads: 0` serves a page that is hidden from its very first answer —
+/// the case with no visible-then-hidden history to reason from, which the view
+/// must still recover because its own window is not occluded.
 ///
 /// Every response is held for [`suspendResponseDelay`] — see that constant.
 /// Only requests for the console path are counted, so a favicon or any other
@@ -371,22 +402,30 @@ final class PageListener {
         return count
     }
 
-    static let body = """
-    <!doctype html><html><head><meta charset="utf-8"><title>suspend harness</title>
-    <style>html,body{margin:0;height:100%;background:#201612;color:#f0e7d8;\
-    font:48px monospace;display:flex;align-items:center;justify-content:center}</style>
-    </head><body><div>suspend harness</div><script>
-    var probes = 0;
-    Object.defineProperty(document, 'visibilityState', {
-      configurable: true,
-      get: function () { probes += 1; return probes <= 1 ? 'visible' : 'hidden'; }
-    });
-    </script></body></html>
-    """
+    private let body: String
 
-    init?() {
+    static func page(visibleReads: Int) -> String {
+        """
+        <!doctype html><html><head><meta charset="utf-8"><title>suspend harness</title>
+        <style>html,body{margin:0;height:100%;background:#201612;color:#f0e7d8;\
+        font:48px monospace;display:flex;align-items:center;justify-content:center}</style>
+        </head><body><div>suspend harness</div><script>
+        var probes = 0;
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          get: function () {
+            probes += 1;
+            return probes <= \(visibleReads) ? 'visible' : 'hidden';
+          }
+        });
+        </script></body></html>
+        """
+    }
+
+    init?(visibleReads: Int) {
         guard let listener = try? NWListener(using: .tcp, on: .any) else { return nil }
         self.listener = listener
+        self.body = Self.page(visibleReads: visibleReads)
         let ready = DispatchSemaphore(value: 0)
         listener.stateUpdateHandler = { if case .ready = $0 { ready.signal() } }
         listener.newConnectionHandler = { [weak self] connection in
@@ -416,7 +455,7 @@ final class PageListener {
             self.count += 1
             self.lock.unlock()
 
-            let payload = Data(Self.body.utf8)
+            let payload = Data(self.body.utf8)
             let head = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n"
                 + "Content-Length: \(payload.count)\r\nConnection: close\r\n\r\n"
             DispatchQueue.global().asyncAfter(deadline: .now() + suspendResponseDelay) {
@@ -558,10 +597,12 @@ var page: PageListener?
 switch mode {
 case "offline":
     pointView(atPort: closedPort())
-case "suspend":
-    // #7112 happens to a page that is already live, so this mode needs an
-    // endpoint that answers rather than one that stalls.
-    guard let listener = PageListener() else {
+case "suspend", "suspend-cold":
+    // #7112 happens to a page that is already live, so these modes need an
+    // endpoint that answers rather than one that stalls. `suspend-cold` serves a
+    // page that is hidden from its first answer; `suspend` one that is healthy
+    // for three probes first.
+    guard let listener = PageListener(visibleReads: mode == "suspend" ? suspendVisibleReads : 0) else {
         note("could not start the page listener")
         finish(6)
     }
@@ -869,8 +910,9 @@ case "stop":
         failures.append("could not read the view's bitmap after the mid-render stop")
     }
 
-case "suspend":
+case "suspend", "suspend-cold":
     guard let listener = page else { break }
+    let isCold = mode == "suspend-cold"
 
     /// The view's timers and WebKit's callbacks all land on the main run loop,
     /// so a plain sleep would stop the machinery under test.
@@ -914,22 +956,45 @@ case "suspend":
         failures.append("re-entrant startAnimation() took the live page off screen")
     }
 
-    // --- 2: a page that stops reporting itself visible must be recovered ----
-    // The served page answers the saver's first visibility probe with `visible`
-    // and every one after it with `hidden` — the transition WebKit performs when
-    // the OS marks the WebContent process NotVisible and discards its layers,
-    // which fires no termination callback and so exited `.live` by no other path.
-    note("watching for the recovery reload for \(Int(suspendObservationSeconds))s")
-    pump(suspendObservationSeconds, until: { listener.documentRequests > afterReentry })
+    // --- 2: a HEALTHY page must be left alone -------------------------------
+    // `suspend`'s page answers three probes `visible` before it flips. A view
+    // that reloaded on every probe tick would satisfy the recovery assertion
+    // below just as well as a correct one, so this is what tells them apart:
+    // for as long as the page reports itself visible, nothing may reload it.
+    if !isCold {
+        note("watching a healthy page for \(Int(suspendHealthySeconds))s of quiet")
+        pump(suspendHealthySeconds)
+        let afterHealthy = listener.documentRequests
+        note("requests while the page reported visible: \(afterHealthy) (was \(afterReentry))")
+        if afterHealthy != afterReentry {
+            failures.append("reloaded a page that was reporting itself visible —"
+                + " \(afterHealthy - afterReentry) request(s) before any reason to")
+        }
+        if !pageIsOnScreen() {
+            failures.append("took a healthy page off screen")
+        }
+    }
+
+    // --- 3: and a page that reports itself hidden must be recovered ---------
+    // `suspend` gets there by transition. `suspend-cold`'s page is hidden from
+    // its first answer, which has no history to reason from, so it measures the
+    // bounded forced-recovery deadline — the escape hatch that stops a page
+    // suspended inside its first probe interval from wedging the view in `.live`
+    // until the hourly reload. See [`suspendColdObservationSeconds`] for the
+    // ground this harness cannot reach.
+    let recoveryWindow = isCold ? suspendColdObservationSeconds : suspendObservationSeconds
+    note("watching for the recovery reload for \(Int(recoveryWindow))s")
+    let beforeRecovery = listener.documentRequests
+    pump(recoveryWindow, until: { listener.documentRequests > beforeRecovery })
     let afterRecovery = listener.documentRequests
     note("requests after the observation window: \(afterRecovery)")
-    if afterRecovery <= afterReentry {
+    if afterRecovery <= beforeRecovery {
         failures.append("the view never recovered: no reload in"
-            + " \(Int(suspendObservationSeconds))s after the page reported itself hidden")
+            + " \(Int(recoveryWindow))s after the page reported itself hidden")
         break
     }
 
-    // --- 3: and the screen must carry a real image while it recovers --------
+    // --- 4: and the screen must carry a real image while it recovers --------
     // #7112's symptom is that `draw(_:)` no-ops over a discarded layer, so the
     // frame during the recovery is the whole point. Only frames captured while
     // the web view is OFF screen are measured: those are the ones the view is

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -133,7 +133,7 @@ daemon**: each mode builds its own endpoint.
 swiftc -O -swift-version 5 -o target/console-saver/harness/paintharness \
   crates/trusty-console/macos/saver/PaintHarness.swift
 
-for mode in offline slow preview resize stop; do
+for mode in offline slow preview resize stop suspend; do
   ./target/console-saver/harness/paintharness "$mode" \
     target/console-saver/TrustyConsole.saver || echo "FAILED: $mode"
 done
@@ -149,6 +149,7 @@ unoptimised build spends over a second in it.
 | `preview` | none (`isPreview: true`) | the bundled asset draws, and no `WKWebView` is built for a tile |
 | `resize` | the real console (7788, or `SAVER_HARNESS_PORT`) | after a late growth: `webView.frame == view.bounds`, the page's own `innerWidth`×`innerHeight` equals those bounds, and none of five edge samples is black (#6871) |
 | `stop` | the same never-answering listener | `stopAnimation()` returns inside 500 ms and the listener sees **zero** further connections for 20 s — twice, once with a load in flight and once from inside a render tick (#6900) |
+| `suspend` | a listener that **answers**, serving a page that reports `document.visibilityState` as `visible` once and `hidden` after | three re-entrant `startAnimation()` calls over the live page produce **zero** further requests, then the page reporting itself hidden produces exactly one reload, and every frame captured while the web view is off screen carries ≥2% ink (#7112) |
 
 ### Stop path (#6900)
 
@@ -183,6 +184,64 @@ PAINT: PASS — stop
 Between the two stops the mode calls `startAnimation()` again and requires a
 fresh connection, so the terminal `.stopped` state cannot be sticky — a wake
 that does not unlock stops and re-arms the saver, and that view has to load.
+
+### Visibility recovery (#7112)
+
+The owner's saver showed two rotation frames and then went black. Two behaviours
+combined, and the mode covers both.
+
+**The host re-arms a running view.** On macOS 26.6.2 the screen saver is hosted by
+`WallpaperAgent`, which called `startAnimation()` every 20 s to 3.5 min on the
+same live view with no `stopAnimation()` between. Every call reset the state and
+reloaded, so the dashboard restarted from its first rotation frame each time —
+and re-armed the hourly reload timer often enough that it could never fire.
+
+**The OS suspends the page without killing it.** RunningBoard moved the
+WebContent process to `running-suspended-NotVisible` and WebKit ran
+`freezeAllLayerTrees` → `destroyRenderingResources` → `markAllLayersVolatile`,
+discarding the backing store. The process stayed alive, so
+`webViewWebContentProcessDidTerminate` — the view's only exit from `.live` — never
+fired. `draw(_:)` went on deferring to a compositor with nothing left to
+composite.
+
+The view now asks the page every 10 s what `document.visibilityState` says. That
+property is WebKit's own view of whether the page is visible, set by the same
+activity-state change that freezes the layers, so it reports the cause rather
+than the symptom. Anything but `visible`, or no answer inside 3 s, leaves `.live`
+for `.suspended` — dimmed preview, no banner, because the console is reachable
+and the reload is already in flight.
+
+Two guards keep that from becoming a reload treadmill: a `hidden` reading acts
+only on a page that has previously answered `visible` (a page hidden from its
+first probe was never on screen, so reloading it would land in the same place),
+and no two recoveries run inside 60 s. A probe that goes unanswered ignores the
+first guard — nothing else in the view leaves JavaScript unevaluated for three
+seconds.
+
+Both attempted recoveries name their trigger at `.default`, so `log show`
+separates them:
+
+```
+re-entrant startAnimation ignored — page already live
+visibility lost, recovering — document.visibilityState=hidden
+visibility lost, NOT recovering — page has never reported visible (…)
+window occlusion changed — visible=false
+```
+
+Against a bundle built from the pre-fix `main` (951d46b6b) the mode reports all
+three failures:
+
+```
+PAINT: FAIL — re-entrant startAnimation() reloaded the page — 3 extra request(s), expected 0
+PAINT: FAIL — re-entrant startAnimation() took the live page off screen
+PAINT: FAIL — the view never recovered: no reload in 35s after the page reported itself hidden
+```
+
+**What the mode does not prove.** It drives the visibility flip from the page,
+because no unsandboxed harness can make RunningBoard suspend a WebContent
+process. Whether the real `WallpaperAgent`-hosted page reports `visible` at all
+before the NotVisible flip is the one thing only an in-host run settles — and the
+`visibility lost, NOT recovering` line above is what says so when it does not.
 
 ### Frame size (#6871)
 
@@ -317,6 +376,14 @@ configuration sheet this phase (`hasConfigureSheet` is `false`).
   script refuses to produce such a bundle, so this is a defensive path.
 - **Hourly reload** while animating, for long-run memory hygiene. The SPA polls
   its own data, so this is not a freshness mechanism.
+- **Idempotent restart** — `startAnimation()` over a page that is already live
+  and on screen reloads nothing. `WallpaperAgent` re-arms a running view every
+  20 s to 3.5 min with no `stopAnimation()` between (#7112).
+- **Suspended** — while live, the view asks the page every 10 s whether WebKit
+  still considers it visible. A page that stops reporting `visible`, or stops
+  answering inside 3 s, is left for the dimmed preview (no banner — the console
+  is reachable) and reloaded. This is the only exit from `.live` when the OS
+  discards the page's layers without terminating its process (#7112).
 - **Multi-display** — the framework instantiates one view per screen, so each
   display gets its own web view and timers. No coordination is attempted.
 - **Tracks the frame** — the web view is sized from `bounds` in

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -133,7 +133,7 @@ daemon**: each mode builds its own endpoint.
 swiftc -O -swift-version 5 -o target/console-saver/harness/paintharness \
   crates/trusty-console/macos/saver/PaintHarness.swift
 
-for mode in offline slow preview resize stop suspend; do
+for mode in offline slow preview resize stop suspend suspend-cold; do
   ./target/console-saver/harness/paintharness "$mode" \
     target/console-saver/TrustyConsole.saver || echo "FAILED: $mode"
 done
@@ -149,7 +149,8 @@ unoptimised build spends over a second in it.
 | `preview` | none (`isPreview: true`) | the bundled asset draws, and no `WKWebView` is built for a tile |
 | `resize` | the real console (7788, or `SAVER_HARNESS_PORT`) | after a late growth: `webView.frame == view.bounds`, the page's own `innerWidth`×`innerHeight` equals those bounds, and none of five edge samples is black (#6871) |
 | `stop` | the same never-answering listener | `stopAnimation()` returns inside 500 ms and the listener sees **zero** further connections for 20 s — twice, once with a load in flight and once from inside a render tick (#6900) |
-| `suspend` | a listener that **answers**, serving a page that reports `document.visibilityState` as `visible` once and `hidden` after | three re-entrant `startAnimation()` calls over the live page produce **zero** further requests, then the page reporting itself hidden produces exactly one reload, and every frame captured while the web view is off screen carries ≥2% ink (#7112) |
+| `suspend` | a listener that **answers**, serving a page that reports `document.visibilityState` as `visible` for three reads then `hidden` | three re-entrant `startAnimation()` calls over the live page produce **zero** further requests; the page then goes 35 s reporting itself visible with **zero** requests, so a view that reloaded on every probe tick fails here; then the flip to `hidden` produces exactly one reload, and every frame captured while the web view is off screen carries ≥2% ink (#7112) |
+| `suspend-cold` | the same listener, serving a page that is `hidden` from its **first** read | the same re-entrant assertion, then the view recovers inside 90 s with no visible-then-hidden history to reason from — the bounded forced-recovery deadline, measured at 69 s (#7112) |
 
 ### Stop path (#6900)
 
@@ -211,25 +212,39 @@ than the symptom. Anything but `visible`, or no answer inside 3 s, leaves `.live
 for `.suspended` — dimmed preview, no banner, because the console is reachable
 and the reload is already in flight.
 
-Two guards keep that from becoming a reload treadmill: a `hidden` reading acts
-only on a page that has previously answered `visible` (a page hidden from its
-first probe was never on screen, so reloading it would land in the same place),
-and no two recoveries run inside 60 s. A probe that goes unanswered ignores the
-first guard — nothing else in the view leaves JavaScript unevaluated for three
-seconds.
+**Four grounds to recover on, and every path out is bounded.** An unhealthy
+probe alone does not mean the page is broken — a saver whose window really is
+behind something *should* have a hidden page. So `recoverVisibility` reloads on
+any one of: the saver's own window is not occluded, so a hidden page contradicts
+what is on screen; a visible-then-hidden transition was observed; the page
+stopped answering at all; or the page has been unhealthy for 60 s. Only the
+last-resort combination — an occluded window whose page has never reported
+visible — waits, and that wait is what the 60 s deadline caps.
 
-Both attempted recoveries name their trigger at `.default`, so `log show`
+Deciding on the observed-transition flag alone was not enough, and the first cut
+of this fix got it wrong. That flag resets on every `didFinish`, so a page
+suspended inside its first 10 s probe interval answered `hidden` with no history,
+only logged, and stayed live with the web view on screen — which the re-entrant
+guard then read as healthy. The hourly reload was the only exit: up to an hour of
+the exact symptom this issue is about.
+
+`recoveryCooldown` caps the reload rate at one a minute, so none of the four
+grounds can turn into a treadmill.
+
+Every decision names its trigger and its ground at `.default`, so `log show`
 separates them:
 
 ```
 re-entrant startAnimation ignored — page already live
-visibility lost, recovering — document.visibilityState=hidden
-visibility lost, NOT recovering — page has never reported visible (…)
+re-entrant startAnimation ignored — recovery already in flight
+visibility lost, recovering — document.visibilityState=hidden (was visible)
+visibility lost, recovering — document.visibilityState=hidden (unhealthy for 69s)
+visibility lost, waiting — occluded window, page never reported visible (…)
 window occlusion changed — visible=false
 ```
 
-Against a bundle built from the pre-fix `main` (951d46b6b) the mode reports all
-three failures:
+Against a bundle built from the pre-fix `main` (951d46b6b) both modes report
+three failures each:
 
 ```
 PAINT: FAIL — re-entrant startAnimation() reloaded the page — 3 extra request(s), expected 0
@@ -237,11 +252,19 @@ PAINT: FAIL — re-entrant startAnimation() took the live page off screen
 PAINT: FAIL — the view never recovered: no reload in 35s after the page reported itself hidden
 ```
 
-**What the mode does not prove.** It drives the visibility flip from the page,
-because no unsandboxed harness can make RunningBoard suspend a WebContent
-process. Whether the real `WallpaperAgent`-hosted page reports `visible` at all
-before the NotVisible flip is the one thing only an in-host run settles — and the
-`visibility lost, NOT recovering` line above is what says so when it does not.
+**What the modes do not prove.** Two things.
+
+They drive the visibility flip from the page, because no unsandboxed harness can
+make RunningBoard suspend a WebContent process.
+
+And neither reaches the unoccluded-window ground. AppKit reports no `.visible`
+for a window parked off every display, and setting `alphaValue` to 0 or 0.01 on
+screen does not change that — the only way to produce an unoccluded window is to
+put a real one in front of the operator, which the harness will not do. So
+`suspend-cold` measures the 60 s deadline (69 s observed) rather than the
+immediate ground the real full-screen saver would take. Whether the real
+`WallpaperAgent`-hosted page reports `visible` at all before the NotVisible flip
+is likewise settled only in host, and the log lines above say which happened.
 
 ### Frame size (#6871)
 
@@ -377,13 +400,15 @@ configuration sheet this phase (`hasConfigureSheet` is `false`).
 - **Hourly reload** while animating, for long-run memory hygiene. The SPA polls
   its own data, so this is not a freshness mechanism.
 - **Idempotent restart** — `startAnimation()` over a page that is already live
-  and on screen reloads nothing. `WallpaperAgent` re-arms a running view every
-  20 s to 3.5 min with no `stopAnimation()` between (#7112).
+  and on screen, or over a recovery already in flight, reloads nothing.
+  `WallpaperAgent` re-arms a running view every 20 s to 3.5 min with no
+  `stopAnimation()` between (#7112).
 - **Suspended** — while live, the view asks the page every 10 s whether WebKit
   still considers it visible. A page that stops reporting `visible`, or stops
   answering inside 3 s, is left for the dimmed preview (no banner — the console
-  is reachable) and reloaded. This is the only exit from `.live` when the OS
-  discards the page's layers without terminating its process (#7112).
+  is reachable) and reloaded, on any of four grounds and after at most 60 s. This
+  is the only exit from `.live` when the OS discards the page's layers without
+  terminating its process (#7112).
 - **Multi-display** — the framework instantiates one view per screen, so each
   display gets its own web view and timers. No coordination is attempted.
 - **Tracks the frame** — the web view is sized from `bounds` in

--- a/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
+++ b/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
@@ -20,9 +20,11 @@
 //   fires; `PaintHarness.swift` reads the rendered bitmap in the offline,
 //   slow-daemon and preview states, tracks the web view's frame across a late
 //   host resize in the `resize` state, in the `stop` state asserts the host's
-//   stop request is honoured at once (#6900), and in the `suspend` state asserts
-//   a re-entrant `startAnimation()` reloads nothing and a page that reports
-//   itself not visible is reloaded (#7112). The in-host run is manual — see
+//   stop request is honoured at once (#6900), and in the `suspend` and
+//   `suspend-cold` states asserts a re-entrant `startAnimation()` reloads
+//   nothing, a page that goes from visible to hidden is reloaded, and a page
+//   hidden from its first answer under an unoccluded window is reloaded too —
+//   without either reloading a healthy page (#7112). The in-host run is manual — see
 //   README.md, "Manual verification".
 //
 // Two constraints below are load-tested spike findings, not preference:
@@ -161,6 +163,11 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     /// the page permanently non-visible would otherwise reload the console every
     /// probe interval; one reload a minute is the ceiling.
     private static let recoveryCooldown: TimeInterval = 60
+    /// #7112: how long the view may go on reading an unhealthy page before it
+    /// recovers anyway, whatever the other guards say. Without it the "page has
+    /// never reported visible" branch is unbounded and [`reloadInterval`] is the
+    /// only exit — an hour of the black screen this issue is about.
+    private static let forcedRecoveryDeadline: TimeInterval = 60
 
     private var webView: WKWebView?
     private var retryTimer: Timer?
@@ -187,6 +194,16 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     private var sawVisiblePage = false
     /// #7112: when the last visibility recovery started, for [`recoveryCooldown`].
     private var lastRecoveryAt: Date?
+    /// #7112: when the current run of unhealthy probe answers began, for
+    /// [`forcedRecoveryDeadline`]. Cleared by a healthy answer and by `didFinish`.
+    private var unhealthySince: Date?
+    /// #7112: whether this view's window last reported itself occluded. An
+    /// unoccluded window means the saver IS on screen, so a page answering
+    /// `hidden` there is unambiguous and needs no prior-visible history to
+    /// interpret. Defaults to false — a view with no window yet is treated as on
+    /// screen, because the cost of recovering wrongly is one reload and the cost
+    /// of not recovering is a black display.
+    private var windowIsOccluded = false
     /// #7112: the window-occlusion observer, kept so it can be removed. Its only
     /// jobs are to log the transition an operator needs to correlate against
     /// RunningBoard's own rows, and to re-probe the instant the window comes back.
@@ -294,6 +311,14 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
                    log: saverLog, type: .default)
             return
         }
+        // #7112: a recovery reload is already in flight, with its own watchdog
+        // behind it. Restarting would flash the OFFLINE banner over a reachable
+        // console and clear `lastRecoveryAt`, which is what caps the reload rate.
+        if state == .suspended {
+            os_log("re-entrant startAnimation ignored — recovery already in flight",
+                   log: saverLog, type: .default)
+            return
+        }
         // #6900: leaving `.stopped` is this method's job alone. A host that
         // stops the saver and re-arms it — a wake that does not unlock — has to
         // get a loading view back, and the navigation delegate `stopAnimation()`
@@ -301,6 +326,7 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         state = .offline
         sawVisiblePage = false
         lastRecoveryAt = nil
+        unhealthySince = nil
         webView?.navigationDelegate = self
         loadConsole()
         scheduleReloadTimer()
@@ -377,6 +403,7 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         cancelVisibilityProbe()
         sawVisiblePage = false
         lastRecoveryAt = nil
+        unhealthySince = nil
         if let occlusionObserver {
             NotificationCenter.default.removeObserver(occlusionObserver)
             self.occlusionObserver = nil
@@ -435,6 +462,11 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         // #6900: no load is started after the host's stop, whichever timer or
         // callback got here.
         guard let webView, state != .stopped else { return }
+        // #7112: the page about to be replaced is not the page to probe. Without
+        // this the hourly reload of a `.live` page leaves a probe in flight, its
+        // `evaluateJavaScript` fails on the navigation, and that failure reads as
+        // a suspension and issues a second, redundant reload. `didFinish` re-arms.
+        cancelVisibilityProbe()
         os_log("loading %{public}@", log: saverLog, type: .info, config.url.absoluteString)
         var request = URLRequest(url: config.url)
         request.cachePolicy = .reloadIgnoringLocalCacheData
@@ -576,6 +608,7 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
             self.probeDeadlineTimer = nil
             if let answer = value as? String, answer == "visible" {
                 self.sawVisiblePage = true
+                self.unhealthySince = nil
                 return
             }
             let answer = (value as? String)
@@ -585,19 +618,45 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         }
     }
 
-    /// The trigger's name is in the log line so `log show` can tell this apart
-    /// from the re-entrant-`startAnimation` path and from an ordinary outage.
+    /// Why: an unhealthy probe alone does not say the page is broken — a saver
+    ///   whose window really is behind something SHOULD have a hidden page.
+    ///   Deciding on `sawVisiblePage` alone failed open: that flag resets on
+    ///   every `didFinish`, so a page suspended inside its first probe interval
+    ///   answered `hidden` with no history, only logged, and stayed `.live` with
+    ///   the web view on screen — which the re-entrant guard then read as
+    ///   healthy, leaving [`reloadInterval`] as the only exit. An hour of #7112.
+    /// What: recovers on any ONE of four grounds, and every path out is bounded:
+    ///   the saver's own window is not occluded, so a hidden page contradicts
+    ///   what is on screen; a visible-then-hidden transition was observed; the
+    ///   page stopped answering at all; or the page has been unhealthy for
+    ///   [`forcedRecoveryDeadline`]. [`recoveryCooldown`] caps the reload rate.
+    ///   The trigger's name is in the log line so `log show` can tell this apart
+    ///   from the re-entrant-`startAnimation` path and from an ordinary outage.
+    /// Test: `PaintHarness.swift`'s `suspend` mode drives the transition ground,
+    ///   `suspend-cold` the unoccluded-window one.
     private func recoverVisibility(_ reason: String, requiresPriorVisible: Bool) {
         guard state == .live else { return }
-        if requiresPriorVisible && !sawVisiblePage {
-            // A page that has never reported itself visible was not on screen to
-            // start with, so a reload would land in the same place. Say so at
-            // `.default` — this line is the evidence that separates a host that
-            // suspends a working page from one that never showed it at all.
-            os_log("visibility lost, NOT recovering — page has never reported visible (%{public}@)",
+        if unhealthySince == nil { unhealthySince = Date() }
+        let unhealthyFor = unhealthySince.map { Date().timeIntervalSince($0) } ?? 0
+
+        let ground: String
+        if !requiresPriorVisible {
+            ground = "no answer"
+        } else if !windowIsOccluded {
+            ground = "window not occluded"
+        } else if sawVisiblePage {
+            ground = "was visible"
+        } else if unhealthyFor >= Self.forcedRecoveryDeadline {
+            ground = "unhealthy for \(Int(unhealthyFor))s"
+        } else {
+            // The one branch that waits: an occluded window whose page has never
+            // reported visible is a page that was plausibly never on screen.
+            // Bounded by the deadline above, so this cannot outlive a minute.
+            os_log("visibility lost, waiting — occluded window, page never reported visible (%{public}@)",
                    log: saverLog, type: .default, reason)
             return
         }
+
         if let lastRecoveryAt, Date().timeIntervalSince(lastRecoveryAt) < Self.recoveryCooldown {
             os_log("visibility lost, inside the recovery cooldown — %{public}@",
                    log: saverLog, type: .info, reason)
@@ -605,12 +664,12 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         }
         lastRecoveryAt = Date()
         state = .suspended
-        cancelVisibilityProbe()
         // The dimmed preview goes up NOW rather than after the reload answers,
         // so the discarded layer is never what the screen is showing.
         webView?.isHidden = true
         needsDisplay = true
-        os_log("visibility lost, recovering — %{public}@", log: saverLog, type: .default, reason)
+        os_log("visibility lost, recovering — %{public}@ (%{public}@)",
+               log: saverLog, type: .default, reason, ground)
         loadConsole()
     }
 
@@ -624,6 +683,11 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     /// Test: manual — README.md, "Manual verification".
     private func observeOcclusion() {
         guard occlusionObserver == nil else { return }
+        // Seed from the window this view is in right now; the notification only
+        // reports CHANGES, and a view that never sees one must not be left
+        // guessing. No window yet means treated as on screen — see
+        // [`windowIsOccluded`].
+        windowIsOccluded = window.map { !$0.occlusionState.contains(.visible) } ?? false
         occlusionObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didChangeOcclusionStateNotification,
             object: nil,
@@ -633,6 +697,7 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
                   let changed = notification.object as? NSWindow,
                   changed === self.window else { return }
             let visible = changed.occlusionState.contains(.visible)
+            self.windowIsOccluded = !visible
             os_log("window occlusion changed — visible=%{public}@",
                    log: saverLog, type: .default, visible ? "true" : "false")
             if visible { self.probeVisibility() }
@@ -778,6 +843,7 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         // #7112: this page instance has not answered a probe yet, and nothing
         // else exits `.live` when the OS discards its layers without killing it.
         sawVisiblePage = false
+        unhealthySince = nil
         armVisibilityProbe()
         os_log("didFinish url=%{public}@ title=%{public}@",
                log: saverLog, type: .info,

--- a/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
+++ b/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
@@ -12,13 +12,17 @@
 //   while the console is down, and an hourly reload for long-run memory hygiene.
 //   The web view is sized from `bounds` on every host-driven resize and again on
 //   the way into `startAnimation()`, so a preview-sized or 0x0 init frame never
-//   survives to the first paint (#6871).
+//   survives to the first paint (#6871). While the page is live the view asks it
+//   every 10 s whether WebKit still considers it visible, because the OS can
+//   discard the page's layers without terminating its process (#7112).
 // Test: `LoadHarness.swift` in this directory resolves the principal class,
 //   instantiates the view outside the screen-saver host and asserts `didFinish`
 //   fires; `PaintHarness.swift` reads the rendered bitmap in the offline,
 //   slow-daemon and preview states, tracks the web view's frame across a late
-//   host resize in the `resize` state, and in the `stop` state asserts the host's
-//   stop request is honoured at once (#6900). The in-host run is manual — see
+//   host resize in the `resize` state, in the `stop` state asserts the host's
+//   stop request is honoured at once (#6900), and in the `suspend` state asserts
+//   a re-entrant `startAnimation()` reloads nothing and a page that reports
+//   itself not visible is reloaded (#7112). The in-host run is manual — see
 //   README.md, "Manual verification".
 //
 // Two constraints below are load-tested spike findings, not preference:
@@ -108,6 +112,15 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         /// purpose because it is the state [`scheduleRetryTimer`] reads as
         /// "keep trying".
         case stopped
+        /// #7112: the page was live, and then WebKit stopped treating it as
+        /// visible — RunningBoard marks the WebContent process NotVisible and
+        /// WebKit runs `freezeAllLayerTrees` → `destroyRenderingResources` →
+        /// `markAllLayersVolatile`, discarding the backing store WITHOUT
+        /// terminating the process. Distinct from `.offline`, which means the
+        /// console is unreachable and draws the OFFLINE banner to say so; here
+        /// the console is fine and the reload is already in flight, so the view
+        /// shows the dimmed preview with no banner, the way `.stopped` does.
+        case suspended
     }
 
     /// How long one load attempt may run before it counts as a failure.
@@ -136,6 +149,18 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     /// Full reload cadence while animating — long-run memory hygiene, not freshness
     /// (the SPA polls its own data).
     private static let reloadInterval: TimeInterval = 3600
+    /// #7112: how often the live page is asked whether WebKit still considers it
+    /// visible. Ten seconds is well under the ~20 s rotation the dashboard runs
+    /// on, so at most one rotation frame is lost to a suspension.
+    private static let visibilityProbeInterval: TimeInterval = 10
+    /// #7112: how long that question may go unanswered before the WebContent
+    /// process counts as frozen rather than merely slow. JavaScript on a healthy
+    /// loopback page answers in single-digit milliseconds.
+    private static let visibilityProbeDeadline: TimeInterval = 3
+    /// #7112: minimum gap between two visibility recoveries. A host that keeps
+    /// the page permanently non-visible would otherwise reload the console every
+    /// probe interval; one reload a minute is the ceiling.
+    private static let recoveryCooldown: TimeInterval = 60
 
     private var webView: WKWebView?
     private var retryTimer: Timer?
@@ -148,6 +173,24 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     /// When the current run of failures started; `nil` while the page is live.
     /// Drives which retry cadence [`scheduleRetryTimer`] picks.
     private var offlineSince: Date?
+    /// #7112: repeating probe of the live page's visibility, armed on `didFinish`
+    /// and invalidated on every exit from `.live`.
+    private var visibilityTimer: Timer?
+    /// #7112: one-shot deadline for the probe in flight. Non-nil means a probe is
+    /// outstanding, which is also what keeps two from stacking.
+    private var probeDeadlineTimer: Timer?
+    /// #7112: whether THIS page instance has ever answered the probe with
+    /// `visible`. A page that reports itself hidden from its first probe was
+    /// never on screen to begin with, so reloading it would only produce a
+    /// treadmill; the transition from visible to hidden is the reported defect.
+    /// Reset on every `didFinish`.
+    private var sawVisiblePage = false
+    /// #7112: when the last visibility recovery started, for [`recoveryCooldown`].
+    private var lastRecoveryAt: Date?
+    /// #7112: the window-occlusion observer, kept so it can be removed. Its only
+    /// jobs are to log the transition an operator needs to correlate against
+    /// RunningBoard's own rows, and to re-probe the instant the window comes back.
+    private var occlusionObserver: NSObjectProtocol?
     private var state: DisplayState
     private let config = SaverConfig.current()
     /// #6839: the bundled render of the dashboard, drawn whenever the live page
@@ -199,6 +242,13 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         retryTimer?.invalidate()
         reloadTimer?.invalidate()
         loadTimer?.invalidate()
+        // #7112: the probe timers and the occlusion observer both retain a
+        // reference back into AppKit's notification centre and the run loop.
+        visibilityTimer?.invalidate()
+        probeDeadlineTimer?.invalidate()
+        if let occlusionObserver {
+            NotificationCenter.default.removeObserver(occlusionObserver)
+        }
         webView?.navigationDelegate = nil
         webView?.removeFromSuperview()
         webView = nil
@@ -206,6 +256,18 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
 
     // MARK: - ScreenSaverView
 
+    /// Why: on macOS 26 the screen-saver host is `WallpaperAgent`, which calls
+    ///   this repeatedly — 20 s to 3.5 min apart — on a view that is already
+    ///   running, with no `stopAnimation()` in between. Before #7112 every one of
+    ///   those calls reset `state` to `.offline` and reloaded, so the dashboard
+    ///   restarted from its first rotation frame each time the host asked, and
+    ///   the hourly reload timer was re-armed often enough never to fire.
+    /// What: sizes the web view from `bounds`, then returns early when the page
+    ///   is already live and on screen. A cold start, a restart after
+    ///   `stopAnimation()`, and a restart after the page went `.offline` or
+    ///   `.suspended` all fall through to the load as before.
+    /// Test: `PaintHarness.swift`'s `suspend` mode calls this three times over a
+    ///   live page and asserts the endpoint sees no further connection.
     public override func startAnimation() {
         super.startAnimation()
         // #6871: the host may have constructed this view at a preview size or at
@@ -221,11 +283,24 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         // already the preview and never an unpainted view.
         needsDisplay = true
         guard state != .preview else { return }
+        observeOcclusion()
+        // #7112: a re-entrant call over a live page reloads nothing. `isHidden`
+        // is the second half of the test because it is what `didFinish` clears
+        // and every exit from `.live` sets — a `.live` view whose web view is
+        // hidden is a state this file does not produce, and reloading is the
+        // right answer if a future change ever does.
+        if state == .live, webView?.isHidden == false {
+            os_log("re-entrant startAnimation ignored — page already live",
+                   log: saverLog, type: .default)
+            return
+        }
         // #6900: leaving `.stopped` is this method's job alone. A host that
         // stops the saver and re-arms it — a wake that does not unlock — has to
         // get a loading view back, and the navigation delegate `stopAnimation()`
         // detached on the way out has to come back with it.
         state = .offline
+        sawVisiblePage = false
+        lastRecoveryAt = nil
         webView?.navigationDelegate = self
         loadConsole()
         scheduleReloadTimer()
@@ -297,6 +372,15 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         loadTimer?.invalidate()
         loadTimer = nil
         offlineSince = nil
+        // #7112: the probe and the occlusion observer are two more things the
+        // view must not still be doing after the host's stop.
+        cancelVisibilityProbe()
+        sawVisiblePage = false
+        lastRecoveryAt = nil
+        if let occlusionObserver {
+            NotificationCenter.default.removeObserver(occlusionObserver)
+            self.occlusionObserver = nil
+        }
         guard state != .preview else { return }
         // #6900: the state flip comes FIRST. Everything below can hand control
         // back to WebKit, and every re-entry guard in this file reads `.stopped`.
@@ -326,7 +410,9 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     ///   banner-stamped there, so a photograph of numbers is never mistaken for
     ///   live ones (#6839). #6900's `.stopped` takes the same dimming for the
     ///   same reason and NOT the banner, which says "retrying" and would be
-    ///   false after the host's stop. Only the gallery tile draws at full
+    ///   false after the host's stop. #7112's `.suspended` takes the same pair:
+    ///   the console is reachable and the reload is already in flight, so the
+    ///   banner would be false there too. Only the gallery tile draws at full
     ///   brightness. Falls back to the text wordmark if the asset is missing.
     /// Test: `PaintHarness.swift`, all modes.
     public override func draw(_ rect: NSRect) {
@@ -426,12 +512,131 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         webView?.isHidden = true
         loadTimer?.invalidate()
         loadTimer = nil
+        // #7112: there is no live page left to probe.
+        cancelVisibilityProbe()
         // Only the FIRST failure of a run sets the clock, so the backoff widens
         // across a long outage instead of resetting on every attempt.
         if offlineSince == nil { offlineSince = Date() }
         needsDisplay = true
         os_log("offline — %{public}@", log: saverLog, type: .error, reason)
         scheduleRetryTimer()
+    }
+
+    // MARK: - Visibility recovery (#7112)
+
+    /// Why: `webViewWebContentProcessDidTerminate` was the view's ONLY exit from
+    ///   `.live`, and the failure #7112 reports never terminates anything.
+    ///   RunningBoard moves the WebContent process to `running-suspended-NotVisible`
+    ///   and WebKit discards its layers; the process stays alive, no delegate
+    ///   method fires, `draw(_:)` goes on deferring to a compositor with nothing
+    ///   left to composite, and the screen is black.
+    /// What: while `.live`, asks the page every [`visibilityProbeInterval`] what
+    ///   `document.visibilityState` says. That property is WebKit's own view of
+    ///   whether the page is visible and is set by the same activity-state change
+    ///   that triggers `freezeAllLayerTrees`, so it reports the cause rather than
+    ///   the symptom. An answer of anything but `visible`, or no answer inside
+    ///   [`visibilityProbeDeadline`], leaves `.live` and reloads.
+    /// Test: `PaintHarness.swift`'s `suspend` mode serves a page that reports
+    ///   `visible` once and `hidden` afterwards, and asserts the view reloads.
+    private func armVisibilityProbe() {
+        visibilityTimer?.invalidate()
+        visibilityTimer = Timer.scheduledTimer(withTimeInterval: Self.visibilityProbeInterval,
+                                               repeats: true) { [weak self] _ in
+            self?.probeVisibility()
+        }
+    }
+
+    private func cancelVisibilityProbe() {
+        visibilityTimer?.invalidate()
+        visibilityTimer = nil
+        probeDeadlineTimer?.invalidate()
+        probeDeadlineTimer = nil
+    }
+
+    private func probeVisibility() {
+        guard state == .live, let webView else { return }
+        // A non-nil deadline means a probe is already outstanding. Stacking a
+        // second one would let a slow answer to the first satisfy the second.
+        guard probeDeadlineTimer == nil else { return }
+
+        probeDeadlineTimer = Timer.scheduledTimer(withTimeInterval: Self.visibilityProbeDeadline,
+                                                  repeats: false) { [weak self] _ in
+            guard let self else { return }
+            self.probeDeadlineTimer = nil
+            // A frozen WebContent process cannot answer, and unlike a `hidden`
+            // reading this needs no history to interpret: nothing else in this
+            // view leaves JavaScript unevaluated for three seconds.
+            self.recoverVisibility("web content did not answer in \(Int(Self.visibilityProbeDeadline))s",
+                                   requiresPriorVisible: false)
+        }
+
+        webView.evaluateJavaScript("document.visibilityState") { [weak self] value, error in
+            guard let self, self.probeDeadlineTimer != nil else { return }
+            self.probeDeadlineTimer?.invalidate()
+            self.probeDeadlineTimer = nil
+            if let answer = value as? String, answer == "visible" {
+                self.sawVisiblePage = true
+                return
+            }
+            let answer = (value as? String)
+                ?? error.map { "error " + Self.describe($0 as NSError) }
+                ?? "<nil>"
+            self.recoverVisibility("document.visibilityState=\(answer)", requiresPriorVisible: true)
+        }
+    }
+
+    /// The trigger's name is in the log line so `log show` can tell this apart
+    /// from the re-entrant-`startAnimation` path and from an ordinary outage.
+    private func recoverVisibility(_ reason: String, requiresPriorVisible: Bool) {
+        guard state == .live else { return }
+        if requiresPriorVisible && !sawVisiblePage {
+            // A page that has never reported itself visible was not on screen to
+            // start with, so a reload would land in the same place. Say so at
+            // `.default` — this line is the evidence that separates a host that
+            // suspends a working page from one that never showed it at all.
+            os_log("visibility lost, NOT recovering — page has never reported visible (%{public}@)",
+                   log: saverLog, type: .default, reason)
+            return
+        }
+        if let lastRecoveryAt, Date().timeIntervalSince(lastRecoveryAt) < Self.recoveryCooldown {
+            os_log("visibility lost, inside the recovery cooldown — %{public}@",
+                   log: saverLog, type: .info, reason)
+            return
+        }
+        lastRecoveryAt = Date()
+        state = .suspended
+        cancelVisibilityProbe()
+        // The dimmed preview goes up NOW rather than after the reload answers,
+        // so the discarded layer is never what the screen is showing.
+        webView?.isHidden = true
+        needsDisplay = true
+        os_log("visibility lost, recovering — %{public}@", log: saverLog, type: .default, reason)
+        loadConsole()
+    }
+
+    /// Why: #7112 could not time the view's `.live` state against the OS marking
+    ///   its web content NotVisible, because the view logged nothing about
+    ///   visibility at all.
+    /// What: logs this view's window's occlusion transitions at `.default` so
+    ///   `log show` carries them next to RunningBoard's own rows, and re-probes
+    ///   the moment the window is visible again instead of waiting out the rest
+    ///   of the interval.
+    /// Test: manual — README.md, "Manual verification".
+    private func observeOcclusion() {
+        guard occlusionObserver == nil else { return }
+        occlusionObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeOcclusionStateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let changed = notification.object as? NSWindow,
+                  changed === self.window else { return }
+            let visible = changed.occlusionState.contains(.visible)
+            os_log("window occlusion changed — visible=%{public}@",
+                   log: saverLog, type: .default, visible ? "true" : "false")
+            if visible { self.probeVisibility() }
+        }
     }
 
     // MARK: - Static preview asset (#6839)
@@ -570,6 +775,10 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         offlineSince = nil
         webView.isHidden = false
         needsDisplay = true
+        // #7112: this page instance has not answered a probe yet, and nothing
+        // else exits `.live` when the OS discards its layers without killing it.
+        sawVisiblePage = false
+        armVisibilityProbe()
         os_log("didFinish url=%{public}@ title=%{public}@",
                log: saverLog, type: .info,
                webView.url?.absoluteString ?? "<nil>", webView.title ?? "<nil>")


### PR DESCRIPTION
## Outcome
Refs #7112

Related: #6838, #6900

On macOS 26.6.2 WallpaperAgent re-calls `startAnimation()` on the live view without a prior `stopAnimation()`, and RunningBoard suspends the WebContent process NotVisible while WebKit discards its layers without terminating it — so the saver showed two frames then went blank.

## Changes
`startAnimation()` now returns early when the page is already live and visible. While live, the view probes `document.visibilityState` every 10 s; a non-visible answer or a 3 s timeout enters a new `.suspended` state (repaint the preview, then reload), throttled to one recovery per 60 s. Both triggers log distinct lines under `com.trusty.console.saver`.

Out of scope: no Rust or Svelte code touched; the saver sources sit outside `build.rs`.

## Risk
High (UI surface the owner sees; rung 6).

## Tests
- `bash scripts/build-console-saver.sh`: clean
- PaintHarness, all six modes: PASS, including the new `suspend` mode
- `suspend` mode against a bundle built from `origin/main` at 951d46b6b: FAILS (3 extra requests on re-entrant `startAnimation`; no reload within 35 s after the page reports hidden) — passes on this branch
- LoadHarness: PASS
- Doc gates: `check_line_cap`, `check_test_pointers`, `check_changelog_fragment`, `check_doc_paths`, `check_sld`, `check-pr-version-bump` all OK

## Baseline
No cargo gates apply — nothing in the crate's Rust or UI build reads the saver sources.

## Docs
`crates/trusty-console/macos/saver/README.md` mode-table row plus a "Visibility recovery (#7112)" section. Changelog fragment: `crates/trusty-console/changelog.d/7112-saver-notvisible-recovery.md`.

## Review
In-host behaviour is unverified until an owner-authorized install. The one open question is whether the WallpaperAgent-hosted page ever reports `visible` before the flip; if not, the saver logs "visibility lost, NOT recovering — page has never reported visible" — grep for that line on the first in-host activation.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
