### PR TITLE
docs(trusty-agents-common): guide agents away from escape-mangling edits (#7121)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7121-base-engineer-escape-sensitive-edits.md
+++ b/crates/trusty-agents-common/changelog.d/7121-base-engineer-escape-sensitive-edits.md
@@ -1,0 +1,3 @@
+Added
+
+- `BASE-ENGINEER.md` gains an "Escape-Sensitive Edits" section: prefer the Write/Edit tool's own `content`/`new_string` argument over a shell one-liner for text containing a regex character class (`\d`, `\s`, `[\w-]`), a literal backslash, or a comment delimiter (`*/`); avoid `perl -pi -e` and similarly shell-quoted `sed` one-liners for that content, since shell quoting and the interpreter's own escape processing can each mangle it before it reaches the file; when a patch needs that content, write a small Node/Python script to an absolute path that embeds the replacement as a raw/triple-quoted string and run that instead; verify byte-for-byte (`od -c`/`xxd`) after the edit (#7121).

--- a/crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md
@@ -22,6 +22,29 @@ layer adds engineering discipline. Do not restate BASE-AGENT content here.
 - Read existing code before writing new code; prefer editing existing files over
   creating new ones; follow the project's established patterns.
 
+## Escape-Sensitive Edits — Write Verbatim, Verify Byte-Exact
+
+Content containing a regex character class (`\d`, `\s`, `[\w-]`), a literal
+backslash, or a comment delimiter (`*/`) is easy to corrupt through a layer
+that re-interprets escapes it should pass through unchanged — the corruption
+is invisible in a normal review pass and silently breaks `grep`/regex use
+against the file (issue #7121).
+
+- Prefer the Write/Edit tool's own `content`/`new_string` argument over a
+  shell one-liner for any change containing that kind of content.
+- Avoid `perl -pi -e '...'` (and similarly shell-quoted `sed` one-liners) for
+  an in-place edit whose replacement text contains `\d`, `\s`, `\w`, `\n` as a
+  literal two-character token, or `*/` — the shell's quoting and the
+  interpreter's own escape processing each get a chance to mangle it before
+  it reaches the file.
+- When a patch needs that content, write a small script to an absolute path
+  (Node with `fs.writeFileSync`, Python with `pathlib.Path.write_text`) that
+  embeds the replacement as a raw or triple-quoted string, then run that
+  script — one interpretation of the string, by the language runtime that
+  owns it, never an intermediate shell.
+- After the edit, verify byte-for-byte over the affected region —
+  `od -c <file>` or `xxd` — not just a visual diff.
+
 ## Right-Level Engineering
 
 Match solution complexity to problem complexity. Over-engineering is a bug, not


### PR DESCRIPTION
## Investigation

#7121 reports the Write tool interpreting backslash escapes in file content
(a regex character class landed as literal control bytes, confirmed via
`od -c`). Traced the code path in this repo:

- `pm_guard.rs` (`EDIT_TOOLS`, `evaluate_main_checkout_write`) only inspects
  `file_path` for its allow/deny decision — it never reads or re-serialises
  `content`.
- `hook_rewrite.rs`'s `updatedInput` mechanism only rewrites Bash commands
  for output compression; it has no Write-tool path.
- This repo's own Write-like tools — `trusty-code/src/tools/fs/write.rs`,
  `write_files.rs`, and `trusty-agents/src/tools/write_file.rs` — all read
  `content` via `serde_json::Value::as_str()` (which correctly decodes JSON
  string escapes) and write it verbatim with `std::fs::write`/
  `tokio::fs::write`. No re-escaping happens anywhere in this path.

**Conclusion: the corruption is in Claude Code's native Write tool (the
harness), not in trusty-tools source.** Nothing in this repo touches Write
tool content.

## What this PR does

The issue's second closure condition asks for BASE-AGENT/BASE-ENGINEER
guidance so agents route around the harness bug rather than waiting for a
fix outside this repo's control. Added an "Escape-Sensitive Edits" section
to `crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md` (the
single shared source both `trusty-mpm` and `trusty-code` embed):
prefer the Write/Edit tool's own `content`/`new_string` argument over a
shell one-liner for text containing a regex character class or comment
delimiter; avoid `perl -pi -e` (and similarly shell-quoted `sed` one-liners)
for that content; write a small Node/Python script to an absolute path when
a patch needs it; verify byte-for-byte (`od -c`/`xxd`) after the edit.

## Rung and gates (docs-only asset change, verified against consumers)

```
cargo fmt --check                                          → EXIT=0
cargo check -p trusty-agents-common                         → EXIT=0
cargo clippy -p trusty-agents-common --all-targets -- -D warnings → EXIT=0 (only pre-existing unrelated bin-target warnings)
cargo test -p trusty-agents-common --no-fail-fast            → test result: ok. 556 passed; 0 failed; 0 ignored
cargo check -p trusty-mpm -p trusty-code                     → EXIT=0 (both consumers compile clean)
cargo test -p trusty-code --lib assets --no-fail-fast        → test result: ok. 14 passed; 0 failed
cargo test -p trusty-mpm --lib bundle --no-fail-fast         → test result: ok. 131 passed; 0 failed (includes pm_prompt_golden_tests::golden_bundled_fallback_prompt and every_bundled_agent_roots_at_base_agent — no golden refresh needed)
bash scripts/check_line_cap.sh                               → OK, 0 violations
bash scripts/check_changelog_fragment.sh --staged            → OK, trusty-agents-common fragment present and valid
```

Fragment: `crates/trusty-agents-common/changelog.d/7121-base-engineer-escape-sensitive-edits.md`

Refs #7121

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01GPG8e4HsXx3bviPTe9wbgv