### PR TITLE
feat(trusty-console): durable NDJSON event log with seq, replay and persisted marker (slice 3b, #6848)

### DIFF
--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -95,13 +95,14 @@ thiserror          = { workspace = true }
 # Spool entries hold the raw webhook body byte-exact; base64 keeps the JSON
 # container from corrupting bytes the HMAC was computed over.
 base64             = { workspace = true }
+# #6848 slice 3b: the durable event-log writer rotates day files on the UTC
+# calendar day (`chrono::Utc::now().date_naive()`) and formats/parses day
+# filenames (`chrono::NaiveDate`) — production code, not just test fixtures,
+# so this moved out of dev-dependencies.
+chrono             = { workspace = true }
 
 [dev-dependencies]
 tempfile       = { workspace = true }
 tokio          = { workspace = true }
 tower          = { workspace = true }
 http-body-util = { workspace = true }
-# #6848: constructing a `HarnessEvent` fixture in the event-bus tests needs
-# `chrono::Utc::now()` for its `at` field; trusty-common re-exports the type
-# but not the constructor.
-chrono         = { workspace = true }

--- a/crates/trusty-console/changelog.d/6848-event-log-slice-3b.md
+++ b/crates/trusty-console/changelog.d/6848-event-log-slice-3b.md
@@ -1,0 +1,17 @@
+Added
+
+- A durable, day-rotated NDJSON event log for the console event-bus (DOC-73
+  §4.3, issue #6848 slice 3b), in `crates/trusty-console/src/event_bus/log/`:
+  console now assigns the single `seq` on every accepted frame (overwriting
+  whatever the producer stamped), recovers that counter's high-water mark from
+  the log's tail on restart (a truncated final line is skipped, not fatal),
+  and retains a configurable number of days of history with rotation that
+  keeps `seq` continuous across the boundary. All log I/O runs on a dedicated
+  writer task behind a bounded channel, so a slow disk never blocks ingest — a
+  full channel drops the write and counts it (`EventBusMetrics::log_dropped`)
+  rather than blocking or failing. A reconnecting subscriber can replay
+  everything persisted after a given `seq`; a request that predates retention,
+  or a range a dropped write left missing, comes back as an explicit gap
+  marker rather than silence. Live-delivered events on the broadcast channel
+  now carry a `persisted` marker, `false` for everything fanned out on this
+  path — durability is confirmed only for events read back from the log.

--- a/crates/trusty-console/src/event_bus/bus.rs
+++ b/crates/trusty-console/src/event_bus/bus.rs
@@ -34,7 +34,8 @@
 //! Test: `super::tests` — `a_subscriber_receives_ingested_events`,
 //! `duplicate_id_is_deduped`, `eviction_at_capacity_drops_the_oldest`,
 //! `ingest_assigns_sequential_console_seqs_starting_at_one`,
-//! `live_fanout_frames_are_never_marked_persisted`.
+//! `live_fanout_frames_are_never_marked_persisted`,
+//! `concurrent_producers_write_the_durable_log_in_seq_order`.
 
 use std::collections::{HashSet, VecDeque};
 use std::sync::Mutex;
@@ -195,14 +196,25 @@ impl EventBus {
     }
 
     /// Accept one frame: dedup by id, assign console's own `seq`, evict the
-    /// oldest if full, push, hand off to the durable log, fan out.
+    /// oldest if full, push, hand off to the durable log, fan out — all
+    /// while still holding the ring lock.
     ///
-    /// Why the lock is held across the whole ring decision and never across
-    /// the fan-out send: `broadcast::Sender::send` is synchronous and does
-    /// not await, so holding the lock across it costs nothing async-wise, but
-    /// the send is still issued after the lock is dropped — a subscriber
-    /// receiving an event must be able to immediately call back into
-    /// [`EventBus::snapshot`] without deadlocking on this same mutex.
+    /// Why the lock is held across the whole decision, INCLUDING the
+    /// durable-log hand-off and the fan-out send (#6848 — moved back under
+    /// the lock after a code-critic review found the gap): `DurableLog::
+    /// enqueue` is a non-blocking `try_send` and `broadcast::Sender::send` is
+    /// synchronous — neither `.await`s or invokes a subscriber's code
+    /// reentrantly, so holding the `std::sync::Mutex` across them costs
+    /// nothing async-wise. Without it, a real ordering bug follows:
+    /// `EventBus` is shared via `Arc` across one tokio task per producer
+    /// connection, and this crate's default multi-threaded runtime can run
+    /// those tasks on different OS threads. The mutex already orders two
+    /// threads' `seq` assignments (5, then 6); if `log.enqueue`/
+    /// `sender.send` ran after the lock was dropped, the OS scheduler would
+    /// be free to run thread B's `try_send(seq=6)` before thread A's
+    /// `try_send(seq=5)`, letting the durable log (and live subscribers)
+    /// observe seq 6 before seq 5 — breaking `replay_since`'s file-order-
+    /// equals-seq-order assumption (`super::log::replay`'s module docs).
     /// What: see module docs for the algorithm. A duplicate never consumes a
     /// `seq` value or reaches the log — only genuinely new events do, which
     /// is what keeps `seq` a compact, gapless (absent backpressure) sequence.
@@ -216,7 +228,8 @@ impl EventBus {
     /// `super::tests::duplicate_id_is_deduped`,
     /// `super::tests::eviction_at_capacity_drops_the_oldest`,
     /// `super::tests::ingest_assigns_sequential_console_seqs_starting_at_one`,
-    /// `super::tests::live_fanout_frames_are_never_marked_persisted`.
+    /// `super::tests::live_fanout_frames_are_never_marked_persisted`,
+    /// `super::tests::concurrent_producers_write_the_durable_log_in_seq_order`.
     pub(crate) fn ingest(&self, mut event: HarnessEvent) -> IngestOutcome {
         let id = event.id;
         let mut ring = self.lock_ring();
@@ -238,9 +251,11 @@ impl EventBus {
             self.counters.evicted.fetch_add(1, Ordering::Relaxed);
         }
         ring.events.push_back(event.clone());
-        drop(ring);
         self.counters.ingested.fetch_add(1, Ordering::Relaxed);
 
+        // #6848: still under `ring`'s lock — see this fn's doc comment for
+        // why that is required, not just harmless, for on-disk/fan-out seq
+        // order to match assignment order under concurrent producers.
         if let Some(log) = &self.log
             && !log.enqueue(event.clone())
         {
@@ -259,6 +274,7 @@ impl EventBus {
             event,
             persisted: false,
         });
+        drop(ring);
         IngestOutcome::Ingested
     }
 

--- a/crates/trusty-console/src/event_bus/bus.rs
+++ b/crates/trusty-console/src/event_bus/bus.rs
@@ -1,27 +1,40 @@
-//! The bounded in-memory ring, dedup set, counters and subscriber fan-out.
+//! The bounded in-memory ring, dedup set, counters, seq assignment and
+//! subscriber fan-out.
 //!
 //! Why: DOC-73 §4.3 gives console two retention tiers — an in-memory ring for
-//! live subscribers and a durable log for replay. This module is the first
-//! tier only; the log is out of scope for this PR (see `super`'s module
-//! docs). The ring exists so a subscriber that attaches after events have
-//! already flowed still gets recent history rather than only what arrives
-//! from that point on, and dedup-by-id exists because a producer's
+//! live subscribers and a durable log for replay (issue #6848 slice 3b, the
+//! `log` submodule). The ring exists so a subscriber that attaches after
+//! events have already flowed still gets recent history rather than only what
+//! arrives from that point on, and dedup-by-id exists because a producer's
 //! [`trusty_common::control_bus`]-based `PushClient` (§4.2, a parallel slice)
 //! replays its local buffer on reconnect — the same event can legitimately
-//! arrive twice.
+//! arrive twice. Console also owns `seq` as of this slice: DOC-73 §4.3 —
+//! "`seq` is now minted once, by console, for every frame it accepted — not
+//! per-process" — so [`EventBus::ingest`] overwrites whatever the producer
+//! stamped with its own monotonic counter, recovered from the durable log's
+//! tail on startup so numbers never repeat across a restart.
 //! What: [`EventBus`] wraps a capacity-bounded `VecDeque<HarnessEvent>` plus a
 //! `HashSet<EventId>` kept in lock-step with it (an id leaves the set the
 //! moment its event is evicted from the ring, so the set never outgrows the
 //! ring and dedup is a window over what the ring currently holds, not a
 //! global history). [`EventBus::ingest`] is the single write path: dedup,
-//! then evict-oldest-if-full, then push and fan out to subscribers over a
-//! [`tokio::sync::broadcast`] channel sized to the ring capacity. Ingest never
-//! blocks on a slow subscriber — `broadcast::Sender::send` is synchronous and
-//! a subscriber that falls behind gets `Lagged` on its own next `recv`,
-//! exactly like the ring's own eviction would have produced, per DOC-73 §4.3's
-//! "ingest never blocks on fan-out" rule.
+//! assign `seq`, evict-oldest-if-full, push, hand off to the durable log (a
+//! non-blocking `try_send`, `log::DurableLog::enqueue`), then fan out to
+//! subscribers over a [`tokio::sync::broadcast`] channel carrying [`BusFrame`]
+//! — `event` plus `persisted`. `persisted` is always `false` on this live
+//! path: by construction the write is still in flight (or was just dropped
+//! under backpressure) at the moment of fan-out, since I/O happens
+//! asynchronously on the writer task, off this hot path. A [`BusFrame`] built
+//! from [`super::log::ReplayItem::Event`] (a later slice's SSE/backfill route)
+//! is `persisted: true` instead — read from the log, it already is. Ingest
+//! never blocks on a slow subscriber — `broadcast::Sender::send` is
+//! synchronous and a subscriber that falls behind gets `Lagged` on its own
+//! next `recv`, exactly like the ring's own eviction would have produced, per
+//! DOC-73 §4.3's "ingest never blocks on fan-out" rule.
 //! Test: `super::tests` — `a_subscriber_receives_ingested_events`,
-//! `duplicate_id_is_deduped`, `eviction_at_capacity_drops_the_oldest`.
+//! `duplicate_id_is_deduped`, `eviction_at_capacity_drops_the_oldest`,
+//! `ingest_assigns_sequential_console_seqs_starting_at_one`,
+//! `live_fanout_frames_are_never_marked_persisted`.
 
 use std::collections::{HashSet, VecDeque};
 use std::sync::Mutex;
@@ -29,6 +42,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::broadcast;
 use trusty_common::control_bus::{EventId, HarnessEvent};
+
+use super::log::DurableLog;
 
 /// Default ring capacity (DOC-73 §4.3: "an in-memory ring, capacity
 /// configurable, defaulting to 8192" — "sized for three (soon four)
@@ -57,16 +72,15 @@ impl Default for EventBusConfig {
     }
 }
 
-/// The three counters this slice makes observable (issue #6848).
+/// The counters this and the prior slice make observable (issues #6848).
 ///
 /// Why: a later slice serves these over a metrics route; today they exist so
-/// the bus's own behavior — dedup, eviction — is provable from outside the
-/// lock rather than only inferable from ring contents.
+/// the bus's own behavior — dedup, eviction, durable-write backpressure — is
+/// provable from outside the lock rather than only inferable from ring
+/// contents.
 /// What: a plain snapshot, one `Ordering::Relaxed` load per field — these are
 /// independent counters, not a transaction, so relaxed ordering is sufficient
 /// and matches how `trusty-console`'s other pollers read their own gauges.
-/// Test: `super::tests::duplicate_id_is_deduped`,
-/// `super::tests::eviction_at_capacity_drops_the_oldest`.
 // Reserved for the metrics route a later slice adds (#6850); exercised today
 // only by this module's own tests.
 #[allow(dead_code)]
@@ -78,6 +92,11 @@ pub(crate) struct EventBusMetrics {
     pub deduped: u64,
     /// Frames evicted from the ring to make room for a newer one.
     pub evicted: u64,
+    /// Frames whose durable-log write was skipped because the writer's
+    /// bounded queue was full (issue #6848 slice 3b). Every one of these is
+    /// a permanent gap `super::log::ReplayItem::Gap` will surface on the next
+    /// replay across it.
+    pub log_dropped: u64,
 }
 
 #[derive(Debug, Default)]
@@ -85,6 +104,7 @@ struct Counters {
     ingested: AtomicU64,
     deduped: AtomicU64,
     evicted: AtomicU64,
+    log_dropped: AtomicU64,
 }
 
 /// What [`EventBus::ingest`] did with one frame.
@@ -98,6 +118,25 @@ pub(crate) enum IngestOutcome {
     Ingested,
     /// Dropped: an event with this id is already in the ring.
     Deduped,
+}
+
+/// One event as delivered to a live subscriber or replayed from the durable
+/// log (issue #6848 slice 3b).
+///
+/// Why a wrapper rather than broadcasting a bare `HarnessEvent`: a subscriber
+/// needs to tell "just happened, durability still in flight" apart from
+/// "read back from the log, already durable" — see the module docs' full
+/// contract. Kept local to `trusty-console` rather than added to
+/// `trusty_common::control_bus::HarnessEvent` because no other crate needs to
+/// agree on it: only this bus's own subscribers (the SSE route a later slice
+/// adds) ever see a `BusFrame`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BusFrame {
+    pub event: HarnessEvent,
+    /// `false` on every live-ingest fan-out (the write is always still
+    /// pending or was just dropped at the moment of send); `true` only for a
+    /// frame built from a replayed, already-written log record.
+    pub persisted: bool,
 }
 
 /// The ring plus its dedup set, always mutated together under one lock.
@@ -114,14 +153,32 @@ struct Ring {
 pub(crate) struct EventBus {
     ring: Mutex<Ring>,
     counters: Counters,
-    sender: broadcast::Sender<HarnessEvent>,
+    sender: broadcast::Sender<BusFrame>,
+    next_seq: AtomicU64,
+    log: Option<DurableLog>,
 }
 
 impl EventBus {
-    /// Build a bus with the given configuration.
+    /// Build a bus with the given configuration and no durable log — seq
+    /// numbering starts fresh at 1 and nothing is ever persisted. Used by
+    /// every test that only exercises the ring, and as the degraded fallback
+    /// when [`super::log::DurableLog::open`] fails (DOC-73 §4.1's
+    /// non-blocking invariant: a console that cannot open its event log still
+    /// serves everything else).
     ///
     /// Test: `super::tests::zero_capacity_is_raised_to_one`.
     pub(crate) fn new(config: EventBusConfig) -> Self {
+        Self::with_log(config, None, 1)
+    }
+
+    /// Build a bus wired to a durable log, resuming seq numbering at
+    /// `recovered_next_seq` (from `log::DurableLog::open`'s
+    /// [`super::log::RecoveredState`]).
+    pub(crate) fn with_log(
+        config: EventBusConfig,
+        log: Option<DurableLog>,
+        recovered_next_seq: u64,
+    ) -> Self {
         let capacity = config.capacity.max(1);
         let (sender, _receiver) = broadcast::channel(capacity);
         Self {
@@ -132,25 +189,35 @@ impl EventBus {
             }),
             counters: Counters::default(),
             sender,
+            next_seq: AtomicU64::new(recovered_next_seq.max(1)),
+            log,
         }
     }
 
-    /// Accept one frame: dedup by id, evict the oldest if full, push, fan out.
+    /// Accept one frame: dedup by id, assign console's own `seq`, evict the
+    /// oldest if full, push, hand off to the durable log, fan out.
     ///
-    /// Why the lock is held across the whole decision and never across the
-    /// fan-out send: `broadcast::Sender::send` is synchronous and does not
-    /// await, so holding the lock across it costs nothing async-wise, but the
-    /// send is still issued after the lock is dropped — a subscriber
+    /// Why the lock is held across the whole ring decision and never across
+    /// the fan-out send: `broadcast::Sender::send` is synchronous and does
+    /// not await, so holding the lock across it costs nothing async-wise, but
+    /// the send is still issued after the lock is dropped — a subscriber
     /// receiving an event must be able to immediately call back into
     /// [`EventBus::snapshot`] without deadlocking on this same mutex.
-    /// What: see module docs for the algorithm. A bus with zero subscribers
-    /// returns a `SendError` from `broadcast::Sender::send`, which is
-    /// discarded — no subscriber is not a failure, it is the common case
-    /// before any SSE route (#6851) attaches.
+    /// What: see module docs for the algorithm. A duplicate never consumes a
+    /// `seq` value or reaches the log — only genuinely new events do, which
+    /// is what keeps `seq` a compact, gapless (absent backpressure) sequence.
+    /// The durable-log hand-off is `DurableLog::enqueue`, a non-blocking
+    /// `try_send`; a full queue increments `log_dropped` and logs a warning
+    /// but never blocks or fails ingest itself (DOC-73 §4.1's non-blocking
+    /// invariant). A bus with zero subscribers returns a `SendError` from
+    /// `broadcast::Sender::send`, which is discarded — no subscriber is not a
+    /// failure, it is the common case before any SSE route (#6851) attaches.
     /// Test: `super::tests::a_subscriber_receives_ingested_events`,
     /// `super::tests::duplicate_id_is_deduped`,
-    /// `super::tests::eviction_at_capacity_drops_the_oldest`.
-    pub(crate) fn ingest(&self, event: HarnessEvent) -> IngestOutcome {
+    /// `super::tests::eviction_at_capacity_drops_the_oldest`,
+    /// `super::tests::ingest_assigns_sequential_console_seqs_starting_at_one`,
+    /// `super::tests::live_fanout_frames_are_never_marked_persisted`.
+    pub(crate) fn ingest(&self, mut event: HarnessEvent) -> IngestOutcome {
         let id = event.id;
         let mut ring = self.lock_ring();
         if !ring.ids.insert(id) {
@@ -158,6 +225,12 @@ impl EventBus {
             self.counters.deduped.fetch_add(1, Ordering::Relaxed);
             return IngestOutcome::Deduped;
         }
+
+        // DOC-73 §4.3: console mints seq once, on acceptance, overwriting
+        // whatever the producer stamped — a per-process value cannot order
+        // across processes.
+        event.seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+
         if ring.events.len() >= ring.capacity
             && let Some(evicted) = ring.events.pop_front()
         {
@@ -167,9 +240,25 @@ impl EventBus {
         ring.events.push_back(event.clone());
         drop(ring);
         self.counters.ingested.fetch_add(1, Ordering::Relaxed);
+
+        if let Some(log) = &self.log
+            && !log.enqueue(event.clone())
+        {
+            self.counters.log_dropped.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(
+                seq = event.seq,
+                "event-bus: durable-log writer is backpressured; this event \
+                 will not be persisted"
+            );
+        }
+
         // Best-effort: no subscriber yet is the common case (#6851 is a later
-        // slice), not a failure to report.
-        let _ = self.sender.send(event);
+        // slice), not a failure to report. Always `persisted: false` — see
+        // the module docs' contract.
+        let _ = self.sender.send(BusFrame {
+            event,
+            persisted: false,
+        });
         IngestOutcome::Ingested
     }
 
@@ -183,8 +272,27 @@ impl EventBus {
     // Reserved for the SSE route a later slice adds (#6851); exercised today
     // only by this module's own tests.
     #[allow(dead_code)]
-    pub(crate) fn subscribe(&self) -> broadcast::Receiver<HarnessEvent> {
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<BusFrame> {
         self.sender.subscribe()
+    }
+
+    /// Replay everything the durable log has persisted after `since_seq`, in
+    /// order. `None` when this bus has no durable log wired (degraded mode —
+    /// see [`EventBus::new`]).
+    ///
+    /// # Errors
+    ///
+    /// `Some(Err(_))` when the log is wired but a day file could not be
+    /// listed or read.
+    // Reserved for the SSE/backfill route a later slice adds (#6851, DOC-73
+    // §4.4); exercised today only by this module's own tests.
+    #[allow(dead_code)]
+    pub(crate) async fn replay_since(
+        &self,
+        since_seq: u64,
+    ) -> Option<Result<Vec<super::log::ReplayItem>, super::log::LogError>> {
+        let log = self.log.as_ref()?;
+        Some(log.replay_since(since_seq).await)
     }
 
     /// A snapshot of the counters as of this call.
@@ -199,6 +307,7 @@ impl EventBus {
             ingested: self.counters.ingested.load(Ordering::Relaxed),
             deduped: self.counters.deduped.load(Ordering::Relaxed),
             evicted: self.counters.evicted.load(Ordering::Relaxed),
+            log_dropped: self.counters.log_dropped.load(Ordering::Relaxed),
         }
     }
 

--- a/crates/trusty-console/src/event_bus/log/config.rs
+++ b/crates/trusty-console/src/event_bus/log/config.rs
@@ -1,0 +1,90 @@
+//! Where the durable event log lives, and how long it is kept.
+//!
+//! Why: the directory and retention window are the two facts every other
+//! `log/` submodule needs and none of them should decide on its own — keeping
+//! both here is what lets [`super::writer`], [`super::recovery`] and
+//! [`super::replay`] agree without importing each other.
+//! What: [`LogConfig`] is the console's private event-log directory
+//! (`<data dir>/trusty-console/event_log/`, resolved through
+//! [`trusty_common::resolve_data_dir`], never a raw `create_dir_all`) plus
+//! `retain_days`. [`day_file_name`]/[`parse_day_file_name`] are the one
+//! filename format every submodule reads and writes
+//! (`YYYY-MM-DD.ndjson`), so a rename in one place can't drift from a parse
+//! in another.
+//! Test: `super::tests::day_file_name_round_trips`,
+//! `super::tests::parse_day_file_name_rejects_a_non_matching_name`.
+
+use std::path::PathBuf;
+
+use chrono::NaiveDate;
+
+use super::error::LogError;
+
+/// Subdirectory of the console data directory the durable log lives under.
+pub(crate) const LOG_SUBDIR: &str = "event_log";
+
+/// Extension every day file carries.
+pub(crate) const LOG_FILE_EXT: &str = "ndjson";
+
+/// How many calendar days of day files are kept by default (DOC-73 §4.3's
+/// "rotated and retained" requirement; no fixed number is specified there, so
+/// a week is the simplest sane default — long enough that a viewer reattaching
+/// after a weekend still gets replay, short enough that an idle console does
+/// not accumulate files forever).
+pub(crate) const DEFAULT_RETAIN_DAYS: u32 = 7;
+
+/// Bounded capacity of the channel between [`super::EventBus::ingest`] and the
+/// writer task. Sized well above any burst this workspace's harnesses are
+/// expected to produce (DOC-73 §4.3's ring defaults to 8192 for the same
+/// reason) while still being a real, enforced bound — see
+/// `super::tests::backpressure_drops_are_counted_and_do_not_block_ingest` for
+/// what happens once it fills.
+pub(crate) const WRITE_CHANNEL_CAPACITY: usize = 4096;
+
+/// Construction-time configuration for [`super::DurableLog`].
+#[derive(Debug, Clone)]
+pub(crate) struct LogConfig {
+    /// Directory the day files live in.
+    pub dir: PathBuf,
+    /// Calendar days of day files retained before rotation deletes the
+    /// oldest.
+    pub retain_days: u32,
+}
+
+impl LogConfig {
+    /// The default configuration: `<console data dir>/event_log/`,
+    /// [`DEFAULT_RETAIN_DAYS`] days retained.
+    ///
+    /// # Errors
+    ///
+    /// [`LogError::ResolveDir`] when the console data directory itself
+    /// cannot be resolved (a degenerate `HOME`/`XDG_DATA_HOME`, unwritable
+    /// filesystem, etc. — see [`trusty_common::resolve_data_dir`]).
+    pub(crate) fn resolve_default() -> Result<Self, LogError> {
+        let base =
+            trusty_common::resolve_data_dir("trusty-console").map_err(LogError::ResolveDir)?;
+        Ok(Self {
+            dir: base.join(LOG_SUBDIR),
+            retain_days: DEFAULT_RETAIN_DAYS,
+        })
+    }
+}
+
+/// The on-disk filename for `date`'s day file: `YYYY-MM-DD.ndjson`.
+///
+/// Test: `super::tests::day_file_name_round_trips`.
+pub(crate) fn day_file_name(date: NaiveDate) -> String {
+    format!("{}.{LOG_FILE_EXT}", date.format("%Y-%m-%d"))
+}
+
+/// Parse a day file's date back out of its filename, `None` for anything that
+/// does not match [`day_file_name`]'s exact format — including another file a
+/// human or another tool dropped in the same directory, which must be ignored
+/// rather than crash the listing.
+///
+/// Test: `super::tests::day_file_name_round_trips`,
+/// `super::tests::parse_day_file_name_rejects_a_non_matching_name`.
+pub(crate) fn parse_day_file_name(name: &str) -> Option<NaiveDate> {
+    let stem = name.strip_suffix(&format!(".{LOG_FILE_EXT}"))?;
+    NaiveDate::parse_from_str(stem, "%Y-%m-%d").ok()
+}

--- a/crates/trusty-console/src/event_bus/log/error.rs
+++ b/crates/trusty-console/src/event_bus/log/error.rs
@@ -1,0 +1,41 @@
+//! Why the durable event log could not do something.
+//!
+//! Why: every fallible operation in `log/` — resolving the directory,
+//! hardening it, opening or reading a day file — needs one error type callers
+//! can match on, rather than each submodule inventing its own. Library code
+//! (this crate is also linked as `trusty_console`, per `Cargo.toml`'s `[lib]`)
+//! uses `thiserror`, not `anyhow`, per this repo's convention.
+//! What: [`LogError`] covers directory resolution/hardening, file open/read/
+//! write, and a malformed on-disk filename encountered during a directory
+//! listing. Test: exercised indirectly by every `log::tests` case that opens
+//! a [`super::DurableLog`] against an unwritable or malformed directory.
+
+use std::path::PathBuf;
+
+/// Errors the durable event log surface can return.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum LogError {
+    /// The console data directory could not be resolved.
+    #[error("resolve the console data directory: {0}")]
+    ResolveDir(#[source] anyhow::Error),
+
+    /// The log directory exists but could not be hardened to `0700` (or
+    /// failed [`trusty_common::uds::prepare_socket_dir`]'s symlink/foreign-
+    /// owner checks — reused here for its directory-hardening guarantee, not
+    /// because this directory holds a socket).
+    #[error("harden the event-log directory at {path}: {source}")]
+    PrepareDir {
+        path: PathBuf,
+        #[source]
+        source: trusty_common::uds::UdsSecurityError,
+    },
+
+    /// A day file could not be listed, opened, read, or written.
+    #[error("{op} the event-log file at {path}: {source}")]
+    Io {
+        op: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}

--- a/crates/trusty-console/src/event_bus/log/format.rs
+++ b/crates/trusty-console/src/event_bus/log/format.rs
@@ -1,0 +1,105 @@
+//! NDJSON line encoding and tolerant, whole-file decoding.
+//!
+//! Why: [`super::recovery`] (seq high-water mark) and [`super::replay`]
+//! (replay-on-reconnect) both need "every event a day file holds, in order",
+//! and both must survive the one on-disk defect a crash can actually leave
+//! behind: a final line cut off mid-write. Sharing one read path here is what
+//! keeps that tolerance rule from being implemented — and drifting — twice.
+//! What: [`encode_line`] is the write side: one `HarnessEvent` as JSON plus a
+//! trailing `\n`. [`read_events`] is the read side: reads the whole file,
+//! parses each non-empty line, and treats a parse failure on the LAST
+//! non-empty line as a truncated write (skipped, logged at debug, not an
+//! error) — a parse failure on any earlier line is still skipped so one
+//! corrupt record cannot make the rest of a day's history unreadable, but it
+//! logs at `warn` because it is not the expected shape of a crash.
+//! Test: `super::tests::read_events_skips_a_truncated_final_line`,
+//! `super::tests::read_events_skips_a_corrupt_interior_line_and_keeps_reading`,
+//! `super::tests::read_events_returns_empty_for_an_empty_file`.
+
+use std::path::Path;
+
+use trusty_common::control_bus::HarnessEvent;
+
+use super::error::LogError;
+
+/// Serialize `event` as one NDJSON line, trailing newline included.
+///
+/// Why infallible: `HarnessEvent` derives `Serialize` over plain, always-
+/// representable field types (no `f64::NAN`-style JSON landmine in this
+/// envelope), so a real serialization failure here would be a bug in the type
+/// itself, not a runtime condition callers should have to handle. `expect` is
+/// the intentional narrow use per this crate's "no `unwrap()`, reserve
+/// `expect()` for invariants that can never occur at runtime" rule.
+pub(crate) fn encode_line(event: &HarnessEvent) -> Vec<u8> {
+    let mut line = serde_json::to_vec(event).expect("HarnessEvent always serializes to valid JSON");
+    line.push(b'\n');
+    line
+}
+
+/// Read every event `path` holds, tolerating a truncated final line.
+///
+/// What: reads the whole file, splits on `\n`, drops empty/whitespace-only
+/// lines, and parses each remaining one as a `HarnessEvent`. A parse failure
+/// on the last non-empty line is assumed to be a write the process died
+/// mid-way through and is silently skipped (this is the contract callers
+/// rely on: "a truncated final line is skipped, not fatal"). A parse failure
+/// anywhere else is also skipped, so one corrupt line cannot cost every event
+/// after it, but is logged at `warn` since it is not the truncated-tail case.
+///
+/// # Errors
+///
+/// [`LogError::Io`] only for the read itself failing (permissions, the file
+/// vanishing between listing and reading). A missing file is NOT an error —
+/// callers that list files before reading them should not normally hit this,
+/// but a `NotFound` here returns an empty `Vec` rather than erroring, so a
+/// file rotated away between listing and reading degrades to "nothing found"
+/// rather than aborting a whole replay.
+///
+/// Test: `super::tests::read_events_skips_a_truncated_final_line`,
+/// `super::tests::read_events_skips_a_corrupt_interior_line_and_keeps_reading`,
+/// `super::tests::read_events_returns_empty_for_an_empty_file`.
+pub(crate) async fn read_events(path: &Path) -> Result<Vec<HarnessEvent>, LogError> {
+    let content = match tokio::fs::read_to_string(path).await {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(LogError::Io {
+                op: "read",
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+
+    let lines: Vec<&str> = content
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    let last_index = lines.len().saturating_sub(1);
+
+    let mut events = Vec::with_capacity(lines.len());
+    for (index, line) in lines.iter().enumerate() {
+        match serde_json::from_str::<HarnessEvent>(line) {
+            Ok(event) => events.push(event),
+            Err(e) if index == last_index => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %e,
+                    "event log: final line did not parse; treating as a truncated \
+                     write and skipping it"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    line = index,
+                    error = %e,
+                    "event log: interior line did not parse; skipping it and \
+                     continuing"
+                );
+            }
+        }
+    }
+    Ok(events)
+}

--- a/crates/trusty-console/src/event_bus/log/mod.rs
+++ b/crates/trusty-console/src/event_bus/log/mod.rs
@@ -1,0 +1,38 @@
+//! The durable, day-rotated NDJSON event log (issue #6848 slice 3b, DOC-73
+//! §4.3).
+//!
+//! Why: slice 3 (PR #7152) shipped the in-memory ring only — a console
+//! restart lost every event, and a viewer that reconnected mid-session had no
+//! way to see what it missed. DOC-73 §4.3 calls for two retention tiers, the
+//! ring and "a durable NDJSON file per day, written by console as each frame
+//! is accepted"; this module is the second tier.
+//! What: [`DurableLog`] is the handle [`super::bus::EventBus`] holds — a
+//! bounded channel to a dedicated writer task, so a slow disk never blocks
+//! ingest. [`LogConfig`] resolves the private directory
+//! (`<console data dir>/event_log/`, hardened via
+//! [`trusty_common::uds::prepare_socket_dir`], never a raw `create_dir_all`)
+//! and the retention window. [`replay::ReplayItem`] is what a reconnecting
+//! subscriber reads back: persisted events plus explicit
+//! [`replay::ReplayItem::Gap`] markers wherever retention or a backpressure
+//! drop left a hole. Submodules: `config` (paths, constants),
+//! `error` (`LogError`), `format` (NDJSON encode + tolerant decode),
+//! `recovery` (seq high-water mark + earliest-retained-seq on startup),
+//! `retention` (day-file deletion), `writer` (`DurableLog` + the write task),
+//! `replay` (replay-on-reconnect).
+//! Test: `tests.rs`.
+
+mod config;
+mod error;
+mod format;
+mod recovery;
+mod replay;
+mod retention;
+mod writer;
+
+#[cfg(test)]
+mod tests;
+
+pub(crate) use config::LogConfig;
+pub(crate) use error::LogError;
+pub(crate) use replay::ReplayItem;
+pub(crate) use writer::DurableLog;

--- a/crates/trusty-console/src/event_bus/log/recovery.rs
+++ b/crates/trusty-console/src/event_bus/log/recovery.rs
@@ -1,0 +1,115 @@
+//! Startup recovery: list day files, and find the seq high-water mark.
+//!
+//! Why: `HarnessEvent.seq` is console-assigned and must never repeat across a
+//! restart (DOC-73 §4.3 — "seq is now minted once, by console"). The only
+//! source of truth for "what was the last seq console handed out" is the log
+//! itself, since the in-memory ring is empty on every fresh process. This
+//! module is what [`super::DurableLog::open`] calls before it starts accepting
+//! new events.
+//! What: [`list_log_files`] enumerates day files in date order, ignoring
+//! anything whose name is not a `day_file_name` (a stray file a human or
+//! another tool dropped in the directory must not abort startup).
+//! [`recover_next_seq`] scans files newest-first and returns the highest seq
+//! found plus one, tolerating a truncated final line via
+//! [`super::format::read_events`]; an empty log starts at 1. [`earliest_seq`]
+//! is the first event's seq in the OLDEST retained file — the boundary
+//! [`super::replay`] compares `since_seq` against to decide whether a replay
+//! request predates everything retention still holds.
+//! Test: `super::tests::recover_next_seq_starts_at_one_with_no_files`,
+//! `super::tests::recover_next_seq_continues_from_the_newest_non_empty_file`,
+//! `super::tests::recover_next_seq_tolerates_a_truncated_final_line`,
+//! `super::tests::earliest_seq_reads_the_oldest_retained_file`.
+
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDate;
+
+use super::config::parse_day_file_name;
+use super::error::LogError;
+use super::format::read_events;
+
+/// One day file, its date parsed out of the filename, and its full path.
+pub(crate) type DayFile = (NaiveDate, PathBuf);
+
+/// List every day file in `dir`, sorted ascending by date (oldest first).
+///
+/// A missing directory is not an error — it returns an empty list, so a
+/// first-ever run (before [`trusty_common::uds::prepare_socket_dir`] has
+/// created anything) recovers cleanly at seq 1 rather than failing.
+///
+/// Test: `super::tests::list_log_files_ignores_non_matching_names`,
+/// `super::tests::list_log_files_sorts_ascending_by_date`.
+pub(crate) async fn list_log_files(dir: &Path) -> Result<Vec<DayFile>, LogError> {
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(source) => {
+            return Err(LogError::Io {
+                op: "list",
+                path: dir.to_path_buf(),
+                source,
+            });
+        }
+    };
+
+    let mut files = Vec::new();
+    loop {
+        let entry = entries.next_entry().await.map_err(|source| LogError::Io {
+            op: "list",
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let Some(entry) = entry else { break };
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if let Some(date) = parse_day_file_name(name) {
+            files.push((date, entry.path()));
+        }
+    }
+    files.sort_by_key(|(date, _)| *date);
+    Ok(files)
+}
+
+/// The seq a fresh [`super::DurableLog`] should assign next: one past the
+/// highest seq recorded anywhere in `files`, or `1` if none is found.
+///
+/// Scans newest-first and stops at the first file that yields at least one
+/// event — under normal operation that is always the very last file, but
+/// scanning backward instead of assuming it tolerates a day boundary that
+/// rolled over onto an empty file right before a crash (`super::tests::
+/// recover_next_seq_continues_from_the_newest_non_empty_file` covers exactly
+/// this).
+///
+/// Test: `super::tests::recover_next_seq_starts_at_one_with_no_files`,
+/// `super::tests::recover_next_seq_continues_from_the_newest_non_empty_file`,
+/// `super::tests::recover_next_seq_tolerates_a_truncated_final_line`.
+pub(crate) async fn recover_next_seq(files: &[DayFile]) -> Result<u64, LogError> {
+    for (_, path) in files.iter().rev() {
+        let events = read_events(path).await?;
+        if let Some(highest) = events.iter().map(|e| e.seq).max() {
+            return Ok(highest + 1);
+        }
+    }
+    Ok(1)
+}
+
+/// The seq of the first event in the OLDEST retained file — `None` when no
+/// file holds a single readable event (a brand-new log, or every retained
+/// file is empty/fully truncated).
+///
+/// This is the boundary [`super::replay::replay_since`] compares an incoming
+/// `since_seq` against: a request older than this value asks for history
+/// retention has already discarded, and must get an explicit gap marker
+/// rather than silently starting from whatever remains.
+///
+/// Test: `super::tests::earliest_seq_reads_the_oldest_retained_file`,
+/// `super::tests::earliest_seq_is_none_for_an_empty_log`.
+pub(crate) async fn earliest_seq(files: &[DayFile]) -> Result<Option<u64>, LogError> {
+    for (_, path) in files {
+        let events = read_events(path).await?;
+        if let Some(first) = events.first() {
+            return Ok(Some(first.seq));
+        }
+    }
+    Ok(None)
+}

--- a/crates/trusty-console/src/event_bus/log/replay.rs
+++ b/crates/trusty-console/src/event_bus/log/replay.rs
@@ -19,7 +19,9 @@
 //! `super::tests::replay_since_a_mid_seq_returns_only_the_remainder`,
 //! `super::tests::replay_since_before_retention_yields_a_leading_gap`,
 //! `super::tests::replay_since_across_a_backpressure_drop_yields_an_interior_gap`,
-//! `super::tests::replay_since_caught_up_returns_no_events_and_no_gap`.
+//! `super::tests::replay_since_a_drop_on_the_first_replayed_seq_yields_a_gap`,
+//! `super::tests::replay_since_caught_up_returns_no_events_and_no_gap`,
+//! `super::tests::replay_since_on_an_empty_log_returns_nothing`.
 
 use std::path::Path;
 
@@ -67,7 +69,16 @@ pub(crate) async fn replay_since(
 ) -> Result<Vec<ReplayItem>, LogError> {
     let files = list_log_files(dir).await?;
     let mut items = Vec::new();
-    let mut previous_seq: Option<u64> = None;
+    // #6848: seed from `since_seq` itself, not `None` — the caller already
+    // has everything up to and including `since_seq`, so a hole immediately
+    // after it (the FIRST event this call returns) must be checked exactly
+    // like every later hole is. Leaving this `None` until the leading-gap
+    // branch below set it meant the first returned event skipped the
+    // `prev + 1` check entirely whenever `since_seq` was already inside the
+    // retained window — the normal reconnect case — silently dropping the
+    // gap marker for a seq that was broadcast live but never durably
+    // written.
+    let mut previous_seq: Option<u64> = Some(since_seq);
 
     if let Some(earliest) = earliest_retained_seq
         && since_seq + 1 < earliest

--- a/crates/trusty-console/src/event_bus/log/replay.rs
+++ b/crates/trusty-console/src/event_bus/log/replay.rs
@@ -1,0 +1,100 @@
+//! Replay-on-reconnect: everything persisted after `since_seq`, in order.
+//!
+//! Why: DOC-73 §4.3 — "a viewer that opens mid-session reads the log to build
+//! the tree it missed, then switches to the live ring at the log's last
+//! `seq`." A gap must never read as silence: retention can have discarded
+//! everything before `since_seq` asked for, and the writer's bounded channel
+//! (`super::config::WRITE_CHANNEL_CAPACITY`) can have dropped an event under
+//! backpressure, leaving a hole inside what IS retained. Both cases surface
+//! as an explicit [`ReplayItem::Gap`] rather than the caller silently getting
+//! fewer events than it expected.
+//! What: [`replay_since`] lists day files, reads every event with
+//! `seq > since_seq` across them in seq order (file order already matches
+//! seq order, since files rotate forward in time and seq only increases), and
+//! interleaves gap markers: one BEFORE the first event if `since_seq` predates
+//! `earliest_retained_seq`, and one wherever two consecutive events' seqs are
+//! not adjacent (a backpressure drop). Every returned event is wrapped
+//! `persisted: true` — read from the log, it always is, by construction.
+//! Test: `super::tests::replay_since_zero_returns_everything_in_order`,
+//! `super::tests::replay_since_a_mid_seq_returns_only_the_remainder`,
+//! `super::tests::replay_since_before_retention_yields_a_leading_gap`,
+//! `super::tests::replay_since_across_a_backpressure_drop_yields_an_interior_gap`,
+//! `super::tests::replay_since_caught_up_returns_no_events_and_no_gap`.
+
+use std::path::Path;
+
+use trusty_common::control_bus::HarnessEvent;
+
+use super::error::LogError;
+use super::format::read_events;
+use super::recovery::list_log_files;
+
+/// One item of a replay: either a persisted event, or an explicit marker that
+/// events between `after_seq` and `before_seq` (both exclusive) are gone and
+/// will never be replayed.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ReplayItem {
+    /// A durably-written event, boxed so this arm does not force every
+    /// [`ReplayItem::Gap`] to carry `HarnessEvent`'s full size too (clippy
+    /// `large_enum_variant`). Always `persisted: true` on the
+    /// [`super::super::bus::BusFrame`] a caller wraps this in — read from the
+    /// log, it already is.
+    Event(Box<HarnessEvent>),
+    /// No event with a seq in `(after_seq, before_seq)` will ever be
+    /// replayed — either retention discarded it, or the writer dropped it
+    /// under backpressure and it was never durably written at all.
+    Gap { after_seq: u64, before_seq: u64 },
+}
+
+/// Replay everything persisted after `since_seq`, in seq order.
+///
+/// `earliest_retained_seq` is [`super::DurableLog`]'s current lower bound —
+/// `None` when nothing has ever been retained. When `since_seq` predates it,
+/// the first item returned is a [`ReplayItem::Gap`] covering
+/// `(since_seq, earliest_retained_seq)` before any event.
+///
+/// # Errors
+///
+/// [`LogError::Io`] if a day file cannot be listed or read — a single file
+/// disappearing between listing and reading degrades to "no events in that
+/// file" (see [`read_events`]), not a hard failure of the whole replay.
+///
+/// Test: see module docs.
+pub(crate) async fn replay_since(
+    dir: &Path,
+    since_seq: u64,
+    earliest_retained_seq: Option<u64>,
+) -> Result<Vec<ReplayItem>, LogError> {
+    let files = list_log_files(dir).await?;
+    let mut items = Vec::new();
+    let mut previous_seq: Option<u64> = None;
+
+    if let Some(earliest) = earliest_retained_seq
+        && since_seq + 1 < earliest
+    {
+        items.push(ReplayItem::Gap {
+            after_seq: since_seq,
+            before_seq: earliest,
+        });
+        previous_seq = Some(earliest - 1);
+    }
+
+    for (_, path) in &files {
+        for event in read_events(path).await? {
+            if event.seq <= since_seq {
+                continue;
+            }
+            if let Some(prev) = previous_seq
+                && event.seq > prev + 1
+            {
+                items.push(ReplayItem::Gap {
+                    after_seq: prev,
+                    before_seq: event.seq,
+                });
+            }
+            previous_seq = Some(event.seq);
+            items.push(ReplayItem::Event(Box::new(event)));
+        }
+    }
+    Ok(items)
+}

--- a/crates/trusty-console/src/event_bus/log/retention.rs
+++ b/crates/trusty-console/src/event_bus/log/retention.rs
@@ -1,0 +1,95 @@
+//! Deleting day files older than the retention window.
+//!
+//! Why: DOC-73 §4.3 calls for a "day-rotated NDJSON log, rotated and
+//! retained" — without a bound, an idle console accumulates one file per day
+//! forever. This module is the bound: applied once at [`super::DurableLog::
+//! open`] (in case files piled up while console was down) and again on every
+//! rotation.
+//! What: [`files_to_delete`] is the pure decision (testable without a
+//! filesystem): given the retained day files and today's date, which ones
+//! fall outside `retain_days`. [`enforce_retention`] lists, decides, and
+//! deletes, then returns the survivors sorted ascending — the caller (the
+//! writer task) uses that to recompute [`super::recovery::earliest_seq`]
+//! without a second directory listing.
+//! Test: `super::tests::files_to_delete_keeps_exactly_retain_days`,
+//! `super::tests::files_to_delete_keeps_everything_within_the_window`,
+//! `super::tests::enforce_retention_deletes_only_the_expired_files`.
+
+use std::path::Path;
+
+use chrono::{Days, NaiveDate};
+
+use super::error::LogError;
+use super::recovery::{DayFile, list_log_files};
+
+/// Which of `files` fall outside the most recent `retain_days` calendar days
+/// counting back from `today` (inclusive of `today`).
+///
+/// `retain_days == 0` is treated as `1` — a retention window of zero would
+/// delete every file including the one still being written, which is never
+/// the intent of a caller passing zero (most likely a misconfigured value,
+/// not "keep nothing").
+///
+/// Test: `super::tests::files_to_delete_keeps_exactly_retain_days`,
+/// `super::tests::files_to_delete_keeps_everything_within_the_window`.
+pub(crate) fn files_to_delete(
+    files: &[DayFile],
+    today: NaiveDate,
+    retain_days: u32,
+) -> Vec<DayFile> {
+    let retain_days = retain_days.max(1);
+    // `Days` only adds; going back `retain_days - 1` days from today gives the
+    // oldest date still kept.
+    let Some(cutoff) = today.checked_sub_days(Days::new(u64::from(retain_days - 1))) else {
+        // A `NaiveDate` underflow (today near the calendar's earliest
+        // representable date) is not a real deployment scenario; keep
+        // everything rather than risk deleting under an unrepresentable
+        // cutoff.
+        return Vec::new();
+    };
+    files
+        .iter()
+        .filter(|(date, _)| *date < cutoff)
+        .cloned()
+        .collect()
+}
+
+/// List `dir`, delete every file [`files_to_delete`] names, and return the
+/// survivors sorted ascending by date.
+///
+/// # Errors
+///
+/// [`LogError::Io`] if the directory cannot be listed, or a file that
+/// [`files_to_delete`] named cannot be removed. A file already gone by the
+/// time the delete runs (`NotFound`) is not an error — another retention pass
+/// or an operator could have removed it first, and the end state is what this
+/// function is asked to guarantee.
+///
+/// Test: `super::tests::enforce_retention_deletes_only_the_expired_files`.
+pub(crate) async fn enforce_retention(
+    dir: &Path,
+    today: NaiveDate,
+    retain_days: u32,
+) -> Result<Vec<DayFile>, LogError> {
+    let files = list_log_files(dir).await?;
+    let doomed = files_to_delete(&files, today, retain_days);
+    for (_, path) in &doomed {
+        match tokio::fs::remove_file(path).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(source) => {
+                return Err(LogError::Io {
+                    op: "delete",
+                    path: path.clone(),
+                    source,
+                });
+            }
+        }
+    }
+    let doomed_paths: std::collections::HashSet<_> =
+        doomed.into_iter().map(|(_, path)| path).collect();
+    Ok(files
+        .into_iter()
+        .filter(|(_, path)| !doomed_paths.contains(path))
+        .collect())
+}

--- a/crates/trusty-console/src/event_bus/log/tests.rs
+++ b/crates/trusty-console/src/event_bus/log/tests.rs
@@ -1,0 +1,470 @@
+//! Tests for the durable NDJSON event log (issue #6848 slice 3b).
+
+use std::path::Path;
+
+use chrono::{NaiveDate, Utc};
+use trusty_common::control_bus::{EventId, HarnessEvent, HarnessPayload, HarnessSource};
+
+use super::config::{LogConfig, day_file_name, parse_day_file_name};
+use super::format::{encode_line, read_events};
+use super::recovery::{earliest_seq, list_log_files, recover_next_seq};
+use super::replay::{ReplayItem, replay_since};
+use super::retention::{enforce_retention, files_to_delete};
+use super::writer::DurableLog;
+
+fn date(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).expect("valid test date")
+}
+
+/// Build a `HarnessEvent` fixture with a given `seq`, everything else fixed.
+fn event(seq: u64) -> HarnessEvent {
+    HarnessEvent {
+        source: HarnessSource::Mpm,
+        session: None,
+        seq,
+        at: Utc::now(),
+        payload: HarnessPayload::Ping,
+        id: EventId::new(),
+        parent_id: None,
+    }
+}
+
+/// Write `events` to `dir`'s day file for `d`, each as one NDJSON line —
+/// bypasses the writer task entirely, for tests that need direct control over
+/// on-disk content (a specific seq sequence, a deliberately corrupt line).
+async fn seed_file(dir: &Path, d: NaiveDate, events: &[HarnessEvent]) {
+    tokio::fs::create_dir_all(dir).await.expect("create dir");
+    let mut content = Vec::new();
+    for e in events {
+        content.extend_from_slice(&encode_line(e));
+    }
+    tokio::fs::write(dir.join(day_file_name(d)), content)
+        .await
+        .expect("seed day file");
+}
+
+/// Append a raw, possibly-invalid line to `dir`'s day file for `d`.
+async fn append_raw_line(dir: &Path, d: NaiveDate, line: &str) {
+    tokio::fs::create_dir_all(dir).await.expect("create dir");
+    use tokio::io::AsyncWriteExt as _;
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join(day_file_name(d)))
+        .await
+        .expect("open day file");
+    f.write_all(line.as_bytes()).await.expect("write raw line");
+}
+
+// ─── config: filename format ────────────────────────────────────────────
+
+#[test]
+fn day_file_name_round_trips() {
+    let d = date(2026, 9, 8);
+    let name = day_file_name(d);
+    assert_eq!(name, "2026-09-08.ndjson");
+    assert_eq!(parse_day_file_name(&name), Some(d));
+}
+
+#[test]
+fn parse_day_file_name_rejects_a_non_matching_name() {
+    assert_eq!(parse_day_file_name("not-a-date.ndjson"), None);
+    assert_eq!(parse_day_file_name("2026-09-08.txt"), None);
+    assert_eq!(parse_day_file_name("README.md"), None);
+}
+
+// ─── format: tolerant whole-file decode ─────────────────────────────────
+
+#[tokio::test]
+async fn read_events_returns_empty_for_an_empty_file() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("empty.ndjson");
+    tokio::fs::write(&path, b"").await.expect("write empty");
+    let events = read_events(&path).await.expect("read");
+    assert!(events.is_empty());
+}
+
+#[tokio::test]
+async fn read_events_skips_a_truncated_final_line() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("truncated.ndjson");
+    let good = event(1);
+    let mut content = encode_line(&good);
+    content.extend_from_slice(b"{\"source\":\"mpm\",\"seq\":2,\"at\":\"trunc");
+    tokio::fs::write(&path, &content).await.expect("write");
+
+    let events = read_events(&path).await.expect("read");
+    assert_eq!(
+        events.len(),
+        1,
+        "the truncated final line is skipped, not fatal"
+    );
+    assert_eq!(events[0].id, good.id);
+}
+
+#[tokio::test]
+async fn read_events_skips_a_corrupt_interior_line_and_keeps_reading() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let path = tmp.path().join("corrupt.ndjson");
+    let first = event(1);
+    let third = event(3);
+    let mut content = encode_line(&first);
+    content.extend_from_slice(b"not json at all\n");
+    content.extend_from_slice(&encode_line(&third));
+    tokio::fs::write(&path, &content).await.expect("write");
+
+    let events = read_events(&path).await.expect("read");
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].id, first.id);
+    assert_eq!(events[1].id, third.id);
+}
+
+// ─── recovery: file listing, seq high-water mark, earliest retained ─────
+
+#[tokio::test]
+async fn list_log_files_ignores_non_matching_names() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    tokio::fs::create_dir_all(tmp.path()).await.expect("dir");
+    tokio::fs::write(tmp.path().join("README.md"), b"hello")
+        .await
+        .expect("write stray file");
+    seed_file(tmp.path(), date(2026, 9, 8), &[event(1)]).await;
+
+    let files = list_log_files(tmp.path()).await.expect("list");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].0, date(2026, 9, 8));
+}
+
+#[tokio::test]
+async fn list_log_files_sorts_ascending_by_date() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(tmp.path(), date(2026, 9, 8), &[event(2)]).await;
+    seed_file(tmp.path(), date(2026, 9, 6), &[event(1)]).await;
+    seed_file(tmp.path(), date(2026, 9, 7), &[event(2)]).await;
+
+    let files = list_log_files(tmp.path()).await.expect("list");
+    let dates: Vec<_> = files.iter().map(|(d, _)| *d).collect();
+    assert_eq!(
+        dates,
+        vec![date(2026, 9, 6), date(2026, 9, 7), date(2026, 9, 8)]
+    );
+}
+
+#[tokio::test]
+async fn recover_next_seq_starts_at_one_with_no_files() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let files = list_log_files(tmp.path()).await.expect("list");
+    assert_eq!(recover_next_seq(&files).await.expect("recover"), 1);
+}
+
+#[tokio::test]
+async fn recover_next_seq_continues_from_the_newest_non_empty_file() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(tmp.path(), date(2026, 9, 6), &[event(1), event(2)]).await;
+    seed_file(
+        tmp.path(),
+        date(2026, 9, 7),
+        &[event(3), event(4), event(5)],
+    )
+    .await;
+    // A day rolled over right before a crash: today's file exists but is
+    // empty. Recovery must not stop at the newest FILE, only the newest
+    // NON-EMPTY one.
+    seed_file(tmp.path(), date(2026, 9, 8), &[]).await;
+
+    let files = list_log_files(tmp.path()).await.expect("list");
+    assert_eq!(recover_next_seq(&files).await.expect("recover"), 6);
+}
+
+#[tokio::test]
+async fn recover_next_seq_tolerates_a_truncated_final_line() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(tmp.path(), date(2026, 9, 8), &[event(1), event(2)]).await;
+    append_raw_line(
+        tmp.path(),
+        date(2026, 9, 8),
+        "{\"source\":\"mpm\",\"seq\":3,\"trunc",
+    )
+    .await;
+
+    let files = list_log_files(tmp.path()).await.expect("list");
+    assert_eq!(
+        recover_next_seq(&files).await.expect("recover"),
+        3,
+        "the truncated seq-3 write never counted; numbering resumes at 3, not 4"
+    );
+}
+
+#[tokio::test]
+async fn earliest_seq_reads_the_oldest_retained_file() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(tmp.path(), date(2026, 9, 6), &[event(5), event(6)]).await;
+    seed_file(tmp.path(), date(2026, 9, 7), &[event(7)]).await;
+
+    let files = list_log_files(tmp.path()).await.expect("list");
+    assert_eq!(earliest_seq(&files).await.expect("earliest"), Some(5));
+}
+
+#[tokio::test]
+async fn earliest_seq_is_none_for_an_empty_log() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let files = list_log_files(tmp.path()).await.expect("list");
+    assert_eq!(earliest_seq(&files).await.expect("earliest"), None);
+}
+
+// ─── retention ───────────────────────────────────────────────────────────
+
+#[test]
+fn files_to_delete_keeps_exactly_retain_days() {
+    let files = vec![
+        (date(2026, 9, 1), std::path::PathBuf::from("1")),
+        (date(2026, 9, 5), std::path::PathBuf::from("5")),
+        (date(2026, 9, 6), std::path::PathBuf::from("6")),
+    ];
+    // retain_days=2 from today=9/6 keeps 9/5 and 9/6; 9/1 is expired.
+    let doomed = files_to_delete(&files, date(2026, 9, 6), 2);
+    assert_eq!(doomed.len(), 1);
+    assert_eq!(doomed[0].0, date(2026, 9, 1));
+}
+
+#[test]
+fn files_to_delete_keeps_everything_within_the_window() {
+    let files = vec![
+        (date(2026, 9, 5), std::path::PathBuf::from("5")),
+        (date(2026, 9, 6), std::path::PathBuf::from("6")),
+    ];
+    let doomed = files_to_delete(&files, date(2026, 9, 6), 7);
+    assert!(doomed.is_empty());
+}
+
+#[tokio::test]
+async fn enforce_retention_deletes_only_the_expired_files() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(tmp.path(), date(2026, 9, 1), &[event(1)]).await;
+    seed_file(tmp.path(), date(2026, 9, 6), &[event(2)]).await;
+
+    let survivors = enforce_retention(tmp.path(), date(2026, 9, 6), 2)
+        .await
+        .expect("enforce");
+    assert_eq!(survivors.len(), 1);
+    assert_eq!(survivors[0].0, date(2026, 9, 6));
+    assert!(!tmp.path().join(day_file_name(date(2026, 9, 1))).exists());
+    assert!(tmp.path().join(day_file_name(date(2026, 9, 6))).exists());
+}
+
+// ─── replay ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn replay_since_zero_returns_everything_in_order() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(tmp.path(), date(2026, 9, 6), &[event(1), event(2)]).await;
+    seed_file(tmp.path(), date(2026, 9, 7), &[event(3)]).await;
+
+    let items = replay_since(tmp.path(), 0, Some(1)).await.expect("replay");
+    let seqs: Vec<u64> = items
+        .into_iter()
+        .map(|i| match i {
+            ReplayItem::Event(e) => e.seq,
+            ReplayItem::Gap { .. } => panic!("no gap expected"),
+        })
+        .collect();
+    assert_eq!(seqs, vec![1, 2, 3]);
+}
+
+#[tokio::test]
+async fn replay_since_a_mid_seq_returns_only_the_remainder() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(
+        tmp.path(),
+        date(2026, 9, 6),
+        &[event(1), event(2), event(3)],
+    )
+    .await;
+
+    let items = replay_since(tmp.path(), 1, Some(1)).await.expect("replay");
+    let seqs: Vec<u64> = items
+        .into_iter()
+        .map(|i| match i {
+            ReplayItem::Event(e) => e.seq,
+            ReplayItem::Gap { .. } => panic!("no gap expected"),
+        })
+        .collect();
+    assert_eq!(seqs, vec![2, 3]);
+}
+
+#[tokio::test]
+async fn replay_since_caught_up_returns_no_events_and_no_gap() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(tmp.path(), date(2026, 9, 6), &[event(1), event(2)]).await;
+
+    let items = replay_since(tmp.path(), 2, Some(1)).await.expect("replay");
+    assert!(items.is_empty());
+}
+
+#[tokio::test]
+async fn replay_since_before_retention_yields_a_leading_gap() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    // Retention already discarded seq 1-4; the oldest retained file starts
+    // at seq 5.
+    seed_file(tmp.path(), date(2026, 9, 7), &[event(5), event(6)]).await;
+
+    let items = replay_since(tmp.path(), 0, Some(5)).await.expect("replay");
+    match &items[0] {
+        ReplayItem::Gap {
+            after_seq,
+            before_seq,
+        } => {
+            assert_eq!(*after_seq, 0);
+            assert_eq!(*before_seq, 5);
+        }
+        ReplayItem::Event(_) => panic!("expected a leading gap marker"),
+    }
+    assert_eq!(items.len(), 3, "gap marker plus the two retained events");
+}
+
+#[tokio::test]
+async fn replay_since_across_a_backpressure_drop_yields_an_interior_gap() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    // seq 2 was never written — dropped under backpressure at ingest time.
+    seed_file(tmp.path(), date(2026, 9, 6), &[event(1), event(3)]).await;
+
+    let items = replay_since(tmp.path(), 0, Some(1)).await.expect("replay");
+    assert_eq!(items.len(), 3, "event 1, a gap for 2, then event 3");
+    assert!(matches!(items[0], ReplayItem::Event(ref e) if e.seq == 1));
+    match &items[1] {
+        ReplayItem::Gap {
+            after_seq,
+            before_seq,
+        } => {
+            assert_eq!(*after_seq, 1);
+            assert_eq!(*before_seq, 3);
+        }
+        ReplayItem::Event(_) => panic!("expected an interior gap marker"),
+    }
+    assert!(matches!(items[2], ReplayItem::Event(ref e) if e.seq == 3));
+}
+
+// ─── DurableLog / writer task ────────────────────────────────────────────
+
+fn config(dir: &Path) -> LogConfig {
+    LogConfig {
+        dir: dir.to_path_buf(),
+        retain_days: 7,
+    }
+}
+
+async fn wait_until(budget: std::time::Duration, mut predicate: impl FnMut() -> bool) {
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        if predicate() {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "condition did not become true within {budget:?}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn open_recovers_next_seq_from_an_existing_log() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let today = Utc::now().date_naive();
+    seed_file(tmp.path(), today, &[event(1), event(2)]).await;
+
+    let (_log, recovered) = DurableLog::open(config(tmp.path()))
+        .await
+        .expect("open existing log");
+    assert_eq!(recovered.next_seq, 3);
+}
+
+#[tokio::test]
+async fn events_written_are_readable_back_in_order() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (log, _recovered) = DurableLog::open(config(tmp.path()))
+        .await
+        .expect("open fresh log");
+
+    assert!(log.enqueue(event(1)));
+    assert!(log.enqueue(event(2)));
+    wait_until(std::time::Duration::from_secs(1), || log.written() >= 2).await;
+
+    let items = log.replay_since(0).await.expect("replay");
+    let seqs: Vec<u64> = items
+        .into_iter()
+        .map(|i| match i {
+            ReplayItem::Event(e) => e.seq,
+            ReplayItem::Gap { .. } => panic!("no gap expected"),
+        })
+        .collect();
+    assert_eq!(seqs, vec![1, 2]);
+}
+
+#[tokio::test]
+async fn backpressure_drops_are_counted_and_do_not_block_enqueue() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    // Capacity 1: the second `enqueue`, issued with no `.await` in between,
+    // races the writer task for the single slot. On this crate's default
+    // (current-thread) `#[tokio::test]` runtime the writer cannot have been
+    // polled yet at this point, so the race is deterministic — the same
+    // reasoning `event_bus::tests::connections_beyond_the_limit_wait_for_a_free_slot`
+    // relies on for its own semaphore-saturation proof.
+    let (log, _recovered) = DurableLog::open_with_capacity(config(tmp.path()), 1)
+        .await
+        .expect("open fresh log");
+
+    let first = log.enqueue(event(1));
+    let second = log.enqueue(event(2));
+    assert!(first, "the first enqueue fills the only slot");
+    assert!(
+        !second,
+        "the second enqueue must not block or panic; it reports backpressure instead"
+    );
+}
+
+#[tokio::test]
+async fn rotation_opens_a_new_file_and_keeps_seq_continuity() {
+    // Simulates the day boundary having already crossed once: a "yesterday"
+    // file holds the tail of a prior day's numbering, and recovery must
+    // resume from it rather than restarting at 1 just because today's file
+    // does not exist yet.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let yesterday = Utc::now().date_naive().pred_opt().expect("valid date");
+    // Seq starts at 1 (as it always does for a genuinely fresh log) so
+    // `earliest_retained_seq` is legitimately 1 and `replay_since(0)` sees no
+    // retention gap — a log that started numbering higher would make
+    // `replay_since` (correctly) report seq 1 onward as lost to retention,
+    // which is not what this test is exercising.
+    seed_file(tmp.path(), yesterday, &[event(1), event(2)]).await;
+
+    let (log, recovered) = DurableLog::open(config(tmp.path()))
+        .await
+        .expect("open log spanning a day boundary");
+    assert_eq!(recovered.next_seq, 3);
+
+    assert!(log.enqueue(event(3)));
+    wait_until(std::time::Duration::from_secs(1), || log.written() >= 1).await;
+
+    let today = Utc::now().date_naive();
+    assert!(
+        tmp.path().join(day_file_name(today)).exists(),
+        "the writer rotates to today's file rather than appending to yesterday's"
+    );
+    let items = log
+        .replay_since(0)
+        .await
+        .expect("replay across the boundary");
+    let seqs: Vec<u64> = items
+        .into_iter()
+        .map(|i| match i {
+            ReplayItem::Event(e) => e.seq,
+            ReplayItem::Gap { .. } => panic!("no gap expected"),
+        })
+        .collect();
+    assert_eq!(
+        seqs,
+        vec![1, 2, 3],
+        "seq stays continuous across the file boundary"
+    );
+}

--- a/crates/trusty-console/src/event_bus/log/tests.rs
+++ b/crates/trusty-console/src/event_bus/log/tests.rs
@@ -1,6 +1,8 @@
 //! Tests for the durable NDJSON event log (issue #6848 slice 3b).
 
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use chrono::{NaiveDate, Utc};
 use trusty_common::control_bus::{EventId, HarnessEvent, HarnessPayload, HarnessSource};
@@ -10,7 +12,7 @@ use super::format::{encode_line, read_events};
 use super::recovery::{earliest_seq, list_log_files, recover_next_seq};
 use super::replay::{ReplayItem, replay_since};
 use super::retention::{enforce_retention, files_to_delete};
-use super::writer::DurableLog;
+use super::writer::{DurableLog, rotate, write_line};
 
 fn date(y: i32, m: u32, d: u32) -> NaiveDate {
     NaiveDate::from_ymd_opt(y, m, d).expect("valid test date")
@@ -344,6 +346,56 @@ async fn replay_since_across_a_backpressure_drop_yields_an_interior_gap() {
     assert!(matches!(items[2], ReplayItem::Event(ref e) if e.seq == 3));
 }
 
+// #6848: regression for the CRITICAL gap-detection bug the code-critic
+// review found — `previous_seq` used to start at `None` and was only seeded
+// inside the leading-retention-gap branch, so a drop on the FIRST seq after
+// `since_seq` (the ordinary reconnect case, no retention gap involved) was
+// never checked against `since_seq` and produced no gap marker at all. Day
+// file holds seq [1, 2, 4, 5] — seq 3 was dropped under backpressure — and a
+// client reconnects from `since_seq = 2`, already inside the retained
+// window. This must fail before the `replay.rs` fix (no `Gap` before event
+// 4) and pass after it.
+#[tokio::test]
+async fn replay_since_a_drop_on_the_first_replayed_seq_yields_a_gap() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    seed_file(
+        tmp.path(),
+        date(2026, 9, 6),
+        &[event(1), event(2), event(4), event(5)],
+    )
+    .await;
+
+    let items = replay_since(tmp.path(), 2, Some(1)).await.expect("replay");
+    assert_eq!(
+        items.len(),
+        3,
+        "a gap for seq 3 immediately, then events 4 and 5"
+    );
+    match &items[0] {
+        ReplayItem::Gap {
+            after_seq,
+            before_seq,
+        } => {
+            assert_eq!(*after_seq, 2);
+            assert_eq!(*before_seq, 4);
+        }
+        ReplayItem::Event(_) => {
+            panic!("expected a gap marker for the seq dropped immediately after since_seq")
+        }
+    }
+    assert!(matches!(items[1], ReplayItem::Event(ref e) if e.seq == 4));
+    assert!(matches!(items[2], ReplayItem::Event(ref e) if e.seq == 5));
+}
+
+#[tokio::test]
+async fn replay_since_on_an_empty_log_returns_nothing() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let items = replay_since(tmp.path(), 0, None)
+        .await
+        .expect("replay an empty log");
+    assert!(items.is_empty(), "no files, no gap, no events");
+}
+
 // ─── DurableLog / writer task ────────────────────────────────────────────
 
 fn config(dir: &Path) -> LogConfig {
@@ -466,5 +518,54 @@ async fn rotation_opens_a_new_file_and_keeps_seq_continuity() {
         seqs,
         vec![1, 2, 3],
         "seq stays continuous across the file boundary"
+    );
+}
+
+// #6848: regression for the CRITICAL missing-fsync-at-rotation finding.
+// Drives `rotate` directly (rather than waiting for a real UTC day change)
+// so the outgoing day's file can be dropped WITHOUT the writer task's own
+// graceful-shutdown sync ever running — the exact "crash before shutdown"
+// scenario the fsync-at-rotation fix protects. Proves both that `rotate`
+// syncs the outgoing handle without erroring and that the seq high-water
+// mark recovers correctly across both files afterward.
+#[tokio::test]
+async fn rotation_fsyncs_the_outgoing_file_before_opening_the_next_one() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let day1 = date(2026, 1, 1);
+    let day2 = date(2026, 1, 2);
+    let earliest_retained_seq = Arc::new(AtomicU64::new(0));
+
+    let (mut file1, path1) = rotate(&config(tmp.path()), day1, &earliest_retained_seq, None)
+        .await
+        .expect("open day1's file");
+    write_line(&mut file1, &path1, &event(1))
+        .await
+        .expect("write seq 1 to day1");
+
+    // The rotation itself fsyncs `file1` before opening day2's file.
+    let (mut file2, path2) = rotate(
+        &config(tmp.path()),
+        day2,
+        &earliest_retained_seq,
+        Some(&mut file1),
+    )
+    .await
+    .expect("rotate to day2's file");
+    write_line(&mut file2, &path2, &event(2))
+        .await
+        .expect("write seq 2 to day2");
+
+    // Ungraceful drop — no writer-task shutdown sync runs. If rotation's own
+    // fsync did not happen, this is exactly the scenario that would lose
+    // day1's data on a real crash.
+    drop(file1);
+    drop(file2);
+
+    let recovered = recover_next_seq(&[(day1, path1), (day2, path2)])
+        .await
+        .expect("recover across both files");
+    assert_eq!(
+        recovered, 3,
+        "both seqs are readable back after an ungraceful drop post-rotation"
     );
 }

--- a/crates/trusty-console/src/event_bus/log/writer.rs
+++ b/crates/trusty-console/src/event_bus/log/writer.rs
@@ -24,9 +24,10 @@
 //! Test: `super::tests::open_recovers_next_seq_from_an_existing_log`,
 //! `super::tests::backpressure_drops_are_counted_and_do_not_block_enqueue`,
 //! `super::tests::events_written_are_readable_back_in_order`,
-//! `super::tests::rotation_opens_a_new_file_and_keeps_seq_continuity`.
+//! `super::tests::rotation_opens_a_new_file_and_keeps_seq_continuity`,
+//! `super::tests::rotation_fsyncs_the_outgoing_file_before_opening_the_next_one`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -170,13 +171,15 @@ async fn run_writer(
 ) {
     let mut open_day: Option<NaiveDate> = None;
     let mut file: Option<tokio::fs::File> = None;
+    let mut current_path: Option<PathBuf> = None;
 
     while let Some(event) = rx.recv().await {
         let today = Utc::now().date_naive();
         if open_day != Some(today) {
-            match rotate(&config, today, &earliest_retained_seq).await {
-                Ok(f) => {
+            match rotate(&config, today, &earliest_retained_seq, file.as_mut()).await {
+                Ok((f, path)) => {
                     file = Some(f);
+                    current_path = Some(path);
                     open_day = Some(today);
                 }
                 Err(e) => {
@@ -190,8 +193,10 @@ async fn run_writer(
             }
         }
 
-        let Some(f) = file.as_mut() else { continue };
-        if let Err(e) = write_line(f, &event).await {
+        let (Some(f), Some(path)) = (file.as_mut(), current_path.as_deref()) else {
+            continue;
+        };
+        if let Err(e) = write_line(f, path, &event).await {
             tracing::error!(
                 error = %e,
                 seq = event.seq,
@@ -209,18 +214,43 @@ async fn run_writer(
 }
 
 /// Open (create/append) `today`'s file, apply retention, and refresh
-/// `earliest_retained_seq` from whatever survives.
-async fn rotate(
+/// `earliest_retained_seq` from whatever survives. `previous` is the
+/// currently-open handle being rotated away from, if any — fsync'd (flush,
+/// then `sync_data`) before the new file is opened, matching the durability
+/// contract this module's own doc comment states ("full fsync happens on
+/// rotation and on writer-task shutdown, not per line"). A sync failure is
+/// logged, not propagated: a rotation that cannot confirm the old file's
+/// durability should still proceed to today's file rather than stop
+/// persisting entirely (DOC-73 §4.1's non-blocking invariant).
+///
+/// Test: `super::tests::rotation_fsyncs_the_outgoing_file_before_opening_the_next_one`.
+pub(super) async fn rotate(
     config: &LogConfig,
     today: NaiveDate,
     earliest_retained_seq: &Arc<AtomicU64>,
-) -> Result<tokio::fs::File, LogError> {
+    previous: Option<&mut tokio::fs::File>,
+) -> Result<(tokio::fs::File, PathBuf), LogError> {
+    // #6848: previously only synced at writer-task shutdown, so a crash
+    // between two rotations could lose an arbitrary, un-fsynced tail of a
+    // whole PRIOR day's file — not just its last line.
+    if let Some(f) = previous {
+        let _ = tokio::io::AsyncWriteExt::flush(f).await;
+        if let Err(source) = f.sync_data().await {
+            tracing::error!(
+                error = %source,
+                "event log: fsync of the outgoing day file failed at rotation; \
+                 its un-synced tail may not survive a crash"
+            );
+        }
+    }
+
     let survivors = enforce_retention(&config.dir, today, config.retain_days).await?;
     let earliest = earliest_seq(&survivors).await?;
     earliest_retained_seq.store(earliest.unwrap_or(0), Ordering::Relaxed);
 
     let path = config.dir.join(day_file_name(today));
-    open_append_0600(&path).await
+    let file = open_append_0600(&path).await?;
+    Ok((file, path))
 }
 
 /// Open `path` for append, creating it at `0600` if absent — matching this
@@ -243,11 +273,23 @@ async fn open_append_0600(path: &std::path::Path) -> Result<tokio::fs::File, Log
             path: path.to_path_buf(),
             source,
         })?;
-    let _ = file
+    // #6848: log instead of discarding — a silent failure here means this
+    // defense-in-depth re-assertion of 0600 can fail with zero
+    // observability (the parent directory's own 0700 hardening still blocks
+    // cross-user access even when this fails, but an operator should still
+    // be able to see it happened).
+    if let Err(e) = file
         .set_permissions(std::fs::Permissions::from_mode(
             trusty_common::uds::SOCKET_MODE,
         ))
-        .await;
+        .await
+    {
+        tracing::warn!(
+            error = %e,
+            path = %path.display(),
+            "event log: could not re-assert 0600 permissions on an existing file"
+        );
+    }
     Ok(file)
 }
 
@@ -265,20 +307,30 @@ async fn open_append_0600(path: &std::path::Path) -> Result<tokio::fs::File, Log
         })
 }
 
-/// Serialize `event` and append it, flushing so a reader opening the file
-/// immediately after sees the line (full `fsync` happens on rotation and
-/// shutdown only — see the module docs' durability trade-off).
-async fn write_line(file: &mut tokio::fs::File, event: &HarnessEvent) -> Result<(), LogError> {
+/// Serialize `event` and append it to `path`'s open `file`, flushing so a
+/// reader opening the file immediately after sees the line (full `fsync`
+/// happens on rotation and shutdown only — see the module docs' durability
+/// trade-off).
+///
+/// `path` is threaded through purely for [`LogError::Io`]'s diagnostic
+/// value — #6848: an earlier version built these with an empty `PathBuf`,
+/// so a write/flush failure logged as `"write the event-log file at : …"`,
+/// dropping the one fact (which day file) an operator needs to act on it.
+pub(super) async fn write_line(
+    file: &mut tokio::fs::File,
+    path: &Path,
+    event: &HarnessEvent,
+) -> Result<(), LogError> {
     use tokio::io::AsyncWriteExt as _;
     let line = encode_line(event);
     file.write_all(&line).await.map_err(|source| LogError::Io {
         op: "write",
-        path: PathBuf::new(),
+        path: path.to_path_buf(),
         source,
     })?;
     file.flush().await.map_err(|source| LogError::Io {
         op: "flush",
-        path: PathBuf::new(),
+        path: path.to_path_buf(),
         source,
     })
 }

--- a/crates/trusty-console/src/event_bus/log/writer.rs
+++ b/crates/trusty-console/src/event_bus/log/writer.rs
@@ -1,0 +1,284 @@
+//! [`DurableLog`]: the handle [`super::bus::EventBus`] holds, and the writer
+//! task behind it.
+//!
+//! Why: DOC-73 §4.3's log is written "as each frame is accepted" but ingest
+//! must never block on it (§4.1's non-blocking invariant, and the "all I/O
+//! off the ingest hot path" design constraint this issue states directly).
+//! Splitting the handle ([`DurableLog`], cheap to hold and clone the pieces
+//! of) from the writer (one task, one open file, all the actual I/O) is what
+//! makes `EventBus::ingest` a synchronous, non-blocking `try_send` rather
+//! than an `await` on disk.
+//! What: [`DurableLog::open`] hardens and prepares the directory, applies
+//! retention, recovers the seq high-water mark, spawns the writer task, and
+//! returns a [`DurableLog`] plus the [`RecoveredState`] the caller (`EventBus
+//! ::with_log`) needs to resume numbering. [`DurableLog::enqueue`] is a
+//! non-blocking `try_send` into a [`WRITE_CHANNEL_CAPACITY`]-bounded channel —
+//! `false` means the writer's queue was full and this event will never be
+//! written (a genuine, permanent gap; [`super::replay`] detects it from the
+//! resulting seq discontinuity, nothing else needs to track it). The writer
+//! task rotates to a new day file at each UTC day boundary (never `event.at`,
+//! which a producer controls and could set to any value), re-applies
+//! retention on every rotation, and re-derives `earliest_retained_seq` from
+//! whatever survives so [`super::replay::replay_since`] always compares
+//! against the truth.
+//! Test: `super::tests::open_recovers_next_seq_from_an_existing_log`,
+//! `super::tests::backpressure_drops_are_counted_and_do_not_block_enqueue`,
+//! `super::tests::events_written_are_readable_back_in_order`,
+//! `super::tests::rotation_opens_a_new_file_and_keeps_seq_continuity`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use chrono::{NaiveDate, Utc};
+use tokio::sync::mpsc;
+use trusty_common::control_bus::HarnessEvent;
+
+use super::config::{LogConfig, WRITE_CHANNEL_CAPACITY, day_file_name};
+use super::error::LogError;
+use super::format::encode_line;
+use super::recovery::{earliest_seq, recover_next_seq};
+use super::replay::{ReplayItem, replay_since};
+use super::retention::enforce_retention;
+
+/// What [`DurableLog::open`] recovered from disk before accepting a single
+/// new event.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RecoveredState {
+    /// The seq [`super::bus::EventBus`] should assign to the next accepted
+    /// event.
+    pub next_seq: u64,
+}
+
+/// A handle to the durable NDJSON event log. Cheap to hold inside
+/// [`super::bus::EventBus`]: the actual file and its I/O live in the writer
+/// task this was opened with.
+pub(crate) struct DurableLog {
+    dir: PathBuf,
+    tx: mpsc::Sender<HarnessEvent>,
+    // Read today only by `written()`, `#[cfg(test)]`-gated below; a later
+    // slice's metrics route (#6850) is the production reader.
+    #[allow(dead_code)]
+    written: Arc<AtomicU64>,
+    // 0 is the "nothing retained yet" sentinel — seq is 1-based, so 0 is never
+    // a real value, and `AtomicU64` avoids a mutex for a single counter two
+    // tasks only ever read or replace wholesale.
+    earliest_retained_seq: Arc<AtomicU64>,
+}
+
+impl DurableLog {
+    /// Open (or create) the durable log at `config.dir`, recover its seq
+    /// high-water mark, apply retention, and spawn the writer task.
+    ///
+    /// # Errors
+    ///
+    /// [`LogError::PrepareDir`] if the directory cannot be hardened to
+    /// `0700`; [`LogError::Io`] if an existing file cannot be listed, read,
+    /// or an expired one deleted. A caller that gets `Err` here should still
+    /// start the bus without durability (`EventBus::new`) rather than fail
+    /// console startup — DOC-73 §4.1's non-blocking invariant covers the log
+    /// exactly as it covers the ingest socket.
+    pub(crate) async fn open(config: LogConfig) -> Result<(Self, RecoveredState), LogError> {
+        Self::open_with_capacity(config, WRITE_CHANNEL_CAPACITY).await
+    }
+
+    /// [`DurableLog::open`] with the writer channel's bound taken explicitly,
+    /// so a test can prove backpressure behavior against a capacity of 1
+    /// instead of enqueuing thousands of events.
+    ///
+    /// Test: `super::tests::backpressure_drops_are_counted_and_do_not_block_enqueue`.
+    pub(crate) async fn open_with_capacity(
+        config: LogConfig,
+        channel_capacity: usize,
+    ) -> Result<(Self, RecoveredState), LogError> {
+        trusty_common::uds::prepare_socket_dir(&config.dir).map_err(|source| {
+            LogError::PrepareDir {
+                path: config.dir.clone(),
+                source,
+            }
+        })?;
+
+        let today = Utc::now().date_naive();
+        let survivors = enforce_retention(&config.dir, today, config.retain_days).await?;
+        let next_seq = recover_next_seq(&survivors).await?;
+        let earliest = earliest_seq(&survivors).await?;
+
+        let (tx, rx) = mpsc::channel(channel_capacity.max(1));
+        let written = Arc::new(AtomicU64::new(0));
+        let earliest_retained_seq = Arc::new(AtomicU64::new(earliest.unwrap_or(0)));
+
+        tokio::spawn(run_writer(
+            config.clone(),
+            rx,
+            Arc::clone(&written),
+            Arc::clone(&earliest_retained_seq),
+        ));
+
+        Ok((
+            Self {
+                dir: config.dir,
+                tx,
+                written,
+                earliest_retained_seq,
+            },
+            RecoveredState { next_seq },
+        ))
+    }
+
+    /// Hand `event` to the writer task. `true` means it was accepted into the
+    /// bounded queue (it WILL be written, though not necessarily yet — see
+    /// the module docs' persisted-flag contract); `false` means the queue was
+    /// full and this event will never reach the log.
+    pub(crate) fn enqueue(&self, event: HarnessEvent) -> bool {
+        self.tx.try_send(event).is_ok()
+    }
+
+    /// How many events the writer has durably written (write + flush
+    /// returned) since this log was opened. Test-only introspection for
+    /// waiting on the writer to catch up without a fixed sleep.
+    #[cfg(test)]
+    pub(crate) fn written(&self) -> u64 {
+        self.written.load(Ordering::Relaxed)
+    }
+
+    /// Replay everything persisted after `since_seq`, in order — see
+    /// [`super::replay::replay_since`].
+    ///
+    /// # Errors
+    ///
+    /// [`LogError::Io`] if a day file cannot be listed or read.
+    pub(crate) async fn replay_since(&self, since_seq: u64) -> Result<Vec<ReplayItem>, LogError> {
+        replay_since(&self.dir, since_seq, self.earliest_retained_seq()).await
+    }
+
+    fn earliest_retained_seq(&self) -> Option<u64> {
+        match self.earliest_retained_seq.load(Ordering::Relaxed) {
+            0 => None,
+            n => Some(n),
+        }
+    }
+}
+
+/// The writer task body: owns the one open file, rotates at a UTC day
+/// boundary, and exits (after a best-effort final sync) once every
+/// [`DurableLog`] clone's sender has dropped and the channel drains.
+async fn run_writer(
+    config: LogConfig,
+    mut rx: mpsc::Receiver<HarnessEvent>,
+    written: Arc<AtomicU64>,
+    earliest_retained_seq: Arc<AtomicU64>,
+) {
+    let mut open_day: Option<NaiveDate> = None;
+    let mut file: Option<tokio::fs::File> = None;
+
+    while let Some(event) = rx.recv().await {
+        let today = Utc::now().date_naive();
+        if open_day != Some(today) {
+            match rotate(&config, today, &earliest_retained_seq).await {
+                Ok(f) => {
+                    file = Some(f);
+                    open_day = Some(today);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "event log: could not rotate to today's file; this event \
+                         will not be persisted"
+                    );
+                    continue;
+                }
+            }
+        }
+
+        let Some(f) = file.as_mut() else { continue };
+        if let Err(e) = write_line(f, &event).await {
+            tracing::error!(
+                error = %e,
+                seq = event.seq,
+                "event log: write failed; this event will not be persisted"
+            );
+            continue;
+        }
+        written.fetch_add(1, Ordering::Relaxed);
+    }
+
+    if let Some(f) = file.as_mut() {
+        let _ = tokio::io::AsyncWriteExt::flush(f).await;
+        let _ = f.sync_data().await;
+    }
+}
+
+/// Open (create/append) `today`'s file, apply retention, and refresh
+/// `earliest_retained_seq` from whatever survives.
+async fn rotate(
+    config: &LogConfig,
+    today: NaiveDate,
+    earliest_retained_seq: &Arc<AtomicU64>,
+) -> Result<tokio::fs::File, LogError> {
+    let survivors = enforce_retention(&config.dir, today, config.retain_days).await?;
+    let earliest = earliest_seq(&survivors).await?;
+    earliest_retained_seq.store(earliest.unwrap_or(0), Ordering::Relaxed);
+
+    let path = config.dir.join(day_file_name(today));
+    open_append_0600(&path).await
+}
+
+/// Open `path` for append, creating it at `0600` if absent — matching this
+/// workspace's `0600`-file convention (`trusty_common::uds::SOCKET_MODE`
+/// reused for the value, not the socket-specific bind path) — and
+/// re-asserting `0600` if a file already existed at a wider mode, the same
+/// defense-in-depth `set_permissions_0600` in `credentials/file_store.rs`
+/// applies to its own private file.
+#[cfg(unix)]
+async fn open_append_0600(path: &std::path::Path) -> Result<tokio::fs::File, LogError> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(trusty_common::uds::SOCKET_MODE)
+        .open(path)
+        .await
+        .map_err(|source| LogError::Io {
+            op: "open",
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let _ = file
+        .set_permissions(std::fs::Permissions::from_mode(
+            trusty_common::uds::SOCKET_MODE,
+        ))
+        .await;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+async fn open_append_0600(path: &std::path::Path) -> Result<tokio::fs::File, LogError> {
+    tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+        .map_err(|source| LogError::Io {
+            op: "open",
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+/// Serialize `event` and append it, flushing so a reader opening the file
+/// immediately after sees the line (full `fsync` happens on rotation and
+/// shutdown only — see the module docs' durability trade-off).
+async fn write_line(file: &mut tokio::fs::File, event: &HarnessEvent) -> Result<(), LogError> {
+    use tokio::io::AsyncWriteExt as _;
+    let line = encode_line(event);
+    file.write_all(&line).await.map_err(|source| LogError::Io {
+        op: "write",
+        path: PathBuf::new(),
+        source,
+    })?;
+    file.flush().await.map_err(|source| LogError::Io {
+        op: "flush",
+        path: PathBuf::new(),
+        source,
+    })
+}

--- a/crates/trusty-console/src/event_bus/mod.rs
+++ b/crates/trusty-console/src/event_bus/mod.rs
@@ -1,33 +1,38 @@
-//! The console-hosted event bus core: UDS ingest, a bounded ring, and a
-//! subscriber fan-out (issue #6848, DOC-73 §4.1-§4.3).
+//! The console-hosted event bus core: UDS ingest, a bounded ring, a durable
+//! log, and a subscriber fan-out (issue #6848, DOC-73 §4.1-§4.3).
 //!
 //! Why: owner ruling 2026-09-05 makes `trusty-console` the one and only event
 //! bus in the workspace — every harness (`trusty-mpm`, `trusty-code`,
 //! `trusty-agents`, `trusty-analyze`) pushes `HarnessEvent` frames here instead
 //! of hosting its own broadcast channel (DOC-73 §4.1). This module is that
 //! bus's core: the socket producers dial, the bounded in-memory ring later
-//! slices read, and the counters that make ingest, dedup and eviction
-//! observable. It does not yet cover the two other §4.3 pieces the wider issue
-//! describes — the durable day-rotated NDJSON log and the console-assigned
-//! `seq` — which land in a follow-up PR; a partial PR against #6848 is
-//! deliberate here, not an oversight.
+//! slices read, the day-rotated durable NDJSON log slice 3b (this PR) adds,
+//! and the counters that make ingest, dedup and eviction observable.
 //!
 //! What: [`bus::EventBus`] holds the ring (capacity configurable, default
 //! 8192 per DOC-73 §4.3), dedups by [`trusty_common::control_bus::EventId`],
-//! and exposes a [`tokio::sync::broadcast`] subscriber API for the SSE fan-out
-//! a later slice (#6851) builds on. [`ingest::bind_ingest`] and
-//! [`ingest::serve_ingest`] are the UDS listener: newline-delimited
+//! assigns the console-owned `seq` DOC-73 §4.3 decides, hands each accepted
+//! frame to the durable log (`log` submodule), and exposes a
+//! [`tokio::sync::broadcast`] subscriber API carrying [`bus::BusFrame`] for
+//! the SSE fan-out a later slice (#6851) builds on. [`ingest::bind_ingest`]
+//! and [`ingest::serve_ingest`] are the UDS listener: newline-delimited
 //! `HarnessEvent` JSON, one connection per producer, a malformed line dropped
-//! and logged rather than closing the connection.
+//! and logged rather than closing the connection. `log` is slice 3b's own
+//! module — see its doc for the durable-log contract in full.
 //!
 //! Test: `tests.rs` — ingest over a real tempdir socket, dedup, eviction at
-//! capacity, and a malformed line surviving to ingest the next valid one.
+//! capacity, seq assignment, and a malformed line surviving to ingest the
+//! next valid one. `log/tests.rs` — seq recovery, truncated-tail tolerance,
+//! replay-with-gap, persisted-flag semantics, rotation continuity,
+//! backpressure.
 
 pub(crate) mod bus;
 pub(crate) mod ingest;
+pub(crate) mod log;
 
 #[cfg(test)]
 mod tests;
 
 pub(crate) use bus::{EventBus, EventBusConfig};
 pub(crate) use ingest::{bind_ingest, ingest_socket_path, serve_ingest};
+pub(crate) use log::{DurableLog, LogConfig};

--- a/crates/trusty-console/src/event_bus/tests.rs
+++ b/crates/trusty-console/src/event_bus/tests.rs
@@ -92,7 +92,54 @@ async fn a_subscriber_receives_ingested_events() {
         .await
         .expect("recv did not time out")
         .expect("channel still open");
-    assert_eq!(received.id, sent_id);
+    assert_eq!(received.event.id, sent_id);
+}
+
+#[tokio::test]
+async fn ingest_assigns_sequential_console_seqs_starting_at_one() {
+    let bus = EventBus::new(EventBusConfig { capacity: 8 });
+    let mut rx = bus.subscribe();
+
+    bus.ingest(make_event(None));
+    bus.ingest(make_event(None));
+
+    let first = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("recv 1")
+        .expect("open");
+    let second = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("recv 2")
+        .expect("open");
+
+    assert_eq!(
+        first.event.seq, 1,
+        "a fresh bus with no recovered log starts at seq 1"
+    );
+    assert_eq!(
+        second.event.seq, 2,
+        "seq is console-assigned and monotonic, overwriting the producer's own \
+         (always 0 from `make_event`)"
+    );
+}
+
+#[tokio::test]
+async fn live_fanout_frames_are_never_marked_persisted() {
+    // The write is always still in flight (or was just dropped) at the
+    // moment of fan-out — see `bus`'s module docs for the full contract.
+    let bus = EventBus::new(EventBusConfig { capacity: 8 });
+    let mut rx = bus.subscribe();
+
+    bus.ingest(make_event(None));
+
+    let received = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("recv did not time out")
+        .expect("channel still open");
+    assert!(
+        !received.persisted,
+        "a bus with no durable log configured must never claim persistence"
+    );
 }
 
 // ─── the UDS ingest listener, over a real socket ───────────────────────────

--- a/crates/trusty-console/src/event_bus/tests.rs
+++ b/crates/trusty-console/src/event_bus/tests.rs
@@ -142,6 +142,86 @@ async fn live_fanout_frames_are_never_marked_persisted() {
     );
 }
 
+// #6848: regression for the HIGH finding that `seq` assignment and the
+// durable-log/broadcast hand-off were not atomic under one lock. Real OS
+// threads (not just tokio tasks) race `EventBus::ingest` — a plain sync
+// call, so `std::thread::spawn` exercises genuine concurrent execution
+// independent of the test runtime's own flavor, matching the review's
+// diagnosed scenario of two producer tasks landing on different OS threads.
+// Before the `bus.rs` fix, `log.enqueue`/`sender.send` ran after the ring
+// lock was dropped, so the OS scheduler could interleave two threads'
+// `try_send` calls out of `seq` order; this asserts the durable log's
+// on-disk order is exactly the assigned order, with no gaps or duplicates.
+#[tokio::test]
+async fn concurrent_producers_write_the_durable_log_in_seq_order() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let (log, recovered) = super::log::DurableLog::open(super::log::LogConfig {
+        dir: tmp.path().to_path_buf(),
+        retain_days: 7,
+    })
+    .await
+    .expect("open a fresh durable log");
+
+    let bus = Arc::new(EventBus::with_log(
+        EventBusConfig { capacity: 256 },
+        Some(log),
+        recovered.next_seq,
+    ));
+
+    const PRODUCERS: usize = 8;
+    let handles: Vec<_> = (0..PRODUCERS)
+        .map(|_| {
+            let bus = Arc::clone(&bus);
+            std::thread::spawn(move || {
+                bus.ingest(make_event(None));
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().expect("producer thread panicked");
+    }
+
+    // Drive the writer task forward until every event is durably written,
+    // then read the on-disk order back.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let seqs = loop {
+        let items = bus
+            .replay_since(0)
+            .await
+            .expect("bus has a durable log")
+            .expect("replay succeeds");
+        let seqs: Vec<u64> = items
+            .into_iter()
+            .map(|i| match i {
+                super::log::ReplayItem::Event(e) => e.seq,
+                super::log::ReplayItem::Gap { .. } => {
+                    panic!("no backpressure expected at this capacity")
+                }
+            })
+            .collect();
+        if seqs.len() == PRODUCERS {
+            break seqs;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "writer did not durably write all {PRODUCERS} events within budget"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    };
+
+    let mut sorted = seqs.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        seqs, sorted,
+        "on-disk seq order must match assignment order under concurrent producers"
+    );
+    assert_eq!(
+        seqs,
+        (1..=PRODUCERS as u64).collect::<Vec<_>>(),
+        "no gaps and no duplicates across the concurrent producers"
+    );
+}
+
 // ─── the UDS ingest listener, over a real socket ───────────────────────────
 
 /// Bind a fresh ingest listener under `tmp` and start serving it in the

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -515,9 +515,46 @@ pub async fn run_serve(args: ServeArgs) -> Result<()> {
                     socket = %socket.display(),
                     "console event-bus ingest ready"
                 );
-                let bus = Arc::new(event_bus::EventBus::new(
-                    event_bus::EventBusConfig::default(),
-                ));
+                // #6848 slice 3b: open the durable NDJSON log before the bus
+                // itself, so seq numbering resumes from the log's recovered
+                // high-water mark rather than restarting at 1 on every
+                // console restart (DOC-73 §4.3). Failing to open it degrades
+                // to `EventBus::new` (no durability, seq restarts at 1) per
+                // the same non-blocking invariant the ingest-bind failure
+                // above already follows — a console that cannot open its
+                // event log still serves everything else.
+                let bus = match event_bus::LogConfig::resolve_default() {
+                    Ok(log_config) => match event_bus::DurableLog::open(log_config).await {
+                        Ok((log, recovered)) => {
+                            info!(
+                                next_seq = recovered.next_seq,
+                                "console event-bus durable log ready"
+                            );
+                            event_bus::EventBus::with_log(
+                                event_bus::EventBusConfig::default(),
+                                Some(log),
+                                recovered.next_seq,
+                            )
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "could not open the console event-bus durable log; \
+                                 events this run will not survive a restart"
+                            );
+                            event_bus::EventBus::new(event_bus::EventBusConfig::default())
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "could not resolve the console event-bus durable log directory; \
+                             events this run will not survive a restart"
+                        );
+                        event_bus::EventBus::new(event_bus::EventBusConfig::default())
+                    }
+                };
+                let bus = Arc::new(bus);
                 tokio::spawn(async move {
                     event_bus::serve_ingest(listener, bus, shutdown_signal()).await;
                 });


### PR DESCRIPTION
## Summary

Slice 3b of #6848 (DOC-73 §4.3), on top of slice 3 (#7152, merged as f3d4a161f). Adds the second retention tier the ring alone couldn't provide: a durable, day-rotated NDJSON log in `crates/trusty-console/src/event_bus/log/`, console-assigned `seq` (overwriting the producer's own), replay-on-reconnect with explicit gap markers, and a `persisted` marker on live-delivered events.

- **Seq ownership moves to console.** `EventBus::ingest` now overwrites `HarnessEvent.seq` with a console-owned monotonic counter (DOC-73 §4.3 — "seq is now minted once, by console, for every frame it accepted, not per-process"), recovered from the log's tail on restart so numbers never repeat. A duplicate (dedup hit) never consumes a seq value.
- **`log/` submodule** (`config`, `error`, `format`, `recovery`, `retention`, `replay`, `writer`): `DurableLog::open` hardens the log directory via `trusty_common::uds::prepare_socket_dir` (0700, reused from the socket-dir hardening path rather than a raw `create_dir_all` — nothing socket-specific about it, it's this crate's only private-dir primitive), applies retention, recovers the seq high-water mark tolerating a truncated final line, and spawns a writer task behind a bounded `mpsc` channel (default capacity 4096) so log I/O never sits on the ingest hot path.
- **Rotation & retention.** One file per UTC calendar day (`YYYY-MM-DD.ndjson`, `Utc::now()` — never the producer-supplied `event.at`), re-applied on every rotation and at startup. Default retention: 7 days. Seq stays continuous across the boundary since it's one in-memory counter, unaffected by which file a line lands in.
- **Replay-on-reconnect.** `DurableLog::replay_since(since_seq)` reads every persisted event after `since_seq` in order. A request older than what retention still holds gets a leading `ReplayItem::Gap` instead of silently starting wherever data happens to remain; a mid-stream hole (a backpressure drop that never reached disk) is detected the same way — a seq discontinuity between two consecutive on-disk records — and surfaces as an interior gap. No side-table is needed for either case.
- **`persisted` marker.** Live-delivered events now travel as `BusFrame { event, persisted }` over the broadcast channel instead of a bare `HarnessEvent`. `persisted` is always `false` on this path — the write is asynchronous by construction, so it is genuinely never confirmed complete at the moment of fan-out. A `BusFrame` built from a replayed `ReplayItem::Event` is `persisted: true` — read from the log, it already is. This is a console-local type; `trusty_common::control_bus::HarnessEvent` is unchanged, so this PR does not touch `trusty-common`.
- **Backpressure.** `DurableLog::enqueue` is a non-blocking `try_send`. A full channel increments `EventBusMetrics::log_dropped`, logs a warning, and drops that event's durability permanently — `ingest()` itself never blocks or fails.

### Design choices made where the issue/spec was silent

- **`persisted` lives in `trusty-console`, not `trusty_common`.** No other crate needs to agree on it (only this bus's own subscribers, the SSE route #6851 adds, ever see a `BusFrame`), and keeping it local avoids a cross-crate touch for a slice explicitly scoped to this crate.
- **Rotation clock is `Utc::now()`, not `event.at`.** A producer's timestamp is untrusted and could place an event in an arbitrary file; wall-clock-at-write-time is what actually rotates.
- **Gap detection reuses seq continuity already on disk** rather than a separate "known drops" side table — every persisted record carries its own `seq`, so a hole in the sequence found during replay IS the gap, with no extra bookkeeping to keep in sync.
- **Durability trade-off:** each write is `write_all` + `flush` (visible to a reader immediately, survives a process crash); a full `fsync` happens on rotation and on writer-task shutdown, not per line — full per-line fsync was judged not worth the I/O cost for this slice's contract, which promises replay-after-restart, not power-loss durability of the last line written.
- **Retention is day-count only** (`retain_days`, default 7), no independent size cap — day rotation combined with the ring's own 8192-event bound already keeps unbounded growth off the table for this slice.

## Test plan

Rung 4 (trusty-console only; no `trusty-common` touch — `EventBusMetrics` gained a field, `EventBus`/`DurableLog` are both `pub(crate)`).

```
cargo fmt --check                                                  # clean
cargo check -p trusty-console --all-targets                        # clean
cargo clippy -p trusty-console --all-targets -- -D warnings        # clean, exit 0
SKIP_UI_BUILD=1 cargo test -p trusty-console --no-fail-fast         # 468 passed; 0 failed; 4 ignored (--lib)
                                                                     # plus every integration target: 13, 6, 2, 1, 16, 6, 18, 5 passed, 0 failed each
bash scripts/check_line_cap.sh                                     # 4 allowlisted (pre-existing), 0 new violations
bash scripts/check_test_pointers.sh                                # 0 dangling pointers (32705 citations resolved)
bash scripts/check_sld.sh                                          # 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh --staged                  # OK
bash scripts/check_rustdoc_links.sh                                # 21 broken links, 0 attributed to trusty-console;
                                                                     # all 21 are pre-existing in trusty-common/trusty-memory/
                                                                     # trusty-mpm, tracked by #7157 (this repo has no
                                                                     # baseline row yet, so the gate itself exits 1 on that
                                                                     # pre-existing debt — verified none of it is new)
```

New tests, `crates/trusty-console/src/event_bus/log/tests.rs` and additions to `event_bus/tests.rs`: filename round-trip, tolerant NDJSON decode (empty/truncated-tail/corrupt-interior), file listing/sort, seq recovery (fresh log, newest-non-empty file, truncated tail), earliest-retained-seq, retention (pure decision + filesystem), replay (full/mid-seq/caught-up/leading-gap/interior-gap), `DurableLog` open/enqueue/write-then-read-back/rotation-continuity, backpressure (bounded-channel-full drop, non-blocking), console seq assignment overwriting the producer's, and `persisted` always `false` on the live path.

## Credential scan

`git diff origin/main...HEAD -- crates/trusty-console/` checked for keys, tokens, absolute home paths, and tests writing outside tempdirs: clean. Every test uses `tempfile::TempDir`.

Refs #6848

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01ER5DBvGQ54K5sgFLb9G5vz