### PR TITLE
fix(tga): compute_dora reads fact_deployments instead of the PR-merge proxy

### DIFF
--- a/crates/trusty-git-analytics/changelog.d/212-dora-fact-deployments.md
+++ b/crates/trusty-git-analytics/changelog.d/212-dora-fact-deployments.md
@@ -1,0 +1,13 @@
+Fixed
+
+- `compute_dora()` now reads `fact_deployments` (`environment='production',
+  status='success'`, filtered to the report period) for deployment frequency
+  and lead time, instead of always counting merged PRs as a deploy proxy
+  (#212). A repo with real production deploy history previously reported
+  `deployment_frequency: 0.0` and `performance_level: "low"` identically to a
+  repo with none, because `compute_dora()` never queried the table. The
+  merged-PR/cycle-time proxy is still used, unchanged, when `fact_deployments`
+  has zero rows for the period. `DoraMetrics` gains
+  `deployment_frequency_source` (`"fact_deployments"` or `"pr_merge_proxy"`),
+  surfaced in `dora_summary.json` and appended to `weekly_dora_metrics.csv`,
+  so a reader can tell which source produced the numbers.

--- a/crates/trusty-git-analytics/changelog.d/212-dora-fact-deployments.md
+++ b/crates/trusty-git-analytics/changelog.d/212-dora-fact-deployments.md
@@ -7,7 +7,15 @@ Fixed
   `deployment_frequency: 0.0` and `performance_level: "low"` identically to a
   repo with none, because `compute_dora()` never queried the table. The
   merged-PR/cycle-time proxy is still used, unchanged, when `fact_deployments`
-  has zero rows for the period. `DoraMetrics` gains
-  `deployment_frequency_source` (`"fact_deployments"` or `"pr_merge_proxy"`),
-  surfaced in `dora_summary.json` and appended to `weekly_dora_metrics.csv`,
-  so a reader can tell which source produced the numbers.
+  has zero rows for the period.
+- Deployment frequency and lead time now carry independent provenance:
+  `DoraMetrics` gains `deployment_frequency_source`
+  (`"fact_deployments"` | `"pr_merge_proxy"` |
+  `"pr_merge_proxy_query_failed"`) and `lead_time_source`
+  (`"measured"` | `"proxy"` | `"unmeasurable"`). `lead_time_hours` is now
+  `Option<f64>` — `None`/`null` when neither a linked deploy nor merged-PR
+  data can produce a value, never a `0.0` presented as measured. A
+  `fact_deployments` query failure (e.g. a pre-migration DB missing the
+  table) is now logged and tagged `"pr_merge_proxy_query_failed"`, distinct
+  from a table that exists with zero in-period rows. All four fields are
+  serialized in `dora_summary.json` and `weekly_dora_metrics.csv`.

--- a/crates/trusty-git-analytics/src/report/aggregator/metrics.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/metrics.rs
@@ -119,6 +119,28 @@ pub(super) fn build_weekly_velocity(
         .collect()
 }
 
+// #212 review round 2: the positional argument list kept growing across the
+// fact_deployments fix; a call site reordering two `DateTime<Utc>` or two
+// `usize` args silently compiles, so the inputs move into one named struct.
+/// Grouped inputs for [`compute_dora`].
+pub(super) struct DoraInputs<'a> {
+    pub(super) rows: &'a [CommitRow],
+    pub(super) flags: &'a RowFlags,
+    pub(super) category_total: &'a HashMap<String, usize>,
+    pub(super) prs: &'a [PrRow],
+    pub(super) deployments: &'a [DeploymentRow],
+    /// `true` when the `fact_deployments` query itself errored (e.g. a
+    /// pre-migration DB missing the table) rather than simply returning no
+    /// rows — [`compute_dora`] tags the proxy fallback distinctly in that
+    /// case so a broken table isn't silently read as an empty one.
+    pub(super) deployments_query_failed: bool,
+    pub(super) period_start: DateTime<Utc>,
+    pub(super) period_end: DateTime<Utc>,
+    pub(super) cycle_time_avg: f64,
+    pub(super) total_weeks: usize,
+    pub(super) revert_count: usize,
+}
+
 /// Why: DORA metrics are the standard rubric stakeholders use to score
 /// engineering performance; computing them in one place keeps the four
 /// values consistent with each other.
@@ -129,39 +151,19 @@ pub(super) fn build_weekly_velocity(
 /// MTTR from the spacing between consecutive bugfix/revert commits;
 /// classifies the team via [`dora_level`].
 /// Test: `aggregator_computes_summary_and_dora_and_quality` (well-formed
-/// `performance_level`); `dora_reads_fact_deployments_when_populated`,
-/// `dora_falls_back_to_pr_proxy_when_fact_deployments_empty`,
-/// `dora_ignores_fact_deployments_rows_outside_the_period`.
-#[allow(clippy::too_many_arguments)]
-pub(super) fn compute_dora(
-    rows: &[CommitRow],
-    flags: &RowFlags,
-    category_total: &HashMap<String, usize>,
-    prs: &[PrRow],
-    deployments: &[DeploymentRow],
-    period_start: DateTime<Utc>,
-    period_end: DateTime<Utc>,
-    cycle_time_avg: f64,
-    total_weeks: usize,
-    revert_count: usize,
-) -> DoraMetrics {
-    let total_weeks_f = total_weeks.max(1) as f64;
-    let total_commits = rows.len();
-    let (deployment_frequency, lead_time_hours, deployment_frequency_source) =
-        deployment_frequency_and_lead_time(
-            rows,
-            prs,
-            deployments,
-            period_start,
-            period_end,
-            cycle_time_avg,
-            total_weeks_f,
-        );
-    let bugfix_total = category_total
+/// `performance_level`); the `dora_*` cases in `report::tests` covering the
+/// measured/proxy/unmeasurable/query-failed provenance split.
+pub(super) fn compute_dora(inputs: DoraInputs<'_>) -> DoraMetrics {
+    let total_weeks_f = inputs.total_weeks.max(1) as f64;
+    let total_commits = inputs.rows.len();
+    let (deployment_frequency, deployment_frequency_source, lead_time_hours, lead_time_source) =
+        deployment_frequency_and_lead_time(&inputs, total_weeks_f);
+    let bugfix_total = inputs
+        .category_total
         .get("bugfix")
         .copied()
         .unwrap_or(0)
-        .max(revert_count);
+        .max(inputs.revert_count);
     let change_failure_rate = if total_commits == 0 {
         0.0
     } else {
@@ -172,9 +174,10 @@ pub(super) fn compute_dora(
     // (assumed bug introduction) to the revert itself. Without a richer
     // mapping we approximate via the gap between consecutive bugfix
     // commits, capped by available data.
-    let mut bugfix_ts: Vec<DateTime<Utc>> = rows
+    let mut bugfix_ts: Vec<DateTime<Utc>> = inputs
+        .rows
         .iter()
-        .zip(flags.is_revert.iter())
+        .zip(inputs.flags.is_revert.iter())
         .filter(|(r, is_rev)| **is_rev || r.category.as_deref() == Some("bugfix"))
         .map(|(r, _)| r.timestamp)
         .collect();
@@ -189,9 +192,13 @@ pub(super) fn compute_dora(
         }
         gaps.iter().sum::<f64>() / gaps.len() as f64
     };
+    // An unmeasurable lead time cannot support any tier that requires a
+    // lead-time bound; treat it as unbounded (fails every tier's `lead_h`
+    // check) rather than the pre-round-2 bug of silently passing as 0.0.
+    let lead_h_for_level = lead_time_hours.unwrap_or(f64::INFINITY);
     let performance_level = dora_level(
         deployment_frequency,
-        lead_time_hours,
+        lead_h_for_level,
         change_failure_rate,
         mttr_hours,
     );
@@ -202,12 +209,17 @@ pub(super) fn compute_dora(
         mttr_hours,
         performance_level,
         deployment_frequency_source,
+        lead_time_source,
     }
 }
 
 // #212: compute_dora previously derived `deploys` from `prs` unconditionally
 // and never read `fact_deployments`, so a repo with real production deploy
 // history reported `deployment_frequency: 0.0` identically to an empty one.
+// #212 review round 2: a deploy can be measured while its lead time is not
+// (an unmatched `git_sha`) — `deployment_frequency_source` and
+// `lead_time_source` are resolved independently so the latter case can never
+// mislabel a proxy/absent lead time as `"measured"`.
 /// Resolve deployment frequency and lead time, preferring the measured
 /// `fact_deployments` signal over the merged-PR-count proxy.
 ///
@@ -216,45 +228,58 @@ pub(super) fn compute_dora(
 /// unentangled from the deploy-frequency fix.
 /// What: filters `deployments` to `[period_start, period_end]` by
 /// `triggered_at`. Empty after filtering → the pre-#212 proxy (merged-PR
-/// count / `cycle_time_avg`), tagged `"pr_merge_proxy"`. Non-empty → count
-/// as `deployment_frequency`, tagged `"fact_deployments"`; lead time
-/// averages `deploy_time - commit_time` over deploys whose `git_sha` matches
-/// a commit in `rows` (deploys with no resolvable link are excluded from
-/// that average, not treated as zero), falling back to `cycle_time_avg` when
-/// no deploy links resolve at all.
-/// Test: `dora_reads_fact_deployments_when_populated`,
-/// `dora_falls_back_to_pr_proxy_when_fact_deployments_empty`,
-/// `dora_ignores_fact_deployments_rows_outside_the_period`.
+/// count), tagged `"pr_merge_proxy"` (or `"pr_merge_proxy_query_failed"`
+/// when `deployments_query_failed`). Non-empty → count as
+/// `deployment_frequency`, tagged `"fact_deployments"`. Lead time is
+/// resolved separately: the average `deploy_time - commit_time` over deploys
+/// whose `git_sha` matches a commit (`"measured"`) when any resolve; else the
+/// PR cycle-time proxy (`"proxy"`) when at least one PR merged; else `None`
+/// (`"unmeasurable"`) — never a bare `0.0` standing in for "no data".
+/// Test: the `dora_*` cases in `report::tests`.
 fn deployment_frequency_and_lead_time(
-    rows: &[CommitRow],
-    prs: &[PrRow],
-    deployments: &[DeploymentRow],
-    period_start: DateTime<Utc>,
-    period_end: DateTime<Utc>,
-    cycle_time_avg: f64,
+    inputs: &DoraInputs<'_>,
     total_weeks_f: f64,
-) -> (f64, f64, String) {
-    let period_deploys: Vec<&DeploymentRow> = deployments
+) -> (f64, String, Option<f64>, String) {
+    let period_deploys: Vec<&DeploymentRow> = inputs
+        .deployments
         .iter()
         .filter(|d| {
             d.triggered_at
-                .is_some_and(|t| t >= period_start && t <= period_end)
+                .is_some_and(|t| t >= inputs.period_start && t <= inputs.period_end)
         })
         .collect();
+    let has_merged_prs = inputs.prs.iter().any(|p| p.merged_at.is_some());
+    let proxy_lead = || {
+        if has_merged_prs {
+            (Some(inputs.cycle_time_avg), "proxy".to_string())
+        } else {
+            (None, "unmeasurable".to_string())
+        }
+    };
 
     if period_deploys.is_empty() {
-        let deploys = prs.iter().filter(|p| p.merged_at.is_some()).count();
+        let deploys = inputs.prs.iter().filter(|p| p.merged_at.is_some()).count();
+        let freq_source = if inputs.deployments_query_failed {
+            "pr_merge_proxy_query_failed"
+        } else {
+            "pr_merge_proxy"
+        };
+        let (lead, lead_source) = proxy_lead();
         return (
             deploys as f64 / total_weeks_f,
-            cycle_time_avg,
-            "pr_merge_proxy".to_string(),
+            freq_source.to_string(),
+            lead,
+            lead_source,
         );
     }
 
     let deployment_frequency = period_deploys.len() as f64 / total_weeks_f;
 
-    let commit_ts: HashMap<&str, DateTime<Utc>> =
-        rows.iter().map(|r| (r.sha.as_str(), r.timestamp)).collect();
+    let commit_ts: HashMap<&str, DateTime<Utc>> = inputs
+        .rows
+        .iter()
+        .map(|r| (r.sha.as_str(), r.timestamp))
+        .collect();
     let mut leads: Vec<f64> = Vec::new();
     for d in &period_deploys {
         let Some(sha) = d.git_sha.as_deref() else {
@@ -267,20 +292,27 @@ fn deployment_frequency_and_lead_time(
             continue;
         };
         let hours = (deploy_time - *commit_time).num_seconds() as f64 / 3600.0;
+        // A deploy that precedes its own linked commit is a data error, not
+        // a legitimate zero/negative lead time; drop it rather than skew the
+        // average negative.
         if hours >= 0.0 {
             leads.push(hours);
         }
     }
-    let lead_time_hours = if leads.is_empty() {
-        cycle_time_avg
+    let (lead_time_hours, lead_time_source) = if !leads.is_empty() {
+        (
+            Some(leads.iter().sum::<f64>() / leads.len() as f64),
+            "measured".to_string(),
+        )
     } else {
-        leads.iter().sum::<f64>() / leads.len() as f64
+        proxy_lead()
     };
 
     (
         deployment_frequency,
-        lead_time_hours,
         "fact_deployments".to_string(),
+        lead_time_hours,
+        lead_time_source,
     )
 }
 

--- a/crates/trusty-git-analytics/src/report/aggregator/metrics.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/metrics.rs
@@ -137,6 +137,13 @@ pub(super) struct DoraInputs<'a> {
     pub(super) period_start: DateTime<Utc>,
     pub(super) period_end: DateTime<Utc>,
     pub(super) cycle_time_avg: f64,
+    // #212 review round 3: `cycle_time_avg` is 0.0 both when it's a genuine
+    // average AND when zero PRs survived `compute_velocity_inputs`' 0.5-720h
+    // outlier filter — `has_merged_prs` (any raw `merged_at`) missed the case
+    // where merges exist but every one was filtered out, so the proxy still
+    // reported a fabricated `Some(0.0)` "measured" lead time. This is the
+    // post-filter count `compute_velocity_inputs` actually averaged over.
+    pub(super) pr_cycle_time_count: usize,
     pub(super) total_weeks: usize,
     pub(super) revert_count: usize,
 }
@@ -233,8 +240,9 @@ pub(super) fn compute_dora(inputs: DoraInputs<'_>) -> DoraMetrics {
 /// `deployment_frequency`, tagged `"fact_deployments"`. Lead time is
 /// resolved separately: the average `deploy_time - commit_time` over deploys
 /// whose `git_sha` matches a commit (`"measured"`) when any resolve; else the
-/// PR cycle-time proxy (`"proxy"`) when at least one PR merged; else `None`
-/// (`"unmeasurable"`) — never a bare `0.0` standing in for "no data".
+/// PR cycle-time proxy (`"proxy"`) when `pr_cycle_time_count > 0` — at least
+/// one merged PR survived `compute_velocity_inputs`' outlier filter; else
+/// `None` (`"unmeasurable"`) — never a bare `0.0` standing in for "no data".
 /// Test: the `dora_*` cases in `report::tests`.
 fn deployment_frequency_and_lead_time(
     inputs: &DoraInputs<'_>,
@@ -248,9 +256,12 @@ fn deployment_frequency_and_lead_time(
                 .is_some_and(|t| t >= inputs.period_start && t <= inputs.period_end)
         })
         .collect();
-    let has_merged_prs = inputs.prs.iter().any(|p| p.merged_at.is_some());
+    // #212 review round 3: gate on the POST-outlier-filter count, not "any
+    // raw merged_at" — a PR set that exists but was entirely filtered out by
+    // `compute_velocity_inputs`' 0.5-720h window must not proxy a fabricated
+    // `Some(0.0)` lead time.
     let proxy_lead = || {
-        if has_merged_prs {
+        if inputs.pr_cycle_time_count > 0 {
             (Some(inputs.cycle_time_avg), "proxy".to_string())
         } else {
             (None, "unmeasurable".to_string())

--- a/crates/trusty-git-analytics/src/report/aggregator/metrics.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/metrics.rs
@@ -23,7 +23,7 @@ use crate::report::models::{
 };
 
 use super::accumulate::{iso_week_label, RowFlags, WeekTotal};
-use super::{CommitRow, PrRow};
+use super::{CommitRow, DeploymentRow, PrRow};
 
 /// Outputs of [`compute_velocity_inputs`].
 pub(super) struct VelocityInputs {
@@ -122,25 +122,41 @@ pub(super) fn build_weekly_velocity(
 /// Why: DORA metrics are the standard rubric stakeholders use to score
 /// engineering performance; computing them in one place keeps the four
 /// values consistent with each other.
-/// What: derives deployment frequency from merged PRs, change-failure-rate
-/// from bugfix totals (clamped by revert count), and MTTR from the spacing
-/// between consecutive bugfix/revert commits; classifies the team via
-/// [`dora_level`].
-/// Test: covered by `aggregator_computes_summary_and_dora_and_quality`
-/// (asserts a well-formed `performance_level` is set).
+/// What: derives deployment frequency and lead time from `fact_deployments`
+/// (issue #212) when the table has rows for the report period, falling back
+/// to the merged-PR-count / cycle-time proxy only when it does not; derives
+/// change-failure-rate from bugfix totals (clamped by revert count), and
+/// MTTR from the spacing between consecutive bugfix/revert commits;
+/// classifies the team via [`dora_level`].
+/// Test: `aggregator_computes_summary_and_dora_and_quality` (well-formed
+/// `performance_level`); `dora_reads_fact_deployments_when_populated`,
+/// `dora_falls_back_to_pr_proxy_when_fact_deployments_empty`,
+/// `dora_ignores_fact_deployments_rows_outside_the_period`.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn compute_dora(
     rows: &[CommitRow],
     flags: &RowFlags,
     category_total: &HashMap<String, usize>,
     prs: &[PrRow],
+    deployments: &[DeploymentRow],
+    period_start: DateTime<Utc>,
+    period_end: DateTime<Utc>,
     cycle_time_avg: f64,
     total_weeks: usize,
     revert_count: usize,
 ) -> DoraMetrics {
     let total_weeks_f = total_weeks.max(1) as f64;
     let total_commits = rows.len();
-    let deploys = prs.iter().filter(|p| p.merged_at.is_some()).count();
-    let deployment_frequency = deploys as f64 / total_weeks_f;
+    let (deployment_frequency, lead_time_hours, deployment_frequency_source) =
+        deployment_frequency_and_lead_time(
+            rows,
+            prs,
+            deployments,
+            period_start,
+            period_end,
+            cycle_time_avg,
+            total_weeks_f,
+        );
     let bugfix_total = category_total
         .get("bugfix")
         .copied()
@@ -175,17 +191,97 @@ pub(super) fn compute_dora(
     };
     let performance_level = dora_level(
         deployment_frequency,
-        cycle_time_avg,
+        lead_time_hours,
         change_failure_rate,
         mttr_hours,
     );
     DoraMetrics {
         deployment_frequency,
-        lead_time_hours: cycle_time_avg,
+        lead_time_hours,
         change_failure_rate,
         mttr_hours,
         performance_level,
+        deployment_frequency_source,
     }
+}
+
+// #212: compute_dora previously derived `deploys` from `prs` unconditionally
+// and never read `fact_deployments`, so a repo with real production deploy
+// history reported `deployment_frequency: 0.0` identically to an empty one.
+/// Resolve deployment frequency and lead time, preferring the measured
+/// `fact_deployments` signal over the merged-PR-count proxy.
+///
+/// Why: isolating the source-selection logic keeps [`compute_dora`]'s
+/// change-failure-rate / MTTR arithmetic (unaffected by this issue)
+/// unentangled from the deploy-frequency fix.
+/// What: filters `deployments` to `[period_start, period_end]` by
+/// `triggered_at`. Empty after filtering → the pre-#212 proxy (merged-PR
+/// count / `cycle_time_avg`), tagged `"pr_merge_proxy"`. Non-empty → count
+/// as `deployment_frequency`, tagged `"fact_deployments"`; lead time
+/// averages `deploy_time - commit_time` over deploys whose `git_sha` matches
+/// a commit in `rows` (deploys with no resolvable link are excluded from
+/// that average, not treated as zero), falling back to `cycle_time_avg` when
+/// no deploy links resolve at all.
+/// Test: `dora_reads_fact_deployments_when_populated`,
+/// `dora_falls_back_to_pr_proxy_when_fact_deployments_empty`,
+/// `dora_ignores_fact_deployments_rows_outside_the_period`.
+fn deployment_frequency_and_lead_time(
+    rows: &[CommitRow],
+    prs: &[PrRow],
+    deployments: &[DeploymentRow],
+    period_start: DateTime<Utc>,
+    period_end: DateTime<Utc>,
+    cycle_time_avg: f64,
+    total_weeks_f: f64,
+) -> (f64, f64, String) {
+    let period_deploys: Vec<&DeploymentRow> = deployments
+        .iter()
+        .filter(|d| {
+            d.triggered_at
+                .is_some_and(|t| t >= period_start && t <= period_end)
+        })
+        .collect();
+
+    if period_deploys.is_empty() {
+        let deploys = prs.iter().filter(|p| p.merged_at.is_some()).count();
+        return (
+            deploys as f64 / total_weeks_f,
+            cycle_time_avg,
+            "pr_merge_proxy".to_string(),
+        );
+    }
+
+    let deployment_frequency = period_deploys.len() as f64 / total_weeks_f;
+
+    let commit_ts: HashMap<&str, DateTime<Utc>> =
+        rows.iter().map(|r| (r.sha.as_str(), r.timestamp)).collect();
+    let mut leads: Vec<f64> = Vec::new();
+    for d in &period_deploys {
+        let Some(sha) = d.git_sha.as_deref() else {
+            continue;
+        };
+        let Some(commit_time) = commit_ts.get(sha) else {
+            continue;
+        };
+        let Some(deploy_time) = d.triggered_at.or(d.completed_at) else {
+            continue;
+        };
+        let hours = (deploy_time - *commit_time).num_seconds() as f64 / 3600.0;
+        if hours >= 0.0 {
+            leads.push(hours);
+        }
+    }
+    let lead_time_hours = if leads.is_empty() {
+        cycle_time_avg
+    } else {
+        leads.iter().sum::<f64>() / leads.len() as f64
+    };
+
+    (
+        deployment_frequency,
+        lead_time_hours,
+        "fact_deployments".to_string(),
+    )
 }
 
 /// Why: a single 0.0–1.0 quality score lets stakeholders compare teams /

--- a/crates/trusty-git-analytics/src/report/aggregator/mod.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/mod.rs
@@ -198,9 +198,23 @@ impl Aggregator {
         let rows = Self::load_rows_filtered(db, canonical_email.as_deref())?;
         let prs = Self::load_prs(db).unwrap_or_default();
         // #212: non-fatal, same pattern as `load_prs` — a query failure (e.g.
-        // a pre-migration DB) falls back to the empty-table path in
-        // `compute_dora` rather than aborting report generation.
-        let deployments = Self::load_deployments(db).unwrap_or_default();
+        // a pre-migration DB missing `fact_deployments`) falls back to the
+        // empty-table path in `compute_dora` rather than aborting report
+        // generation. #212 review round 2: the failure is still logged and
+        // threaded through as `deployments_query_failed` so `compute_dora`
+        // can tag the fallback `"pr_merge_proxy_query_failed"` — a broken
+        // table must not read identically to a genuinely empty one.
+        let (deployments, deployments_query_failed) = match Self::load_deployments(db) {
+            Ok(rows) => (rows, false),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "fact_deployments query failed; DORA deployment frequency \
+                     falls back to the PR-merge proxy"
+                );
+                (Vec::new(), true)
+            }
+        };
         let unresolved_db = if canonical_email.is_none() {
             Self::count_unresolved_author_commits(db).unwrap_or(0)
         } else {
@@ -208,7 +222,7 @@ impl Aggregator {
             // meaningful for the per-author view — suppress it.
             0
         };
-        let mut data = Self::aggregate(rows, prs, deployments);
+        let mut data = Self::aggregate(rows, prs, deployments, deployments_query_failed);
 
         // Issue #68 / #67: surface coverage and unresolved-identity counts
         // so consumers know the scope of the report. `repository_coverage`
@@ -569,6 +583,7 @@ impl Aggregator {
         rows: Vec<CommitRow>,
         prs: Vec<PrRow>,
         deployments: Vec<DeploymentRow>,
+        deployments_query_failed: bool,
     ) -> ReportData {
         let generated_at = Utc::now().to_rfc3339();
         let mut data = ReportData::empty(generated_at);
@@ -622,18 +637,19 @@ impl Aggregator {
             velocity_inputs.cycle_time_avg,
         );
 
-        let dora = Some(compute_dora(
-            &rows,
-            &row_flags,
-            &acc.category_total,
-            &prs,
-            &deployments,
-            acc.min_ts,
-            acc.max_ts,
-            velocity_inputs.cycle_time_avg,
+        let dora = Some(compute_dora(DoraInputs {
+            rows: &rows,
+            flags: &row_flags,
+            category_total: &acc.category_total,
+            prs: &prs,
+            deployments: &deployments,
+            deployments_query_failed,
+            period_start: acc.min_ts,
+            period_end: acc.max_ts,
+            cycle_time_avg: velocity_inputs.cycle_time_avg,
             total_weeks,
-            acc.revert_count,
-        ));
+            revert_count: acc.revert_count,
+        }));
 
         let quality = Some(compute_quality(
             total_commits,
@@ -717,5 +733,5 @@ use accumulate::{
 };
 use metrics::{
     build_summary, build_weekly_velocity, check_weekly_coverage_drift, compute_developer_activity,
-    compute_dora, compute_quality, compute_velocity_inputs, configured_alias_emails,
+    compute_dora, compute_quality, compute_velocity_inputs, configured_alias_emails, DoraInputs,
 };

--- a/crates/trusty-git-analytics/src/report/aggregator/mod.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/mod.rs
@@ -71,6 +71,23 @@ pub(super) struct PrRow {
     pub(super) merged_at: Option<DateTime<Utc>>,
 }
 
+// #212: canonical deploy-event row for DORA deployment-frequency / lead-time.
+/// Minimal `fact_deployments` row used by [`metrics::compute_dora`].
+///
+/// Why: `compute_dora` previously derived deployment frequency from a
+/// merged-PR-count proxy and never read the `fact_deployments` table the
+/// schema (issue #212) added — a repo with real production deploy history
+/// reported `deployment_frequency: 0.0` identically to one with none.
+/// What: the subset of `fact_deployments` columns needed to count
+/// production deploys in-period and, when a row names a commit SHA, join it
+/// back to that commit's timestamp for a measured lead time.
+/// Test: `report::tests::dora_reads_fact_deployments_when_populated`.
+pub(super) struct DeploymentRow {
+    pub(super) triggered_at: Option<DateTime<Utc>>,
+    pub(super) completed_at: Option<DateTime<Utc>>,
+    pub(super) git_sha: Option<String>,
+}
+
 /// Default regex patterns identifying machine-generated commits.
 ///
 /// Why: keep boilerplate (lock-file bumps, version bumps, merge commits, …)
@@ -180,6 +197,10 @@ impl Aggregator {
 
         let rows = Self::load_rows_filtered(db, canonical_email.as_deref())?;
         let prs = Self::load_prs(db).unwrap_or_default();
+        // #212: non-fatal, same pattern as `load_prs` — a query failure (e.g.
+        // a pre-migration DB) falls back to the empty-table path in
+        // `compute_dora` rather than aborting report generation.
+        let deployments = Self::load_deployments(db).unwrap_or_default();
         let unresolved_db = if canonical_email.is_none() {
             Self::count_unresolved_author_commits(db).unwrap_or(0)
         } else {
@@ -187,7 +208,7 @@ impl Aggregator {
             // meaningful for the per-author view — suppress it.
             0
         };
-        let mut data = Self::aggregate(rows, prs);
+        let mut data = Self::aggregate(rows, prs, deployments);
 
         // Issue #68 / #67: surface coverage and unresolved-identity counts
         // so consumers know the scope of the report. `repository_coverage`
@@ -326,6 +347,53 @@ impl Aggregator {
                 state,
                 created_at,
                 merged_at,
+            });
+        }
+        Ok(out)
+    }
+
+    // #212: compute_dora previously never read this table.
+    /// Load production-deploy rows for DORA deployment-frequency / lead-time.
+    ///
+    /// Why: `fact_deployments` (issue #212) is the canonical deploy-event
+    /// hub every DORA query should join through; a repo with real deploy
+    /// history was reporting `deployment_frequency: 0.0` because nothing
+    /// queried it.
+    /// What: returns `environment='production' AND status='success'` rows
+    /// with a parseable `triggered_at`; other rows are silently dropped,
+    /// matching [`Self::load_prs`]'s handling of an un-parseable timestamp.
+    /// Test: `report::tests::dora_reads_fact_deployments_when_populated`.
+    fn load_deployments(db: &Database) -> Result<Vec<DeploymentRow>> {
+        let conn = db.connection();
+        let mut stmt = conn
+            .prepare(
+                "SELECT triggered_at, completed_at, git_sha FROM fact_deployments \
+                 WHERE environment = 'production' AND status = 'success'",
+            )
+            .map_err(crate::core::TgaError::from)?;
+        let rows = stmt
+            .query_map([], |row| {
+                let triggered: Option<String> = row.get(0)?;
+                let completed: Option<String> = row.get(1)?;
+                let git_sha: Option<String> = row.get(2)?;
+                Ok((triggered, completed, git_sha))
+            })
+            .map_err(crate::core::TgaError::from)?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (triggered_s, completed_s, git_sha) = r.map_err(crate::core::TgaError::from)?;
+            let triggered_at = triggered_s
+                .as_deref()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc));
+            let completed_at = completed_s
+                .as_deref()
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc));
+            out.push(DeploymentRow {
+                triggered_at,
+                completed_at,
+                git_sha,
             });
         }
         Ok(out)
@@ -497,7 +565,11 @@ impl Aggregator {
     /// Test: indirectly via `Aggregator::build` tests; behaviour is a
     /// pure refactor — every output field is produced by a named helper
     /// below.
-    fn aggregate(rows: Vec<CommitRow>, prs: Vec<PrRow>) -> ReportData {
+    fn aggregate(
+        rows: Vec<CommitRow>,
+        prs: Vec<PrRow>,
+        deployments: Vec<DeploymentRow>,
+    ) -> ReportData {
         let generated_at = Utc::now().to_rfc3339();
         let mut data = ReportData::empty(generated_at);
 
@@ -555,6 +627,9 @@ impl Aggregator {
             &row_flags,
             &acc.category_total,
             &prs,
+            &deployments,
+            acc.min_ts,
+            acc.max_ts,
             velocity_inputs.cycle_time_avg,
             total_weeks,
             acc.revert_count,

--- a/crates/trusty-git-analytics/src/report/aggregator/mod.rs
+++ b/crates/trusty-git-analytics/src/report/aggregator/mod.rs
@@ -647,6 +647,7 @@ impl Aggregator {
             period_start: acc.min_ts,
             period_end: acc.max_ts,
             cycle_time_avg: velocity_inputs.cycle_time_avg,
+            pr_cycle_time_count: velocity_inputs.pr_count,
             total_weeks,
             revert_count: acc.revert_count,
         }));

--- a/crates/trusty-git-analytics/src/report/formatters/csv.rs
+++ b/crates/trusty-git-analytics/src/report/formatters/csv.rs
@@ -375,6 +375,7 @@ pub fn write_weekly_dora_csv(data: &ReportData, output_dir: &Path) -> Result<Pat
         "change_failure_rate",
         "mttr_hours",
         "performance_level",
+        "deployment_frequency_source",
     ])?;
     if let Some(d) = &data.dora {
         w.write_record([
@@ -383,6 +384,7 @@ pub fn write_weekly_dora_csv(data: &ReportData, output_dir: &Path) -> Result<Pat
             &format!("{:.4}", d.change_failure_rate),
             &format!("{:.2}", d.mttr_hours),
             d.performance_level.as_str(),
+            d.deployment_frequency_source.as_str(),
         ])?;
     }
     w.flush()?;

--- a/crates/trusty-git-analytics/src/report/formatters/csv.rs
+++ b/crates/trusty-git-analytics/src/report/formatters/csv.rs
@@ -376,15 +376,24 @@ pub fn write_weekly_dora_csv(data: &ReportData, output_dir: &Path) -> Result<Pat
         "mttr_hours",
         "performance_level",
         "deployment_frequency_source",
+        "lead_time_source",
     ])?;
     if let Some(d) = &data.dora {
+        // #212 review round 2: `lead_time_hours` is `None` when genuinely
+        // unmeasurable — an empty cell, never a `0.0` that would misread as
+        // a measured zero.
+        let lead_time_cell = d
+            .lead_time_hours
+            .map(|h| format!("{h:.2}"))
+            .unwrap_or_default();
         w.write_record([
             &format!("{:.4}", d.deployment_frequency),
-            &format!("{:.2}", d.lead_time_hours),
+            &lead_time_cell,
             &format!("{:.4}", d.change_failure_rate),
             &format!("{:.2}", d.mttr_hours),
             d.performance_level.as_str(),
             d.deployment_frequency_source.as_str(),
+            d.lead_time_source.as_str(),
         ])?;
     }
     w.flush()?;

--- a/crates/trusty-git-analytics/src/report/models.rs
+++ b/crates/trusty-git-analytics/src/report/models.rs
@@ -269,6 +269,14 @@ pub struct DoraMetrics {
     pub mttr_hours: f64,
     /// Aggregate performance band: `"elite" | "high" | "medium" | "low"`.
     pub performance_level: String,
+    // #212: distinguishes a measured `fact_deployments` reading from the
+    // PR-merge proxy so a report reader can tell which source produced
+    // `deployment_frequency` / `lead_time_hours`.
+    /// Data source for `deployment_frequency` / `lead_time_hours`:
+    /// `"fact_deployments"` when the table had rows for the report period,
+    /// `"pr_merge_proxy"` when it was empty and merged-PR count/cycle-time
+    /// stood in for it.
+    pub deployment_frequency_source: String,
 }
 
 /// Period-level velocity summary.

--- a/crates/trusty-git-analytics/src/report/models.rs
+++ b/crates/trusty-git-analytics/src/report/models.rs
@@ -260,23 +260,41 @@ pub struct WeeklyVelocity {
 pub struct DoraMetrics {
     /// Deployment frequency in deploys per week.
     pub deployment_frequency: f64,
-    /// Average lead time (PR open → merge) in hours. Zero if no PR data.
-    pub lead_time_hours: f64,
+    // #212 review round 2: `0.0` used to double as both "measured zero" and
+    // "no data at all" — a deploy that named a `git_sha` with no matching
+    // commit and zero `pull_requests` rows silently rendered as a measured
+    // `0.0`. `None` now means genuinely unmeasurable; see
+    // `lead_time_source` for which case produced the value.
+    /// Average lead time in hours: measured (`fact_deployments` row →
+    /// linked commit) when available, else the PR open→merge proxy, else
+    /// `None`.
+    pub lead_time_hours: Option<f64>,
     /// Change failure rate: bugfix commits / total commits.
     pub change_failure_rate: f64,
     /// MTTR approximation: average hours between a bug-introducing commit and
     /// its bugfix commit. Zero if no commit-pairs found.
     pub mttr_hours: f64,
     /// Aggregate performance band: `"elite" | "high" | "medium" | "low"`.
+    /// An unmeasurable lead time (see [`Self::lead_time_source`]) fails every
+    /// tier's lead-time bound, so it never classifies above `"low"`.
     pub performance_level: String,
     // #212: distinguishes a measured `fact_deployments` reading from the
     // PR-merge proxy so a report reader can tell which source produced
-    // `deployment_frequency` / `lead_time_hours`.
-    /// Data source for `deployment_frequency` / `lead_time_hours`:
-    /// `"fact_deployments"` when the table had rows for the report period,
-    /// `"pr_merge_proxy"` when it was empty and merged-PR count/cycle-time
-    /// stood in for it.
+    // `deployment_frequency`.
+    /// Data source for `deployment_frequency`: `"fact_deployments"` when the
+    /// table had in-period `environment='production' AND status='success'`
+    /// rows, `"pr_merge_proxy"` when it did not, `"pr_merge_proxy_query_failed"`
+    /// when the query itself errored (e.g. a pre-migration DB missing the
+    /// table) — distinct from a genuinely empty table.
     pub deployment_frequency_source: String,
+    // #212 review round 2: split from `deployment_frequency_source` because
+    // a deploy can be measured while its lead time is not (unmatched
+    // `git_sha`).
+    /// Data source for `lead_time_hours`: `"measured"` (deploy→commit link
+    /// resolved), `"proxy"` (PR open→merge cycle time stood in), or
+    /// `"unmeasurable"` (neither signal was available — `lead_time_hours` is
+    /// `None`).
+    pub lead_time_source: String,
 }
 
 /// Period-level velocity summary.

--- a/crates/trusty-git-analytics/src/report/tests.rs
+++ b/crates/trusty-git-analytics/src/report/tests.rs
@@ -1431,6 +1431,33 @@ fn dora_falls_back_to_pr_proxy_when_fact_deployments_empty() {
 }
 
 #[test]
+fn dora_lead_time_is_unmeasurable_when_merged_prs_are_all_outlier_filtered() {
+    // #212 review round 3: `cycle_time_avg` reads 0.0 both as a genuine
+    // average and as "zero PRs survived the 0.5-720h outlier filter" —
+    // gating the proxy on "any raw merged_at" missed this case and returned
+    // a fabricated `Some(0.0)` tagged `"proxy"`. One merged PR exists (so a
+    // naive `merged_at.is_some()` check would wrongly treat lead time as
+    // available), but its cycle time is 960h, outside the filter window, and
+    // no deploys exist to source frequency from either.
+    let db = seed_db();
+    db.connection()
+        .execute(
+            "INSERT INTO pull_requests \
+                 (pr_number, title, author, state, created_at, merged_at) \
+             VALUES (1, 'pr', 'alice', 'merged', '2024-01-01T00:00:00+00:00', \
+                 '2024-02-10T00:00:00+00:00')",
+            [],
+        )
+        .expect("insert outlier-filtered merged pr");
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert_eq!(dora.lead_time_hours, None);
+    assert_eq!(dora.lead_time_source, "unmeasurable");
+}
+
+#[test]
 fn dora_ignores_fact_deployments_rows_outside_the_period() {
     // Report period is 2024-01-15 .. 2024-01-22 (two ISO weeks, from
     // `seed_db()`'s two commits). Five deploys land inside it; three land

--- a/crates/trusty-git-analytics/src/report/tests.rs
+++ b/crates/trusty-git-analytics/src/report/tests.rs
@@ -1343,3 +1343,85 @@ fn persist_weekly_engineer_upserts_rows() {
     assert_eq!(total, 2, "re-persisting must not duplicate the grain key");
     assert_eq!(row("dana@example.com"), (6, 2, 1, pct));
 }
+
+// #212: `compute_dora` computed `deploys` from merged PRs and never queried
+// `fact_deployments`, so a repo with real production deploy history reported
+// `deployment_frequency: 0.0` — identically to a repo with none.
+
+/// Insert one `fact_deployments` row (`environment='production',
+/// status='success'`, repo `"repo-a"` to match [`baseline_config`]).
+fn seed_deployment(db: &Database, deploy_id: &str, triggered_at: &str) {
+    db.connection()
+        .execute(
+            "INSERT INTO fact_deployments \
+                 (deploy_id, repo, environment, triggered_at, status) \
+             VALUES (?1, 'repo-a', 'production', ?2, 'success')",
+            rusqlite::params![deploy_id, triggered_at],
+        )
+        .expect("insert fact_deployments row");
+}
+
+#[test]
+fn dora_reads_fact_deployments_when_populated() {
+    // `seed_db()` seeds two commits a week apart (2024-01-15 .. 2024-01-22),
+    // so the report period spans exactly those two ISO weeks and
+    // `pull_requests` has zero rows — the pre-#212 proxy has nothing to count.
+    let db = seed_db();
+    for i in 0..70 {
+        seed_deployment(&db, &format!("deploy-{i}"), "2024-01-18T00:00:00+00:00");
+    }
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert!(
+        dora.deployment_frequency > 0.0,
+        "70 production deploys in-period must not read as zero"
+    );
+    assert_eq!(dora.deployment_frequency_source, "fact_deployments");
+    assert_ne!(
+        dora.performance_level, "low",
+        "70 deploys / 2 weeks must not classify the way the zero-deploy \
+         proxy would"
+    );
+}
+
+#[test]
+fn dora_falls_back_to_pr_proxy_when_fact_deployments_empty() {
+    // No `fact_deployments` rows and no `pull_requests` rows: the same
+    // zero-signal proxy path the pre-#212 code always used.
+    let db = seed_db();
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert_eq!(dora.deployment_frequency, 0.0);
+    assert_eq!(dora.deployment_frequency_source, "pr_merge_proxy");
+}
+
+#[test]
+fn dora_ignores_fact_deployments_rows_outside_the_period() {
+    // Report period is 2024-01-15 .. 2024-01-22 (two ISO weeks, from
+    // `seed_db()`'s two commits). Five deploys land inside it; three land
+    // months outside it and must not be counted.
+    let db = seed_db();
+    for i in 0..5 {
+        seed_deployment(&db, &format!("in-period-{i}"), "2024-01-18T00:00:00+00:00");
+    }
+    for i in 0..3 {
+        seed_deployment(
+            &db,
+            &format!("out-of-period-{i}"),
+            "2023-06-01T00:00:00+00:00",
+        );
+    }
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert!(
+        (dora.deployment_frequency - 2.5).abs() < 1e-9,
+        "expected 5 in-period deploys / 2 weeks = 2.5, got {}",
+        dora.deployment_frequency
+    );
+    assert_eq!(dora.deployment_frequency_source, "fact_deployments");
+}

--- a/crates/trusty-git-analytics/src/report/tests.rs
+++ b/crates/trusty-git-analytics/src/report/tests.rs
@@ -1347,18 +1347,35 @@ fn persist_weekly_engineer_upserts_rows() {
 // #212: `compute_dora` computed `deploys` from merged PRs and never queried
 // `fact_deployments`, so a repo with real production deploy history reported
 // `deployment_frequency: 0.0` — identically to a repo with none.
+// #212 review round 2: a deploy can be measured while its lead time is not
+// (an unmatched `git_sha`) — `lead_time_hours: 0.0` must never be presented
+// as `"measured"` when it is really absent-or-proxied data.
 
-/// Insert one `fact_deployments` row (`environment='production',
-/// status='success'`, repo `"repo-a"` to match [`baseline_config`]).
-fn seed_deployment(db: &Database, deploy_id: &str, triggered_at: &str) {
+/// Insert one `fact_deployments` row for repo `"repo-a"` (matches
+/// [`baseline_config`]), with full control over `environment`/`status`/
+/// `git_sha` so tests can exercise the WHERE-clause filter and the lead-time
+/// commit link independently.
+fn seed_deployment_full(
+    db: &Database,
+    deploy_id: &str,
+    triggered_at: &str,
+    environment: &str,
+    status: &str,
+    git_sha: Option<&str>,
+) {
     db.connection()
         .execute(
             "INSERT INTO fact_deployments \
-                 (deploy_id, repo, environment, triggered_at, status) \
-             VALUES (?1, 'repo-a', 'production', ?2, 'success')",
-            rusqlite::params![deploy_id, triggered_at],
+                 (deploy_id, repo, environment, triggered_at, status, git_sha) \
+             VALUES (?1, 'repo-a', ?2, ?3, ?4, ?5)",
+            rusqlite::params![deploy_id, environment, triggered_at, status, git_sha],
         )
         .expect("insert fact_deployments row");
+}
+
+/// Insert a `production`/`success` row with no `git_sha` link.
+fn seed_deployment(db: &Database, deploy_id: &str, triggered_at: &str) {
+    seed_deployment_full(db, deploy_id, triggered_at, "production", "success", None);
 }
 
 #[test]
@@ -1366,8 +1383,19 @@ fn dora_reads_fact_deployments_when_populated() {
     // `seed_db()` seeds two commits a week apart (2024-01-15 .. 2024-01-22),
     // so the report period spans exactly those two ISO weeks and
     // `pull_requests` has zero rows — the pre-#212 proxy has nothing to count.
+    // One deploy links to commit `aaa111` (2h after it) so the classifier
+    // has a genuine measured lead time and isn't forced to `"low"` purely
+    // because the other 69 have no resolvable link.
     let db = seed_db();
-    for i in 0..70 {
+    seed_deployment_full(
+        &db,
+        "deploy-linked",
+        "2024-01-15T12:00:00+00:00",
+        "production",
+        "success",
+        Some("aaa111"),
+    );
+    for i in 0..69 {
         seed_deployment(&db, &format!("deploy-{i}"), "2024-01-18T00:00:00+00:00");
     }
 
@@ -1379,10 +1407,12 @@ fn dora_reads_fact_deployments_when_populated() {
         "70 production deploys in-period must not read as zero"
     );
     assert_eq!(dora.deployment_frequency_source, "fact_deployments");
+    assert_eq!(dora.lead_time_source, "measured");
+    assert_eq!(dora.lead_time_hours, Some(2.0));
     assert_ne!(
         dora.performance_level, "low",
-        "70 deploys / 2 weeks must not classify the way the zero-deploy \
-         proxy would"
+        "70 deploys / 2 weeks with a measured 2h lead must not classify the \
+         way the zero-deploy proxy would"
     );
 }
 
@@ -1396,6 +1426,8 @@ fn dora_falls_back_to_pr_proxy_when_fact_deployments_empty() {
 
     assert_eq!(dora.deployment_frequency, 0.0);
     assert_eq!(dora.deployment_frequency_source, "pr_merge_proxy");
+    assert_eq!(dora.lead_time_hours, None);
+    assert_eq!(dora.lead_time_source, "unmeasurable");
 }
 
 #[test]
@@ -1424,4 +1456,133 @@ fn dora_ignores_fact_deployments_rows_outside_the_period() {
         dora.deployment_frequency
     );
     assert_eq!(dora.deployment_frequency_source, "fact_deployments");
+}
+
+#[test]
+fn dora_falls_back_to_pr_proxy_when_all_fact_deployments_rows_are_outside_period() {
+    // Distinct from `dora_falls_back_to_pr_proxy_when_fact_deployments_empty`:
+    // the table is NOT empty, every row is simply outside the report period,
+    // which must resolve to the same proxy path as a genuinely empty table.
+    let db = seed_db();
+    for i in 0..4 {
+        seed_deployment(&db, &format!("out-{i}"), "2023-06-01T00:00:00+00:00");
+    }
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert_eq!(dora.deployment_frequency, 0.0);
+    assert_eq!(dora.deployment_frequency_source, "pr_merge_proxy");
+}
+
+#[test]
+fn dora_excludes_non_production_or_failed_deployment_rows() {
+    let db = seed_db();
+    // In-period, but excluded by `environment='production' AND
+    // status='success'`.
+    seed_deployment_full(
+        &db,
+        "staging-1",
+        "2024-01-18T00:00:00+00:00",
+        "staging",
+        "success",
+        None,
+    );
+    seed_deployment_full(
+        &db,
+        "failed-1",
+        "2024-01-18T01:00:00+00:00",
+        "production",
+        "failure",
+        None,
+    );
+    // The one row that should count.
+    seed_deployment(&db, "prod-success-1", "2024-01-18T02:00:00+00:00");
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert_eq!(dora.deployment_frequency_source, "fact_deployments");
+    assert!(
+        (dora.deployment_frequency - 0.5).abs() < 1e-9,
+        "only the production/success row should count: 1 deploy / 2 weeks = 0.5, got {}",
+        dora.deployment_frequency
+    );
+}
+
+#[test]
+fn dora_lead_time_falls_back_to_proxy_when_deploy_git_sha_is_unmatched() {
+    // Deploys are measured (frequency source stays `"fact_deployments"`),
+    // but every `git_sha` names a commit that doesn't exist. With merged-PR
+    // data available, lead time falls back to the PR proxy — never a bare
+    // `cycle_time_avg` mislabeled `"measured"`.
+    let db = seed_db();
+    seed_deployment_full(
+        &db,
+        "deploy-unmatched",
+        "2024-01-18T00:00:00+00:00",
+        "production",
+        "success",
+        Some("deadbeef"),
+    );
+    db.connection()
+        .execute(
+            "INSERT INTO pull_requests \
+                 (pr_number, title, author, state, created_at, merged_at) \
+             VALUES (1, 'pr', 'alice', 'merged', '2024-01-15T08:00:00+00:00', \
+                 '2024-01-15T10:00:00+00:00')",
+            [],
+        )
+        .expect("insert merged pr");
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert_eq!(dora.deployment_frequency_source, "fact_deployments");
+    assert_eq!(dora.lead_time_source, "proxy");
+    assert_eq!(dora.lead_time_hours, Some(2.0));
+}
+
+#[test]
+fn dora_lead_time_is_unmeasurable_when_no_deploy_link_and_no_prs() {
+    // This is the exact HIGH-severity repro from the round-1 review: deploys
+    // measured, zero PRs, no deploy names a resolvable commit — lead time
+    // must be `None`/`"unmeasurable"`, never `Some(0.0)` mislabeled
+    // `"measured"`.
+    let db = seed_db();
+    seed_deployment_full(
+        &db,
+        "deploy-unmatched",
+        "2024-01-18T00:00:00+00:00",
+        "production",
+        "success",
+        Some("deadbeef"),
+    );
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert_eq!(dora.deployment_frequency_source, "fact_deployments");
+    assert!(dora.deployment_frequency > 0.0);
+    assert_eq!(dora.lead_time_hours, None);
+    assert_eq!(dora.lead_time_source, "unmeasurable");
+}
+
+#[test]
+fn dora_marks_proxy_source_distinctly_when_fact_deployments_query_fails() {
+    // Simulates a pre-migration / corrupt DB missing `fact_deployments`
+    // entirely — distinct from a table that exists but has zero rows.
+    let db = seed_db();
+    db.connection()
+        .execute("DROP TABLE fact_deployments", [])
+        .expect("drop fact_deployments to simulate a missing/corrupt table");
+
+    let data = Aggregator::build(&db, &baseline_config()).expect("aggregate");
+    let dora = data.dora.as_ref().expect("dora present");
+
+    assert_eq!(dora.deployment_frequency, 0.0);
+    assert_eq!(
+        dora.deployment_frequency_source,
+        "pr_merge_proxy_query_failed"
+    );
 }


### PR DESCRIPTION
## Summary

`compute_dora()` at `crates/trusty-git-analytics/src/report/aggregator/metrics.rs` counted deployment frequency from merged PRs and never queried `fact_deployments` (issue #212's own schema). A repo with real production deploy history reported `deployment_frequency: 0.0` and `performance_level: "low"` identically to a repo with none — confirmed live across 24/59 audited repos with populated `fact_deployments` (up to 329 rows) and 59/59 reporting `"low"`.

- `compute_dora()` now filters `fact_deployments` to `environment='production' AND status='success'` and the report period (`triggered_at` within `[period_start, period_end]`). When rows exist: deployment frequency is the in-period count / weeks, and lead time averages `deploy_time - commit_time` over deploys whose `git_sha` resolves to a known commit (deploys with no resolvable link are excluded from the average, not treated as zero). When the table has zero rows for the period, the pre-#212 proxy (merged-PR count / cycle-time average) is used unchanged.
- `DoraMetrics` gains `deployment_frequency_source` (`"fact_deployments"` | `"pr_merge_proxy"`), serialized in `dora_summary.json` and appended to `weekly_dora_metrics.csv`, so a reader can tell measured from proxy.
- New `Aggregator::load_deployments` mirrors the existing `load_prs` loader; `aggregate()` threads the loaded rows through.

## Test plan

Rung 3 (localized crate behavior), all `-p tga`:

- `cargo fmt --check` — clean
- `cargo check -p tga` — clean
- `cargo clippy -p tga --all-targets -- -D warnings` — clean
- `cargo test -p tga --no-fail-fast -- --test-threads=4` — `1620 passed; 0 failed; 7 ignored` (every target ran)
- `bash scripts/check_line_cap.sh` — 0 violations
- `bash scripts/check_changelog_fragment.sh` — OK
- `bash scripts/check_test_pointers.sh` — 0 dangling pointers

Three new regression tests in `crates/trusty-git-analytics/src/report/tests.rs`, each verified to fail (compile error: `deployment_frequency_source` doesn't exist) against the pre-fix source via a scoped `git stash`:

- `dora_reads_fact_deployments_when_populated` — 70 `fact_deployments` rows, 0 `pull_requests` → `deployment_frequency > 0.0`, `performance_level != "low"`
- `dora_falls_back_to_pr_proxy_when_fact_deployments_empty` — no rows in either table → `deployment_frequency_source == "pr_merge_proxy"`
- `dora_ignores_fact_deployments_rows_outside_the_period` — 5 in-period + 3 out-of-period rows → only the 5 counted

No other crate depends on `trusty-git-analytics`, so this stays rung 3 (no `trusty-review` / `trusty-audit` check needed).

Refs #212

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01ER5DBvGQ54K5sgFLb9G5vz
