### PR TITLE
fix(trusty-mpm): issue audit accepts any crate component label, not only trusty-mpm

### DIFF
--- a/crates/trusty-mpm/changelog.d/7123-audit-component-labels.md
+++ b/crates/trusty-mpm/changelog.d/7123-audit-component-labels.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `tm issue audit` now accepts any of the repository's own crate labels as the owning component, not only `trusty-mpm`. The check read its accepted set from the labels the harness SEEDS (`policy_labels_configured`), which on this workspace is `trusty-mpm` alone, so every correctly labelled non-mpm issue reported `component label FAIL none of [trusty-mpm] present` — #7116, #7128 and #7132–#7140 all did. The accepted set now also carries each `[workspace] members` crate's package name and directory name, and the FAIL line names the whole set. An issue with no component label at all still FAILs (#7123).

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/audit.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/audit.rs
@@ -20,6 +20,7 @@
 //! `an_empty_window_is_not_a_failure`, and `cli_parses_issue_audit_*` in
 //! `tests.rs`.
 
+use trusty_mpm::core::component_labels::ComponentLabels;
 use trusty_mpm::core::gh_identity::GhEnv;
 use trusty_mpm::core::issue_audit::{IssueAudit, audit_issue, render_audit, render_summary};
 use trusty_mpm::core::issue_audit_gh::{AuditWindow, list_open_issues, view_issue};
@@ -33,7 +34,8 @@ use trusty_mpm::core::trusty_tools_config::ResolvedTicketing;
 /// report. With `recent` or `since` set, lists the matching OPEN issues and
 /// prints the summary table. With none of the three, errors rather than
 /// guessing a default window. `gh` runs in the current directory, which is what
-/// selects the repository.
+/// selects the repository — and, since #7123, also what selects the crate
+/// labels that satisfy the owning-component rule.
 /// Test: see the module doc; the pure halves are unit-tested in the library.
 pub(crate) fn run(
     ticketing: &ResolvedTicketing,
@@ -42,13 +44,21 @@ pub(crate) fn run(
     recent: Option<usize>,
     since: Option<String>,
 ) -> anyhow::Result<()> {
+    // #7123: the accepted component labels are the audited repository's own
+    // crate labels, not just the ones the harness seeds.
+    let cwd = std::env::current_dir().ok();
+    let components = ComponentLabels::resolve(ticketing, cwd.as_deref());
     let audits = match (issue, recent, since) {
         (Some(number), _, _) => {
             let facts = view_issue(number, None, gh_env)?;
-            vec![audit_issue(&facts, ticketing)]
+            vec![audit_issue(&facts, ticketing, &components)]
         }
-        (None, Some(n), _) => audit_window(&AuditWindow::Recent(n), ticketing, gh_env)?,
-        (None, None, Some(date)) => audit_window(&AuditWindow::Since(date), ticketing, gh_env)?,
+        (None, Some(n), _) => {
+            audit_window(&AuditWindow::Recent(n), ticketing, &components, gh_env)?
+        }
+        (None, None, Some(date)) => {
+            audit_window(&AuditWindow::Since(date), ticketing, &components, gh_env)?
+        }
         (None, None, None) => anyhow::bail!(
             "name an issue number, or pass --recent <n> / --since <YYYY-MM-DD> to audit a window"
         ),
@@ -61,11 +71,12 @@ pub(crate) fn run(
 fn audit_window(
     window: &AuditWindow,
     ticketing: &ResolvedTicketing,
+    components: &ComponentLabels,
     gh_env: &GhEnv,
 ) -> anyhow::Result<Vec<IssueAudit>> {
     Ok(list_open_issues(window, None, gh_env)?
         .iter()
-        .map(|f| audit_issue(f, ticketing))
+        .map(|f| audit_issue(f, ticketing, components))
         .collect())
 }
 
@@ -118,6 +129,13 @@ mod tests {
         serde_json::from_str(json).expect("the fixture parses")
     }
 
+    /// The accepted component labels, named literally (#7123) — these cases
+    /// exercise rendering and the exit rule, not the derivation, which
+    /// `ComponentLabels`'s own tests cover.
+    fn components() -> ComponentLabels {
+        ComponentLabels::from_names([String::from("trusty-mpm")])
+    }
+
     const COMPLIANT: &str = r#"{
       "number": 7093,
       "milestone": {"title": "Backlog · mpm/core"},
@@ -146,7 +164,7 @@ mod tests {
 
     #[test]
     fn single_issue_output_is_the_per_requirement_report() {
-        let audits = vec![audit_issue(&facts(COMPLIANT), &standard())];
+        let audits = vec![audit_issue(&facts(COMPLIANT), &standard(), &components())];
         let text = render_report(&audits);
         assert!(text.starts_with("#7093\n"), "{text}");
         assert!(text.contains("milestone"), "{text}");
@@ -156,8 +174,8 @@ mod tests {
     #[test]
     fn a_window_prints_the_summary_table() {
         let audits = vec![
-            audit_issue(&facts(COMPLIANT), &standard()),
-            audit_issue(&facts(NO_PROJECT), &standard()),
+            audit_issue(&facts(COMPLIANT), &standard(), &components()),
+            audit_issue(&facts(NO_PROJECT), &standard(), &components()),
         ];
         let text = render_report(&audits);
         assert!(text.contains("verdict"), "the table header renders: {text}");
@@ -167,14 +185,14 @@ mod tests {
 
     #[test]
     fn a_failing_audit_exits_nonzero() {
-        let audits = vec![audit_issue(&facts(NO_PROJECT), &standard())];
+        let audits = vec![audit_issue(&facts(NO_PROJECT), &standard(), &components())];
         let err = exit_result(&audits).expect_err("a violation must exit 1");
         assert!(err.to_string().contains("#7104"), "{err}");
     }
 
     #[test]
     fn a_passing_audit_exits_zero() {
-        let audits = vec![audit_issue(&facts(COMPLIANT), &standard())];
+        let audits = vec![audit_issue(&facts(COMPLIANT), &standard(), &components())];
         assert!(exit_result(&audits).is_ok());
     }
 

--- a/crates/trusty-mpm/src/core/component_labels.rs
+++ b/crates/trusty-mpm/src/core/component_labels.rs
@@ -1,0 +1,278 @@
+//! The component labels an issue audit ACCEPTS, derived from the repository's
+//! own crates rather than from the harness's seed table (#7123).
+//!
+//! Why: [`crate::core::policy_labels`] answers "which labels does trusty-mpm
+//! CREATE" — the `trusty-mpm` convention label, `ws/<session>`, and whatever
+//! `agents.ticketing.extra_labels` adds. #7097's audit reused that answer for a
+//! different question, "which labels SATISFY the owning-component rule", and
+//! the two are not the same set. On a workspace with ~30 crates the seed table
+//! names one of them, so every correctly labelled non-mpm issue audited as
+//! `component label FAIL none of [trusty-mpm] present` — #7116, #7128 and
+//! #7132–#7140 all did. The owner ruling of 2026-09-06 stands and is the reason
+//! this module exists rather than a widening of the seed table: `trusty-mpm` is
+//! a component label scoped to `crates/trusty-mpm/`, never a stand-in for "some
+//! component label", so an issue owned by another crate has to be able to name
+//! that crate and pass.
+//!
+//! What: [`ComponentLabels`], the accepted set, and [`ComponentLabels::resolve`],
+//! which unions the seed table with the workspace's own crate labels — the
+//! `[package] name` of every member of the root `Cargo.toml`'s `[workspace]
+//! members`, plus the hyphenated spelling of any name carrying a `_`, since a
+//! GitHub label name cannot contain one (`trusty_review` is labelled
+//! `trusty-review`).
+//!
+//! The accepted set is deliberately a SUPERSET of the seeded set, and nothing
+//! here feeds label creation: `tm issue seed-labels` and session launch still
+//! read [`crate::core::policy_labels::policy_labels_configured`], so this
+//! module never causes a `gh label create`. A crate label already exists in the
+//! repository that owns the crate; seeding thirty of them elsewhere would be a
+//! different, unasked-for change.
+//!
+//! Every filesystem read here is bounded and fail-closed: an unreadable,
+//! oversized or malformed manifest contributes no names, leaving the seed table
+//! as the accepted set — exactly the pre-#7123 behaviour, never a wider one.
+//!
+//! Test: `component_labels_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::policy_labels::policy_labels_configured;
+use crate::core::trusty_tools_config::ResolvedTicketing;
+
+/// Largest `Cargo.toml` this module will read.
+///
+/// Why: a manifest past this size is pathological, not large, and the audit
+/// must not stall on one.
+const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+
+/// Maximum workspace members enumerated for one resolve.
+///
+/// Why: bounds directory enumeration on a hostile or generated repository. A
+/// workspace with more members than this is not one whose component labels a
+/// FAIL line could usefully name anyway.
+const MAX_MEMBERS: usize = 512;
+
+/// The component labels that satisfy the owning-component rule.
+///
+/// Why: the audit needs one value it can ask "does this label name a
+/// component", built in one place, so a caller cannot assemble a different set
+/// than the one this module documents.
+/// What: an order-preserving, de-duplicated list — the seed table's names
+/// first, then the workspace crate labels. [`Self::resolve`] is the derivation;
+/// [`Self::from_names`] exists for callers that already hold a set (tests, and
+/// any future caller with a non-Cargo source).
+/// Test: `resolve_accepts_every_workspace_crate_label`,
+/// `from_names_deduplicates`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ComponentLabels {
+    names: Vec<String>,
+}
+
+impl ComponentLabels {
+    /// The accepted set for `ticketing`, widened by the workspace rooted at or
+    /// above `start_dir`.
+    ///
+    /// Why: the audit runs `gh` in the current directory, so the repository
+    /// whose issues it reads is the repository whose crates should satisfy the
+    /// component rule. Passing the directory in rather than reading it here
+    /// keeps the caller in charge of which repository is meant.
+    /// What: the names [`policy_labels_configured`] yields with NO session name
+    /// — `ws/<session>` is a workstream, not a component — then every crate
+    /// label found by walking up from `start_dir` to the Cargo workspace root.
+    /// `None`, no workspace root, or an unreadable manifest all yield just the
+    /// seed table.
+    /// Test: `resolve_accepts_every_workspace_crate_label`,
+    /// `resolve_without_a_workspace_is_the_seed_table`,
+    /// `resolve_ignores_a_malformed_manifest`.
+    #[must_use]
+    pub fn resolve(ticketing: &ResolvedTicketing, start_dir: Option<&Path>) -> Self {
+        // #7123: `None` for the session — a `ws/<session>` label names the
+        // workstream that filed the issue, never the component that owns it.
+        let mut names: Vec<String> = policy_labels_configured(ticketing, None)
+            .into_iter()
+            .map(|l| l.name)
+            .collect();
+        if let Some(root) = start_dir.and_then(cargo_workspace_root) {
+            names.extend(workspace_crate_labels(&root));
+        }
+        Self::from_names(names)
+    }
+
+    /// Build a set from names already in hand, de-duplicated in first-seen
+    /// order.
+    #[must_use]
+    pub fn from_names(names: impl IntoIterator<Item = String>) -> Self {
+        let mut out: Vec<String> = Vec::new();
+        for name in names {
+            if !name.is_empty() && !out.iter().any(|existing| existing == &name) {
+                out.push(name);
+            }
+        }
+        Self { names: out }
+    }
+
+    /// Whether `label` satisfies the owning-component rule.
+    #[must_use]
+    pub fn accepts(&self, label: &str) -> bool {
+        self.names.iter().any(|n| n == label)
+    }
+
+    /// The accepted names, in the order a report should name them.
+    #[must_use]
+    pub fn names(&self) -> &[String] {
+        &self.names
+    }
+}
+
+/// The Cargo workspace root at or above `start`, if any.
+///
+/// Why: the audit is run from anywhere inside a checkout — the repo root, a
+/// crate directory, a worktree — and the member list lives only in the root
+/// manifest.
+/// What: the nearest ancestor (starting with `start` itself) whose `Cargo.toml`
+/// declares a `[workspace]` table. `None` when no ancestor does.
+/// Test: `workspace_root_is_found_from_a_nested_directory`,
+/// `no_workspace_root_outside_a_workspace`.
+fn cargo_workspace_root(start: &Path) -> Option<PathBuf> {
+    for dir in start.ancestors() {
+        let manifest = dir.join("Cargo.toml");
+        let Some(raw) = read_bounded(&manifest) else {
+            continue;
+        };
+        if raw
+            .parse::<toml::Value>()
+            .ok()
+            .is_some_and(|v| v.get("workspace").is_some())
+        {
+            return Some(dir.to_path_buf());
+        }
+    }
+    None
+}
+
+/// Every crate label the workspace rooted at `root` declares.
+///
+/// Why: the accepted set has to be the workspace's CRATES, so it is derived
+/// from each member's `[package] name` rather than from its directory. A
+/// directory name would add path segments no repository labels an issue with —
+/// this workspace's two nested Tauri members both sit in `…/ui/src-tauri`, and
+/// `src-tauri` is not a component. GitHub label names cannot contain `_`, so a
+/// package spelled with one is labelled with `-` instead (`trusty_review` is
+/// labelled `trusty-review`), and both spellings are accepted.
+/// What: expands each `[workspace] members` pattern, then for each existing
+/// member directory yields its `[package] name` and, when that name carries a
+/// `_`, the hyphenated form. Capped at [`MAX_MEMBERS`]; every read is
+/// fail-closed.
+/// Test: `resolve_accepts_every_workspace_crate_label`,
+/// `an_underscored_package_is_accepted_hyphenated`,
+/// `a_nested_member_contributes_no_path_segment`.
+fn workspace_crate_labels(root: &Path) -> Vec<String> {
+    let Some(raw) = read_bounded(&root.join("Cargo.toml")) else {
+        return Vec::new();
+    };
+    let Ok(manifest) = raw.parse::<toml::Value>() else {
+        return Vec::new();
+    };
+    let patterns: Vec<String> = manifest
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(toml::Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut labels = Vec::new();
+    let mut members = 0usize;
+    for pattern in patterns {
+        for dir in expand_member(root, &pattern) {
+            if members >= MAX_MEMBERS {
+                return labels;
+            }
+            members += 1;
+            if let Some(name) = package_name(&dir) {
+                if name.contains('_') {
+                    labels.push(name.replace('_', "-"));
+                }
+                labels.push(name);
+            }
+        }
+    }
+    labels
+}
+
+/// The `[package] name` declared by `dir/Cargo.toml`, if any.
+fn package_name(dir: &Path) -> Option<String> {
+    let raw = read_bounded(&dir.join("Cargo.toml"))?;
+    raw.parse::<toml::Value>()
+        .ok()?
+        .get("package")?
+        .get("name")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// Expand one `members` pattern into the member directories that exist.
+///
+/// Why: `crates/*` and `crates/trusty-audit/ui/src-tauri` are both real entries
+/// in this workspace's member list, so the expansion has to handle a glob
+/// segment and a plain path with the same code.
+/// What: walks the pattern segment by segment. A `*` (or `**`) segment replaces
+/// each candidate with its subdirectories, sorted so the result is
+/// deterministic; every other segment is joined literally. Only directories
+/// survive, and the total is capped at [`MAX_MEMBERS`].
+/// Test: `member_glob_expands_one_level`, `member_literal_path_is_kept`,
+/// `member_pattern_that_matches_nothing_yields_nothing`.
+fn expand_member(root: &Path, pattern: &str) -> Vec<PathBuf> {
+    let mut candidates = vec![root.to_path_buf()];
+    for segment in pattern.split('/').filter(|s| !s.is_empty() && *s != ".") {
+        let mut next = Vec::new();
+        for candidate in &candidates {
+            if next.len() >= MAX_MEMBERS {
+                break;
+            }
+            if segment == "*" || segment == "**" {
+                let Ok(entries) = std::fs::read_dir(candidate) else {
+                    continue;
+                };
+                let mut dirs: Vec<PathBuf> = entries
+                    .flatten()
+                    .map(|e| e.path())
+                    .filter(|p| p.is_dir())
+                    .collect();
+                dirs.sort();
+                next.extend(dirs);
+            } else {
+                let joined = candidate.join(segment);
+                if joined.is_dir() {
+                    next.push(joined);
+                }
+            }
+        }
+        next.truncate(MAX_MEMBERS);
+        candidates = next;
+        if candidates.is_empty() {
+            return candidates;
+        }
+    }
+    candidates
+}
+
+/// Read a manifest, refusing anything oversized or unreadable.
+///
+/// Why: one place holds the size cap and the fail-closed rule, so the two
+/// callers cannot drift apart on either.
+fn read_bounded(path: &Path) -> Option<String> {
+    let meta = std::fs::metadata(path).ok()?;
+    if !meta.is_file() || meta.len() > MAX_MANIFEST_BYTES {
+        return None;
+    }
+    std::fs::read_to_string(path).ok()
+}
+
+#[cfg(test)]
+#[path = "component_labels_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/component_labels_tests.rs
+++ b/crates/trusty-mpm/src/core/component_labels_tests.rs
@@ -1,0 +1,186 @@
+//! Tests for [`super`] — the accepted component-label set (#7123).
+//!
+//! Every test builds a throwaway workspace in a `TempDir`, so nothing here
+//! depends on the checkout it runs in.
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::{ComponentLabels, cargo_workspace_root, expand_member};
+use crate::core::trusty_tools_config::ResolvedTicketing;
+
+/// Write a crate directory with a `[package] name`.
+fn crate_at(root: &Path, dir: &str, package: &str) {
+    let path = root.join(dir);
+    fs::create_dir_all(&path).unwrap();
+    fs::write(
+        path.join("Cargo.toml"),
+        format!("[package]\nname = \"{package}\"\nversion = \"0.1.0\"\n"),
+    )
+    .unwrap();
+}
+
+/// A workspace shaped like this repo's: a `crates/*` glob, one crate whose
+/// package name differs from its directory (`tga`), and one nested member
+/// listed by full path.
+fn workspace() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/*\", \"crates/trusty-audit/ui/src-tauri\"]\n\
+         resolver = \"2\"\n",
+    )
+    .unwrap();
+    crate_at(root, "crates/trusty-mpm", "trusty-mpm");
+    crate_at(root, "crates/trusty-audit", "trusty-audit");
+    crate_at(root, "crates/trusty-console", "trusty-console");
+    crate_at(root, "crates/trusty-git-analytics", "tga");
+    crate_at(root, "crates/trusty-review", "trusty_review");
+    crate_at(root, "crates/trusty-audit/ui/src-tauri", "trusty-audit-ui");
+    tmp
+}
+
+#[test]
+fn resolve_accepts_every_workspace_crate_label() {
+    let tmp = workspace();
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), Some(tmp.path()));
+    for expected in [
+        "trusty-mpm",
+        "trusty-audit",
+        "trusty-console",
+        "tga",
+        "trusty-audit-ui",
+    ] {
+        assert!(
+            labels.accepts(expected),
+            "expected `{expected}` to be accepted; set was {:?}",
+            labels.names()
+        );
+    }
+}
+
+#[test]
+fn an_underscored_package_is_accepted_hyphenated() {
+    // A GitHub label name cannot contain `_`, so the package `trusty_review` is
+    // labelled `trusty-review`. Both spellings satisfy the rule.
+    let tmp = workspace();
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), Some(tmp.path()));
+    assert!(labels.accepts("trusty_review"), "the package name");
+    assert!(
+        labels.accepts("trusty-review"),
+        "the label spelling; set was {:?}",
+        labels.names()
+    );
+}
+
+#[test]
+fn a_nested_member_contributes_no_path_segment() {
+    // #7123: deriving from the directory rather than the package would accept
+    // `src-tauri`, which names no component and nothing labels an issue with.
+    let tmp = workspace();
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), Some(tmp.path()));
+    assert!(!labels.accepts("src-tauri"), "set was {:?}", labels.names());
+    assert!(labels.accepts("trusty-audit-ui"), "the package it declares");
+}
+
+#[test]
+fn resolve_finds_the_workspace_from_a_nested_directory() {
+    let tmp = workspace();
+    let nested = tmp.path().join("crates/trusty-mpm");
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), Some(&nested));
+    assert!(labels.accepts("trusty-console"));
+}
+
+#[test]
+fn resolve_without_a_workspace_is_the_seed_table() {
+    let tmp = TempDir::new().unwrap();
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), Some(tmp.path()));
+    assert_eq!(labels.names(), ["trusty-mpm"]);
+}
+
+#[test]
+fn resolve_with_no_directory_is_the_seed_table() {
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), None);
+    assert_eq!(labels.names(), ["trusty-mpm"]);
+}
+
+#[test]
+fn resolve_ignores_a_malformed_manifest() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("Cargo.toml"), "[workspace\nmembers = [").unwrap();
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), Some(tmp.path()));
+    assert_eq!(labels.names(), ["trusty-mpm"]);
+}
+
+#[test]
+fn resolve_never_accepts_a_workstream_label() {
+    let tmp = workspace();
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), Some(tmp.path()));
+    assert!(!labels.accepts("ws/trusty-tools-ec"));
+}
+
+#[test]
+fn from_names_deduplicates() {
+    let labels = ComponentLabels::from_names(
+        ["a", "b", "a", ""]
+            .into_iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+    );
+    assert_eq!(labels.names(), ["a", "b"]);
+}
+
+#[test]
+fn workspace_root_is_found_from_a_nested_directory() {
+    let tmp = workspace();
+    let found = cargo_workspace_root(&tmp.path().join("crates/trusty-audit/ui/src-tauri"))
+        .expect("the fixture declares a workspace");
+    assert_eq!(
+        fs::canonicalize(&found).unwrap(),
+        fs::canonicalize(tmp.path()).unwrap()
+    );
+}
+
+#[test]
+fn no_workspace_root_outside_a_workspace() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("nothing/here");
+    fs::create_dir_all(&dir).unwrap();
+    assert_eq!(cargo_workspace_root(&dir), None);
+}
+
+#[test]
+fn member_glob_expands_one_level() {
+    let tmp = workspace();
+    let dirs = expand_member(tmp.path(), "crates/*");
+    let names: Vec<String> = dirs
+        .iter()
+        .filter_map(|d| d.file_name()?.to_str().map(ToString::to_string))
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "trusty-audit",
+            "trusty-console",
+            "trusty-git-analytics",
+            "trusty-mpm",
+            "trusty-review"
+        ]
+    );
+}
+
+#[test]
+fn member_literal_path_is_kept() {
+    let tmp = workspace();
+    let dirs = expand_member(tmp.path(), "crates/trusty-audit/ui/src-tauri");
+    assert_eq!(dirs, [tmp.path().join("crates/trusty-audit/ui/src-tauri")]);
+}
+
+#[test]
+fn member_pattern_that_matches_nothing_yields_nothing() {
+    let tmp = workspace();
+    assert!(expand_member(tmp.path(), "services/*").is_empty());
+}

--- a/crates/trusty-mpm/src/core/issue_audit.rs
+++ b/crates/trusty-mpm/src/core/issue_audit.rs
@@ -10,11 +10,12 @@
 //!
 //! What: the [`IssueFacts`] wire shape `gh issue view --json` /
 //! `gh issue list --json` return, [`audit_issue`] folding one issue's facts
-//! against a [`ResolvedTicketing`] into an [`IssueAudit`], and the two
-//! renderers ([`render_audit`] for one issue, [`render_summary`] for a batch).
-//! Everything here is pure — the `gh` reads live in
-//! [`crate::core::issue_audit_gh`], so every verdict is unit-testable against
-//! fixture JSON with no network.
+//! against a [`ResolvedTicketing`] and a [`ComponentLabels`] set into an
+//! [`IssueAudit`], and the two renderers ([`render_audit`] for one issue,
+//! [`render_summary`] for a batch). Everything here is pure — the `gh` reads
+//! live in [`crate::core::issue_audit_gh`] and the Cargo-manifest reads in
+//! [`crate::core::component_labels`], so every verdict is unit-testable against
+//! fixture JSON with no network and no filesystem.
 //!
 //! # What is and is not a failure
 //!
@@ -32,7 +33,7 @@
 
 use serde::Deserialize;
 
-use crate::core::policy_labels::policy_labels_configured;
+use crate::core::component_labels::ComponentLabels;
 use crate::core::trusty_tools_config::ResolvedTicketing;
 
 /// The `--json` field list both `gh issue view` and `gh issue list` are asked
@@ -245,22 +246,28 @@ pub const SUMMARY_REQUIREMENTS: &[&str] = &[REQ_PROJECT, REQ_MILESTONE, REQ_COMP
 /// What: four rows in a fixed order. `project` and `milestone` are PASS/FAIL
 /// only when `project_required` / `milestone_required` are set and INFO
 /// otherwise; an unset milestone with a `no-milestone: <reason>` comment is
-/// SKIP with the reason quoted. `component label` requires at least one of the
-/// component labels [`policy_labels_configured`] yields with NO session name —
-/// the `ws/<session>` workstream label is deliberately excluded, since a
-/// workstream is not a component. `relationships` is always INFO.
+/// SKIP with the reason quoted. `component label` requires at least one label
+/// from `components` — the accepted set [`ComponentLabels`] derives, which is
+/// the seed table plus the repository's own crate labels (#7123). The
+/// `ws/<session>` workstream label is never in it, since a workstream is not a
+/// component. `relationships` is always INFO.
 /// Test: `a_compliant_issue_passes_every_requirement`, `a_missing_project_fails`,
 /// `an_unset_milestone_with_a_reason_comment_is_a_skip`,
 /// `an_unset_milestone_without_a_comment_fails`,
 /// `an_unrequired_milestone_is_informational`,
 /// `a_missing_component_label_fails`,
+/// `a_non_mpm_crate_component_label_passes`,
 /// `relationships_are_never_a_failure`.
 #[must_use]
-pub fn audit_issue(facts: &IssueFacts, ticketing: &ResolvedTicketing) -> IssueAudit {
+pub fn audit_issue(
+    facts: &IssueFacts,
+    ticketing: &ResolvedTicketing,
+    components: &ComponentLabels,
+) -> IssueAudit {
     let rows = vec![
         project_row(facts, ticketing),
         milestone_row(facts, ticketing),
-        component_row(facts, ticketing),
+        component_row(facts, components),
         relationships_row(facts),
     ];
     IssueAudit {
@@ -355,25 +362,27 @@ fn no_milestone_reason(comments: &[CommentRef]) -> Option<String> {
 }
 
 /// The `component label` row.
-fn component_row(facts: &IssueFacts, ticketing: &ResolvedTicketing) -> AuditRow {
-    // #7097: `None` for the session — `ws/<session>` is a workstream label, and
-    // accepting it here would let a workstream satisfy the component rule.
-    let components: Vec<String> = policy_labels_configured(ticketing, None)
-        .into_iter()
-        .map(|l| l.name)
-        .collect();
+///
+/// Why: #7123 — this row used to build its own accepted set from the labels the
+/// harness SEEDS, which on this workspace is `trusty-mpm` alone, so an issue
+/// correctly labelled with the crate that owns it failed. The accepted set is
+/// now [`ComponentLabels`]'s, and the FAIL line names every label in it so the
+/// fix is a label the reader can copy rather than a guess.
+/// Test: `a_missing_component_label_fails`,
+/// `a_non_mpm_crate_component_label_passes`.
+fn component_row(facts: &IssueFacts, components: &ComponentLabels) -> AuditRow {
     let present: Vec<&str> = facts
         .labels
         .iter()
         .map(|l| l.name.as_str())
-        .filter(|name| components.iter().any(|c| c == name))
+        .filter(|name| components.accepts(name))
         .collect();
     let (verdict, detail) = if present.is_empty() {
         (
             Verdict::Fail,
             format!(
                 "none of [{}] present (labels: {})",
-                components.join(", "),
+                components.names().join(", "),
                 if facts.labels.is_empty() {
                     "none".to_string()
                 } else {

--- a/crates/trusty-mpm/src/core/issue_audit_tests.rs
+++ b/crates/trusty-mpm/src/core/issue_audit_tests.rs
@@ -12,6 +12,18 @@ fn standard() -> ResolvedTicketing {
     resolve_ticketing(&TrustyToolsConfig::default()).expect("the defaults resolve")
 }
 
+/// The accepted component labels this workspace's crates yield (#7123), named
+/// literally so no test here reads a Cargo manifest — `ComponentLabels`'s own
+/// tests cover the derivation.
+fn components() -> ComponentLabels {
+    ComponentLabels::from_names(
+        ["trusty-mpm", "trusty-audit", "trusty-console", "tga"]
+            .into_iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+    )
+}
+
 /// A real `gh issue view 7093 --json <AUDIT_JSON_FIELDS>` payload, captured
 /// live on 2026-09-08. A compliant issue: milestone, project, component label.
 const COMPLIANT: &str = r#"{
@@ -86,7 +98,7 @@ fn json_fields_cover_every_audited_requirement() {
 
 #[test]
 fn a_compliant_issue_passes_every_requirement() {
-    let audit = audit_issue(&parse(COMPLIANT), &standard());
+    let audit = audit_issue(&parse(COMPLIANT), &standard(), &components());
     assert!(!audit.failed(), "{:?}", audit.rows);
     assert_eq!(row(&audit, "project").verdict, Verdict::Pass);
     assert_eq!(row(&audit, "milestone").verdict, Verdict::Pass);
@@ -97,7 +109,7 @@ fn a_compliant_issue_passes_every_requirement() {
 #[test]
 fn a_missing_project_fails() {
     let json = COMPLIANT.replace(r#"[{"title": "trusty-mpm"}]"#, "[]");
-    let audit = audit_issue(&parse(&json), &standard());
+    let audit = audit_issue(&parse(&json), &standard(), &components());
     assert!(audit.failed());
     assert_eq!(audit.failing_requirements(), vec!["project"]);
     assert!(
@@ -110,7 +122,7 @@ fn a_missing_project_fails() {
 #[test]
 fn an_unset_milestone_without_a_comment_fails() {
     let json = COMPLIANT.replace(r#"{"title": "Backlog · mpm/core"}"#, "null");
-    let audit = audit_issue(&parse(&json), &standard());
+    let audit = audit_issue(&parse(&json), &standard(), &components());
     assert_eq!(row(&audit, "milestone").verdict, Verdict::Fail);
     assert!(
         row(&audit, "milestone").detail.contains("no-milestone:"),
@@ -129,7 +141,7 @@ fn an_unset_milestone_with_a_reason_comment_is_a_skip() {
             r#""comments": []"#,
             r#""comments": [{"body": "no-milestone: spike, retired before the next release"}]"#,
         );
-    let audit = audit_issue(&parse(&json), &standard());
+    let audit = audit_issue(&parse(&json), &standard(), &components());
     let milestone = row(&audit, "milestone");
     assert_eq!(milestone.verdict, Verdict::Skip);
     assert!(
@@ -163,7 +175,7 @@ fn the_no_milestone_comment_is_matched_case_insensitively() {
             r#""comments": []"#,
             r#""comments": [{"body": "No-Milestone: tracked upstream"}]"#,
         );
-    let audit = audit_issue(&parse(&json), &standard());
+    let audit = audit_issue(&parse(&json), &standard(), &components());
     assert_eq!(row(&audit, "milestone").verdict, Verdict::Skip);
 }
 
@@ -178,7 +190,7 @@ fn a_no_milestone_note_inside_a_longer_comment_counts() {
             r#""comments": []"#,
             r#""comments": [{"body": "Filed per the standard.\nno-milestone: no release owns this yet\n"}]"#,
         );
-    let audit = audit_issue(&parse(&json), &standard());
+    let audit = audit_issue(&parse(&json), &standard(), &components());
     let milestone = row(&audit, "milestone");
     assert_eq!(milestone.verdict, Verdict::Skip);
     assert!(
@@ -203,7 +215,7 @@ fn an_unrequired_milestone_is_informational() {
     let json = COMPLIANT
         .replace(r#"{"title": "Backlog · mpm/core"}"#, "null")
         .replace(r#"[{"title": "trusty-mpm"}]"#, "[]");
-    let audit = audit_issue(&parse(&json), &relaxed);
+    let audit = audit_issue(&parse(&json), &relaxed, &components());
     assert_eq!(row(&audit, "milestone").verdict, Verdict::Info);
     assert_eq!(row(&audit, "project").verdict, Verdict::Info);
     assert!(!audit.failed());
@@ -216,7 +228,7 @@ fn a_missing_component_label_fails() {
         r#"[{"name": "enhancement"}, {"name": "trusty-mpm"}]"#,
         r#"[{"name": "enhancement"}]"#,
     );
-    let audit = audit_issue(&parse(&json), &standard());
+    let audit = audit_issue(&parse(&json), &standard(), &components());
     let component = row(&audit, "component label");
     assert_eq!(component.verdict, Verdict::Fail);
     assert!(
@@ -224,6 +236,79 @@ fn a_missing_component_label_fails() {
         "the failure names both the accepted set and what was found: {}",
         component.detail
     );
+}
+
+/// A throwaway workspace whose crate labels are the ones #7139 carries.
+///
+/// Why: the two #7123 regressions below have to run the real derivation — a
+/// hand-written label list would still pass if `ComponentLabels::resolve`
+/// stopped reading the workspace, which is the exact defect they guard.
+fn workspace_fixture() -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/*\"]\n",
+    )
+    .unwrap();
+    for (dir, package) in [
+        ("trusty-mpm", "trusty-mpm"),
+        ("trusty-audit", "trusty-audit"),
+        ("trusty-git-analytics", "tga"),
+    ] {
+        let path = tmp.path().join("crates").join(dir);
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(
+            path.join("Cargo.toml"),
+            format!("[package]\nname = \"{package}\"\nversion = \"0.1.0\"\n"),
+        )
+        .unwrap();
+    }
+    tmp
+}
+
+#[test]
+fn a_non_mpm_crate_component_label_passes() {
+    // #7123: #7139's real labels — `tga` and `trusty-audit`, no `trusty-mpm`.
+    // Before the fix the accepted set was the seed table alone, so this audited
+    // `FAIL none of [trusty-mpm] present`.
+    let tmp = workspace_fixture();
+    let resolved = ComponentLabels::resolve(&standard(), Some(tmp.path()));
+    let json = COMPLIANT.replace(
+        r#"[{"name": "enhancement"}, {"name": "trusty-mpm"}]"#,
+        r#"[{"name": "enhancement"}, {"name": "P2"}, {"name": "tga"}, {"name": "trusty-audit"}]"#,
+    );
+    let audit = audit_issue(&parse(&json), &standard(), &resolved);
+    let component = row(&audit, "component label");
+    assert_eq!(
+        component.verdict,
+        Verdict::Pass,
+        "detail was: {}",
+        component.detail
+    );
+    assert_eq!(component.detail, "tga, trusty-audit");
+    assert!(!audit.failed());
+}
+
+#[test]
+fn an_issue_with_no_crate_label_still_fails_against_the_widened_set() {
+    // #7123 widened the accepted set; it did not weaken the rule to "any label
+    // present". An issue carrying only a type and a priority still FAILs, and
+    // the failure names the accepted set so the fix is a label to copy.
+    let tmp = workspace_fixture();
+    let resolved = ComponentLabels::resolve(&standard(), Some(tmp.path()));
+    let json = COMPLIANT.replace(
+        r#"[{"name": "enhancement"}, {"name": "trusty-mpm"}]"#,
+        r#"[{"name": "enhancement"}, {"name": "P2"}]"#,
+    );
+    let audit = audit_issue(&parse(&json), &standard(), &resolved);
+    let component = row(&audit, "component label");
+    assert_eq!(component.verdict, Verdict::Fail);
+    assert!(
+        component.detail.contains("tga") && component.detail.contains("trusty-audit"),
+        "the failure names the accepted set: {}",
+        component.detail
+    );
+    assert!(audit.failed());
 }
 
 #[test]
@@ -234,7 +319,7 @@ fn a_workstream_label_never_satisfies_the_component_rule() {
         r#"[{"name": "enhancement"}, {"name": "trusty-mpm"}]"#,
         r#"[{"name": "ws/trusty-tools-ec"}]"#,
     );
-    let audit = audit_issue(&parse(&json), &standard());
+    let audit = audit_issue(&parse(&json), &standard(), &components());
     assert_eq!(row(&audit, "component label").verdict, Verdict::Fail);
 }
 
@@ -242,7 +327,7 @@ fn a_workstream_label_never_satisfies_the_component_rule() {
 fn relationships_are_never_a_failure() {
     // A standalone issue legitimately has none, so their absence is reported
     // and never gates.
-    let audit = audit_issue(&parse(COMPLIANT), &standard());
+    let audit = audit_issue(&parse(COMPLIANT), &standard(), &components());
     let rel = row(&audit, "relationships");
     assert_eq!(rel.verdict, Verdict::Info);
     assert!(rel.detail.contains("no parent"), "{}", rel.detail);
@@ -262,7 +347,7 @@ fn relationships_report_what_is_set() {
             r#""subIssues": {"nodes": [], "totalCount": 0}"#,
             r#""subIssues": {"nodes": [], "totalCount": 3}"#,
         );
-    let audit = audit_issue(&parse(&json), &standard());
+    let audit = audit_issue(&parse(&json), &standard(), &components());
     let rel = row(&audit, "relationships");
     assert_eq!(rel.verdict, Verdict::Info);
     assert!(rel.detail.contains("parent #6918"), "{}", rel.detail);
@@ -273,7 +358,7 @@ fn relationships_report_what_is_set() {
 
 #[test]
 fn render_audit_prints_one_line_per_requirement() {
-    let text = render_audit(&audit_issue(&parse(COMPLIANT), &standard()));
+    let text = render_audit(&audit_issue(&parse(COMPLIANT), &standard(), &components()));
     assert!(text.starts_with("#7093\n"), "{text}");
     for requirement in ["project", "milestone", "component label", "relationships"] {
         assert!(
@@ -287,10 +372,11 @@ fn render_audit_prints_one_line_per_requirement() {
 
 #[test]
 fn render_summary_tabulates_every_issue() {
-    let compliant = audit_issue(&parse(COMPLIANT), &standard());
+    let compliant = audit_issue(&parse(COMPLIANT), &standard(), &components());
     let broken = audit_issue(
         &parse(&COMPLIANT.replace(r#"[{"title": "trusty-mpm"}]"#, "[]")),
         &standard(),
+        &components(),
     );
     let text = render_summary(&[compliant, broken]);
     assert!(text.contains("issue"), "{text}");
@@ -300,7 +386,7 @@ fn render_summary_tabulates_every_issue() {
 
 #[test]
 fn render_summary_counts_only_failures() {
-    let audits = vec![audit_issue(&parse(COMPLIANT), &standard())];
+    let audits = vec![audit_issue(&parse(COMPLIANT), &standard(), &components())];
     let text = render_summary(&audits);
     assert!(text.contains("1 issue(s) audited, 0 with a FAIL"), "{text}");
 }

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -74,6 +74,10 @@ pub mod claude_mpm_session;
 // the memory-tier default table, and the one host-root resolution site.
 pub mod builders;
 
+// #7123: the component labels an issue audit ACCEPTS — the seed table plus the
+// repository's own crate labels. Distinct from `policy_labels`, which answers
+// which labels the harness CREATES.
+pub mod component_labels;
 pub mod compress;
 pub mod config;
 /// Unrecognised-key reporting for the host-level config files (#5207).

--- a/crates/trusty-mpm/src/daemon/doctor_issue_audit.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_issue_audit.rs
@@ -26,6 +26,7 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::core::component_labels::ComponentLabels;
 use crate::core::doctor::{CheckStatus, DoctorCheck};
 use crate::core::gh_identity::GhEnv;
 use crate::core::issue_audit::{IssueAudit, audit_issue};
@@ -70,22 +71,30 @@ pub(super) async fn check_issue_audit_recent(project_dir: Option<&Path>) -> Doct
 ///
 /// Why: the whole blocking half in one place, so the async wrapper above holds
 /// no logic of its own.
-/// What: resolves the operator's `agents.ticketing` standard, computes the
-/// window's start date in UTC, lists the matching open issues with an ambient
-/// `gh` identity, and audits each. Every failure — a malformed config block, a
-/// missing `gh`, a parse error — becomes an `Err(String)`, which the fold turns
-/// into UNDETERMINED rather than a pass.
+/// What: resolves the operator's `agents.ticketing` standard, resolves the
+/// accepted component labels from the same directory `gh` runs in (#7123),
+/// computes the window's start date in UTC, lists the matching open issues with
+/// an ambient `gh` identity, and audits each. Every failure — a malformed
+/// config block, a missing `gh`, a parse error — becomes an `Err(String)`,
+/// which the fold turns into UNDETERMINED rather than a pass.
 /// Test: exercised live; the fold's branches are unit-tested.
 fn audit_recent_window(project_dir: Option<&Path>) -> Result<Vec<IssueAudit>, String> {
     let ticketing = resolve_ticketing(&TrustyToolsConfig::load())
         .map_err(|e| format!("the agents.ticketing block did not resolve: {e}"))?;
+    // #7123: the audited repository's own crate labels satisfy the
+    // owning-component rule, so the accepted set comes from the same directory
+    // `gh` reads the issues from.
+    let components = ComponentLabels::resolve(&ticketing, project_dir);
     let since = (chrono::Utc::now() - chrono::Duration::days(AUDIT_WINDOW_DAYS))
         .format("%Y-%m-%d")
         .to_string();
     let window = AuditWindow::Since(since);
     let facts =
         list_open_issues(&window, project_dir, &GhEnv::default()).map_err(|e| e.to_string())?;
-    Ok(facts.iter().map(|f| audit_issue(f, &ticketing)).collect())
+    Ok(facts
+        .iter()
+        .map(|f| audit_issue(f, &ticketing, &components))
+        .collect())
 }
 
 /// Fold an audit outcome into a [`DoctorCheck`] (pure).


### PR DESCRIPTION
## Diagnosis

`tm issue audit`'s `component label` row built its accepted set from
`policy_labels_configured(ticketing, None)` — `crates/trusty-mpm/src/core/issue_audit.rs`,
`component_row`. That function answers a different question: which labels does
trusty-mpm CREATE (`tm issue seed-labels`, session launch). It returns the
`trusty-mpm` convention label plus `agents.ticketing.extra_labels`, and the
owner's `~/.trusty-tools/trusty-mpm/config.yaml` declares no extras — so the
accepted set was literally `[trusty-mpm]`. It was not a fallback and not a
config gap: the check read a hardcoded seed table on purpose, for the wrong
purpose. Every issue owned by another crate therefore failed:
`component label FAIL none of [trusty-mpm] present (labels: enhancement, P2, tga, trusty-audit)`
on #7139, and the same on #7116, #7128 and #7132–#7140.

What the standard actually says (`tm-ticketing`, "Labels"): the owning-component
family is "the crate or subsystem the defect actually lives in", one or more —
and `trusty-mpm` "applies only when the code at fault sits under
`crates/trusty-mpm/`". So the accepted set is the workspace's crates.

## Fix

New `crates/trusty-mpm/src/core/component_labels.rs` — `ComponentLabels`, the
set the audit accepts:

- the seed table's names (so a configured `extra_labels` entry still counts,
  and `ws/<session>` still never does), then
- the `[package] name` of every `[workspace] members` crate, read from the root
  `Cargo.toml` found by walking up from the directory `gh` runs in, plus the
  hyphenated spelling of any name carrying a `_` (a GitHub label name cannot
  contain one, which is why the package `trusty_review` is labelled
  `trusty-review`).

Derived from the package name rather than the directory: a directory would add
`src-tauri` from the two nested Tauri members, which names no component. The
FAIL line names the whole accepted set, and an issue with no component label
still FAILs — this widens the accepted set, it does not weaken the rule to "any
label present".

Label creation is untouched: `tm issue seed-labels` and session launch still
read `policy_labels_configured`, so the owner ruling of 2026-09-06 stands —
`trusty-mpm` is a component label scoped to `crates/trusty-mpm/`, never a
stand-in for "some component label". Every manifest read is size-bounded and
fail-closed, so an unreadable or malformed `Cargo.toml` leaves exactly the
pre-#7123 accepted set rather than a wider one.

`audit_issue` takes the set as a third argument and stays pure; the two
production callers (`bin/tm/commands/issue/audit.rs`, `daemon/doctor_issue_audit.rs`)
resolve it from the directory they already run `gh` in.

## Gates — rung 3 (localized behavior inside one crate)

```
cargo fmt --check                                        EXIT=0
cargo check -p trusty-mpm --all-targets                  EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings  EXIT=0
cargo test -p trusty-mpm --no-fail-fast                  EXIT=0
    55 targets, 11149 passed, 0 failed, 18 ignored
bash scripts/check_line_cap.sh          OK (4654 files, 0 violations)
bash scripts/check_test_pointers.sh     OK (32520 citations, 0 dangling)
bash scripts/check_changelog_fragment.sh  OK trusty-mpm
bash scripts/check_sld.sh               OK (0 errors, 0 warnings)
```

### Regression tests, before and after

`a_non_mpm_crate_component_label_passes` and
`an_issue_with_no_crate_label_still_fails_against_the_widened_set` build a real
throwaway workspace and run the real derivation, so neutering
`ComponentLabels::resolve`'s crate discovery reproduces the pre-fix verdict.

Before (crate discovery removed):

```
test core::issue_audit::tests::a_non_mpm_crate_component_label_passes ... FAILED
assertion `left == right` failed: detail was: none of [trusty-mpm] present (labels: enhancement, P2, tga, trusty-audit)
  left: Fail
 right: Pass

test core::issue_audit::tests::an_issue_with_no_crate_label_still_fails_against_the_widened_set ... FAILED
the failure names the accepted set: none of [trusty-mpm] present (labels: enhancement, P2)

test core::component_labels::tests::resolve_accepts_every_workspace_crate_label ... FAILED
expected `trusty-audit` to be accepted; set was ["trusty-mpm"]

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 6233 filtered out
```

After:

```
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 6204 filtered out  (issue_audit)
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 6223 filtered out  (component_labels)
```

## Live verification

`cargo run -p trusty-mpm --bin tm -- issue audit 7139` from this branch's
worktree — the issue the report cited, labels `enhancement, P2, tga, trusty-audit`:

```
#7139
  project          PASS  tga
  milestone        PASS  trusty-audit — client re-run package
  component label  PASS  tga, trusty-audit
  relationships    INFO  no parent; blocked-by 0; sub-issues 0
EXIT=0
```

`tm issue audit 7116` (labels `bug, P2, ui, trusty-console`) likewise reports
`component label PASS trusty-console`, exit 0.

The rule is not weakened — `tm issue audit 7104`, which carries `enhancement`
and no component, still exits 1:

```
#7104
  component label  FAIL  none of [trusty-mpm, tc-services, trusty-agents, trusty-agents-common,
  trusty-agents-local, trusty-analyze, trusty-audit, trusty-channels, trusty-code, trusty-code-gui,
  trusty-code-tui, trusty-common, trusty-console, trusty-cto-db, trusty-embedderd, trusty-embedderd-py,
  tga, trusty-gworkspace, trusty-installer, trusty-kb, trusty-mcp, trusty-memory, trusty-mpm-gui,
  trusty-progress, trusty-publish-guard, trusty-review, trusty-search, trusty-sld-lint,
  trusty-agents-ui, trusty-audit-ui] present (labels: enhancement)
Error: 1 issue(s) violate the ticketing standard: #7104
```

Refs #7123

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01GPG8e4HsXx3bviPTe9wbgv
