### PR TITLE
fix(trusty-console): saver bundle ships thumbnail.png/@2x so the Settings gallery shows the console preview

### DIFF
--- a/crates/trusty-console/changelog.d/6839-saver-gallery-thumbnail.md
+++ b/crates/trusty-console/changelog.d/6839-saver-gallery-thumbnail.md
@@ -1,0 +1,10 @@
+Fixed
+- The System Settings screen-saver gallery showed the generic placeholder tile
+  instead of the console preview. The gallery reads
+  `Contents/Resources/thumbnail.png` and `thumbnail@2x.png` by name and never
+  instantiates the saver view, so the `isPreview: true` draw path added earlier
+  could only ever reach the in-pane Preview.
+  `scripts/build-console-saver.sh` now derives both files from
+  `ConsolePreview.png` with `sips` — 90×58 and 180×116, centre-cropped to the
+  tile aspect, matching the pair Apple's `Random.saver` ships
+  ([#6839](https://github.com/bobmatnyc/trusty-tools/issues/6839)).

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -77,6 +77,15 @@ PREVIEW_MAX_BYTES=300000 bash scripts/render-console-saver-preview.sh
 Commit the regenerated PNG — the build copies it from the source tree, and a
 bundle without it is rejected before the compile starts.
 
+The gallery tile and the in-pane Preview are two separate mechanisms. System
+Settings builds the tile by reading `Contents/Resources/thumbnail.png` and
+`thumbnail@2x.png` by name; it never constructs the view, so the
+`isPreview: true` draw path reaches only the Preview pane. The build derives
+both thumbnails from the same `ConsolePreview.png` with `sips` — 90×58 and
+180×116, centre-cropped to the tile aspect, matching the pair Apple's
+`Random.saver` ships — so nothing extra is committed and the two can never
+disagree (#6839).
+
 ## Install
 
 ```bash

--- a/scripts/build-console-saver.sh
+++ b/scripts/build-console-saver.sh
@@ -10,9 +10,10 @@
 # What: compiles crates/trusty-console/macos/saver/TrustyConsoleSaver.swift to a
 # dylib with swiftc, assembles target/console-saver/TrustyConsole.saver from it
 # plus the Info.plist template (injecting the trusty-console crate version) and
-# the static preview asset the gallery tile and the offline fallback draw
-# (#6839), lints the plist, codesigns the bundle, verifies the signature, and
-# zips the result with ditto.
+# the static preview asset the in-pane Preview and the offline fallback draw
+# (#6839), derives the two gallery-tile thumbnails from that same asset with
+# sips, lints the plist, codesigns the bundle, verifies the signature, and zips
+# the result with ditto.
 #
 # Signing: `CODESIGN_IDENTITY` set → Developer ID with `--options runtime
 # --timestamp` (Gatekeeper/notarization path). Unset → ad-hoc (`--sign -`), which
@@ -44,6 +45,12 @@ CARGO_TOML="$REPO_ROOT/crates/trusty-console/Cargo.toml"
 # draw. Regenerate with scripts/render-console-saver-preview.sh.
 PREVIEW_ASSET="$SRC_DIR/Resources/ConsolePreview.png"
 
+# #6839: gallery reads thumbnail.png/@2x by name; the isPreview draw never feeds
+# the tile. Sizes match Random.saver's pair, the only Apple saver on this host
+# that ships them and the only one that gets a real tile.
+THUMBNAIL_WIDTH=90
+THUMBNAIL_HEIGHT=58
+
 MODULE_NAME="TrustyConsoleSaver"
 DEPLOYMENT_TARGET="13.0"
 
@@ -58,7 +65,7 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   exit 1
 fi
 
-for tool in swiftc codesign plutil ditto; do
+for tool in swiftc codesign plutil ditto sips; do
   command -v "$tool" >/dev/null 2>&1 || { echo "ERROR: $tool not found on PATH." >&2; exit 1; }
 done
 
@@ -117,6 +124,38 @@ chmod 755 "$EXECUTABLE"
 # --- assemble --------------------------------------------------------------
 cp "$PREVIEW_ASSET" "$BUNDLE/Contents/Resources/ConsolePreview.png"
 echo "==> preview asset: $(wc -c < "$PREVIEW_ASSET" | tr -d ' ') bytes"
+
+# #6839: gallery reads thumbnail.png/@2x by name; the isPreview draw never feeds
+# the tile. Derived here from the same source render so the two never diverge.
+SRC_W="$(sips -g pixelWidth "$PREVIEW_ASSET" | awk '/pixelWidth/ { print $2 }')"
+SRC_H="$(sips -g pixelHeight "$PREVIEW_ASSET" | awk '/pixelHeight/ { print $2 }')"
+if [[ -z "$SRC_W" || -z "$SRC_H" ]]; then
+  echo "ERROR: sips could not read the pixel size of $PREVIEW_ASSET" >&2
+  exit 1
+fi
+
+# The largest box at the tile's aspect that fits inside the source. sips crops
+# on the centre, so this keeps the middle of the render and drops the overhang.
+read -r CROP_W CROP_H < <(
+  awk -v sw="$SRC_W" -v sh="$SRC_H" -v tw="$THUMBNAIL_WIDTH" -v th="$THUMBNAIL_HEIGHT" \
+    'BEGIN {
+       if (sw * th > sh * tw) { printf "%d %d\n", int(sh * tw / th), sh }
+       else                   { printf "%d %d\n", sw, int(sw * th / tw) }
+     }'
+)
+
+for scale in 1 2; do
+  if [[ "$scale" == 1 ]]; then
+    thumb="$BUNDLE/Contents/Resources/thumbnail.png"
+  else
+    thumb="$BUNDLE/Contents/Resources/thumbnail@2x.png"
+  fi
+  cp "$PREVIEW_ASSET" "$thumb"
+  sips --cropToHeightWidth "$CROP_H" "$CROP_W" "$thumb" >/dev/null
+  sips --resampleHeightWidth \
+    "$((THUMBNAIL_HEIGHT * scale))" "$((THUMBNAIL_WIDTH * scale))" "$thumb" >/dev/null
+  echo "==> thumbnail ${scale}x: $((THUMBNAIL_WIDTH * scale))x$((THUMBNAIL_HEIGHT * scale)) from ${CROP_W}x${CROP_H} crop of ${SRC_W}x${SRC_H}"
+done
 
 cp "$SRC_DIR/Info.plist" "$BUNDLE/Contents/Info.plist"
 plutil -replace CFBundleShortVersionString -string "$VERSION" "$BUNDLE/Contents/Info.plist"


### PR DESCRIPTION
## The mechanism

The System Settings gallery tile and the in-pane Preview are two different
mechanisms, and #6842 only fixed the second one.

The Wallpaper → Screen Saver gallery builds a saver's tile by reading
`Contents/Resources/thumbnail.png` and `thumbnail@2x.png` **by name**. It does
not instantiate the saver view to make the tile: on this host (Darwin 25.6),
`log show` against the saver's logging subsystem records zero entries for the
whole time the picker is open. So the `isPreview: true` draw path in
`TrustyConsoleSaver.swift` — which does work — can only ever reach the Preview
pane, and the gallery fell back to the generic placeholder, exactly as the owner
reports.

Apple's own bundles are the evidence, and neither declares an Info.plist key for
it:

| Bundle | `thumbnail.png` / `@2x` | Gallery tile |
|---|---|---|
| `/System/Library/Screen Savers/Random.saver` | both present | real tile |
| `/System/Library/Screen Savers/FloatingMessage.saver` | neither | generic placeholder |

```
$ sips -g pixelWidth -g pixelHeight -g format \
    "/System/Library/Screen Savers/Random.saver/Contents/Resources/thumbnail.png" \
    "/System/Library/Screen Savers/Random.saver/Contents/Resources/thumbnail@2x.png"
…/thumbnail.png
  pixelWidth: 90
  pixelHeight: 58
  format: png
…/thumbnail@2x.png
  pixelWidth: 180
  pixelHeight: 116
  format: png

$ plutil -p "/System/Library/Screen Savers/Random.saver/Contents/Info.plist" | grep -i -E 'thumb|preview|image'
$ echo $?
1
```

`find /System/Library /System/Applications -name 'thumbnail@2x.png' -path '*.saver*'`
returns `Random.saver` alone, so that pair is the only sample on this host — and
it is the sample that works.

## The change

`scripts/build-console-saver.sh` derives both thumbnails from the same
`Resources/ConsolePreview.png` the Preview and offline fallback already draw:
centre-crop the 1920×1080 render to 1675×1080 (the 90:58 tile aspect), then
resample to 90×58 and 180×116. `sips` is a macOS built-in, so no new dependency;
generating at build time means no extra binaries are committed and the tile can
never disagree with the preview it comes from.

The Swift `isPreview` draw path is untouched — it still serves the in-pane
Preview.

## Gates

Build, then verify the bundle:

```
$ bash scripts/build-console-saver.sh
==> trusty-console 0.11.0 → …/target/console-saver/TrustyConsole.saver
    archs: arm64
==> swiftc arm64
==> preview asset: 115758 bytes
==> thumbnail 1x: 90x58 from 1675x1080 crop of 1920x1080
==> thumbnail 2x: 180x116 from 1675x1080 crop of 1920x1080
…/Contents/Info.plist: OK
==> codesign (ad-hoc; set CODESIGN_IDENTITY for a distributable bundle)
…/TrustyConsole.saver: valid on disk
…/TrustyConsole.saver: satisfies its Designated Requirement

$ ls -l target/console-saver/TrustyConsole.saver/Contents/Resources/
total 272
-rw-r--r--  1 masa  staff  115758 Sep  8 08:42 ConsolePreview.png
-rw-r--r--  1 masa  staff    4729 Sep  8 08:42 thumbnail.png
-rw-r--r--  1 masa  staff   11484 Sep  8 08:42 thumbnail@2x.png

$ sips -g pixelWidth -g pixelHeight …/thumbnail.png …/thumbnail@2x.png
…/thumbnail.png
  pixelWidth: 90
  pixelHeight: 58
…/thumbnail@2x.png
  pixelWidth: 180
  pixelHeight: 116

$ codesign -dv --verbose=2 target/console-saver/TrustyConsole.saver
Identifier=com.trusty.console.saver
Format=bundle with Mach-O thin (arm64)
CodeDirectory v=20400 size=465 flags=0x2(adhoc) hashes=8+3 location=embedded
Signature=adhoc
Info.plist entries=12
Sealed Resources version=2 rules=13 files=3
```

`Sealed Resources … files=3` is the seal covering all three resources, so the
two new PNGs are inside the signature rather than beside it.

```
$ cargo test -p trusty-common --features unconditional-only --no-fail-fast launchd_labels
     Running unittests src/lib.rs (target/debug/deps/trusty_common-e945a959c57e1101)
running 27 tests
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 468 filtered out; finished in 0.97s

$ bash scripts/check_doc_paths.sh
doc-paths gate: 62 file(s) scanned — every backtick path citation resolves.

$ bash scripts/check_sld.sh
sld-lint: scanned 63 spec doc(s) + 3770 code file(s); resolved 41 frontmatter + 77 inline reference(s), rejected 0 + 0 on path shape; 0 error(s), 0 warning(s)

$ bash scripts/check_changelog_fragment.sh
changelog-fragment gate: scanned 3 changed path(s); attributed 0 crate-source path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
```

Test ladder rung 1–2: the diff is one build script, one README paragraph and one
changelog fragment. No crate `src/**` changed, so no Rust behavior is in scope;
the bundle build above is the direct evidence for what did change.

## Still owed

The gallery tile itself can only be confirmed by installing the bundle and
opening System Settings → Wallpaper → Screen Saver. This PR does not install
anything and touches no running process.

Refs #6839

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01GPG8e4HsXx3bviPTe9wbgv
