### PR TITLE
harden(trusty-mpm): refuse cross-session worktree removal, escalate cwd collisions

### DIFF
--- a/crates/trusty-mpm/changelog.d/3764-liveness-recheck-and-canon-fallback.md
+++ b/crates/trusty-mpm/changelog.d/3764-liveness-recheck-and-canon-fallback.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `foreign_active_claim`'s nonexistent-path fallback now canonicalizes
+  through the nearest existing ancestor and lexically normalizes the result,
+  instead of comparing raw, un-normalized strings — closing a fail-open gap
+  where a phantom `Active` record spelled with a `..` segment or reached via
+  a symlinked ancestor slipped past the #3764 guard undetected (#3764).
+- `dedup_stale_duplicates`'s `plan_dedup` loser branch now re-probes tmux
+  liveness immediately before `decommission_dedup_loser`, matching the
+  recheck the `#3396` (`workspace_dup_losers`) branch already ran — a loser
+  whose tmux session went live between planning and the destructive call is
+  now skipped instead of killed (#3764).

--- a/crates/trusty-mpm/changelog.d/3764-worktree-deletion-guard.md
+++ b/crates/trusty-mpm/changelog.d/3764-worktree-deletion-guard.md
@@ -1,0 +1,13 @@
+Added
+
+- `SessionManager::decommission` now refuses to remove a workspace when a
+  DIFFERENT `Active` managed session also claims that exact directory (by
+  `workspace_path` or `cwd`) — the #1744 cwd-collision shape that preceded
+  the #3715 cross-session worktree-corruption incident. The new
+  `workspace_guard::foreign_active_claim` check runs unconditionally, ahead
+  of every disk mutation, and refuses with the new
+  `ManagedError::ForeignActiveWorkspaceClaim` error (#3764).
+- The `SessionStart` hook's ambiguous-cwd skip (2+ `Active` managed sessions
+  sharing one cwd) now logs at `ERROR` instead of `WARN`, so it reaches
+  `tm doctor` / `list_recent_errors` instead of passing almost silently
+  (#3764).

--- a/crates/trusty-mpm/src/daemon/api/session_start_correlation.rs
+++ b/crates/trusty-mpm/src/daemon/api/session_start_correlation.rs
@@ -146,11 +146,22 @@ pub(crate) async fn correlate_session_start(
             }
         }
         n => {
-            tracing::warn!(
+            // #3764: escalated from `warn!` to `error!` — this collision was
+            // the observed precursor state hours before the #3715 worktree
+            // corruption incident, and at `warn!` it passed almost silently.
+            // ERROR-level events are what `list_recent_errors`/`tm doctor`
+            // surface to an operator; a silent `warn!` here meant the exact
+            // shape that preceded real data loss had no operator-visible
+            // signal at all. This does not change the SKIP behavior below —
+            // attribution is still refused to avoid mis-assignment — only the
+            // log level, which is now proportionate to what this state has
+            // already once preceded.
+            tracing::error!(
                 cwd = %cwd_str,
                 n,
                 "SessionStart: {n} Active managed sessions share the same cwd — \
-                 skipping claude_session_id attribution to avoid mis-assignment (#1744)"
+                 skipping claude_session_id attribution to avoid mis-assignment; this is a \
+                 known precursor to cross-session worktree corruption (#3764, #1744, #3715)"
             );
         }
     }

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1780,6 +1780,119 @@ async fn session_start_hook_correlates_claude_id() {
     );
 }
 
+/// #3764: the #1744 ambiguous-cwd skip is now an ERROR-level alarm, not a
+/// silent `warn!` — this collision was the precursor state observed hours
+/// before the #3715 worktree-corruption incident.
+///
+/// Why: `correlate_session_start`'s `n => { .. }` arm used to log at `warn!`,
+/// which passed almost silently. Captures the SAME
+/// [`trusty_common::log_buffer::LogBufferLayer`] entry point
+/// `dedup_tests::reconcile_warns_that_a_terminal_record_has_a_live_tmux_session`
+/// already uses, so this asserts the actual emitted level rather than merely
+/// that the SKIP behavior (no attribution) still holds.
+/// Test: this function IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn session_start_hook_escalates_ambiguous_cwd_to_error() {
+    use tracing::instrument::WithSubscriber;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    crate::test_support::enable_event_capture();
+
+    use crate::session_manager::{ManagedSessionState, SessionManager};
+
+    // Inline minimal fake driver, mirroring `make_state_with_active_managed`
+    // above — needed here too because two records must share one manager.
+    struct MinFake {
+        sessions: std::sync::Mutex<Vec<String>>,
+    }
+    impl crate::session_manager::ManagedTmuxDriver for MinFake {
+        fn create_session(
+            &self,
+            name: &str,
+            _: &str,
+        ) -> Result<(), crate::session_manager::ManagedError> {
+            self.sessions.lock().unwrap().push(name.to_owned());
+            Ok(())
+        }
+        fn kill_session(&self, name: &str) -> Result<(), crate::session_manager::ManagedError> {
+            self.sessions.lock().unwrap().retain(|n| n != name);
+            Ok(())
+        }
+        fn send_line(&self, _: &str, _: &str) -> Result<(), crate::session_manager::ManagedError> {
+            Ok(())
+        }
+        fn capture(
+            &self,
+            _: &str,
+            _: usize,
+        ) -> Result<String, crate::session_manager::ManagedError> {
+            Ok(String::new())
+        }
+        fn list_sessions(&self) -> Result<Vec<String>, crate::session_manager::ManagedError> {
+            Ok(self.sessions.lock().unwrap().clone())
+        }
+    }
+
+    let ws = std::path::PathBuf::from("/tmp/test-ws-ambiguous-cwd-3764");
+    let tmp = tempfile::TempDir::new().unwrap();
+    let fake: Arc<dyn crate::session_manager::ManagedTmuxDriver> = Arc::new(MinFake {
+        sessions: std::sync::Mutex::new(Vec::new()),
+    });
+    let mgr = SessionManager::new(tmp.path(), fake).await.unwrap();
+
+    // Two independent managed sessions, both promoted to Active with the
+    // SAME workspace path — the exact #1744 precursor shape.
+    for _ in 0..2 {
+        let record = mgr
+            .create(
+                "task".into(),
+                Some(ws.clone()),
+                None,
+                Some(ws.clone()),
+                None,
+                None,
+            )
+            .await
+            .expect("create managed session");
+        mgr.set_workspace(&record.id, ws.clone(), ManagedSessionState::Active)
+            .await
+            .expect("set Active");
+    }
+
+    let mgr_arc = Arc::new(mgr);
+    let state = Arc::new(DaemonState::with_session_manager(mgr_arc));
+    std::mem::forget(tmp);
+
+    let claude_id = "550e8400-e29b-41d4-a716-446655440099";
+    let post = HookPost {
+        session_id: claude_id.to_string(),
+        event: HookEvent::SessionStart,
+        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+    };
+
+    let buffer = trusty_common::log_buffer::LogBuffer::new(64);
+    let subscriber = tracing_subscriber::registry().with(
+        trusty_common::log_buffer::LogBufferLayer::new(buffer.clone()),
+    );
+    let _ = ingest_hook(State(std::sync::Arc::clone(&state)), Json(post))
+        .with_subscriber(subscriber)
+        .await
+        .expect("ingest_hook must still succeed — the collision is reported, not fatal");
+
+    let lines = buffer.tail(64);
+    let line = lines
+        .iter()
+        .find(|l| l.contains("Active managed sessions share the same cwd"))
+        .unwrap_or_else(|| {
+            panic!("the #1744 ambiguous-cwd collision must be reported. Captured lines: {lines:#?}")
+        });
+    assert!(
+        line.contains("ERROR"),
+        "a 2+-Active-session cwd collision must log at ERROR, not a lower level (#3764): {line}"
+    );
+}
+
 // `session_start_hook_does_not_overwrite_with_different_id` (the original
 // #4337 fix's test) is superseded by `session_start_hook_still_refuses_a_live_subagent_id`
 // below, which additionally seeds a real transcript fixture so the id is

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -842,12 +842,15 @@ impl SessionManager {
     /// indistinguishable, by path alone, from the #1744 cross-session
     /// collision `check_no_foreign_active_claim` refuses. Unlike that guard
     /// (which reads only the STORE's `state` field), dedup has already asked
-    /// the OS directly: it re-verifies immediately before this call that the
-    /// LOSER's own tmux session is not live and that it is not SM-owned (see
-    /// the call site in `dedup.rs`), which is a stronger and more accurate
-    /// liveness signal than a record's persisted `state`. Routing dedup's
-    /// call through the ordinary [`decommission`](Self::decommission) broke
-    /// `dedup_collapses_the_dead_sibling_when_tmux_answers` and
+    /// the OS directly: for BOTH the shapes it collapses, it re-verifies
+    /// immediately before this call — via a fresh tmux-liveness probe, not a
+    /// snapshot taken earlier in the pass (#3764 review fix, both call
+    /// sites in `dedup.rs`) — that the LOSER's own tmux session is not live;
+    /// the exact-workspace-duplicate (`#3396`) shape additionally rechecks
+    /// that the loser is not SM-owned. Either recheck is a stronger and more
+    /// accurate liveness signal than a record's persisted `state`. Routing
+    /// dedup's call through the ordinary [`decommission`](Self::decommission)
+    /// broke `dedup_collapses_the_dead_sibling_when_tmux_answers` and
     /// `reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record` —
     /// the guard is correct to refuse an UNVERIFIED same-path collision, and
     /// wrong to refuse one dedup has already resolved.
@@ -856,7 +859,8 @@ impl SessionManager {
     /// preserves its existing no-op behavior here, matching every other
     /// dedup/reap call site).
     /// Test: `dedup_collapses_the_dead_sibling_when_tmux_answers`,
-    /// `reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record`.
+    /// `reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record`,
+    /// `dedup_skips_a_plan_dedup_loser_whose_tmux_went_live_before_act`.
     pub(crate) async fn decommission_dedup_loser(
         &self,
         id: &ManagedSessionId,

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -23,7 +23,7 @@ use crate::core::trusty_tools_config::{TrustyToolsConfig, workspace_root};
 use super::manager::{ManagedError, SessionManager};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::search_gc;
-use super::workspace_guard::is_safe_to_remove;
+use super::workspace_guard::{foreign_active_claim, is_safe_to_remove};
 use super::worktree_protection;
 use super::worktree_registry;
 use super::worktree_safety::{DirtyWorktree, inspect_dirt, worktree_remove_command};
@@ -626,6 +626,13 @@ impl SessionManager {
     /// a local-path/adopt record does NOT delete the directory.
     /// `decommission_owner_gate_refuses_foreign_caller`,
     /// `decommission_owner_gate_allows_terminal_owner` (#3649).
+    ///
+    /// #3764: BEFORE any of the above, and regardless of `caller`, this also
+    /// refuses when a session OTHER than `id` is `Active` with a workspace or
+    /// cwd that resolves to the same directory as `id`'s own `workspace_path`
+    /// — see [`check_no_foreign_active_claim`](Self::check_no_foreign_active_claim)
+    /// and [`ManagedError::ForeignActiveWorkspaceClaim`]. Test:
+    /// `decommission_refuses_a_foreign_active_workspace_collision`.
     pub async fn decommission(
         &self,
         id: &ManagedSessionId,
@@ -736,6 +743,50 @@ impl SessionManager {
         Ok(())
     }
 
+    /// The #3764 session-identity guard: refuse when a session OTHER than
+    /// `record` is `Active` with a workspace/cwd that resolves to the same
+    /// directory as `record.workspace_path`.
+    ///
+    /// Why: `check_worktree_owner` above only fires when a caller identifies
+    /// itself — every production call site except the bulk age-based reaper
+    /// passes `caller: None`, which makes that gate a no-op in practice for
+    /// most decommissions. This gate closes the gap: it consults the store
+    /// directly and runs on EVERY decommission, because the collision it
+    /// detects (#1744: two `Active` records naming one directory) is not
+    /// something a caller's own identity has any bearing on — see
+    /// `workspace_guard::foreign_active_claim`, which does the actual
+    /// comparison.
+    /// What: a no-op when `record.workspace_path` is `None` (nothing to
+    /// collide on). Otherwise lists every managed session and asks
+    /// `foreign_active_claim`; a hit refuses with
+    /// [`ManagedError::ForeignActiveWorkspaceClaim`] BEFORE any disk mutation
+    /// — this runs ahead of `graceful_terminate_runtime` and every removal
+    /// branch below.
+    /// Test: `decommission_refuses_a_foreign_active_workspace_collision`,
+    /// `decommission_refuses_a_foreign_active_cwd_collision`,
+    /// `decommission_allows_a_terminal_sibling_sharing_the_path`,
+    /// `decommission_allows_an_uncontested_workspace`.
+    async fn check_no_foreign_active_claim(
+        &self,
+        record: &SessionRecord,
+    ) -> Result<(), ManagedError> {
+        let Some(ws) = record.workspace_path.as_deref() else {
+            return Ok(());
+        };
+        let records = self.list().await;
+        if let Some(other) = foreign_active_claim(ws, &record.id, &records) {
+            warn!(
+                id = %record.id,
+                other = %other,
+                workspace = %ws.display(),
+                "decommission: refusing — an Active sibling session also claims this \
+                 workspace/cwd (#3764, #1744)"
+            );
+            return Err(ManagedError::ForeignActiveWorkspaceClaim(record.id, other));
+        }
+        Ok(())
+    }
+
     /// Internal: decommission with an explicit managed root (test seam).
     ///
     /// Why: tests need to inject a temp directory as the managed root to keep the
@@ -779,12 +830,72 @@ impl SessionManager {
         managed_root: &Path,
         caller: Option<ManagedSessionId>,
     ) -> Result<(SessionRecord, bool), ManagedError> {
+        self.decommission_with_root_checked(id, managed_root, caller, true)
+            .await
+    }
+
+    /// Decommission a known DUPLICATE-workspace loser, EXEMPT from the #3764
+    /// foreign-active-claim guard (#3764 review fix).
+    ///
+    /// Why: `dedup_stale_duplicates`'s whole job is to collapse two records
+    /// that name the SAME `workspace_path` — one kept, one removed — which is
+    /// indistinguishable, by path alone, from the #1744 cross-session
+    /// collision `check_no_foreign_active_claim` refuses. Unlike that guard
+    /// (which reads only the STORE's `state` field), dedup has already asked
+    /// the OS directly: it re-verifies immediately before this call that the
+    /// LOSER's own tmux session is not live and that it is not SM-owned (see
+    /// the call site in `dedup.rs`), which is a stronger and more accurate
+    /// liveness signal than a record's persisted `state`. Routing dedup's
+    /// call through the ordinary [`decommission`](Self::decommission) broke
+    /// `dedup_collapses_the_dead_sibling_when_tmux_answers` and
+    /// `reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record` —
+    /// the guard is correct to refuse an UNVERIFIED same-path collision, and
+    /// wrong to refuse one dedup has already resolved.
+    /// What: same teardown as `decommission`, with the foreign-active-claim
+    /// check (only) skipped. The #3649 owner gate still runs (`caller: None`
+    /// preserves its existing no-op behavior here, matching every other
+    /// dedup/reap call site).
+    /// Test: `dedup_collapses_the_dead_sibling_when_tmux_answers`,
+    /// `reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record`.
+    pub(crate) async fn decommission_dedup_loser(
+        &self,
+        id: &ManagedSessionId,
+    ) -> Result<(SessionRecord, bool), ManagedError> {
+        let config = TrustyToolsConfig::load();
+        let managed_root = workspace_root(&config);
+        self.decommission_with_root_checked(id, &managed_root, None, false)
+            .await
+    }
+
+    /// The shared body behind [`decommission_with_root`](Self::decommission_with_root)
+    /// and [`decommission_dedup_loser`](Self::decommission_dedup_loser).
+    ///
+    /// `check_foreign_claim` gates ONLY `check_no_foreign_active_claim`
+    /// (#3764) — every other guard (the #3649 owner gate, containment, dirty
+    /// checks) still runs regardless.
+    async fn decommission_with_root_checked(
+        &self,
+        id: &ManagedSessionId,
+        managed_root: &Path,
+        caller: Option<ManagedSessionId>,
+        check_foreign_claim: bool,
+    ) -> Result<(SessionRecord, bool), ManagedError> {
         let mut record = self.get(id).await?;
 
         // #3649 owner gate: only applies when a SESSION identifies itself as
         // the caller. `None` (operator/daemon-internal) preserves full
         // pre-#3649 authority unconditionally — see the doc above.
         self.check_worktree_owner(&record, caller, id).await?;
+
+        // #3764: unlike the owner gate above, this runs UNCONDITIONALLY for
+        // every caller EXCEPT `decommission_dedup_loser` — it does not depend
+        // on any caller identifying itself, because the hazard is a STORE
+        // inconsistency (two `Active` records naming the same directory,
+        // #1744), not a caller impersonating an owner. See
+        // `check_no_foreign_active_claim`.
+        if check_foreign_claim {
+            self.check_no_foreign_active_claim(&record).await?;
+        }
 
         // #2033: derive the trusty-search index id for a disposable workspace
         // (SM-owned clone or in-project worktree — see

--- a/crates/trusty-mpm/src/session_manager/decommission_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_tests.rs
@@ -474,3 +474,193 @@ async fn decommission_clears_pending_decision() {
     assert!(stored.pending_decision.is_none());
     assert!(stored.proposed_default.is_none());
 }
+
+// ── #3764: foreign-active-workspace-claim guard ─────────────────────────────
+
+/// Build an [`owned_record`]-style record that additionally names
+/// `workspace_path` — the #3764 tests key on the collision, not on
+/// `worktree_owner`.
+fn record_claiming(
+    id: ManagedSessionId,
+    state: ManagedSessionState,
+    workspace_path: std::path::PathBuf,
+) -> SessionRecord {
+    let mut record = owned_record(id, state);
+    record.workspace_path = Some(workspace_path);
+    record.worktree_owner = None;
+    record
+}
+
+/// Two `Active` records naming the same `workspace_path` — the #1744
+/// precursor shape — refuse decommission of either.
+#[tokio::test]
+async fn decommission_refuses_a_foreign_active_workspace_collision() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(
+        dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+
+    let shared = std::path::PathBuf::from("/tmp/shared-collision-workspace");
+    let session_a = ManagedSessionId::new();
+    let session_b = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(record_claiming(
+            session_a,
+            ManagedSessionState::Active,
+            shared.clone(),
+        ))
+        .await
+        .expect("upsert A");
+    mgr.store
+        .write()
+        .await
+        .upsert(record_claiming(
+            session_b,
+            ManagedSessionState::Active,
+            shared,
+        ))
+        .await
+        .expect("upsert B");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let err = mgr
+        .decommission_with_root(&session_b, managed_root.path(), None)
+        .await
+        .expect_err("a second Active record naming the same workspace_path must refuse");
+    match err {
+        ManagedError::ForeignActiveWorkspaceClaim(target, other) => {
+            assert_eq!(target, session_b);
+            assert_eq!(other, session_a);
+        }
+        other => panic!("expected ForeignActiveWorkspaceClaim, got {other:?}"),
+    }
+
+    // Nothing must have been mutated — the record stays Active.
+    let record = mgr.get(&session_b).await.expect("get B");
+    assert_eq!(record.state, ManagedSessionState::Active);
+}
+
+/// The same collision keyed on `cwd` rather than `workspace_path` also
+/// refuses — the field #1744 was actually keyed on.
+#[tokio::test]
+async fn decommission_refuses_a_foreign_active_cwd_collision() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(
+        dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+
+    let shared = std::path::PathBuf::from("/tmp/shared-collision-cwd");
+    let session_a = ManagedSessionId::new();
+    let session_b = ManagedSessionId::new();
+    let mut record_a = owned_record(session_a, ManagedSessionState::Active);
+    record_a.cwd = shared.clone();
+    mgr.store
+        .write()
+        .await
+        .upsert(record_a)
+        .await
+        .expect("upsert A");
+    mgr.store
+        .write()
+        .await
+        .upsert(record_claiming(
+            session_b,
+            ManagedSessionState::Active,
+            shared,
+        ))
+        .await
+        .expect("upsert B");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let err = mgr
+        .decommission_with_root(&session_b, managed_root.path(), None)
+        .await
+        .expect_err("a sibling's cwd matching this workspace_path must refuse");
+    assert!(matches!(
+        err,
+        ManagedError::ForeignActiveWorkspaceClaim(_, _)
+    ));
+}
+
+/// A sibling record in a TERMINAL state sharing the same path never blocks —
+/// only `Active` is a live claim.
+#[tokio::test]
+async fn decommission_allows_a_terminal_sibling_sharing_the_path() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(
+        dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+
+    let shared = std::path::PathBuf::from("/tmp/shared-terminal-path");
+    let session_a = ManagedSessionId::new();
+    let session_b = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(record_claiming(
+            session_a,
+            ManagedSessionState::Decommissioned,
+            shared.clone(),
+        ))
+        .await
+        .expect("upsert A");
+    mgr.store
+        .write()
+        .await
+        .upsert(record_claiming(
+            session_b,
+            ManagedSessionState::Active,
+            shared,
+        ))
+        .await
+        .expect("upsert B");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let (record, _workspace_removed) = mgr
+        .decommission_with_root(&session_b, managed_root.path(), None)
+        .await
+        .expect("a terminal sibling's stale claim must never block decommission");
+    assert_eq!(record.state, ManagedSessionState::Decommissioned);
+}
+
+/// No sibling at all claims the path — the ordinary, uncontested case.
+#[tokio::test]
+async fn decommission_allows_an_uncontested_workspace() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(
+        dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+
+    let session_id = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(record_claiming(
+            session_id,
+            ManagedSessionState::Active,
+            std::path::PathBuf::from("/tmp/nobody-else-here"),
+        ))
+        .await
+        .expect("upsert");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let (record, _workspace_removed) = mgr
+        .decommission_with_root(&session_id, managed_root.path(), None)
+        .await
+        .expect("an uncontested workspace must decommission normally");
+    assert_eq!(record.state, ManagedSessionState::Decommissioned);
+}

--- a/crates/trusty-mpm/src/session_manager/dedup.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup.rs
@@ -237,13 +237,48 @@ impl SessionManager {
                      resolves to an existing directory; refusing to decommission (#2306)"
                 );
                 continue;
+            } else {
+                // #3764 recheck (parity with the #3396 branch above):
+                // `plan_dedup`'s own live-group guard already refuses to
+                // select a loser out of a group where ANY member's
+                // `tmux_name` is in the `live_names` SNAPSHOT taken at the
+                // top of this function — but that snapshot can go stale in
+                // the time between the planning pass and this call (a
+                // resumed/reattached session, or a rename). Re-probe tmux
+                // directly, right here, immediately before the destructive
+                // call — never reuse the stale top-of-function snapshot for
+                // this check, or it could never catch the race it exists
+                // for. An unobservable tmux is refused the same way
+                // `observed_live_managed_names` refuses everywhere else: no
+                // record is decommissioned without positive evidence its
+                // session is gone.
+                let live_names = match self.observed_live_managed_names() {
+                    Ok(names) => names,
+                    Err(e) => {
+                        warn!(
+                            id = %id,
+                            "dedup: could not re-probe tmux liveness before decommission \
+                             ({e}); refusing to decommission without positive evidence (#3764)"
+                        );
+                        continue;
+                    }
+                };
+                if live_names.contains(&current.tmux_name) {
+                    warn!(
+                        id = %id,
+                        name = %current.tmux_name,
+                        "dedup: belt-and-suspenders skip — loser's tmux session is now live; \
+                         refusing to decommission an active session (#3764)"
+                    );
+                    continue;
+                }
             }
             // #3764: dedup's whole job is collapsing two records that name
             // the SAME workspace_path, which the ordinary #3764 guard cannot
             // tell apart from the #1744 cross-session collision it exists to
             // refuse. The tmux-liveness and workspace_owned rechecks above
-            // are the stronger signal dedup already applied — see
-            // `decommission_dedup_loser`'s doc.
+            // (both branches, now) are the stronger signal dedup already
+            // applied — see `decommission_dedup_loser`'s doc.
             match self.decommission_dedup_loser(id).await {
                 Ok((rec, _removed)) => {
                     info!(

--- a/crates/trusty-mpm/src/session_manager/dedup.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup.rs
@@ -238,7 +238,13 @@ impl SessionManager {
                 );
                 continue;
             }
-            match self.decommission(id, None).await {
+            // #3764: dedup's whole job is collapsing two records that name
+            // the SAME workspace_path, which the ordinary #3764 guard cannot
+            // tell apart from the #1744 cross-session collision it exists to
+            // refuse. The tmux-liveness and workspace_owned rechecks above
+            // are the stronger signal dedup already applied — see
+            // `decommission_dedup_loser`'s doc.
+            match self.decommission_dedup_loser(id).await {
                 Ok((rec, _removed)) => {
                     info!(
                         id = %id,

--- a/crates/trusty-mpm/src/session_manager/dedup_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup_tests.rs
@@ -21,11 +21,13 @@
 
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 use chrono::{Duration, Utc};
 use tempfile::TempDir;
 
 use super::dedup::{is_resolved_existing, plan_dedup, plan_workspace_duplicates};
+use super::manager::{ManagedError, ManagedTmuxDriver};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::tests::FakeTmuxDriver;
 use crate::session_manager::SessionManager;
@@ -1151,6 +1153,117 @@ async fn dedup_collapses_the_dead_sibling_when_tmux_answers() {
     assert!(
         *fake.ensure_server_up_calls.lock().unwrap() >= 1,
         "the liveness query must run the server-up guard before listing"
+    );
+}
+
+/// A driver whose `list_sessions` answers DEAD on the first call, then LIVE
+/// from the second call onward.
+///
+/// Why: `plan_dedup`'s own live-group guard already refuses to select a
+/// loser out of any group where a member's `tmux_name` is in the SAME
+/// `live_names` snapshot used to plan — so proving the #3764 fresh re-probe
+/// actually fires needs a driver whose answer CHANGES between
+/// `dedup_stale_duplicates`'s one-time planning snapshot (call 1) and the
+/// per-loser recheck the fix adds (call 2), not a driver simply seeded live
+/// throughout.
+/// What: `list_sessions` returns `[]` once, then `[live_name]` for every
+/// subsequent call. `ensure_server_up` uses the trait default (`Ok(())`).
+/// Test: `dedup_skips_a_plan_dedup_loser_whose_tmux_went_live_before_act`.
+struct LateArrivalTmuxDriver {
+    calls: Mutex<u32>,
+    live_name: String,
+}
+
+impl ManagedTmuxDriver for LateArrivalTmuxDriver {
+    fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+        Ok(String::new())
+    }
+
+    fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+        let mut calls = self.calls.lock().unwrap();
+        *calls += 1;
+        if *calls == 1 {
+            Ok(Vec::new())
+        } else {
+            Ok(vec![self.live_name.clone()])
+        }
+    }
+}
+
+/// A `plan_dedup` loser whose tmux session goes live between the planning
+/// snapshot and the act-time recheck is NOT decommissioned (#3764).
+///
+/// Why: pins the fix in `dedup_stale_duplicates`'s `plan_dedup` branch —
+/// before this fix that branch reached `decommission_dedup_loser` (which
+/// kills by live tmux name unconditionally) with no tmux-liveness recheck at
+/// all, unlike the sibling `#3396` (`workspace_dup_losers`) branch.
+/// What: two `/unknown`-only records share one `source_id`; `tm-old` is
+/// older so `plan_dedup` selects it as the loser and `tm-new` as the
+/// survivor — both read DEAD on `LateArrivalTmuxDriver`'s first
+/// `list_sessions` call, the one `dedup_stale_duplicates` uses to plan. Its
+/// second call (the fresh per-loser recheck this fix adds) reports `tm-old`
+/// live, so the loser must be skipped, not decommissioned.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn dedup_skips_a_plan_dedup_loser_whose_tmux_went_live_before_act() {
+    let dir = TempDir::new().unwrap();
+    let fake = std::sync::Arc::new(LateArrivalTmuxDriver {
+        calls: Mutex::new(0),
+        live_name: "tm-old".to_string(),
+    });
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let old = rec(
+        "tm-old",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        1,
+    );
+    let new = rec(
+        "tm-new",
+        Some("proj"),
+        None,
+        ManagedSessionState::Stopped,
+        50,
+    );
+    let old_id = old.id;
+    let new_id = new.id;
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(old).await.unwrap();
+        store.upsert(new).await.unwrap();
+    }
+
+    let mut to_resume = Vec::new();
+    let decommissioned = mgr.dedup_stale_duplicates(&mut to_resume).await.unwrap();
+
+    assert!(
+        decommissioned.is_empty(),
+        "the loser's tmux session went live before the destructive call and must be \
+         skipped: {decommissioned:?}"
+    );
+    assert_ne!(
+        mgr.get(&old_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "a loser whose tmux session is live at act time must survive"
+    );
+    assert_ne!(
+        mgr.get(&new_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "the survivor was never a loser"
     );
 }
 

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -147,6 +147,24 @@ pub enum ManagedError {
     /// caller (#3649). `(caller, owner, target)`.
     #[error("session {0} refused to decommission {2}'s worktree — owned by session {1}")]
     WorktreeOwnerMismatch(ManagedSessionId, ManagedSessionId, ManagedSessionId),
+
+    /// Decommission refused because an `Active` session OTHER than the target
+    /// also claims the target's workspace directory (#3764). `(target,
+    /// foreign_active_session)`.
+    ///
+    /// Why: the #3715 incident's precursor was exactly this — two `Active`
+    /// records canonicalizing to one worktree path (#1744) — with no caller
+    /// needing to identify itself at all, which is why this check runs
+    /// unconditionally rather than only when `caller` is `Some(..)` like
+    /// [`WorktreeOwnerMismatch`](Self::WorktreeOwnerMismatch). Removing the
+    /// directory while a sibling record still reads it as `Active` would
+    /// silently destroy that sibling's live work.
+    #[error(
+        "refusing to remove session {0}'s workspace — session {1} is also Active with a \
+         workspace or cwd that resolves to the same directory (#3764); stop or decommission \
+         session {1} first"
+    )]
+    ForeignActiveWorkspaceClaim(ManagedSessionId, ManagedSessionId),
 }
 
 // [`ManagedTmuxDriver`] lives in `driver.rs` (issue #1955 SLOC split — the

--- a/crates/trusty-mpm/src/session_manager/workspace_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/workspace_guard.rs
@@ -20,22 +20,97 @@
 //! same directory?
 //! Test: `is_safe_to_remove_*` and `foreign_active_claim_*` unit tests below.
 
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use tracing::warn;
 
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 
-/// Canonicalize `path`, falling back to the raw form on failure.
+/// Canonicalize `path`, resolving through the nearest EXISTING ancestor and
+/// lexically normalizing the remainder when the full path itself does not
+/// exist (#3764 review fix).
 ///
 /// Why: shared by both directions of the comparison
 /// [`foreign_active_claim`] makes — the candidate path AND every other
 /// record's `workspace_path`/`cwd` — so a canonicalize failure on either side
-/// degrades to a raw-string comparison instead of silently excusing the
-/// comparison entirely. A path that no longer exists on disk (already
-/// destroyed) must still be comparABLE by its last-known spelling.
-fn canon_or_raw(path: &Path) -> std::path::PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+/// must still produce a comparable value. A path that no longer exists on
+/// disk (already destroyed) must still be comparABLE by its last-known
+/// spelling. The original fallback (`path.to_path_buf()` verbatim) only
+/// achieved that for BYTE-IDENTICAL spellings: a phantom `Active` record
+/// naming the same directory via a `..` segment, or via a symlinked alias of
+/// a real ancestor directory, compared unequal to a cleanly-spelled candidate
+/// and silently slipped past the guard — fail-open in a check whose entire
+/// job is catching same-directory collisions the store does not enforce.
+/// What: if `path` exists, delegates to `fs::canonicalize` directly (resolves
+/// symlinks and normalizes `.`/`..` via the OS). If it does not, walks
+/// [`Path::ancestors`] to find the nearest ancestor that DOES exist,
+/// canonicalizes THAT ancestor (resolving any symlink in it), and re-appends
+/// the non-existent remainder — so a symlinked parent is still resolved even
+/// though the leaf under it is gone. Either way, lexically normalizes
+/// ([`normalize_lexically`]) the result to collapse `.` segments, `..`
+/// segments, duplicate separators, and a trailing separator — covering the
+/// case where no ancestor at all exists on this host (a fully phantom path),
+/// which has nothing to canonicalize against.
+/// Test: `foreign_active_claim_catches_a_nonexistent_path_spelled_with_a_trailing_slash`,
+/// `foreign_active_claim_catches_a_nonexistent_path_with_dot_dot_segments`,
+/// `foreign_active_claim_catches_a_nonexistent_path_through_a_symlinked_parent`.
+fn canon_or_raw(path: &Path) -> PathBuf {
+    if let Ok(canon) = std::fs::canonicalize(path) {
+        return canon;
+    }
+    // `ancestors()` yields `path` itself first (already tried above and
+    // failed), then each parent up to the root — skip(1) starts at the
+    // nearest candidate PARENT.
+    for ancestor in path.ancestors().skip(1) {
+        if let (Ok(canon_ancestor), Ok(remainder)) =
+            (std::fs::canonicalize(ancestor), path.strip_prefix(ancestor))
+        {
+            return normalize_lexically(&canon_ancestor.join(remainder));
+        }
+    }
+    // Nothing on disk to canonicalize against at all — lexical normalization
+    // is the only comparison basis left.
+    normalize_lexically(path)
+}
+
+/// Lexically collapse `.` segments, `..` segments, and duplicate/trailing
+/// separators — WITHOUT touching the filesystem.
+///
+/// Why: [`canon_or_raw`] needs this both as its last-resort fallback (nothing
+/// on disk to canonicalize against) and to normalize the remainder re-appended
+/// after a partial (ancestor-only) canonicalization, which has not itself been
+/// through any `..`-collapsing.
+/// What: rebuilds `path` component-by-component: a `CurDir` (`.`) is dropped;
+/// a `ParentDir` (`..`) pops the previously-pushed component (mirroring the
+/// well-known cargo `normalize_path` lexical algorithm — never touches disk,
+/// so it can't tell a real directory from a dangling one, but that's exactly
+/// what makes it safe to run on a path that doesn't exist); every other
+/// component is pushed verbatim. Rebuilding via `Path::components()` already
+/// collapses duplicate and trailing separators, since that iterator never
+/// yields an empty segment.
+/// Test: exercised indirectly through `canon_or_raw`'s callers — a private
+/// helper with no externally-observable contract of its own.
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut out = if let Some(prefix @ Component::Prefix(_)) = components.peek().copied() {
+        components.next();
+        PathBuf::from(prefix.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(_) => unreachable!("a Prefix can only ever be the first component"),
+            Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::Normal(segment) => out.push(segment),
+        }
+    }
+    out
 }
 
 /// Does any `Active` session record OTHER than `self_id` also claim
@@ -348,6 +423,137 @@ mod tests {
 
         let self_id = ManagedSessionId::new();
         assert_eq!(foreign_active_claim(&unclaimed, &self_id, &[]), None);
+    }
+
+    // ── `canon_or_raw` fail-open regression coverage (#3764 review fix) ─────
+    //
+    // Every test below points the CANDIDATE (the path `foreign_active_claim`
+    // is asked about) at a leaf that never exists on disk — mirroring
+    // production, where `check_no_foreign_active_claim` is asked about the
+    // very record being decommissioned, whose `workspace_path` may already be
+    // gone. The old `canon_or_raw` fell back to the raw, un-normalized
+    // `PathBuf` on a canonicalize failure, so it only ever matched a phantom
+    // sibling record spelled BYTE-IDENTICALLY. Each test spells the sibling's
+    // `workspace_path` differently — a `..` segment, a trailing separator (via
+    // a symlinked alias so the difference survives `PathBuf`'s own trailing-
+    // slash normalization), and a symlinked-alias ancestor with no other
+    // spelling quirk — and asserts the collision is still caught.
+
+    /// A phantom sibling spelled with a trailing separator, reached through a
+    /// symlinked alias of the candidate's real ancestor, is still caught.
+    ///
+    /// Why: `PathBuf`'s own `Eq` already normalizes a bare trailing slash
+    /// away, so a trailing slash alone never distinguished old from new code.
+    /// Routing the trailing-slash spelling through a symlinked alias (built
+    /// the same way as
+    /// `foreign_active_claim_catches_a_nonexistent_path_through_a_symlinked_parent`)
+    /// keeps the two RAW strings genuinely different — `.../parent-alias/
+    /// workspace/` vs `.../parent-real/workspace` — so the old raw fallback
+    /// provably fails this case while the fix's ancestor canonicalization
+    /// (which resolves the symlink before comparing) provably catches it.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_claim_catches_a_nonexistent_path_spelled_with_a_trailing_slash() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let parent_real = root.path().join("parent-real");
+        std::fs::create_dir_all(&parent_real).unwrap();
+        let parent_alias = root.path().join("parent-alias");
+        std::os::unix::fs::symlink(&parent_real, &parent_alias).unwrap();
+
+        // Neither leaf ever exists — both sides fall back to `canon_or_raw`'s
+        // failure branch.
+        let candidate = parent_real.join("workspace");
+        let phantom_spelling =
+            PathBuf::from(format!("{}/", parent_alias.join("workspace").display()));
+
+        let self_id = ManagedSessionId::new();
+        let other_id = ManagedSessionId::new();
+        let records = vec![record_at(
+            other_id,
+            ManagedSessionState::Active,
+            phantom_spelling,
+        )];
+
+        assert_eq!(
+            foreign_active_claim(&candidate, &self_id, &records),
+            Some(other_id),
+            "a phantom record reached via a symlinked alias, spelled with a \
+             trailing slash, must still be caught as the same directory"
+        );
+    }
+
+    /// A phantom sibling spelled with a `..` segment is still caught.
+    ///
+    /// Why: unlike a trailing slash, `PathBuf`'s own `Eq` never collapses a
+    /// literal `..` component — `/a/b/../c` and `/a/c` compare unequal even
+    /// though they name the same location. The old raw fallback therefore
+    /// missed this collision outright, with no symlink needed to prove it:
+    /// `sub` need not even exist for the phantom record's stored path to be
+    /// spelled through it.
+    /// What: `root` is the nearest EXISTING ancestor for both the candidate
+    /// (`root/target`) and the phantom (`root/sub/../target`, where `sub`
+    /// never exists) — the fix canonicalizes `root` for both and lexically
+    /// collapses the phantom's `..` segment, landing on the same value.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_claim_catches_a_nonexistent_path_with_dot_dot_segments() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let candidate = root.path().join("target");
+        let phantom_spelling = root.path().join("sub").join("..").join("target");
+
+        let self_id = ManagedSessionId::new();
+        let other_id = ManagedSessionId::new();
+        let records = vec![record_at(
+            other_id,
+            ManagedSessionState::Active,
+            phantom_spelling,
+        )];
+
+        assert_eq!(
+            foreign_active_claim(&candidate, &self_id, &records),
+            Some(other_id),
+            "a phantom record spelled with a `..` segment must still be \
+             caught as the same directory"
+        );
+    }
+
+    /// A phantom sibling reached through a symlinked PARENT directory — no
+    /// spelling quirk beyond the alias itself — is still caught.
+    ///
+    /// Why: this isolates the ancestor-canonicalization half of the fix from
+    /// the lexical-normalization half the two tests above exercise. The
+    /// candidate's own ancestor, `parent-real`, is a real directory; the
+    /// phantom record names the SAME directory via `parent-alias`, a symlink
+    /// to `parent-real`, then a workspace leaf that never exists under
+    /// either name. Byte-for-byte, `.../parent-real/workspace` and
+    /// `.../parent-alias/workspace` are different strings — the old raw
+    /// fallback could not tell they name one physical directory.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_claim_catches_a_nonexistent_path_through_a_symlinked_parent() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let parent_real = root.path().join("parent-real");
+        std::fs::create_dir_all(&parent_real).unwrap();
+        let parent_alias = root.path().join("parent-alias");
+        std::os::unix::fs::symlink(&parent_real, &parent_alias).unwrap();
+
+        let candidate = parent_real.join("workspace");
+        let phantom_spelling = parent_alias.join("workspace");
+
+        let self_id = ManagedSessionId::new();
+        let other_id = ManagedSessionId::new();
+        let records = vec![record_at(
+            other_id,
+            ManagedSessionState::Active,
+            phantom_spelling,
+        )];
+
+        assert_eq!(
+            foreign_active_claim(&candidate, &self_id, &records),
+            Some(other_id),
+            "a phantom record reached via a symlinked parent directory must \
+             still be caught as the same directory"
+        );
     }
 
     // ── is_safe_to_remove unit tests (#1511) ────────────────────────────────

--- a/crates/trusty-mpm/src/session_manager/workspace_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/workspace_guard.rs
@@ -1,19 +1,96 @@
-//! Path-containment guard for workspace deletion (#1511).
+//! Path-containment AND session-identity guards for workspace deletion (#1511,
+//! #3764).
 //!
 //! Why: `SessionManager::decommission` previously `remove_dir_all`'d
 //! `workspace_path` unconditionally, which deleted a live user repo when the
 //! #1502 local-path spawn set `workspace_path` to a real on-disk directory.
 //! This module provides the belt-and-suspenders containment guard that prevents
 //! any path OUTSIDE the SM's managed workspace root from being deleted —
-//! regardless of the `workspace_owned` flag.
+//! regardless of the `workspace_owned` flag. #3764 widens the module's
+//! question from "is this path safe to touch at all" to "does anyone ELSE
+//! also claim it": the #3715 incident's precursor was a 3-way cwd collision
+//! (#1744) — three `Active` session records canonicalizing to one worktree
+//! path — hours before that path was destroyed. Path containment alone never
+//! sees that; it only ever asks about ONE path and ONE managed root.
 //! What: [`is_safe_to_remove`] canonicalizes both paths and verifies that the
 //! workspace is strictly INSIDE the managed root, rejecting: path == root, path
 //! outside root, paths with too few components, and `$HOME`.
-//! Test: `is_safe_to_remove_*` unit tests below.
+//! [`foreign_active_claim`] answers the session-identity question: does any
+//! `Active` record OTHER than the one being acted on also canonicalize to the
+//! same directory?
+//! Test: `is_safe_to_remove_*` and `foreign_active_claim_*` unit tests below.
 
 use std::path::Path;
 
 use tracing::warn;
+
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+/// Canonicalize `path`, falling back to the raw form on failure.
+///
+/// Why: shared by both directions of the comparison
+/// [`foreign_active_claim`] makes — the candidate path AND every other
+/// record's `workspace_path`/`cwd` — so a canonicalize failure on either side
+/// degrades to a raw-string comparison instead of silently excusing the
+/// comparison entirely. A path that no longer exists on disk (already
+/// destroyed) must still be comparABLE by its last-known spelling.
+fn canon_or_raw(path: &Path) -> std::path::PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Does any `Active` session record OTHER than `self_id` also claim
+/// `workspace_path` (#3764)?
+///
+/// Why: `is_safe_to_remove` answers "is this path inside the managed root",
+/// never "does a SIBLING session also believe this is theirs". The #3715
+/// incident's own precursor state (#1744: three `Active` records sharing one
+/// cwd) is invisible to path containment by construction — it is a
+/// same-path, cross-RECORD question, not a path-vs-root one. This check
+/// closes that hole at the one place every daemon-routed removal already
+/// passes through: before `SessionManager::decommission_with_root` mutates
+/// disk, it now asks this question first, unconditionally — unlike
+/// [`super::manager::ManagedError::WorktreeOwnerMismatch`]'s gate, which only
+/// fires when a caller identifies itself, this runs regardless of caller,
+/// because the hazard is a store inconsistency (two `Active` records naming
+/// one directory), not a caller impersonating an owner.
+///
+/// What: canonicalizes `workspace_path` (falling back to the raw path on a
+/// canonicalize failure — a destroyed directory must still compare) and scans
+/// `records` for the first `Active` record whose id is not `self_id` and
+/// whose `workspace_path` OR `cwd` canonicalizes (or, on failure, compares
+/// raw) to the same path. Returns that record's id.
+///
+/// A record in any state other than `Active` is never a conflict — a
+/// `Stopped`/`Errored`/terminal record's directory is exactly what the
+/// caller's own worktree-reclaim machinery ([`super::worktree_reclaim`]'s
+/// gate 2) already expects to reclaim, and treating it as a live claim here
+/// would refuse ordinary, safe cleanup.
+/// Test: `foreign_active_claim_finds_a_colliding_workspace_path`,
+/// `foreign_active_claim_finds_a_colliding_cwd`,
+/// `foreign_active_claim_ignores_a_non_active_record`,
+/// `foreign_active_claim_ignores_the_records_own_id`,
+/// `foreign_active_claim_returns_none_when_unclaimed`.
+pub(crate) fn foreign_active_claim(
+    workspace_path: &Path,
+    self_id: &ManagedSessionId,
+    records: &[SessionRecord],
+) -> Option<ManagedSessionId> {
+    let canon_target = canon_or_raw(workspace_path);
+    records
+        .iter()
+        .find(|r| {
+            if r.id == *self_id || r.state != ManagedSessionState::Active {
+                return false;
+            }
+            let ws_matches = r
+                .workspace_path
+                .as_deref()
+                .is_some_and(|p| canon_or_raw(p) == canon_target || p == workspace_path);
+            let cwd_matches = canon_or_raw(&r.cwd) == canon_target || r.cwd == workspace_path;
+            ws_matches || cwd_matches
+        })
+        .map(|r| r.id)
+}
 
 /// Decide whether `workspace_path` is safe to `remove_dir_all` (#1511).
 ///
@@ -104,7 +181,174 @@ pub(crate) fn is_safe_to_remove(workspace_path: &Path, managed_root: &Path) -> b
 mod tests {
     use std::path::PathBuf;
 
-    use super::is_safe_to_remove;
+    use super::{
+        ManagedSessionId, ManagedSessionState, SessionRecord, foreign_active_claim,
+        is_safe_to_remove,
+    };
+
+    /// Build a bare [`SessionRecord`] naming `workspace_path` and `state`, for
+    /// the [`foreign_active_claim`] tests below. Mirrors the field list
+    /// `decommission_tests::owned_record` uses for the same purpose.
+    fn record_at(
+        id: ManagedSessionId,
+        state: ManagedSessionState,
+        workspace_path: PathBuf,
+    ) -> SessionRecord {
+        SessionRecord {
+            id,
+            tmux_name: format!("tm-foreign-claim-{id}"),
+            cwd: PathBuf::from("/tmp/unrelated-cwd"),
+            task: "task".into(),
+            state,
+            created_at: chrono::Utc::now(),
+            last_activity_at: None,
+            workspace_path: Some(workspace_path),
+            repo_url: None,
+            branch: None,
+            pending_decision: None,
+            proposed_default: None,
+            correlation: Default::default(),
+            runtime: Default::default(),
+            ephemeral: false,
+            workspace_owned: false,
+            source_id: None,
+            claude_session_id: None,
+            scrollback_path: None,
+            last_cwd: None,
+            deliverable_id: None,
+            pane_id: None,
+            injection_status: Default::default(),
+            worktree_owner: None,
+            terminal_at: None,
+            stop_cause: None,
+        }
+    }
+
+    // ── foreign_active_claim unit tests (#3764) ─────────────────────────────
+
+    /// Another `Active` record whose `workspace_path` matches the candidate is
+    /// a conflict.
+    ///
+    /// Why: this is the #1744 precursor shape — two `Active` records naming
+    /// one directory.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_claim_finds_a_colliding_workspace_path() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let shared = root.path().join("shared-worktree");
+        std::fs::create_dir_all(&shared).unwrap();
+
+        let self_id = ManagedSessionId::new();
+        let other_id = ManagedSessionId::new();
+        let records = vec![record_at(
+            other_id,
+            ManagedSessionState::Active,
+            shared.clone(),
+        )];
+
+        assert_eq!(
+            foreign_active_claim(&shared, &self_id, &records),
+            Some(other_id),
+            "an Active sibling record naming the same path must be reported"
+        );
+    }
+
+    /// A collision on `cwd` (not `workspace_path`) is also caught.
+    ///
+    /// Why: the #1744 collision this guards against was keyed on `cwd`, not
+    /// `workspace_path` — a record can claim a directory as its `cwd` before a
+    /// `workspace_path` is ever recorded for it.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_claim_finds_a_colliding_cwd() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let shared = root.path().join("shared-cwd");
+        std::fs::create_dir_all(&shared).unwrap();
+
+        let self_id = ManagedSessionId::new();
+        let other_id = ManagedSessionId::new();
+        let mut other = record_at(
+            other_id,
+            ManagedSessionState::Active,
+            root.path().join("elsewhere"),
+        );
+        other.cwd = shared.clone();
+        let records = vec![other];
+
+        assert_eq!(
+            foreign_active_claim(&shared, &self_id, &records),
+            Some(other_id),
+            "an Active sibling record whose cwd matches must be reported"
+        );
+    }
+
+    /// A record in any non-`Active` state is never a conflict.
+    ///
+    /// Why: a `Stopped`/`Decommissioned` record's directory is exactly what
+    /// ordinary reclaim is FOR — treating a terminal record as a live claim
+    /// would refuse safe cleanup, not just unsafe cleanup.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_claim_ignores_a_non_active_record() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let shared = root.path().join("shared-terminal");
+        std::fs::create_dir_all(&shared).unwrap();
+
+        let self_id = ManagedSessionId::new();
+        let other_id = ManagedSessionId::new();
+        let records = vec![record_at(
+            other_id,
+            ManagedSessionState::Decommissioned,
+            shared.clone(),
+        )];
+
+        assert_eq!(
+            foreign_active_claim(&shared, &self_id, &records),
+            None,
+            "a terminal-state record must never block removal"
+        );
+    }
+
+    /// The record's own id is never reported as a conflict with itself.
+    ///
+    /// Why: `records` passed to this function typically includes the record
+    /// being decommissioned itself; excluding `self_id` is what makes an
+    /// ordinary, uncontested decommission possible at all.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_claim_ignores_the_records_own_id() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let shared = root.path().join("own-workspace");
+        std::fs::create_dir_all(&shared).unwrap();
+
+        let self_id = ManagedSessionId::new();
+        let records = vec![record_at(
+            self_id,
+            ManagedSessionState::Active,
+            shared.clone(),
+        )];
+
+        assert_eq!(
+            foreign_active_claim(&shared, &self_id, &records),
+            None,
+            "a record must never conflict with itself"
+        );
+    }
+
+    /// No record at all claiming the path returns `None`.
+    ///
+    /// Why: this is the ordinary, uncontested case that must stay fast and
+    /// silent — most decommissions have no sibling collision.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_claim_returns_none_when_unclaimed() {
+        let root = crate::test_support::hermetic_temp_dir();
+        let unclaimed = root.path().join("nobody-here");
+        std::fs::create_dir_all(&unclaimed).unwrap();
+
+        let self_id = ManagedSessionId::new();
+        assert_eq!(foreign_active_claim(&unclaimed, &self_id, &[]), None);
+    }
 
     // ── is_safe_to_remove unit tests (#1511) ────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implements the prevention and detection halves of #3764.

- **Prevention** — `crates/trusty-mpm/src/session_manager/workspace_guard.rs`
  adds `foreign_active_claim`: does any `Active` managed session OTHER than
  the one being decommissioned also claim the same directory (by
  `workspace_path` or `cwd`)? `SessionManager::decommission_with_root`
  (`decommission.rs`) now calls this UNCONDITIONALLY, ahead of every disk
  mutation, refusing with the new `ManagedError::ForeignActiveWorkspaceClaim`
  — this is the #1744 3-way cwd-collision shape that preceded the #3715
  worktree-corruption incident, and it is not gated on any caller identifying
  itself (unlike the existing #3649 `check_worktree_owner`, which is a no-op
  for every production call site except the bulk age-based reaper).
- **Exemption for legitimate duplicate collapse** — `dedup_stale_duplicates`
  (`dedup.rs`) intentionally collapses two records naming the SAME
  `workspace_path`, which is indistinguishable from the #1744 hazard by path
  alone. Routing dedup's decommission call through the new guard broke two
  existing tests; added `decommission_dedup_loser`, a narrow exempt path
  dedup now calls instead — dedup already re-verifies actual tmux liveness
  immediately before this call, a stronger signal than the store's persisted
  `state` field.
- **Detection** — `daemon/api/session_start_correlation.rs`'s
  `correlate_session_start` ambiguous-cwd branch (2+ `Active` sessions
  sharing one cwd) is escalated from `WARN` to `ERROR`, per issue item 2 —
  confirmed still un-escalated by direct code read (the 2026-09-03 sizing
  comment said the same). `ERROR` reaches `tm doctor` /
  `list_recent_errors`, so this collision — previously silent — now surfaces.

## Out of scope (issue item 3)

Issue #3764 item 3 — forensic-capture-on-F3 runbook/hook (snapshotting
`log show` and `tmux capture-pane` before a canonicalize-failure streak
crashes the runtime) — is not implemented here. It is a separate,
independent piece of work (a capture mechanism, not a guard), and the owner
ruling that claimed all three parts predates this session's work. Left for a
follow-up PR.

## Test plan

Rung 5 (process lifecycle / persistence).

- `cargo fmt --check` — clean.
- `cargo check -p trusty-mpm --all-targets` — clean.
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean.
- `cargo test -p trusty-mpm --no-fail-fast` — **6239 passed; 0 failed; 8
  ignored** (lib) + every integration-test binary green, including the two
  `tm`-bin unittest runs (2258 each) — full raw tail available on request.
- `bash scripts/check_line_cap.sh` — 0 violations.
- `bash scripts/check_changelog_fragment.sh --staged` — fragment present and
  valid.

New regression tests (fail before this change, pass after):
- `workspace_guard::tests::foreign_active_claim_finds_a_colliding_workspace_path`
- `workspace_guard::tests::foreign_active_claim_finds_a_colliding_cwd`
- `workspace_guard::tests::foreign_active_claim_ignores_a_non_active_record`
- `workspace_guard::tests::foreign_active_claim_ignores_the_records_own_id`
- `workspace_guard::tests::foreign_active_claim_returns_none_when_unclaimed`
- `decommission_tests::decommission_refuses_a_foreign_active_workspace_collision`
- `decommission_tests::decommission_refuses_a_foreign_active_cwd_collision`
- `decommission_tests::decommission_allows_a_terminal_sibling_sharing_the_path`
- `decommission_tests::decommission_allows_an_uncontested_workspace`
- `daemon::api::tests::session_start_hook_escalates_ambiguous_cwd_to_error`
  (captures the actual emitted level via `trusty_common::log_buffer`, not
  just the SKIP behavior)

No `code-critic` round yet — one follows per the dispatch instructions.


## Fix round

Two review findings addressed, each with a regression test verified to fail
before the fix and pass after (confirmed empirically by temporarily reverting
each fix and re-running the new test):

1. **HIGH** — `crates/trusty-mpm/src/session_manager/workspace_guard.rs:57`
   (`canon_or_raw`): the nonexistent-path fallback compared raw,
   un-normalized `PathBuf`s, so a phantom `Active` record spelled with a `..`
   segment or reached via a symlinked ancestor directory compared unequal to
   a cleanly-spelled candidate and slipped past the #3764 guard — fail-open.
   Fixed: when the full path doesn't exist, canonicalize the nearest existing
   ancestor (`Path::ancestors()`) and re-append the lexically-normalized
   remainder (collapses `.`, `..`, duplicate/trailing separators).
   Tests: `foreign_active_claim_catches_a_nonexistent_path_spelled_with_a_trailing_slash`,
   `foreign_active_claim_catches_a_nonexistent_path_with_dot_dot_segments`,
   `foreign_active_claim_catches_a_nonexistent_path_through_a_symlinked_parent`.

2. **MEDIUM** — `crates/trusty-mpm/src/session_manager/dedup.rs:226-247`
   (`dedup_stale_duplicates`): the `plan_dedup`-sourced loser branch reached
   `decommission_dedup_loser` with only an `is_resolved_existing` recheck and
   no fresh tmux-liveness re-probe, unlike the sibling `workspace_dup_losers`
   (`#3396`) branch. Fixed: added the same re-probe immediately before the
   destructive call, skipping and logging if the loser's tmux session has
   gone live since planning. Corrected the doc comment on
   `decommission_dedup_loser` (`decommission.rs`) and the `dedup.rs`
   call-site comment so the "dedup re-verifies tmux liveness first" claim is
   true for both branches.
   Test: `dedup_skips_a_plan_dedup_loser_whose_tmux_went_live_before_act`
   (a custom `LateArrivalTmuxDriver` whose `list_sessions()` answers dead on
   the planning-snapshot call, then live on the fresh per-loser recheck).

Gates run (all green): `cargo fmt --check`, `cargo check -p trusty-mpm`,
`cargo clippy -p trusty-mpm --all-targets -- -D warnings`,
`cargo test -p trusty-mpm workspace_guard/dedup/decommission --no-fail-fast`,
full `cargo test -p trusty-mpm --no-fail-fast` (6247+ tests, 0 failed),
`check_line_cap.sh`, `check_test_pointers.sh`,
`check_changelog_fragment.sh --staged`.

New changelog fragment:
`crates/trusty-mpm/changelog.d/3764-liveness-recheck-and-canon-fallback.md`.

Refs #3764

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
