### PR TITLE
fix(tga): audit report names the GitHub PR leg when fetch_prs is off

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/7132-pr-leg-declared-absent.md
+++ b/crates/trusty-git-analytics/changelog.d/7132-pr-leg-declared-absent.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `tga audit`'s report now names the "GitHub pull requests" collection leg as
+  not attempted when `github.fetch_prs` is off (or no `github:` block exists)
+  against repositories whose `origin` remote is GitHub-hosted (#7132). Before
+  this, a config that never enabled `github.fetch_prs` left `pull_requests`
+  empty with the `collect` stage reporting `Succeeded` and nothing in the
+  Gaps & Caveats section explaining why — indistinguishable, on the page, from
+  an org with no PR history at all.

--- a/crates/trusty-git-analytics/src/audit/sweep.rs
+++ b/crates/trusty-git-analytics/src/audit/sweep.rs
@@ -234,10 +234,11 @@ pub async fn run_full_sweep(
 /// its stage `Succeeded` with empty tables, which reads on the page exactly
 /// like a leg that ran and found nothing. This is the recorded-skip half of
 /// #5620's split; the blind half is what the declaration replaces.
-/// What: one [`DeclaredSkip`] per declaring section. Only GitHub work items
-/// today — the other providers have no declarer, so adding one is a matching
-/// arm here rather than a redesign.
-/// Test: `super::tests::a_declared_absent_leg_is_named_in_the_gap_lines`.
+/// What: one [`DeclaredSkip`] per declaring section — GitHub work items (an
+/// operator-authored reason), plus GitHub pull requests (#7132, inferred: the
+/// leg is off by config default rather than by an explicit reason string).
+/// Test: `super::tests::a_declared_absent_leg_is_named_in_the_gap_lines`,
+/// `super::tests::a_disabled_github_pr_leg_against_github_repos_is_named_in_the_gap_lines`.
 fn record_declared_skips(stats: &mut AuditSweepStats, config: &Config) {
     if let Some(reason) = config
         .github
@@ -247,6 +248,22 @@ fn record_declared_skips(stats: &mut AuditSweepStats, config: &Config) {
         stats.record_declared_skip(DeclaredSkip {
             leg: "GitHub work items".to_owned(),
             reason: reason.to_owned(),
+        });
+    }
+
+    // #7132: `github.fetch_prs` defaults to `false`, so a config that never
+    // turns it on leaves `pull_requests` empty with the `collect` stage
+    // reporting `Succeeded` — indistinguishable, on the page, from an org
+    // with no PR history at all. Fire only against repos that actually look
+    // GitHub-hosted, so a GitLab/Bitbucket-only config stays silent.
+    let fetch_prs_on = config.github.as_ref().is_some_and(|gh| gh.fetch_prs);
+    if !fetch_prs_on && crate::collect::collector::has_github_like_repos(&config.repositories) {
+        stats.record_declared_skip(DeclaredSkip {
+            leg: "GitHub pull requests".to_owned(),
+            reason: "`github.fetch_prs` is not enabled (add a `github:` block with \
+                     `fetch_prs: true` and a token) even though a configured \
+                     repository's `origin` remote is a GitHub URL"
+                .to_owned(),
         });
     }
 }

--- a/crates/trusty-git-analytics/src/audit/tests.rs
+++ b/crates/trusty-git-analytics/src/audit/tests.rs
@@ -852,6 +852,81 @@ async fn a_declared_absent_leg_is_named_in_the_gap_lines() {
     );
 }
 
+/// Issue #7132: a DD audit against 59 real GitHub repos shipped `pull_requests`
+/// empty in every one, with nothing on the report page saying PR collection
+/// was never attempted — `github.fetch_prs` defaults to `false`, and unlike
+/// the GitHub work-items leg above, the PR leg had no [`DeclaredSkip`].
+///
+/// Against the pre-fix code this fails at the last assertion: the `collect`
+/// stage reports `Succeeded` with an empty `pull_requests` table and the Gaps
+/// section says nothing about it — indistinguishable from an org with no PR
+/// history.
+#[tokio::test]
+async fn a_disabled_github_pr_leg_against_github_repos_is_named_in_the_gap_lines() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo_path = dir.path().join("acme-service");
+    // `sshx://` is not a real transport, so this fails at git2's transport
+    // lookup with no network I/O — deterministic, same technique as
+    // `init_repo_with_dead_origin` above. It still names a `github.com` host,
+    // which is all `has_github_like_repos` inspects.
+    init_repo_with_dead_origin(&repo_path, "sshx://git@github.com/acme/acme-service.git");
+
+    // No `github:` block at all — the shape the issue's engagement used:
+    // repos cloned from GitHub, but no API config to fetch PRs with.
+    let mut config = Config::default();
+    config
+        .repositories
+        .push(crate::core::config::RepositoryConfig {
+            name: Some("acme-service".to_string()),
+            path: repo_path,
+            branch: None,
+            since_date: None,
+            until_date: None,
+            org: None,
+            head_only: false,
+            fetch_timeout_secs: None,
+        });
+
+    let mut db = Database::open(&dir.path().join("tga.db")).expect("open db");
+    let options = SweepOptions {
+        output: Some(dir.path().join("out")),
+        weeks: Some(1),
+    };
+    let stats = run_full_sweep(&config, &mut db, &options, None)
+        .await
+        .expect("sweep");
+
+    let collect = stats
+        .outcomes
+        .iter()
+        .find(|o| o.stage == SweepStage::Collect)
+        .expect("collect stage ran");
+    assert_eq!(
+        collect.status,
+        StageStatus::Succeeded,
+        "an unattempted PR leg must not fail the collect stage: {:?}",
+        collect.status
+    );
+
+    let lines = crate::audit::sweep_gap_lines(&stats, NO_SECRETS);
+    let declared = lines
+        .iter()
+        .find(|l| l.contains("GitHub pull requests"))
+        .unwrap_or_else(|| panic!("no Gaps line names the unattempted PR leg: {lines:#?}"));
+    assert!(
+        declared.contains("was not attempted"),
+        "the line must say the leg never ran: {declared}"
+    );
+    assert!(
+        declared.contains("fetch_prs"),
+        "the line must point at the config knob: {declared}"
+    );
+    assert!(
+        declared.contains("unassessed"),
+        "the line must mark the affected sections unassessed: {declared}"
+    );
+}
+
 /// A declared reason is text this process did not author — it is a config
 /// value, so it travels the same redaction path a stage message does. Also
 /// pins the ordering: failed stages, then stale repositories, then declared

--- a/crates/trusty-git-analytics/src/collect/collector.rs
+++ b/crates/trusty-git-analytics/src/collect/collector.rs
@@ -1203,7 +1203,14 @@ impl CollectionPipeline {
 /// Test: covered indirectly — exercised by `tga collect` runs against
 /// real clones; pure-string parsing is covered by
 /// `crate::collect::github::client::extract_owner_repo_from_url`.
-fn has_github_like_repos(repositories: &[crate::core::config::RepositoryConfig]) -> bool {
+///
+/// `pub(crate)` since #7132: `audit::sweep::record_declared_skips` reuses this
+/// same detection to declare the "GitHub pull requests" leg absent when
+/// `github.fetch_prs` is off against GitHub-hosted repos, so the report names
+/// the gap instead of shipping an empty `pull_requests` table silently.
+pub(crate) fn has_github_like_repos(
+    repositories: &[crate::core::config::RepositoryConfig],
+) -> bool {
     for repo_cfg in repositories {
         let Ok(repo) = git2::Repository::open(&repo_cfg.path) else {
             continue;


### PR DESCRIPTION
Root cause: `github.fetch_prs` defaults to `false`, and unlike the GitHub work-items leg (`work_items_unavailable` / `DeclaredSkip`), the PR-fetch leg had no disclosure mechanism — a config that never turns it on leaves `pull_requests` empty while the `collect` stage still reports `Succeeded`, so a DD audit report reads as a clean pass with no PR history rather than as a leg that was never attempted (#7132). Reproduced with a local repo whose `origin` remote names a GitHub host and default config: `run_full_sweep` produces gap lines for jira/pr-metrics/stale-fetch but nothing naming the PR leg.

Fix: `audit::sweep::record_declared_skips` now also records a `DeclaredSkip` for "GitHub pull requests" when `github.fetch_prs` is not `true` against a repository whose `origin` remote is GitHub-hosted (reusing `collector::has_github_like_repos`, made `pub(crate)`), so `sweep_gap_lines` names the gap in the report.

Rung 3 (localized behavior inside one crate). Gate commands and counts:
- `cargo fmt --check` — clean
- `cargo check -p tga` — clean
- `cargo clippy -p tga --all-targets -- -D warnings` — clean
- `cargo test -p tga --no-fail-fast` — `test result: ok. 1616 passed; 0 failed; 7 ignored` (plus 10 other test-binary targets, all `ok`)
- `bash scripts/check_line_cap.sh` — OK
- `bash scripts/check_changelog_fragment.sh --staged` — OK

Regression test: `audit::tests::a_disabled_github_pr_leg_against_github_repos_is_named_in_the_gap_lines` — confirmed failing on pre-fix code (no gap line names the PR leg) and passing after the fix.

Refs #7132

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01GPG8e4HsXx3bviPTe9wbgv