### PR TITLE
fix(trusty-review): drop hardcoded CAST vendor claim from DD template

### DIFF
--- a/crates/trusty-review/changelog.d/7136-dd-vendor-provenance.md
+++ b/crates/trusty-review/changelog.d/7136-dd-vendor-provenance.md
@@ -1,3 +1,4 @@
 Fixed
 
 - The CAST DD template's Report Metadata table no longer hardcodes `CAST (CAST Software) — CAST Highlight + CAST Imaging` as the Vendor / methodology value. That static string carried no provenance marker, unlike every other row in the same table, and could read as a factual claim that CAST Software's platform produced the analysis — no CAST product is invoked; trusty-analyze/trusty-search did the analysis. The row now renders `{{vendor_methodology}}`, the same self-known, provenance-tagged value the generic technical-DD template already used.
+- The CAST DD template's `## 3. CAST Scoring Model & Normalization` section no longer cites the unmeasured historical CAST benchmark figure ("~3,467 apps") as fact. The "Peer-benchmark population" row now names this reporter's own analysis-corpus population instead of borrowing CAST's proprietary-corpus number, matching the disclaimer the per-application Peer Benchmark Position table already carries.

--- a/crates/trusty-review/changelog.d/7136-dd-vendor-provenance.md
+++ b/crates/trusty-review/changelog.d/7136-dd-vendor-provenance.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The CAST DD template's Report Metadata table no longer hardcodes `CAST (CAST Software) — CAST Highlight + CAST Imaging` as the Vendor / methodology value. That static string carried no provenance marker, unlike every other row in the same table, and could read as a factual claim that CAST Software's platform produced the analysis — no CAST product is invoked; trusty-analyze/trusty-search did the analysis. The row now renders `{{vendor_methodology}}`, the same self-known, provenance-tagged value the generic technical-DD template already used.

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -390,6 +390,42 @@ fn cast_template_instruct_override_never_renders() {
     assert!(md.contains("Acme Due Diligence"), "report still renders");
 }
 
+/// Why (#7136): the CAST template's Report Metadata table used to hardcode
+/// `CAST (CAST Software) — CAST Highlight + CAST Imaging` as the Vendor /
+/// methodology value — a static string with no provenance marker, unlike
+/// every other row in the same table, that a reader could mistake for a
+/// factual claim that CAST Software's platform produced the analysis. No
+/// CAST product is invoked; trusty-analyze/trusty-search did the analysis.
+/// What: renders the bundled CAST template and asserts the Vendor /
+/// methodology row now carries the same self-known, provenance-tagged
+/// `vendor_methodology` value the generic template already renders — never
+/// the literal "CAST Software" vendor claim.
+/// Test: this test itself.
+#[test]
+fn cast_template_vendor_methodology_carries_provenance_not_cast_vendor_claim() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let model = fixture_model(tmp.path());
+    let template = TemplateLoader::bundled_only()
+        .load("report-technical-dd-cast")
+        .expect("bundled cast template");
+    let reporter = Reporter::new(tmp.path());
+    let md = reporter.render(&model, &template);
+
+    assert!(
+        !md.contains("CAST (CAST Software)"),
+        "must not hardcode a vendor attribution: {md}"
+    );
+    let expected_row = format!(
+        "| Vendor / methodology | {}{} |",
+        model.vendor_methodology,
+        crate::report::provenance::MEASURED_TAG
+    );
+    assert!(
+        md.contains(&expected_row),
+        "expected self-known, tagged vendor/methodology row {expected_row:?} in: {md}"
+    );
+}
+
 /// Why: the model must assemble deterministically from the manifest.
 /// What: asserts repository count, metrics presence, and no git info for a
 /// non-existent local path.

--- a/crates/trusty-review/src/report/reporter_tests.rs
+++ b/crates/trusty-review/src/report/reporter_tests.rs
@@ -396,10 +396,20 @@ fn cast_template_instruct_override_never_renders() {
 /// every other row in the same table, that a reader could mistake for a
 /// factual claim that CAST Software's platform produced the analysis. No
 /// CAST product is invoked; trusty-analyze/trusty-search did the analysis.
-/// What: renders the bundled CAST template and asserts the Vendor /
+/// Closure condition 2 (same issue): the `## 3. CAST Scoring Model &
+/// Normalization` section's "Peer-benchmark population" row cited a
+/// historical CAST benchmark figure ("~3,467 apps") as fact, unmarked, even
+/// though this reporter never had access to CAST's proprietary corpus — the
+/// per-application Peer Benchmark Position table right below already says so
+/// via a `code_only:non_code` boundary. The fabricated count is gone; the row
+/// now names the reporter's own analysis-corpus population instead of
+/// borrowing CAST's number.
+/// What: renders the bundled CAST template and asserts (1) the Vendor /
 /// methodology row now carries the same self-known, provenance-tagged
 /// `vendor_methodology` value the generic template already renders — never
-/// the literal "CAST Software" vendor claim.
+/// the literal "CAST Software" vendor claim — and (2) the CAST Scoring Model
+/// table no longer states the unmeasured "~3,467 apps" figure, instead
+/// pointing at this reporter's own analysis corpus.
 /// Test: this test itself.
 #[test]
 fn cast_template_vendor_methodology_carries_provenance_not_cast_vendor_claim() {
@@ -423,6 +433,15 @@ fn cast_template_vendor_methodology_carries_provenance_not_cast_vendor_claim() {
     assert!(
         md.contains(&expected_row),
         "expected self-known, tagged vendor/methodology row {expected_row:?} in: {md}"
+    );
+
+    assert!(
+        !md.contains("3,467"),
+        "must not cite the unmeasured historical CAST benchmark figure: {md}"
+    );
+    assert!(
+        md.contains("population drawn from this reporter's own analysis corpus"),
+        "expected the peer-benchmark population row to name its own corpus, not CAST's: {md}"
     );
 }
 

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -103,7 +103,7 @@ in the coverage data provided — and name it specifically.
 | Field | Value |
 |---|---|
 | Source document | {{source_document_reference}} |
-| Vendor / methodology | CAST (CAST Software) — CAST Highlight + CAST Imaging |
+| Vendor / methodology | {{vendor_methodology}} |
 | Report date / version | {{report_date}} / {{report_version}} |
 | Inference models | {{inference_models}} |
 | Target / deal codename | {{target_codename}} |

--- a/crates/trusty-review/templates/report-technical-dd-cast.md
+++ b/crates/trusty-review/templates/report-technical-dd-cast.md
@@ -143,7 +143,7 @@ expected >3.40; 2–5yr >3.20; 5–10yr >3.00; >10yr >2.70.
 | AMBER threshold (normalized) | 33–66 (native 2.00–2.99) |
 | GREEN threshold (normalized) | > 66 (native >= 3.00) |
 | Health factors aggregated | Application-level grades aggregate from technical criteria and rules directly (not from module-level grades); application and module grades can diverge |
-| Peer-benchmark population | All technologies (size TBD from analysis corpus; historical CAST reference: ~3,467 apps), plus technology-specific peer sets (HTML5, .NET, Java, Python, Go, etc.) |
+| Peer-benchmark population | All technologies (population drawn from this reporter's own analysis corpus, not CAST's proprietary corpus — see Peer Benchmark Position), plus technology-specific peer sets (HTML5, .NET, Java, Python, Go, etc.) |
 
 ## 4. Per-Application Scorecard
 


### PR DESCRIPTION
## Root cause

`crates/trusty-review/templates/report-technical-dd-cast.md:106` hardcoded the Report Metadata table's Vendor / methodology row as `CAST (CAST Software) — CAST Highlight + CAST Imaging` — a static literal with no provenance marker, unlike every other row in the same table (e.g. `Report date / version | {{report_date}} / {{report_version}}`, both `⁽ᵐ⁾`-tagged). The sibling generic template (`report-technical-dd.md:77`) already fills this row from the model's self-known, provenance-tagged `vendor_methodology` value (`crates/trusty-review/src/report/model.rs:32`) — the CAST template never adopted that mechanism when it was authored, and instead named a vendor whose product is never invoked (trusty-analyze/trusty-search perform the analysis; the template only imitates CAST's report format).

Closure condition 2 of #7136: the `## 3. CAST Scoring Model & Normalization` section (`report-technical-dd-cast.md:146`) cited a historical CAST benchmark figure — "historical CAST reference: ~3,467 apps" — as fact, with no provenance marker, even though this reporter never had access to CAST's proprietary corpus. The per-application Peer Benchmark Position table right below it (`report-technical-dd-cast.md:179`) already discloses that exact boundary via a `code_only:non_code` marker ("CAST's proprietary reference corpus of thousands of scanned applications"), so the top-of-document methodology table contradicted the boundary the report itself states lower down.

## Fix

1. Replace the static Vendor / methodology row with the `{{vendor_methodology}}` placeholder, matching the generic template exactly. `build_scope` (`src/report/reporter.rs:349`) already fills this placeholder with `tag(&model.vendor_methodology, Provenance::Measured)` for every render — no new plumbing, no vendor name hardcoded, and the row now carries the same `⁽ᵐ⁾` marker as its neighbors.
2. Replace the "Peer-benchmark population" row's `~3,467 apps` citation with a description of this reporter's own analysis-corpus population, never CAST's — no number invented, and consistent with the `code_only:non_code` disclaimer already on the per-application benchmark table.

## Rung 3 gates (localized template + test change inside trusty-review)

```
cargo fmt --check                                              → EXIT=0
cargo check -p trusty-review                                   → EXIT=0
cargo clippy -p trusty-review --all-targets -- -D warnings     → EXIT=0
cargo test -p trusty-review --no-fail-fast                     → EXIT=0
  lib:      2225 passed; 0 failed; 5 ignored
  main:     80 passed; 0 failed
  8 integration test binaries: 25 passed; 0 failed (cast_template_golden: 6 passed)
bash scripts/check_line_cap.sh                                 → OK (4654 tracked .rs files, 0 violations)
bash scripts/check_changelog_fragment.sh --staged               → OK
bash scripts/check_test_pointers.sh                             → OK (32520 Test: pointers, 0 dangling)
```

Regression test: `report::reporter::tests::cast_template_vendor_methodology_carries_provenance_not_cast_vendor_claim` (`crates/trusty-review/src/report/reporter_tests.rs`) now covers both closure conditions:
- confirmed it fails against the pre-fix template (asserted the literal `CAST (CAST Software)` string was absent and the tagged `vendor_methodology` row was present) and passes after fix 1.
- extended with two assertions for fix 2 — the rendered report no longer contains `3,467`, and it names the reporter's own corpus (`"population drawn from this reporter's own analysis corpus"`) — confirmed these fail against the pre-fix template and pass after fix 2.

Refs #7136

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01GPG8e4HsXx3bviPTe9wbgv
