### PR TITLE
fix(tga): audit's data-handling note runs the real attestation, not the pre-#5218 pending placeholder

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/7140-retention-note-stale.md
+++ b/crates/trusty-git-analytics/changelog.d/7140-retention-note-stale.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `tga audit`'s Gaps & Caveats data-handling line now runs the real
+  data-retention attestation #5218 shipped, instead of unconditionally
+  quoting the pre-#5218 placeholder saying an attestation is "pending
+  (#5218)" (#7140). Every DD report generated after `tga` 7.1.0 carried that
+  stale sentence even though #5218 had already shipped. The line now states a
+  clean scan's table/column coverage, names finding counts when the scan
+  turns up a content-bearing column or a diff-shaped row, and — only if the
+  scan itself cannot run — says so and why, still stating tga's schema-level
+  no-file-content claim rather than falling silent.

--- a/crates/trusty-git-analytics/src/audit/gaps.rs
+++ b/crates/trusty-git-analytics/src/audit/gaps.rs
@@ -7,7 +7,8 @@
 //! reads, so the wording lives in one place instead of being formatted at the
 //! call site.
 //! What: [`sweep_gap_lines`] (one line per failed stage) and
-//! [`DATA_HANDLING_NOTE`] (§10's placeholder attestation, #5244).
+//! [`data_handling_note`] (§10's attestation line, now backed by the real
+//! scan #5218 shipped, #7140).
 //! Test: `super::tests`.
 //!
 //! ## Redaction happens here, before the excerpt is cut
@@ -31,7 +32,11 @@
 
 use std::collections::BTreeMap;
 
+use rusqlite::Connection;
 use trusty_common::credentials::scrub_secrets;
+
+use crate::core::inspect::attest::{self, Verdict, NOT_A_NO_CODE_CLAIM, NO_CONTENT_CLAIM};
+use crate::core::inspect::schema;
 
 use super::repo_index::RepoIndexStatus;
 use super::stage::{AuditSweepStats, StageStatus};
@@ -44,23 +49,58 @@ use super::stage::{AuditSweepStats, StageStatus};
 /// and in the sweep's own record; this is the reader's excerpt.
 pub(crate) const MAX_REASON_CHARS: usize = 160;
 
-/// The placeholder data-retention statement AUDIT carries until #5218 ships.
+/// The data-retention line AUDIT's Gaps & Caveats section carries.
 ///
 /// Why: DOC-67 §10 — an acquirer's counterparty asks what the tool retained
-/// before granting access, and #5218 is the authoritative mechanism for that
-/// answer. Until it ships, the report must say an attestation is *pending*
-/// rather than assert one, and must not paraphrase a claim it cannot yet
-/// enforce.
-/// What: states that the formal attestation is pending, and states §10's
-/// verified scope claim exactly as §10 words it — "no file content, diffs,
-/// patches, hunks, or blobs", never the broader "no code", because free-text
-/// columns can carry whatever an author pasted into them.
-/// Test: `super::tests::data_handling_note_is_a_pending_claim`.
-pub const DATA_HANDLING_NOTE: &str = "Data handling: a formal data-retention attestation for \
-this run is pending (#5218) and is not asserted here. tga's database records commit, \
-pull-request, and ticket metadata; it stores no file content, diffs, patches, hunks, or blobs. \
-Free-text fields it does store — commit messages, pull-request and ticket titles — are retained \
-verbatim and carry whatever their authors wrote into them.";
+/// before granting access. #5218 shipped the real attestation
+/// (`core::inspect::attest`, also reachable by hand via `tga inspect attest`),
+/// but the sweep path kept asserting the pre-#5218 placeholder verbatim, so
+/// every `tga audit` report still said the attestation was "pending (#5218)"
+/// after #5218 shipped and closed (#7140). This runs the real scan against
+/// the sweep's own connection instead of quoting a fact about tga's release
+/// history.
+/// What: reads the live schema and scans every free-text column, exactly as
+/// `tga inspect attest` does, then reports one sentence: a clean scan states
+/// §10's claim with the tables/columns it covers; a scan with findings names
+/// the finding counts instead of asserting the claim unreviewed; a scan that
+/// cannot run (a schema-read failure) says so and why, and still states the
+/// schema-level claim so the report never falls silent on data handling.
+/// Test: `super::tests::{data_handling_note_states_a_clean_attestation,
+/// data_handling_note_states_findings_instead_of_asserting_the_claim}`.
+pub fn data_handling_note(conn: &Connection) -> String {
+    match schema::snapshot(conn).and_then(|snapshot| attest::attest(conn, &snapshot)) {
+        Ok(attestation) => match attestation.verdict {
+            Verdict::Consistent => format!(
+                "Data handling: a data-retention attestation ran for this database — {} \
+                 table(s) and {} free-text column(s) scanned, no findings. {} {}",
+                attestation.tables_scanned,
+                attestation.scanned_columns.len(),
+                attestation.claim,
+                attestation.caveat
+            ),
+            Verdict::Findings => {
+                let flagged: i64 = attestation
+                    .scanned_columns
+                    .iter()
+                    .map(|s| s.diff_shaped_rows)
+                    .sum();
+                format!(
+                    "Data handling: a data-retention attestation ran for this database and \
+                     found {} content-bearing column(s) and {flagged} row(s) of diff-shaped \
+                     text — the claim that {} does not hold unreviewed for this run. Run \
+                     `tga inspect attest` against this database for the full finding list.",
+                    attestation.content_columns.len(),
+                    attestation.claim
+                )
+            }
+        },
+        Err(e) => format!(
+            "Data handling: a data-retention attestation could not be run against this \
+             database ({e}); none is asserted for this run. {NO_CONTENT_CLAIM} \
+             {NOT_A_NO_CODE_CLAIM}"
+        ),
+    }
+}
 
 /// The words a stale-refs gap line opens with (#6782).
 ///

--- a/crates/trusty-git-analytics/src/audit/mod.rs
+++ b/crates/trusty-git-analytics/src/audit/mod.rs
@@ -49,7 +49,7 @@ pub use analyze::{
 /// of a copy that can drift away from it (#5308 review).
 #[cfg(test)]
 pub(crate) use gaps::MAX_REASON_CHARS;
-pub use gaps::{index_gap_lines, sweep_gap_lines, DATA_HANDLING_NOTE, STALE_FETCH_HEADLINE};
+pub use gaps::{data_handling_note, index_gap_lines, sweep_gap_lines, STALE_FETCH_HEADLINE};
 pub use repo_index::{
     ensure_repositories_indexed, index_id_for, resolve_search_binary, RepoIndexOutcome,
     RepoIndexStatus, DEFAULT_SEARCH_BIN, ENV_SEARCH_BIN,

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -910,16 +910,53 @@ fn long_stage_reasons_are_truncated() {
     );
 }
 
+/// #7140: the sweep must call the real attestation #5218 shipped instead of
+/// unconditionally asserting the pre-#5218 "pending" placeholder. A clean
+/// database — no content-bearing columns, no diff-shaped rows — states the
+/// attestation actually ran and passed, never that one is still pending.
 #[test]
-fn data_handling_note_is_a_pending_claim() {
-    let note = crate::audit::DATA_HANDLING_NOTE;
-    // DOC-67 §10: pending, never asserted — and #5218 is where the real one comes from.
-    assert!(note.contains("pending"), "{note}");
-    assert!(note.contains("#5218"), "{note}");
-    // §10's exact scope claim; the broader "no code" claim is wrong and must
-    // not appear, because free-text columns can carry pasted snippets.
+fn data_handling_note_states_a_clean_attestation() {
+    let db = Database::open_in_memory().expect("open in-memory db");
+    let note = crate::audit::data_handling_note(db.connection());
+
+    assert!(
+        !note.contains("pending"),
+        "a real attestation ran; it must not say pending: {note}"
+    );
+    assert!(!note.contains("#5218"), "{note}");
+    assert!(note.contains("no findings"), "{note}");
+    // §10's exact scope claim, plus its caveat that this is not the broader
+    // "no code" claim — free-text columns can still carry a pasted snippet.
     assert!(note.contains("no file content, diffs, patches, hunks, or blobs"));
-    assert!(!note.contains("no code"), "{note}");
+    assert!(
+        note.contains("not a claim that the database contains no code"),
+        "{note}"
+    );
+}
+
+/// A database carrying a diff pasted into a commit message must be named as a
+/// finding, not folded into a silent "consistent" claim — DOC-67 §9's rule
+/// that an unassessed or contradicted claim is stated, never hidden.
+#[test]
+fn data_handling_note_states_findings_instead_of_asserting_the_claim() {
+    let db = Database::open_in_memory().expect("open in-memory db");
+    db.connection()
+        .execute(
+            "INSERT INTO commits (sha, author_name, author_email, timestamp, message, repository) \
+             VALUES ('deadbee', 'Ada', 'ada@example.com', '2026-01-01T00:00:00Z', ?1, 'r')",
+            ["fix: paste\n\ndiff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n"],
+        )
+        .expect("insert commit");
+
+    let note = crate::audit::data_handling_note(db.connection());
+
+    assert!(
+        !note.contains("pending"),
+        "a real attestation ran; it must not say pending: {note}"
+    );
+    assert!(note.contains("found"), "{note}");
+    assert!(note.contains("diff-shaped"), "{note}");
+    assert!(note.contains("does not hold unreviewed"), "{note}");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/trusty-git-analytics/src/commands/audit.rs
+++ b/crates/trusty-git-analytics/src/commands/audit.rs
@@ -18,11 +18,10 @@ use clap::Args;
 
 use anyhow::Context as _;
 use tga::audit::{
-    ensure_analyze_daemon, ensure_repositories_indexed, ensure_search_daemon, index_gap_lines,
-    require_inference_credential, require_rendered_report_carries_synthesis,
+    data_handling_note, ensure_analyze_daemon, ensure_repositories_indexed, ensure_search_daemon,
+    index_gap_lines, require_inference_credential, require_rendered_report_carries_synthesis,
     require_review_supports_required_inference, resolve_review_binary, run_full_sweep,
     run_review_report, sweep_gap_lines, AuditSweepStats, SweepOptions, SweepStage,
-    DATA_HANDLING_NOTE,
 };
 use tga::core::config::Config;
 use tga::core::db::Database;
@@ -267,7 +266,10 @@ pub async fn run(config: Config, db: &mut Database, args: AuditArgs) -> anyhow::
         }
     };
 
-    gaps.push(DATA_HANDLING_NOTE.to_string());
+    // #7140: the sweep's own connection reads back what this run's database
+    // actually holds, so the report states the real attestation instead of
+    // quoting a fact about tga's release history.
+    gaps.push(data_handling_note(db.connection()));
     let mut manifest = build_dd_manifest(
         &config,
         &DdManifestOptions {


### PR DESCRIPTION
## Root cause

`crates/trusty-git-analytics/src/audit/gaps.rs::DATA_HANDLING_NOTE` was a `pub const` written while #5218 was unshipped, stating the data-retention attestation was "pending (#5218)". `crates/trusty-git-analytics/src/commands/audit.rs::run` pushed it into every `tga audit` run's Gaps & Caveats section unconditionally. #5218 shipped the real attestation (`core::inspect::attest`, callable by hand via `tga inspect attest`), but nothing wired it into the `tga audit` sweep path, so every DD report generated after `tga` 7.1.0 kept stating the pending placeholder verbatim (#7140).

## Fix

`DATA_HANDLING_NOTE` is now `data_handling_note(conn: &Connection) -> String` in `crates/trusty-git-analytics/src/audit/gaps.rs`. It runs the same schema read (`core::inspect::schema::snapshot`) and column scan (`core::inspect::attest::attest`) `tga inspect attest` runs, against the sweep's own connection (`commands/audit.rs::run` now calls `data_handling_note(db.connection())`), and reports:

- a clean scan (`Verdict::Consistent`): states the claim, the caveat, and the tables/columns scanned — no "pending", no "#5218".
- a scan with findings (`Verdict::Findings`): names the content-bearing column count and diff-shaped row count instead of asserting the claim unreviewed.
- a scan that cannot run (schema-read failure): states that and why, and still states the schema-level claim so the report never falls silent on data handling.

## Rung and gates (rung 3, localized behavior inside `tga`)

```
cargo fmt --check                                        # EXIT=0
cargo check -p tga                                        # EXIT=0
cargo clippy -p tga --all-targets -- -D warnings           # EXIT=0
cargo test -p tga --no-fail-fast                           # test result: ok. 1616 passed; 0 failed; 7 ignored (11 test targets)
bash scripts/check_line_cap.sh                             # 4654 tracked .rs files, 0 violations
bash scripts/check_test_pointers.sh                        # 32521 Test: citations resolved, 0 dangling
bash scripts/check_changelog_fragment.sh --staged          # trusty-git-analytics fragment present and valid
```

Regression tests added in `crates/trusty-git-analytics/src/audit/tests.rs`:
- `data_handling_note_states_a_clean_attestation` — asserts the note for a fresh in-memory database never says "pending" or "#5218", and states "no findings".
- `data_handling_note_states_findings_instead_of_asserting_the_claim` — inserts a commit with a diff pasted into its message and asserts the note names the finding instead of asserting the claim clean.

Both fail against the pre-fix constant (which unconditionally said "pending (#5218)" regardless of any real scan) and pass against the fix.

Refs #7140

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01GPG8e4HsXx3bviPTe9wbgv