### PR TITLE
fix(trusty-console): saver install restarts WallpaperAgent so Settings shows the new bundle name

### DIFF
--- a/crates/trusty-console/changelog.d/7128-saver-install-restarts-wallpaperagent.md
+++ b/crates/trusty-console/changelog.d/7128-saver-install-restarts-wallpaperagent.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `scripts/install-console-saver.sh` restarts System Settings, `legacyScreenSaver`
+  and `WallpaperAgent` after a successful install. All three cache the saver
+  bundle's display-name metadata, so after #7129 renamed the bundle's
+  `CFBundleName`/`CFBundleDisplayName` to "Trusty Console" the Screen Saver tile
+  kept showing the old name across a reinstall until those processes were
+  killed by hand. The script now does that itself and prints which processes it
+  restarted ([#7128](https://github.com/bobmatnyc/trusty-tools/issues/7128)).

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -86,7 +86,13 @@ bash scripts/install-console-saver.sh --dry-run          # print every step, tou
 bash scripts/install-console-saver.sh --uninstall
 ```
 
-It installs to `~/Library/Screen Savers/TrustyConsole.saver` with `cp -R`.
+It installs to `~/Library/Screen Savers/TrustyConsole.saver` with `cp -R`, then
+restarts System Settings, `legacyScreenSaver` and `WallpaperAgent` — all three
+cache the saver bundle's display-name metadata (`CFBundleName`/
+`CFBundleDisplayName`), so a renamed bundle keeps showing the old name in the
+Screen Saver tile across a reinstall until they are restarted (#7128).
+`--uninstall` does not restart them; see the #7128 comment in the script for
+why.
 
 **Why `cp` here and not `cargo install`.** CLAUDE.md bans `cp` for installing
 release *binaries* on macOS: a `cp` over an on-`PATH` executable leaves a stale
@@ -332,10 +338,14 @@ harness's weakest assertion.
 
 The in-host run cannot be scripted. One operator step remains:
 
-> System Settings → Screen Saver → select **Trusty Console** → Preview.
+> System Settings → Wallpaper → "Screen Saver…" → select **Trusty Console** →
+> Preview.
 >
 > <!-- #7128: the tile label is CFBundleDisplayName/CFBundleName, not the
-> `TrustyConsole.saver` filename, which is unchanged. -->
+> `TrustyConsole.saver` filename, which is unchanged. On this macOS build the
+> Screen Saver pane lives under Wallpaper, not its own top-level item, and the
+> x-apple.systempreferences:com.apple.ScreenSaver-Settings.extension URL lands
+> on General instead. -->
 
 
 Watch it decide, live:

--- a/scripts/install-console-saver.sh
+++ b/scripts/install-console-saver.sh
@@ -9,9 +9,13 @@
 # (#6520).
 #
 # What: builds the bundle (or takes a prebuilt one via `--from`), removes any
-# installed copy, `cp -R`s the new one into `~/Library/Screen Savers/`, prints the
-# installed path and its codesign verdict, and prints the one manual step that
-# cannot be automated. `--uninstall` removes it.
+# installed copy, `cp -R`s the new one into `~/Library/Screen Savers/`, restarts
+# the processes that cache saver bundle metadata (System Settings,
+# legacyScreenSaver, WallpaperAgent) so a renamed bundle shows its new name
+# immediately, prints the installed path and its codesign verdict, and prints
+# the one manual step that cannot be automated. `--uninstall` removes it and
+# does not restart those processes — see the #7128 comment at the restart
+# site for why.
 #
 # Usage:
 #   bash scripts/install-console-saver.sh
@@ -112,12 +116,34 @@ else
   echo "installed: $DEST"
   codesign --verify --deep --strict --verbose=2 "$DEST"
   codesign -dv "$DEST"
+
+  # #7128: WallpaperAgent caches saver bundle metadata across reinstalls, and
+  # System Settings and legacyScreenSaver hold their own copies of it too —
+  # the Screen Saver tile keeps showing the previous CFBundleName/
+  # CFBundleDisplayName until these are restarted, even though the bundle on
+  # disk already carries the new one. Not run on --uninstall: nothing is left
+  # at $DEST for a cached name to be stale about, and the existing
+  # "repopulates on reopen" note above covers the separate saver-list cache.
+  echo
+  echo "==> restarting processes that cache the saver's bundle metadata"
+  RESTARTED=()
+  for proc in "System Settings" legacyScreenSaver WallpaperAgent; do
+    if killall "$proc" 2>/dev/null; then
+      RESTARTED+=("$proc")
+    fi
+  done
+  if [[ ${#RESTARTED[@]} -gt 0 ]]; then
+    echo "restarted: ${RESTARTED[*]}"
+  else
+    echo "restarted: none were running"
+  fi
 fi
 
 cat <<EOF
 
 MANUAL STEP — this cannot be scripted:
-  System Settings → Screen Saver → select "Trusty Console", then Preview.
+  System Settings → Wallpaper → "Screen Saver…" → select "Trusty Console", then
+  Preview.
 
   The console must be running and reachable at http://127.0.0.1:7788 (or the
   port set with: defaults -currentHost write $SAVER_IDENTIFIER ConsolePort <port>).


### PR DESCRIPTION
Follow-up to #7128. PR #7129 renamed the saver bundle's CFBundleName/CFBundleDisplayName to "Trusty Console", but System Settings kept showing the old name after `scripts/install-console-saver.sh` reinstalled it — WallpaperAgent, and to a lesser extent legacyScreenSaver and System Settings itself, cache the bundle's display-name metadata across a reinstall. Live evidence 2026-09-08: WallpaperAgent and System Settings had both been running since 08:17, through the reinstall, and the tile still read the old name; after `killall`, both tiles read "Trusty Console". The script now restarts all three (System Settings, legacyScreenSaver, WallpaperAgent) after a successful install and prints which ones it restarted — not on `--uninstall`, since nothing is left at the destination for a cached name to be stale about, and the script's existing "repopulates on reopen" note already covers the separate saver-list cache. Also updated the MANUAL STEP text and the saver README: on this macOS build the Screen Saver pane lives under System Settings → Wallpaper → "Screen Saver…", not its own top-level item, and the `x-apple.systempreferences:com.apple.ScreenSaver-Settings.extension` URL lands on General instead.

Gates:
- `bash -n scripts/install-console-saver.sh` → exit 0
- `shellcheck scripts/install-console-saver.sh` → exit 0, no findings
- `bash scripts/check_doc_paths.sh` → exit 0, no output
- `bash scripts/check_sld.sh` → exit 0, no output
- `bash scripts/check_changelog_fragment.sh --staged` → exit 0
- `cargo test -p trusty-common --features unconditional-only --no-fail-fast launchd_labels` → `test result: ok. 27 passed; 0 failed; 0 ignored`, including `no_stray_launchd_label_literals_in_workspace_sources`

Refs #7128

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01GPG8e4HsXx3bviPTe9wbgv