### PR TITLE
fix(trusty-console): saver display name reads "Trusty Console" in System Settings

### DIFF
--- a/crates/trusty-console/changelog.d/7128-saver-display-name.md
+++ b/crates/trusty-console/changelog.d/7128-saver-display-name.md
@@ -1,0 +1,8 @@
+Changed
+- The screen saver's tile in System Settings > Screen Saver > Other reads
+  `Trusty Console` instead of `TrustyConsole`. The bundle's `Info.plist` now
+  sets `CFBundleDisplayName` and `CFBundleName` to the spaced form; the bundle
+  identifier `com.trusty.console.saver`, the `TrustyConsole.saver` filename, the
+  `CFBundleExecutable` and the principal class are unchanged, so launchd, the
+  `log` subsystem predicate and Settings' selected-saver state still resolve
+  ([#7128](https://github.com/bobmatnyc/trusty-tools/issues/7128)).

--- a/crates/trusty-console/macos/saver/Info.plist
+++ b/crates/trusty-console/macos/saver/Info.plist
@@ -25,8 +25,18 @@
 	<string>com.trusty.console.saver</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<!--
+	  #7128: Settings label reads "Trusty Console". System Settings > Screen
+	  Saver renders CFBundleDisplayName when present and CFBundleName otherwise,
+	  falling back to the `.saver` filename only when neither is set. Both carry
+	  the spaced form so the tile reads the same either way. The
+	  CFBundleIdentifier value above is unchanged — launchd, the `log` subsystem
+	  predicate and Settings' selected-saver state all key on it.
+	-->
+	<key>CFBundleDisplayName</key>
+	<string>Trusty Console</string>
 	<key>CFBundleName</key>
-	<string>TrustyConsole</string>
+	<string>Trusty Console</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -332,7 +332,11 @@ harness's weakest assertion.
 
 The in-host run cannot be scripted. One operator step remains:
 
-> System Settings → Screen Saver → select **TrustyConsole** → Preview.
+> System Settings → Screen Saver → select **Trusty Console** → Preview.
+>
+> <!-- #7128: the tile label is CFBundleDisplayName/CFBundleName, not the
+> `TrustyConsole.saver` filename, which is unchanged. -->
+
 
 Watch it decide, live:
 

--- a/scripts/install-console-saver.sh
+++ b/scripts/install-console-saver.sh
@@ -117,7 +117,7 @@ fi
 cat <<EOF
 
 MANUAL STEP — this cannot be scripted:
-  System Settings → Screen Saver → select "TrustyConsole", then Preview.
+  System Settings → Screen Saver → select "Trusty Console", then Preview.
 
   The console must be running and reachable at http://127.0.0.1:7788 (or the
   port set with: defaults -currentHost write $SAVER_IDENTIFIER ConsolePort <port>).


### PR DESCRIPTION
System Settings > Screen Saver > Other labelled the saver tile "TrustyConsole", because the bundle's `CFBundleName` carried the unspaced form. The pane renders `CFBundleDisplayName` when present and `CFBundleName` otherwise, falling back to the `.saver` filename only when neither is set, so `crates/trusty-console/macos/saver/Info.plist` now sets both to `Trusty Console`. `CFBundleIdentifier`, `CFBundleExecutable`, `NSPrincipalClass` and the `TrustyConsole.saver` filename are unchanged, so launchd, the `log` subsystem predicate and Settings' selected-saver state still resolve. The static preview asset (#6839) is looked up by its own resource name, `ConsolePreview`, not by the bundle name, and still resolves in the rebuilt bundle. The two places that echoed the Settings label back to the reader — the install script's manual step and the saver README's manual-verification section — now say "Trusty Console" too.

Built with `bash scripts/build-console-saver.sh`:

```
$ plutil -p target/console-saver/TrustyConsole.saver/Contents/Info.plist \
    | grep -E 'CFBundle(Name|DisplayName|Identifier|Executable)'
  "CFBundleDisplayName" => "Trusty Console"
  "CFBundleExecutable" => "TrustyConsoleSaver"
  "CFBundleIdentifier" => "com.trusty.console.saver"
  "CFBundleName" => "Trusty Console"
```

The bundle also signs and verifies: `codesign -dv` reports `Identifier=com.trusty.console.saver`, and `Contents/Resources/` still carries `ConsolePreview.png`.

Gates. No Rust `src/**` changed, so this is test-ladder rung 1 (docs/asset only) plus the one Rust test that reads this file:

- `bash scripts/check_line_cap.sh` — `measured 4648 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.`
- `bash scripts/check_changelog_fragment.sh` — `scanned 4 changed path(s); attributed 0 crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK.` A fragment ships anyway at `crates/trusty-console/changelog.d/7128-saver-display-name.md`.
- `bash scripts/check_doc_paths.sh` — `62 file(s) scanned — every backtick path citation resolves.`
- `bash scripts/check_sld.sh` — `0 error(s), 0 warning(s)`
- `cargo test -p trusty-common --features unconditional-only --no-fail-fast launchd_labels` — `test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 468 filtered out`
- `bash -n scripts/install-console-saver.sh` — clean

That last one is not incidental. A first draft spelled the bundle identifier out inside the new plist comment, and `no_stray_launchd_label_literals_in_workspace_sources` failed on it: the scanner exempts a reverse-DNS literal only under `<key>CFBundleIdentifier</key>`, and an XML comment is not stripped. The comment now refers to the key rather than restating its value.

Still owed, and unscriptable: install the bundle and confirm the tile in System Settings reads "Trusty Console". This PR does not install it.

Refs #7128

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01GPG8e4HsXx3bviPTe9wbgv
