### PR TITLE
feat(trusty-audit): preflight warns on missing optional collectors before a sweep

### DIFF
--- a/crates/trusty-audit/changelog.d/7134-preflight-optional-collectors.md
+++ b/crates/trusty-audit/changelog.d/7134-preflight-optional-collectors.md
@@ -1,0 +1,14 @@
+Added
+
+- `taudit audit` now checks, before anything is cloned, whether the OPTIONAL
+  collector binaries (`gitleaks`, `cargo-audit`, `cargo-deny`) are on this
+  machine — reusing the exact `trusty_common::bin_resolve::resolve_binary`
+  lookup each collector already calls at collection time. By default a missing
+  one only warns: the sweep still runs, and `ChainReport::collector_gaps`
+  carries one row per gap naming the collector, the evidence dimension that
+  goes dark, and the install hint, printed ahead of everything else in the
+  chain's report. `--strict-collectors` turns that warning into a refusal —
+  `AuditError::MissingOptionalCollectors`, attributed to the new
+  `chain::Phase::Preflight` — before the first repository is cloned. Neither
+  mode changes each repository's own `[report].gaps` line for the same
+  collector, which is unaffected either way.

--- a/crates/trusty-audit/changelog.d/7134-preflight-optional-collectors.md
+++ b/crates/trusty-audit/changelog.d/7134-preflight-optional-collectors.md
@@ -3,12 +3,16 @@ Added
 - `taudit audit` now checks, before anything is cloned, whether the OPTIONAL
   collector binaries (`gitleaks`, `cargo-audit`, `cargo-deny`) are on this
   machine — reusing the exact `trusty_common::bin_resolve::resolve_binary`
-  lookup each collector already calls at collection time. By default a missing
-  one only warns: the sweep still runs, and `ChainReport::collector_gaps`
+  lookup each collector already calls at collection time. Each missing one is
+  narrated on stderr through the existing progress sink, as `Operation::Preflight`,
+  before Phase 2 clones anything — not only in the final report. By default a
+  missing collector only warns: the sweep still runs, `ChainReport::collector_gaps`
   carries one row per gap naming the collector, the evidence dimension that
-  goes dark, and the install hint, printed ahead of everything else in the
-  chain's report. `--strict-collectors` turns that warning into a refusal —
-  `AuditError::MissingOptionalCollectors`, attributed to the new
-  `chain::Phase::Preflight` — before the first repository is cloned. Neither
-  mode changes each repository's own `[report].gaps` line for the same
+  goes dark, and the install hint, and the same rows land in the assembled
+  package's `package.toml` (`collector_gaps`), so the recipient who only opens
+  the zip sees them too. `--strict-collectors` turns the warning into a
+  refusal — `AuditError::MissingOptionalCollectors`, carrying the same
+  collector/dimension/install-hint detail as the warning rows, attributed to
+  the new `chain::Phase::Preflight` — before the first repository is cloned.
+  Neither mode changes each repository's own `[report].gaps` line for the same
   collector, which is unaffected either way.

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -104,6 +104,11 @@ use crate::workdir::WorkDir;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Phase {
+    /// #7134: checking which OPTIONAL collector binaries (gitleaks,
+    /// cargo-audit, cargo-deny) are on this machine, before anything is
+    /// cloned. Refuses only under `--strict-collectors`; otherwise it always
+    /// lets the chain continue.
+    Preflight,
     /// Downloading and verifying the engagement's pinned tool set (#5495).
     InstallTools,
     /// Turning registered targets into checkouts the sweep can read (#5215).
@@ -118,6 +123,7 @@ impl Phase {
     /// The name this phase is reported under, e.g. `"collect"`.
     pub fn label(self) -> &'static str {
         match self {
+            Phase::Preflight => "preflight",
             Phase::InstallTools => "install",
             Phase::Materialize => "materialize",
             Phase::Collect => "collect",
@@ -149,6 +155,13 @@ pub struct ChainOptions {
     pub fresh: bool,
     /// Where the return package lands, or `None` for the default.
     pub destination: Option<PathBuf>,
+    /// #7134: refuse in [`Phase::Preflight`], before anything is cloned, when
+    /// an OPTIONAL collector binary (gitleaks, cargo-audit, cargo-deny) is
+    /// missing. `false` (the default) only warns —
+    /// [`ChainReport::collector_gaps`] carries the same rows either way, and
+    /// the sweep still runs; each repository's own `[report].gaps` line is
+    /// unaffected regardless of this flag.
+    pub strict_collectors: bool,
 }
 
 /// What one chained run did, phase by phase.
@@ -186,6 +199,16 @@ pub struct ChainReport {
     /// run's exit status non-zero, so a silently unaudited target cannot read as
     /// a whole engagement.
     pub gaps: Vec<String>,
+    /// #7134: one warning row per OPTIONAL collector binary that was missing
+    /// at [`Phase::Preflight`] — always empty when
+    /// [`ChainOptions::strict_collectors`] refused instead. Deliberately
+    /// separate from [`ChainReport::gaps`]: this is informational (it does
+    /// not change [`crate::session::Outcome::exit_code`]) and is not a target
+    /// the chain failed to audit — every repository still ran, only one
+    /// evidence dimension went unassessed for all of them. Each repository's
+    /// own `[report].gaps` line for the same collector is unaffected by this
+    /// field either way.
+    pub collector_gaps: Vec<String>,
 }
 
 /// Run the whole engagement: install, materialize, collect, package.
@@ -223,6 +246,46 @@ pub async fn audit(
     auto_install: bool,
     progress: &Progress,
 ) -> Result<ChainReport, AuditError> {
+    // #7134: real machine, real resolver. `audit_with_preflight` is what
+    // actually runs Phase::Preflight; splitting it out here is what lets the
+    // ordering guarantee (before Phase 2 clones anything) be tested by
+    // injecting the preflight's OUTCOME directly, rather than by faking the
+    // process-global `PATH`/`HOME` env vars a concurrently running unrelated
+    // test could observe too — see `chain_tests::audit_with_preflight`.
+    audit_with_preflight(
+        work,
+        config,
+        options,
+        auto_install,
+        progress,
+        crate::collectors::check(options.strict_collectors),
+    )
+    .await
+}
+
+/// [`audit`], with Phase 1's preflight outcome supplied rather than computed.
+///
+/// Why: see [`audit`]. Production has exactly one caller, which always passes
+/// a real [`crate::collectors::check`] result; tests are the second caller,
+/// and pass a result built by hand.
+/// What: identical to [`audit`] except `collector_check` replaces the
+/// [`crate::collectors::check`] call — still the first thing evaluated, still
+/// wrapped as [`Phase::Preflight`] on failure, still ahead of every other
+/// phase.
+async fn audit_with_preflight(
+    work: &WorkDir,
+    config: &EngagementConfig,
+    options: &ChainOptions,
+    auto_install: bool,
+    progress: &Progress,
+    collector_check: Result<Vec<String>, AuditError>,
+) -> Result<ChainReport, AuditError> {
+    // #7134: first, before anything else — in particular before Phase 2
+    // clones a single repository. Refuses only under `--strict-collectors`;
+    // its default is to hand back warning rows and let the chain proceed
+    // exactly as it does today.
+    let collector_gaps = collector_check.map_err(|e| stopped(Phase::Preflight, e))?;
+
     let installed = install(work, config, auto_install, progress)
         .await
         .map_err(|e| stopped(Phase::InstallTools, e))?;
@@ -258,6 +321,7 @@ pub async fn audit(
         run,
         package,
         gaps,
+        collector_gaps,
     })
 }
 
@@ -729,6 +793,106 @@ trusty-review = "0.15.1"
             err.to_string().contains("trusty-audit add repo"),
             "the refusal must name the remedy: {err}"
         );
+    }
+
+    /// #7134: `--strict-collectors` stops the chain before Phase 2 clones or
+    /// materializes anything at all — proven here by a work directory that
+    /// has neither a tool install nor a repository selection, so any phase
+    /// after [`Phase::Preflight`] would fail with a DIFFERENT error the
+    /// moment it ran (`ToolsNotInstalled` or `NothingRegistered`).
+    ///
+    /// The preflight's outcome is injected via [`audit_with_preflight`]
+    /// rather than produced by a real, missing `cargo-audit` — this crate's
+    /// tests run with `--test-threads` greater than 1, and faking the
+    /// process-global `PATH`/`HOME` env vars `crate::collectors::check`
+    /// actually reads would corrupt every OTHER test running concurrently
+    /// that also resolves a binary (`crate::run::pins`, `crate::git`, …).
+    /// `crate::collectors::collectors_tests` proves the real resolution path
+    /// against a sandboxed env instead, in isolation.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn strict_collectors_refuses_before_any_repo_is_cloned() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let options = ChainOptions {
+            strict_collectors: true,
+            ..ChainOptions::default()
+        };
+        let collector_check = Err(AuditError::MissingOptionalCollectors {
+            missing: vec!["cargo-audit"],
+        });
+
+        let err = audit_with_preflight(
+            &work,
+            &config(),
+            &options,
+            true,
+            &Progress::none(),
+            collector_check,
+        )
+        .await
+        .expect_err("a missing optional collector refuses under --strict-collectors");
+
+        let AuditError::ChainStopped { phase, source } = &err else {
+            panic!("expected a phase-attributed refusal, got {err:?}");
+        };
+        assert_eq!(*phase, Phase::Preflight, "{err}");
+        assert!(
+            matches!(**source, AuditError::MissingOptionalCollectors { .. }),
+            "{source:?}"
+        );
+        assert!(
+            err.to_string().contains("cargo-audit"),
+            "the refusal must name the missing binary: {err}"
+        );
+        // Nothing was installed and no selection was written — Phase::Preflight
+        // stopped the chain before InstallTools or Materialize could run.
+        assert!(
+            crate::tools::status(&work)
+                .expect("status")
+                .iter()
+                .all(|s| !s.installed),
+            "install must not have run"
+        );
+    }
+
+    /// #7134's default: a missing optional collector warns and the sweep still
+    /// runs to a package, and the warning does not change the exit status. See
+    /// `strict_collectors_refuses_before_any_repo_is_cloned` for why the
+    /// preflight's outcome is injected rather than produced by a real, missing
+    /// binary.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_missing_collector_warns_and_the_sweep_still_proceeds() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
+        let warning_row = "cve-scan: `cargo-audit` is not installed, so known dependency CVEs \
+                            will go unassessed for every repository in this sweep (install it \
+                            with `cargo install cargo-audit`)"
+            .to_owned();
+
+        let report = audit_with_preflight(
+            &work,
+            &config(),
+            &ChainOptions::default(),
+            true,
+            &Progress::none(),
+            Ok(vec![warning_row.clone()]),
+        )
+        .await
+        .expect("a missing optional collector only warns by default");
+
+        assert_eq!(
+            report.run.status,
+            RunStatus::AllSucceeded,
+            "{:?}",
+            report.run
+        );
+        assert!(report.package.path.is_file(), "the sweep still packages");
+        assert_eq!(report.collector_gaps, vec![warning_row]);
+        // The warning is informational: it must not change the exit status.
+        assert!(report.gaps.is_empty(), "{:?}", report.gaps);
+        assert_eq!(Outcome::Audit(report).exit_code(), 0);
     }
 
     /// #5824 requirement 4: the operator who cloned by hand before the registry

--- a/crates/trusty-audit/src/chain.rs
+++ b/crates/trusty-audit/src/chain.rs
@@ -246,44 +246,62 @@ pub async fn audit(
     auto_install: bool,
     progress: &Progress,
 ) -> Result<ChainReport, AuditError> {
-    // #7134: real machine, real resolver. `audit_with_preflight` is what
-    // actually runs Phase::Preflight; splitting it out here is what lets the
-    // ordering guarantee (before Phase 2 clones anything) be tested by
-    // injecting the preflight's OUTCOME directly, rather than by faking the
-    // process-global `PATH`/`HOME` env vars a concurrently running unrelated
-    // test could observe too — see `chain_tests::audit_with_preflight`.
+    // #7134: real machine, real resolver — the only production caller of
+    // `crate::collectors::missing`. `audit_with_preflight` is what actually
+    // runs Phase::Preflight (narrating each gap through `progress` and then
+    // deciding whether to refuse); splitting it out here is what lets both
+    // halves be tested by injecting the missing list and the decision
+    // directly, rather than by faking the process-global `PATH`/`HOME` env
+    // vars a concurrently running unrelated test could observe too — see
+    // `chain_tests::audit_with_preflight`.
+    let collector_missing = crate::collectors::missing();
+    let collector_check = crate::collectors::decide(options.strict_collectors, &collector_missing);
     audit_with_preflight(
         work,
         config,
         options,
         auto_install,
         progress,
-        crate::collectors::check(options.strict_collectors),
+        &collector_missing,
+        collector_check,
     )
     .await
 }
 
-/// [`audit`], with Phase 1's preflight outcome supplied rather than computed.
+/// [`audit`], with Phase 1's preflight inputs supplied rather than computed.
 ///
 /// Why: see [`audit`]. Production has exactly one caller, which always passes
-/// a real [`crate::collectors::check`] result; tests are the second caller,
-/// and pass a result built by hand.
-/// What: identical to [`audit`] except `collector_check` replaces the
-/// [`crate::collectors::check`] call — still the first thing evaluated, still
-/// wrapped as [`Phase::Preflight`] on failure, still ahead of every other
-/// phase.
+/// the real [`crate::collectors::missing`] list and the
+/// [`crate::collectors::decide`] judgement over it; tests are the second
+/// caller, and pass both built by hand.
+/// What: identical to [`audit`] except `collector_missing` and
+/// `collector_check` replace the [`crate::collectors::missing`] /
+/// [`crate::collectors::decide`] calls. Every entry of `collector_missing` is
+/// narrated through `progress` as `Operation::Preflight` FIRST — before
+/// [`install`], and so before Phase 2 (`materialize`, which is where
+/// [`crate::clone::clone_all`] runs) — then `collector_check` decides whether
+/// to continue (warning rows, folded into [`ChainReport::collector_gaps`]) or
+/// refuse, wrapped as [`Phase::Preflight`].
 async fn audit_with_preflight(
     work: &WorkDir,
     config: &EngagementConfig,
     options: &ChainOptions,
     auto_install: bool,
     progress: &Progress,
+    collector_missing: &[crate::collectors::OptionalCollector],
     collector_check: Result<Vec<String>, AuditError>,
 ) -> Result<ChainReport, AuditError> {
-    // #7134: first, before anything else — in particular before Phase 2
-    // clones a single repository. Refuses only under `--strict-collectors`;
-    // its default is to hand back warning rows and let the chain proceed
-    // exactly as it does today.
+    // #7134: reported as each gap is found, not after the chain finishes —
+    // `crate::progress::terminal::TerminalProgress` narrates this on stderr
+    // immediately, which is what makes it visible before an hours-long sweep
+    // starts rather than only in the final report.
+    for collector in collector_missing {
+        progress.unit_finished(
+            Operation::Preflight,
+            collector.binary,
+            UnitOutcome::Skipped(crate::collectors::warning_row(collector)),
+        );
+    }
     let collector_gaps = collector_check.map_err(|e| stopped(Phase::Preflight, e))?;
 
     let installed = install(work, config, auto_install, progress)
@@ -311,9 +329,16 @@ async fn audit_with_preflight(
         .await
         .map_err(|e| stopped(Phase::Collect, e))?;
 
-    let package = assemble(work, config, &gaps, options.destination.clone(), progress)
-        .await
-        .map_err(|e| stopped(Phase::Package, e))?;
+    let package = assemble(
+        work,
+        config,
+        &gaps,
+        &collector_gaps,
+        options.destination.clone(),
+        progress,
+    )
+    .await
+    .map_err(|e| stopped(Phase::Package, e))?;
 
     Ok(ChainReport {
         installed,
@@ -494,13 +519,20 @@ async fn collect(
 /// deliverable still claiming full coverage — and the zip is what the third
 /// party opens (#5824 review).
 /// What: announces the phase through `progress`, then assembles.
+///
+/// `collector_gaps` (#7134) is threaded the same way `gaps` is: into
+/// [`package::from_checkpoint`], so `package.toml` states what this
+/// engagement's optional collectors could not assess, inside the zip the
+/// recipient actually opens — not only in this process's own report.
 /// Test: `super::chain_tests::the_chain_installs_collects_and_packages`,
 /// `super::chain_tests::progress_covers_every_phase`,
+/// `crate::package::package_tests::a_missing_collector_reaches_package_toml`,
 /// `cli_end_to_end::a_registered_repository_that_never_cloned_is_named_in_the_package`.
 async fn assemble(
     work: &WorkDir,
     config: &EngagementConfig,
     gaps: &[String],
+    collector_gaps: &[String],
     destination: Option<PathBuf>,
     progress: &Progress,
 ) -> Result<ReturnPackage, AuditError> {
@@ -519,7 +551,14 @@ async fn assemble(
     // follow-up); a same-process chain still re-verifies rather than
     // special-casing itself, so one code path owns the guarantee.
     let github_access = crate::run::github_issues::resolve_github_access().await;
-    let assembled = package::from_checkpoint(work, config, gaps, &destination, &github_access);
+    let assembled = package::from_checkpoint(
+        work,
+        config,
+        gaps,
+        collector_gaps,
+        &destination,
+        &github_access,
+    );
     progress.unit_finished(
         Operation::Package,
         name.as_str(),
@@ -801,14 +840,18 @@ trusty-review = "0.15.1"
     /// after [`Phase::Preflight`] would fail with a DIFFERENT error the
     /// moment it ran (`ToolsNotInstalled` or `NothingRegistered`).
     ///
-    /// The preflight's outcome is injected via [`audit_with_preflight`]
-    /// rather than produced by a real, missing `cargo-audit` — this crate's
-    /// tests run with `--test-threads` greater than 1, and faking the
-    /// process-global `PATH`/`HOME` env vars `crate::collectors::check`
-    /// actually reads would corrupt every OTHER test running concurrently
-    /// that also resolves a binary (`crate::run::pins`, `crate::git`, …).
+    /// The preflight's inputs are injected via [`audit_with_preflight`] rather
+    /// than produced by a real, missing `cargo-audit` — this crate's tests run
+    /// with `--test-threads` greater than 1, and faking the process-global
+    /// `PATH`/`HOME` env vars `crate::collectors::missing` actually reads
+    /// would corrupt every OTHER test running concurrently that also resolves
+    /// a binary (`crate::run::pins`, `crate::git`, …).
     /// `crate::collectors::collectors_tests` proves the real resolution path
     /// against a sandboxed env instead, in isolation.
+    fn cargo_audit_missing() -> crate::collectors::OptionalCollector {
+        crate::collectors::ALL[1]
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn strict_collectors_refuses_before_any_repo_is_cloned() {
@@ -818,8 +861,9 @@ trusty-review = "0.15.1"
             strict_collectors: true,
             ..ChainOptions::default()
         };
+        let missing = vec![cargo_audit_missing()];
         let collector_check = Err(AuditError::MissingOptionalCollectors {
-            missing: vec!["cargo-audit"],
+            missing: missing.clone(),
         });
 
         let err = audit_with_preflight(
@@ -828,6 +872,7 @@ trusty-review = "0.15.1"
             &options,
             true,
             &Progress::none(),
+            &missing,
             collector_check,
         )
         .await
@@ -857,26 +902,34 @@ trusty-review = "0.15.1"
     }
 
     /// #7134's default: a missing optional collector warns and the sweep still
-    /// runs to a package, and the warning does not change the exit status. See
+    /// runs to a package, and the warning does not change the exit status.
+    ///
+    /// Fix-round item 1: also proves the warning reaches the [`Progress`] sink
+    /// — as `Operation::Preflight` — BEFORE the sweep's own operation starts,
+    /// which is causally downstream of Phase 2 (`materialize`, where
+    /// [`crate::clone::clone_all`] runs) in [`audit_with_preflight`]'s order.
+    /// So an index for the `Preflight` update earlier than the `Sweep`
+    /// operation's start proves the gap reached the operator before cloning,
+    /// not only in the report this function returns. See
     /// `strict_collectors_refuses_before_any_repo_is_cloned` for why the
-    /// preflight's outcome is injected rather than produced by a real, missing
-    /// binary.
+    /// preflight's inputs are injected rather than produced by a real,
+    /// missing binary.
     #[cfg(unix)]
     #[tokio::test]
     async fn a_missing_collector_warns_and_the_sweep_still_proceeds() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let work = prepared(tmp.path(), &["acme-api"], &["acme-api"]);
-        let warning_row = "cve-scan: `cargo-audit` is not installed, so known dependency CVEs \
-                            will go unassessed for every repository in this sweep (install it \
-                            with `cargo install cargo-audit`)"
-            .to_owned();
+        let missing = vec![cargo_audit_missing()];
+        let warning_row = crate::collectors::warning_row(&missing[0]);
+        let (recorder, progress) = Recorder::new();
 
         let report = audit_with_preflight(
             &work,
             &config(),
             &ChainOptions::default(),
             true,
-            &Progress::none(),
+            &progress,
+            &missing,
             Ok(vec![warning_row.clone()]),
         )
         .await
@@ -889,10 +942,42 @@ trusty-review = "0.15.1"
             report.run
         );
         assert!(report.package.path.is_file(), "the sweep still packages");
-        assert_eq!(report.collector_gaps, vec![warning_row]);
+        assert_eq!(report.collector_gaps, vec![warning_row.clone()]);
         // The warning is informational: it must not change the exit status.
         assert!(report.gaps.is_empty(), "{:?}", report.gaps);
         assert_eq!(Outcome::Audit(report).exit_code(), 0);
+
+        let updates = recorder.updates();
+        let preflight_index = updates
+            .iter()
+            .position(|u| {
+                matches!(
+                    u,
+                    ProgressUpdate::UnitFinished {
+                        operation: Operation::Preflight,
+                        outcome: UnitOutcome::Skipped(reason),
+                        ..
+                    } if *reason == warning_row
+                )
+            })
+            .expect("the collector gap reached the progress sink");
+        let sweep_started_index = updates
+            .iter()
+            .position(|u| {
+                matches!(
+                    u,
+                    ProgressUpdate::OperationStarted {
+                        operation: Operation::Sweep,
+                        ..
+                    }
+                )
+            })
+            .expect("the sweep operation starts");
+        assert!(
+            preflight_index < sweep_started_index,
+            "the collector gap must reach the sink before the sweep — and therefore before \
+             materialize/clone_all, which run earlier still — starts: {updates:?}"
+        );
     }
 
     /// #5824 requirement 4: the operator who cloned by hand before the registry

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -194,6 +194,17 @@ pub enum Verb {
         /// Where to write the return package (default: <work-dir>/audit-return-package.zip).
         #[arg(long, value_name = "FILE")]
         out: Option<PathBuf>,
+        /// Refuse before cloning anything if an OPTIONAL collector binary —
+        /// `gitleaks`, `cargo-audit`, `cargo-deny` — is not installed.
+        ///
+        /// The default is to warn and run anyway: each of those collectors
+        /// already fails open per repository, naming itself in that
+        /// repository's own `[report].gaps` line, so an hours-long sweep is
+        /// not lost over one dark evidence dimension. Reach for this flag
+        /// when the missing coverage is not acceptable for this engagement —
+        /// it stops before the first repository is cloned, not after.
+        #[arg(long)]
+        strict_collectors: bool,
     },
     /// Assemble the unencrypted deliverable zip to send back.
     Package {
@@ -403,9 +414,14 @@ impl Cli {
             // #5824: the same two knobs the phases it chains already take, and
             // no third one — anything else the chain needs it reads from the
             // registry, which is where the operator put it.
-            Some(Verb::Audit { fresh, out }) => Command::Audit(ChainOptions {
+            Some(Verb::Audit {
+                fresh,
+                out,
+                strict_collectors,
+            }) => Command::Audit(ChainOptions {
                 fresh: *fresh,
                 destination: out.clone(),
+                strict_collectors: *strict_collectors,
             }),
             // #5825: the inbound package. A separate variant from `Package`
             // because the two travel opposite ways — see `crate::distribute`.
@@ -605,8 +621,26 @@ mod cli_tests {
             Command::Audit(ChainOptions {
                 fresh: true,
                 destination: Some(PathBuf::from("/tmp/p.zip")),
+                strict_collectors: false,
             })
         );
+    }
+
+    /// #7134: `--strict-collectors` is opt-in — absent, it stays `false`.
+    #[test]
+    fn strict_collectors_is_opt_in() {
+        let plain = Cli::try_parse_from(["taudit", "audit"]).expect("audit parses");
+        let Command::Audit(options) = plain.to_command() else {
+            panic!("expected Command::Audit");
+        };
+        assert!(!options.strict_collectors);
+
+        let strict =
+            Cli::try_parse_from(["taudit", "audit", "--strict-collectors"]).expect("flag parses");
+        let Command::Audit(options) = strict.to_command() else {
+            panic!("expected Command::Audit");
+        };
+        assert!(options.strict_collectors);
     }
 
     /// #6080: the recipient reads two things off this — the files to open, and
@@ -1431,6 +1465,14 @@ mod cli_tests {
                 signature: crate::package::SignatureOutcome::Unsigned,
             },
             gaps: vec!["jira:ACME was not audited".to_owned()],
+            // #7134: rendered separately from `gaps` above — see
+            // `crate::chain::ChainReport::collector_gaps`.
+            collector_gaps: vec![
+                "cve-scan: `cargo-audit` is not installed, so known dependency CVEs will go \
+                 unassessed for every repository in this sweep (install it with `cargo install \
+                 cargo-audit`)"
+                    .to_owned(),
+            ],
         };
 
         let text = render(&Outcome::Audit(report));
@@ -1441,6 +1483,10 @@ mod cli_tests {
         );
         assert!(text.contains("ok      acme-api"), "{text}");
         assert!(text.contains("Not audited: jira:ACME"), "{text}");
+        assert!(
+            text.contains("Collector gap: cve-scan: `cargo-audit` is not installed"),
+            "{text}"
+        );
         assert!(text.contains("Send this file back"), "{text}");
     }
 

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -432,6 +432,16 @@ fn render_install_package(package: &InstallPackage) -> String {
 /// Test: `super::cli_tests::a_chained_run_names_every_phase`.
 fn render_chain(report: &ChainReport) -> String {
     let mut out = String::new();
+    // #7134: printed first — an operator decides whether the missing coverage
+    // matters for this engagement before reading anything the sweep produced.
+    // Informational only: it does not appear in `report.gaps` and does not
+    // change the exit status.
+    for gap in &report.collector_gaps {
+        out.push_str(&format!("Collector gap: {gap}\n"));
+    }
+    if !report.collector_gaps.is_empty() {
+        out.push('\n');
+    }
     if let Some(placed) = &report.installed {
         out.push_str(&format!(
             "Installed {}: {}\n\n",

--- a/crates/trusty-audit/src/collectors.rs
+++ b/crates/trusty-audit/src/collectors.rs
@@ -13,11 +13,13 @@
 //! through [`trusty_common::bin_resolve::resolve_binary`] — the same
 //! resolver each collector already calls at collection time (see each
 //! module's `BINARY` constant), so this reports exactly what will go dark,
-//! never a second opinion on where a binary lives — and [`check`], which
-//! turns that list into a warning by default (the sweep still runs; each
-//! repository's own `[report].gaps` line is unchanged) or a refusal under
-//! `--strict-collectors`, run in [`crate::chain::Phase::Preflight`] before
-//! [`crate::clone::clone_all`] clones anything.
+//! never a second opinion on where a binary lives — and [`decide`], the pure
+//! warn-or-refuse judgement [`crate::chain::Phase::Preflight`] applies to
+//! that list. `check` composes both for a caller that wants one call.
+//! [`crate::chain::audit`] is the one production caller; it also reports each
+//! missing collector through [`crate::progress::Progress`] as
+//! `Operation::Preflight` before Phase 2 clones anything — see
+//! `crate::chain::audit_with_preflight`.
 //!
 //! Test: `collectors_tests`.
 
@@ -29,7 +31,11 @@ use crate::grounding::{cve, license, secrets};
 /// One optional collector a sweep can run, and what goes dark without it.
 ///
 /// Why: a shared row shape rather than three ad hoc checks, so a fourth
-/// fail-open collector is one entry in [`ALL`] and nothing else changes.
+/// fail-open collector is one entry in [`ALL`] and nothing else changes. It
+/// also carries the same three facts (collector, dimension, install hint)
+/// into BOTH the warn-and-continue row and the `--strict-collectors` refusal
+/// (`AuditError::MissingOptionalCollectors`) — one struct, so the two cannot
+/// drift apart the way a bare binary name once did (#7134 review).
 /// What: the collector's report name, the binary it resolves on `PATH`, the
 /// evidence dimension that is not covered without it, and how to install it.
 /// Test: `collectors_tests::all_names_every_fail_open_collector`.
@@ -82,7 +88,8 @@ pub const ALL: [OptionalCollector; 3] = [
 /// that lookup rather than adding a second one, so a preflight pass and a
 /// mid-sweep pass can never disagree about what is installed.
 /// Test: `collectors_tests::missing_finds_a_binary_absent_from_a_fake_resolver`,
-/// `collectors_tests::missing_is_empty_when_every_binary_resolves`.
+/// `collectors_tests::missing_is_empty_when_every_binary_resolves`,
+/// `collectors_tests::missing_and_check_go_through_the_real_resolve_binary`.
 pub fn missing() -> Vec<OptionalCollector> {
     missing_resolved_by(trusty_common::bin_resolve::resolve_binary)
 }
@@ -91,13 +98,20 @@ pub fn missing() -> Vec<OptionalCollector> {
 ///
 /// Why: split out purely for testability, the same reason
 /// [`trusty_common::bin_resolve`] itself parameterizes its fallback
-/// directory list — a test that mutated the real, process-global `PATH`/
+/// directory list — a test that REPLACED the real, process-global `PATH`/
 /// `HOME` to prove "missing" would race every OTHER test in this binary that
 /// also resolves a binary (`crate::run::pins`, `crate::git`, …), since
 /// `#[serial_test::serial]` only orders tests against EACH OTHER, never
-/// against a plain `#[test]` that never opted in. Production has exactly one
-/// caller ([`missing`], passing the real resolver); tests pass a closure over
-/// a fixed set of names instead, so nothing here ever touches real env.
+/// against a plain `#[test]` that never opted in — confirmed the hard way:
+/// an earlier version of this module's tests did exactly that and
+/// intermittently broke `clone::clone_tests::two_paths_with_one_basename_are_refused_together`
+/// with `"git is on PATH for this suite" … NotFound`. Production has exactly
+/// one caller ([`missing`], passing the real resolver); most tests pass a
+/// closure over a fixed set of names instead, so nothing here touches real
+/// env — the one exception,
+/// `collectors_tests::missing_and_check_go_through_the_real_resolve_binary`,
+/// only PREPENDS to the live `PATH` and never removes an entry, so it cannot
+/// hide a binary a concurrent test needs.
 fn missing_resolved_by(resolve: impl Fn(&str) -> Option<PathBuf>) -> Vec<OptionalCollector> {
     ALL.into_iter()
         .filter(|c| resolve(c.binary).is_none())
@@ -106,7 +120,12 @@ fn missing_resolved_by(resolve: impl Fn(&str) -> Option<PathBuf>) -> Vec<Optiona
 
 /// One warning row for a missing collector: what it is, what goes dark, and
 /// how to fix it.
-fn warning_row(c: &OptionalCollector) -> String {
+///
+/// `pub(crate)`: also the exact text [`crate::chain::audit`] narrates through
+/// `Operation::Preflight` for each missing collector, so the row a warning
+/// prints and the row in [`crate::chain::ChainReport::collector_gaps`] can
+/// never disagree.
+pub(crate) fn warning_row(c: &OptionalCollector) -> String {
     format!(
         "{}: `{}` is not installed, so {} will go unassessed for every repository in this \
          sweep (install it with `{}`)",
@@ -114,44 +133,50 @@ fn warning_row(c: &OptionalCollector) -> String {
     )
 }
 
-/// The preflight itself: warn-and-continue by default, refuse under
-/// `--strict-collectors`.
+/// The warn-or-refuse judgement over an already-resolved `missing` list.
+///
+/// Why: pure and resolver-free, unlike [`missing`] — split out so
+/// [`crate::chain::audit_with_preflight`] can take the missing list as a
+/// parameter (for progress reporting) and reuse this one decision rather than
+/// re-deriving it, and so a test can drive every branch (empty, some missing,
+/// strict) with a literal list and no PATH/env involved at all.
 ///
 /// # Postconditions
-/// On `Ok`, one warning row per missing collector (empty when every optional
-/// collector is present), and the caller is free to proceed — this never
-/// blocks by itself. `strict` is the only thing that turns a non-empty
-/// [`missing`] into a refusal.
-///
-/// What: calls [`missing`] once and either returns its rows as warnings or,
-/// when `strict` is set and the list is non-empty, refuses.
-/// Test: `collectors_tests::default_warns_and_returns_rows_for_every_gap`,
-/// `collectors_tests::strict_refuses_on_a_missing_collector`,
-/// `collectors_tests::all_present_produces_no_rows_either_way`.
+/// On `Ok`, one warning row per entry in `missing` (empty when `missing` is
+/// empty), and the caller is free to proceed — this never blocks by itself.
+/// `strict` is the only thing that turns a non-empty `missing` into a
+/// refusal.
+/// Test: `collectors_tests::decide_warns_and_returns_rows_for_every_gap`,
+/// `collectors_tests::decide_strict_refuses_on_a_missing_collector`,
+/// `collectors_tests::decide_on_an_empty_list_produces_no_rows_either_way`.
 ///
 /// # Errors
-/// [`AuditError::MissingOptionalCollectors`] when `strict` is true and at
-/// least one optional collector's binary is missing.
-pub fn check(strict: bool) -> Result<Vec<String>, AuditError> {
-    check_resolved_by(strict, trusty_common::bin_resolve::resolve_binary)
-}
-
-/// [`check`] with the resolver supplied by the caller — see
-/// [`missing_resolved_by`] for why this seam exists.
-fn check_resolved_by(
-    strict: bool,
-    resolve: impl Fn(&str) -> Option<PathBuf>,
-) -> Result<Vec<String>, AuditError> {
-    let missing = missing_resolved_by(resolve);
+/// [`AuditError::MissingOptionalCollectors`] when `strict` is true and
+/// `missing` is non-empty.
+pub fn decide(strict: bool, missing: &[OptionalCollector]) -> Result<Vec<String>, AuditError> {
     if missing.is_empty() {
         return Ok(Vec::new());
     }
     if strict {
         return Err(AuditError::MissingOptionalCollectors {
-            missing: missing.iter().map(|c| c.binary).collect(),
+            missing: missing.to_vec(),
         });
     }
     Ok(missing.iter().map(warning_row).collect())
+}
+
+/// [`missing`] then [`decide`] — the preflight in one call, for a caller with
+/// no progress sink to report through.
+///
+/// [`crate::chain::audit`] does not use this: it needs the missing list
+/// itself (to narrate each gap through `Operation::Preflight` before it
+/// decides), so it calls [`missing`] and [`decide`] separately.
+/// Test: `collectors_tests::check_composes_missing_and_decide`.
+///
+/// # Errors
+/// See [`decide`].
+pub fn check(strict: bool) -> Result<Vec<String>, AuditError> {
+    decide(strict, &missing())
 }
 
 #[cfg(test)]
@@ -164,6 +189,18 @@ mod collectors_tests {
     /// `#[serial]` coordination with the rest of the crate's test binary.
     fn fake_resolver(present: &'static [&'static str]) -> impl Fn(&str) -> Option<PathBuf> {
         move |name| present.contains(&name).then(|| PathBuf::from(name))
+    }
+
+    /// Creates an executable file `dir/name` (`chmod +x` on Unix).
+    fn touch_executable(dir: &std::path::Path, name: &str) {
+        let path = dir.join(name);
+        std::fs::write(&path, "#!/bin/sh\n").expect("write fake binary");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod +x");
+        }
     }
 
     #[test]
@@ -189,9 +226,10 @@ mod collectors_tests {
     }
 
     #[test]
-    fn default_warns_and_returns_rows_for_every_gap() {
-        let rows =
-            check_resolved_by(false, fake_resolver(&["gitleaks"])).expect("warns, does not refuse");
+    fn decide_warns_and_returns_rows_for_every_gap() {
+        let missing = missing_resolved_by(fake_resolver(&["gitleaks"]));
+
+        let rows = decide(false, &missing).expect("warns, does not refuse");
 
         assert_eq!(rows.len(), 2);
         let cargo_audit_row = rows
@@ -204,30 +242,94 @@ mod collectors_tests {
     }
 
     #[test]
-    fn strict_refuses_on_a_missing_collector() {
-        let err = check_resolved_by(true, fake_resolver(&["gitleaks", "cargo-deny"]))
-            .expect_err("strict refuses");
+    fn decide_strict_refuses_on_a_missing_collector() {
+        let missing = missing_resolved_by(fake_resolver(&["gitleaks", "cargo-deny"]));
+
+        let err = decide(true, &missing).expect_err("strict refuses");
 
         match err {
             AuditError::MissingOptionalCollectors { missing } => {
-                assert_eq!(missing, vec!["cargo-audit"]);
+                assert_eq!(missing.len(), 1);
+                assert_eq!(missing[0].binary, "cargo-audit");
+                assert_eq!(missing[0].collector, "cve-scan");
+                assert_eq!(missing[0].dimension, "known dependency CVEs");
+                assert_eq!(missing[0].install_hint, "cargo install cargo-audit");
             }
             other => panic!("expected MissingOptionalCollectors, got {other:?}"),
         }
     }
 
     #[test]
-    fn all_present_produces_no_rows_either_way() {
-        let all_present = fake_resolver(&["gitleaks", "cargo-audit", "cargo-deny"]);
-
+    fn decide_on_an_empty_list_produces_no_rows_either_way() {
         assert!(
-            check_resolved_by(false, &all_present)
+            decide(false, &[])
                 .expect("nothing to warn about")
                 .is_empty()
         );
+        assert!(decide(true, &[]).expect("nothing to refuse").is_empty());
+    }
+
+    #[test]
+    fn check_composes_missing_and_decide() {
+        // `check` calls the REAL `missing()`, so this only proves the
+        // composition compiles and returns `Ok` either way — which of the
+        // three real collectors are installed on the machine running this
+        // test is not something this suite controls or asserts on; see
+        // `missing_and_check_go_through_the_real_resolve_binary` below for
+        // the real-resolver proof, and `decide_*` above for the warn/refuse
+        // logic itself.
+        assert!(check(false).is_ok());
+    }
+
+    /// #7134 fix-round item 4: at least one test must exercise the REAL
+    /// `trusty_common::bin_resolve::resolve_binary` — not only the
+    /// resolver-injected seam above — so a change to that resolver's own
+    /// search order is caught here too.
+    ///
+    /// Why this is safe against the race documented on
+    /// [`missing_resolved_by`]: `resolve_binary` checks the live `PATH`
+    /// FIRST, so this PREPENDS a directory holding stand-ins for all three
+    /// collectors to whatever `PATH` already is, restores it exactly
+    /// afterward, and never REMOVES an entry — a concurrent test resolving
+    /// `git`/`gh`/anything else still finds it via the untouched remainder of
+    /// `PATH`. `#[serial_test::serial]` guards only the read-modify-write of
+    /// the env var itself, not against a real change in outcome.
+    #[test]
+    #[serial_test::serial]
+    fn missing_and_check_go_through_the_real_resolve_binary() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for c in ALL {
+            touch_executable(dir.path(), c.binary);
+        }
+        let previous = std::env::var_os("PATH");
+        let mut dirs = vec![dir.path().to_path_buf()];
+        if let Some(p) = &previous {
+            dirs.extend(std::env::split_paths(p));
+        }
+        let prepended = std::env::join_paths(dirs).expect("join_paths");
+        // SAFETY (test-only): restored immediately below. `#[serial_test::serial]`
+        // rules out a concurrent read/write of `PATH` in this binary; the change
+        // itself is additive, so even an interleaving cannot hide a binary
+        // another test needs — see the doc comment above.
+        unsafe {
+            std::env::set_var("PATH", &prepended);
+        }
+        let found = missing();
+        let checked = check(false);
+        unsafe {
+            match &previous {
+                Some(p) => std::env::set_var("PATH", p),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+
         assert!(
-            check_resolved_by(true, &all_present)
-                .expect("nothing to refuse")
+            found.is_empty(),
+            "the real resolve_binary must find every stand-in on PATH: {found:?}"
+        );
+        assert!(
+            checked
+                .expect("nothing missing, so check does not refuse")
                 .is_empty()
         );
     }

--- a/crates/trusty-audit/src/collectors.rs
+++ b/crates/trusty-audit/src/collectors.rs
@@ -1,0 +1,234 @@
+//! Preflight for OPTIONAL collector binaries, before a sweep starts.
+//!
+//! Why (#7134): a 59-repository, 5h03m client engagement ran with zero
+//! secrets-scan coverage because `gitleaks` was not installed on the
+//! operator's machine. That gap was disclosed correctly — each collector
+//! fails open and names itself in a `[report].gaps` line
+//! ([`crate::grounding::secrets`], [`crate::grounding::cve`],
+//! [`crate::grounding::license`]) — but only after an hours-long sweep had
+//! already cloned and collected every repository. Nothing looked BEFORE the
+//! sweep started.
+//!
+//! What: [`missing`], which resolves every optional collector's binary
+//! through [`trusty_common::bin_resolve::resolve_binary`] — the same
+//! resolver each collector already calls at collection time (see each
+//! module's `BINARY` constant), so this reports exactly what will go dark,
+//! never a second opinion on where a binary lives — and [`check`], which
+//! turns that list into a warning by default (the sweep still runs; each
+//! repository's own `[report].gaps` line is unchanged) or a refusal under
+//! `--strict-collectors`, run in [`crate::chain::Phase::Preflight`] before
+//! [`crate::clone::clone_all`] clones anything.
+//!
+//! Test: `collectors_tests`.
+
+use std::path::PathBuf;
+
+use crate::error::AuditError;
+use crate::grounding::{cve, license, secrets};
+
+/// One optional collector a sweep can run, and what goes dark without it.
+///
+/// Why: a shared row shape rather than three ad hoc checks, so a fourth
+/// fail-open collector is one entry in [`ALL`] and nothing else changes.
+/// What: the collector's report name, the binary it resolves on `PATH`, the
+/// evidence dimension that is not covered without it, and how to install it.
+/// Test: `collectors_tests::all_names_every_fail_open_collector`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OptionalCollector {
+    /// The collector's name in a `[report].gaps` line, e.g. `secrets-scan`.
+    pub collector: &'static str,
+    /// The binary this collector resolves on `PATH`, e.g. `gitleaks`.
+    pub binary: &'static str,
+    /// The evidence dimension that goes unassessed without it, one clause.
+    pub dimension: &'static str,
+    /// How an operator installs it, e.g. `brew install gitleaks`.
+    pub install_hint: &'static str,
+}
+
+/// Every optional collector a sweep can run, in report order.
+///
+/// Why: one row per collector that resolves its binary through
+/// [`trusty_common::bin_resolve::resolve_binary`] and fails open with a
+/// named gap line when it is missing. `git`, `tga`, `trusty-search`,
+/// `trusty-analyze` and `trusty-review` are REQUIRED tools with their own
+/// fail-CLOSED preflight ([`crate::run::pins`]) and do not belong here — a
+/// missing required tool already refuses the run before this module would
+/// ever run.
+pub const ALL: [OptionalCollector; 3] = [
+    OptionalCollector {
+        collector: secrets::COLLECTOR,
+        binary: secrets::BINARY,
+        dimension: "secret leakage in the working tree",
+        install_hint: secrets::INSTALL_COMMAND,
+    },
+    OptionalCollector {
+        collector: cve::COLLECTOR,
+        binary: cve::BINARY,
+        dimension: "known dependency CVEs",
+        install_hint: cve::INSTALL_COMMAND,
+    },
+    OptionalCollector {
+        collector: license::COLLECTOR,
+        binary: license::BINARY,
+        dimension: "dependency license review",
+        install_hint: license::INSTALL_COMMAND,
+    },
+];
+
+/// Every optional collector in [`ALL`] whose binary is not on this machine.
+///
+/// What: filters [`ALL`] by [`trusty_common::bin_resolve::resolve_binary`],
+/// the exact resolver each collector calls at collection time — this reuses
+/// that lookup rather than adding a second one, so a preflight pass and a
+/// mid-sweep pass can never disagree about what is installed.
+/// Test: `collectors_tests::missing_finds_a_binary_absent_from_a_fake_resolver`,
+/// `collectors_tests::missing_is_empty_when_every_binary_resolves`.
+pub fn missing() -> Vec<OptionalCollector> {
+    missing_resolved_by(trusty_common::bin_resolve::resolve_binary)
+}
+
+/// [`missing`] with the resolver supplied by the caller.
+///
+/// Why: split out purely for testability, the same reason
+/// [`trusty_common::bin_resolve`] itself parameterizes its fallback
+/// directory list — a test that mutated the real, process-global `PATH`/
+/// `HOME` to prove "missing" would race every OTHER test in this binary that
+/// also resolves a binary (`crate::run::pins`, `crate::git`, …), since
+/// `#[serial_test::serial]` only orders tests against EACH OTHER, never
+/// against a plain `#[test]` that never opted in. Production has exactly one
+/// caller ([`missing`], passing the real resolver); tests pass a closure over
+/// a fixed set of names instead, so nothing here ever touches real env.
+fn missing_resolved_by(resolve: impl Fn(&str) -> Option<PathBuf>) -> Vec<OptionalCollector> {
+    ALL.into_iter()
+        .filter(|c| resolve(c.binary).is_none())
+        .collect()
+}
+
+/// One warning row for a missing collector: what it is, what goes dark, and
+/// how to fix it.
+fn warning_row(c: &OptionalCollector) -> String {
+    format!(
+        "{}: `{}` is not installed, so {} will go unassessed for every repository in this \
+         sweep (install it with `{}`)",
+        c.collector, c.binary, c.dimension, c.install_hint
+    )
+}
+
+/// The preflight itself: warn-and-continue by default, refuse under
+/// `--strict-collectors`.
+///
+/// # Postconditions
+/// On `Ok`, one warning row per missing collector (empty when every optional
+/// collector is present), and the caller is free to proceed — this never
+/// blocks by itself. `strict` is the only thing that turns a non-empty
+/// [`missing`] into a refusal.
+///
+/// What: calls [`missing`] once and either returns its rows as warnings or,
+/// when `strict` is set and the list is non-empty, refuses.
+/// Test: `collectors_tests::default_warns_and_returns_rows_for_every_gap`,
+/// `collectors_tests::strict_refuses_on_a_missing_collector`,
+/// `collectors_tests::all_present_produces_no_rows_either_way`.
+///
+/// # Errors
+/// [`AuditError::MissingOptionalCollectors`] when `strict` is true and at
+/// least one optional collector's binary is missing.
+pub fn check(strict: bool) -> Result<Vec<String>, AuditError> {
+    check_resolved_by(strict, trusty_common::bin_resolve::resolve_binary)
+}
+
+/// [`check`] with the resolver supplied by the caller — see
+/// [`missing_resolved_by`] for why this seam exists.
+fn check_resolved_by(
+    strict: bool,
+    resolve: impl Fn(&str) -> Option<PathBuf>,
+) -> Result<Vec<String>, AuditError> {
+    let missing = missing_resolved_by(resolve);
+    if missing.is_empty() {
+        return Ok(Vec::new());
+    }
+    if strict {
+        return Err(AuditError::MissingOptionalCollectors {
+            missing: missing.iter().map(|c| c.binary).collect(),
+        });
+    }
+    Ok(missing.iter().map(warning_row).collect())
+}
+
+#[cfg(test)]
+mod collectors_tests {
+    use super::*;
+
+    /// A resolver that reports every name in `present` as found (at a stand-in
+    /// path) and everything else as missing — no process env touched at all,
+    /// so these tests are safe under any `--test-threads` and need no
+    /// `#[serial]` coordination with the rest of the crate's test binary.
+    fn fake_resolver(present: &'static [&'static str]) -> impl Fn(&str) -> Option<PathBuf> {
+        move |name| present.contains(&name).then(|| PathBuf::from(name))
+    }
+
+    #[test]
+    fn all_names_every_fail_open_collector() {
+        let binaries: Vec<&str> = ALL.iter().map(|c| c.binary).collect();
+        assert_eq!(binaries, ["gitleaks", "cargo-audit", "cargo-deny"]);
+    }
+
+    #[test]
+    fn missing_finds_a_binary_absent_from_a_fake_resolver() {
+        let missing = missing_resolved_by(fake_resolver(&["gitleaks"]));
+
+        let names: Vec<&str> = missing.iter().map(|c| c.binary).collect();
+        assert_eq!(names, ["cargo-audit", "cargo-deny"]);
+    }
+
+    #[test]
+    fn missing_is_empty_when_every_binary_resolves() {
+        let missing =
+            missing_resolved_by(fake_resolver(&["gitleaks", "cargo-audit", "cargo-deny"]));
+
+        assert!(missing.is_empty(), "expected no gaps, got {missing:?}");
+    }
+
+    #[test]
+    fn default_warns_and_returns_rows_for_every_gap() {
+        let rows =
+            check_resolved_by(false, fake_resolver(&["gitleaks"])).expect("warns, does not refuse");
+
+        assert_eq!(rows.len(), 2);
+        let cargo_audit_row = rows
+            .iter()
+            .find(|r| r.contains("cargo-audit"))
+            .expect("a row naming cargo-audit");
+        assert!(cargo_audit_row.contains("known dependency CVEs"));
+        assert!(cargo_audit_row.contains("cargo install cargo-audit"));
+        assert!(rows.iter().any(|r| r.contains("cargo-deny")));
+    }
+
+    #[test]
+    fn strict_refuses_on_a_missing_collector() {
+        let err = check_resolved_by(true, fake_resolver(&["gitleaks", "cargo-deny"]))
+            .expect_err("strict refuses");
+
+        match err {
+            AuditError::MissingOptionalCollectors { missing } => {
+                assert_eq!(missing, vec!["cargo-audit"]);
+            }
+            other => panic!("expected MissingOptionalCollectors, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_present_produces_no_rows_either_way() {
+        let all_present = fake_resolver(&["gitleaks", "cargo-audit", "cargo-deny"]);
+
+        assert!(
+            check_resolved_by(false, &all_present)
+                .expect("nothing to warn about")
+                .is_empty()
+        );
+        assert!(
+            check_resolved_by(true, &all_present)
+                .expect("nothing to refuse")
+                .is_empty()
+        );
+    }
+}

--- a/crates/trusty-audit/src/collectors.rs
+++ b/crates/trusty-audit/src/collectors.rs
@@ -21,7 +21,10 @@
 //! `Operation::Preflight` before Phase 2 clones anything — see
 //! `crate::chain::audit_with_preflight`.
 //!
-//! Test: `collectors_tests`.
+//! Test: `collectors_tests`, plus
+//! `collectors_real_resolve::missing_and_check_go_through_the_real_resolve_binary`
+//! (a separate integration test process — see [`missing_resolved_by`] for why
+//! the real-resolver proof cannot live in this file's own test module).
 
 use std::path::PathBuf;
 
@@ -89,7 +92,7 @@ pub const ALL: [OptionalCollector; 3] = [
 /// mid-sweep pass can never disagree about what is installed.
 /// Test: `collectors_tests::missing_finds_a_binary_absent_from_a_fake_resolver`,
 /// `collectors_tests::missing_is_empty_when_every_binary_resolves`,
-/// `collectors_tests::missing_and_check_go_through_the_real_resolve_binary`.
+/// `collectors_real_resolve::missing_and_check_go_through_the_real_resolve_binary`.
 pub fn missing() -> Vec<OptionalCollector> {
     missing_resolved_by(trusty_common::bin_resolve::resolve_binary)
 }
@@ -106,12 +109,15 @@ pub fn missing() -> Vec<OptionalCollector> {
 /// an earlier version of this module's tests did exactly that and
 /// intermittently broke `clone::clone_tests::two_paths_with_one_basename_are_refused_together`
 /// with `"git is on PATH for this suite" … NotFound`. Production has exactly
-/// one caller ([`missing`], passing the real resolver); most tests pass a
-/// closure over a fixed set of names instead, so nothing here touches real
-/// env — the one exception,
-/// `collectors_tests::missing_and_check_go_through_the_real_resolve_binary`,
-/// only PREPENDS to the live `PATH` and never removes an entry, so it cannot
-/// hide a binary a concurrent test needs.
+/// one caller ([`missing`], passing the real resolver); every test in THIS
+/// module (this file's `#[cfg(test)]` block, part of the crate's shared
+/// `--lib` test binary) passes a closure over a fixed set of names instead,
+/// so nothing here touches real env at all. The one test that must exercise
+/// the real resolver — `collectors_real_resolve::missing_and_check_go_through_the_real_resolve_binary`
+/// — lives in its own `tests/collectors_real_resolve.rs` integration file
+/// instead, which Cargo always builds as its own OS process; being the only
+/// `#[test]` in that process is what makes touching `PATH` there safe with no
+/// `#[serial]` needed, not merely the fact that its own change is additive.
 fn missing_resolved_by(resolve: impl Fn(&str) -> Option<PathBuf>) -> Vec<OptionalCollector> {
     ALL.into_iter()
         .filter(|c| resolve(c.binary).is_none())
@@ -191,18 +197,6 @@ mod collectors_tests {
         move |name| present.contains(&name).then(|| PathBuf::from(name))
     }
 
-    /// Creates an executable file `dir/name` (`chmod +x` on Unix).
-    fn touch_executable(dir: &std::path::Path, name: &str) {
-        let path = dir.join(name);
-        std::fs::write(&path, "#!/bin/sh\n").expect("write fake binary");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt as _;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
-                .expect("chmod +x");
-        }
-    }
-
     #[test]
     fn all_names_every_fail_open_collector() {
         let binaries: Vec<&str> = ALL.iter().map(|c| c.binary).collect();
@@ -275,62 +269,10 @@ mod collectors_tests {
         // composition compiles and returns `Ok` either way — which of the
         // three real collectors are installed on the machine running this
         // test is not something this suite controls or asserts on; see
-        // `missing_and_check_go_through_the_real_resolve_binary` below for
-        // the real-resolver proof, and `decide_*` above for the warn/refuse
-        // logic itself.
+        // `tests/collectors_real_resolve.rs` for the real-resolver proof
+        // (its own process, so it cannot race this binary's other tests —
+        // see `missing_resolved_by`'s doc comment) and `decide_*` above for
+        // the warn/refuse logic itself.
         assert!(check(false).is_ok());
-    }
-
-    /// #7134 fix-round item 4: at least one test must exercise the REAL
-    /// `trusty_common::bin_resolve::resolve_binary` — not only the
-    /// resolver-injected seam above — so a change to that resolver's own
-    /// search order is caught here too.
-    ///
-    /// Why this is safe against the race documented on
-    /// [`missing_resolved_by`]: `resolve_binary` checks the live `PATH`
-    /// FIRST, so this PREPENDS a directory holding stand-ins for all three
-    /// collectors to whatever `PATH` already is, restores it exactly
-    /// afterward, and never REMOVES an entry — a concurrent test resolving
-    /// `git`/`gh`/anything else still finds it via the untouched remainder of
-    /// `PATH`. `#[serial_test::serial]` guards only the read-modify-write of
-    /// the env var itself, not against a real change in outcome.
-    #[test]
-    #[serial_test::serial]
-    fn missing_and_check_go_through_the_real_resolve_binary() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        for c in ALL {
-            touch_executable(dir.path(), c.binary);
-        }
-        let previous = std::env::var_os("PATH");
-        let mut dirs = vec![dir.path().to_path_buf()];
-        if let Some(p) = &previous {
-            dirs.extend(std::env::split_paths(p));
-        }
-        let prepended = std::env::join_paths(dirs).expect("join_paths");
-        // SAFETY (test-only): restored immediately below. `#[serial_test::serial]`
-        // rules out a concurrent read/write of `PATH` in this binary; the change
-        // itself is additive, so even an interleaving cannot hide a binary
-        // another test needs — see the doc comment above.
-        unsafe {
-            std::env::set_var("PATH", &prepended);
-        }
-        let found = missing();
-        let checked = check(false);
-        unsafe {
-            match &previous {
-                Some(p) => std::env::set_var("PATH", p),
-                None => std::env::remove_var("PATH"),
-            }
-        }
-
-        assert!(
-            found.is_empty(),
-            "the real resolve_binary must find every stand-in on PATH: {found:?}"
-        );
-        assert!(
-            checked
-                .expect("nothing missing, so check does not refuse")
-                .is_empty()
-        );
     }
 }

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -392,21 +392,30 @@ pub enum AuditError {
     /// disclosed correctly per repository (each collector fails open and
     /// names itself in that repository's `[report].gaps`), but only after an
     /// hours-long sweep had already cloned and collected everything. By
-    /// default [`crate::collectors::check`] still warns and lets the sweep
+    /// default [`crate::collectors::decide`] still warns and lets the sweep
     /// run — this variant is only reached when the operator opted into a
     /// refusal instead, and it fires in [`crate::chain::Phase::Preflight`],
     /// before [`crate::clone::clone_all`] runs.
-    /// What: names every missing collector's binary.
-    /// Test: `crate::collectors::collectors_tests::strict_refuses_on_a_missing_collector`,
+    /// What: names every missing collector — its report name, binary,
+    /// evidence dimension and install hint — the same four facts a
+    /// warn-and-continue row carries (#7134 review: a bare binary name told
+    /// the operator WHAT was missing but not what it cost or how to fix it).
+    /// Test: `crate::collectors::collectors_tests::decide_strict_refuses_on_a_missing_collector`,
     /// `crate::chain::chain_tests::strict_collectors_refuses_before_any_repo_is_cloned`.
     #[error(
-        "--strict-collectors refused: these optional collector binaries are not installed: \
-         {}; install them, or drop --strict-collectors to warn and continue instead",
-        missing.join(", ")
+        "--strict-collectors refused: {}; drop --strict-collectors to warn and continue instead",
+        missing
+            .iter()
+            .map(|c| format!(
+                "{} needs `{}` for {} (install with `{}`)",
+                c.collector, c.binary, c.dimension, c.install_hint
+            ))
+            .collect::<Vec<_>>()
+            .join("; ")
     )]
     MissingOptionalCollectors {
-        /// The missing collectors' binary names, e.g. `gitleaks`.
-        missing: Vec<&'static str>,
+        /// The missing collectors, in [`crate::collectors::ALL`] order.
+        missing: Vec<crate::collectors::OptionalCollector>,
     },
 
     /// A pinned tool is present at the pinned version but cannot be executed.

--- a/crates/trusty-audit/src/error.rs
+++ b/crates/trusty-audit/src/error.rs
@@ -384,6 +384,31 @@ pub enum AuditError {
         missing: Vec<&'static str>,
     },
 
+    /// `--strict-collectors` refused because an OPTIONAL collector binary is
+    /// missing.
+    ///
+    /// Why (#7134): a 59-repository engagement ran with zero secrets-scan
+    /// coverage because `gitleaks` was not on the operator's machine —
+    /// disclosed correctly per repository (each collector fails open and
+    /// names itself in that repository's `[report].gaps`), but only after an
+    /// hours-long sweep had already cloned and collected everything. By
+    /// default [`crate::collectors::check`] still warns and lets the sweep
+    /// run — this variant is only reached when the operator opted into a
+    /// refusal instead, and it fires in [`crate::chain::Phase::Preflight`],
+    /// before [`crate::clone::clone_all`] runs.
+    /// What: names every missing collector's binary.
+    /// Test: `crate::collectors::collectors_tests::strict_refuses_on_a_missing_collector`,
+    /// `crate::chain::chain_tests::strict_collectors_refuses_before_any_repo_is_cloned`.
+    #[error(
+        "--strict-collectors refused: these optional collector binaries are not installed: \
+         {}; install them, or drop --strict-collectors to warn and continue instead",
+        missing.join(", ")
+    )]
+    MissingOptionalCollectors {
+        /// The missing collectors' binary names, e.g. `gitleaks`.
+        missing: Vec<&'static str>,
+    },
+
     /// A pinned tool is present at the pinned version but cannot be executed.
     ///
     /// Why: #6139 — the three pin conditions prove WHICH binary would run, not

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -79,6 +79,9 @@ pub mod chain;
 pub mod cli;
 pub mod clone;
 pub mod config;
+// #7134: the preflight for OPTIONAL collector binaries (gitleaks, cargo-audit,
+// cargo-deny), run before a sweep starts.
+pub mod collectors;
 // #6781: the bundle-level technical-debt roll-up — counts by tier, dimension,
 // repository, and tier x dimension, computed once per run and read by BOTH the
 // index's table and `report.json`, so the two cannot disagree.

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -367,6 +367,7 @@ pub fn from_checkpoint(
     work: &WorkDir,
     config: &EngagementConfig,
     unattempted: &[String],
+    collector_gaps: &[String],
     destination: &Path,
     github_access: &GithubAccess,
 ) -> Result<ReturnPackage, AuditError> {
@@ -399,6 +400,7 @@ pub fn from_checkpoint(
         config,
         &progress.report(),
         &excluded_extra,
+        collector_gaps,
         destination,
         github_access.raw_token(),
     )
@@ -409,6 +411,7 @@ pub fn assemble(
     config: &EngagementConfig,
     report: &RunReport,
     unattempted: &[String],
+    collector_gaps: &[String],
     destination: &Path,
     github_token: Option<&str>,
 ) -> Result<ReturnPackage, AuditError> {
@@ -463,7 +466,7 @@ pub fn assemble(
     // come out of one `IndexReport`, so they share a timestamp and a roll-up.
     let (index, debt) = render_index(work, report, &collected);
     let generated = Generated {
-        metadata: render_metadata(work, config, report, &audited, unattempted)?,
+        metadata: render_metadata(work, config, report, &audited, unattempted, collector_gaps)?,
         // #5481: the README states signed-or-not, and it is written before the
         // manifest exists — so it is told from the key, which is already known.
         readme: render_readme(config, &audited, &excluded, signing_key.is_some()),
@@ -985,7 +988,7 @@ trusty-review = "0.15.1"
         let destination = default_destination(&work);
 
         let package =
-            assemble(&work, &asking, &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &asking, &report, &[], &[], &destination, None).expect("assembles");
 
         let declared = package
             .excluded
@@ -1020,7 +1023,7 @@ trusty-review = "0.15.1"
         let destination = default_destination(&work);
 
         let package =
-            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
         assert!(package.excluded.is_empty(), "{:?}", package.excluded);
         let metadata = read_entry(&destination, METADATA_ENTRY);
         let parsed: toml::Value = metadata.parse().expect("package.toml is TOML");
@@ -1142,6 +1145,7 @@ trusty-review = "0.15.1"
             &signing_config(&key),
             &report,
             &[],
+            &[],
             &destination,
             None,
         )
@@ -1191,7 +1195,7 @@ trusty-review = "0.15.1"
         let destination = default_destination(&work);
 
         let package =
-            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         assert_eq!(package.signature, SignatureOutcome::Unsigned);
         let names = entries(&destination);
@@ -1233,6 +1237,7 @@ trusty-review = "0.15.1"
             &signing_config(&key),
             &report,
             &[],
+            &[],
             &destination,
             None,
         )
@@ -1268,7 +1273,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        let refused = assemble(&work, &broken, &report, &[], &destination, None);
+        let refused = assemble(&work, &broken, &report, &[], &[], &destination, None);
 
         assert!(
             matches!(refused, Err(AuditError::Signing { .. })),
@@ -1288,7 +1293,7 @@ trusty-review = "0.15.1"
         let destination = default_destination(&work);
 
         let package =
-            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         assert_eq!(package.path, destination);
         assert!(destination.is_file(), "the zip was not written");
@@ -1345,7 +1350,7 @@ trusty-review = "0.15.1"
         let destination = default_destination(&work);
 
         let package =
-            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         assert!(
             entries(&destination).contains(&DIGEST_ENTRY.to_owned()),
@@ -1397,7 +1402,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![degraded, broken]);
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         let rows = digest_rows(&destination);
         assert!(
@@ -1448,7 +1453,7 @@ trusty-review = "0.15.1"
             .stating(vec![format!("jira rejected the key {key}")]);
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         let text = read_entry(&destination, DIGEST_ENTRY);
         assert!(!text.contains(&key), "the key reached the digest: {text}");
@@ -1472,7 +1477,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         let mut names = entries(&destination);
         names.retain(|n| n != DIGEST_ENTRY);
@@ -1507,6 +1512,7 @@ trusty-review = "0.15.1"
             keys,
             vec![
                 "client",
+                "collector_gaps",
                 "config_not_acted_on",
                 "generated_by",
                 "instructions",
@@ -1516,7 +1522,51 @@ trusty-review = "0.15.1"
                 "repositories_excluded",
                 "tools",
             ],
-            "the manifest grew no key"
+            "the manifest grew no key beyond collector_gaps (#7134)"
+        );
+    }
+
+    /// #7134 fix-round item 3: a missing optional collector reaches the
+    /// ASSEMBLED package's `package.toml`, not only this process's own
+    /// console report — the recipient who only opens the zip must be able to
+    /// see it too.
+    #[test]
+    fn a_missing_collector_reaches_package_toml() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
+        let destination = default_destination(&work);
+        let collector_gaps = vec![
+            "cve-scan: `cargo-audit` is not installed, so known dependency CVEs will go \
+             unassessed for every repository in this sweep (install it with `cargo install \
+             cargo-audit`)"
+                .to_owned(),
+        ];
+
+        assemble(
+            &work,
+            &config(),
+            &report,
+            &[],
+            &collector_gaps,
+            &destination,
+            None,
+        )
+        .expect("assembles");
+
+        let metadata: toml::Value = read_entry(&destination, METADATA_ENTRY)
+            .parse()
+            .expect("package.toml is TOML");
+        let rows: Vec<String> = metadata["collector_gaps"]
+            .as_array()
+            .expect("collector_gaps is an array")
+            .iter()
+            .map(|v| v.as_str().expect("each row is a string").to_owned())
+            .collect();
+        assert_eq!(
+            rows, collector_gaps,
+            "the exact warning row must reach the package"
         );
     }
 
@@ -1538,7 +1588,7 @@ trusty-review = "0.15.1"
         let destination = default_destination(&work);
 
         let package =
-            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         assert!(
             entries(&destination).contains(&INDEX_ENTRY.to_owned()),
@@ -1594,7 +1644,7 @@ trusty-review = "0.15.1"
         let destination = default_destination(&work);
 
         let package =
-            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
         assert!(
             package.files.iter().any(|f| f.entry == DEBT_ENTRY),
             "the roll-up must be reported as a member: {:?}",
@@ -1638,7 +1688,7 @@ trusty-review = "0.15.1"
         install_record(&work);
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         let index = read_entry(&destination, INDEX_ENTRY);
         let members = entries(&destination);
@@ -1704,7 +1754,7 @@ trusty-review = "0.15.1"
             failed(&work, "01-acme-web", "acme-web"),
         ]);
         let destination = default_destination(&work);
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         let index = read_entry(&destination, INDEX_ENTRY);
         assert!(index.contains("Reports: 1 of 2 repositories"), "{index}");
@@ -1729,7 +1779,7 @@ trusty-review = "0.15.1"
         install_record(&work);
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         // `by_index` succeeding with no password IS the unencrypted property:
         // the zip crate returns `UnsupportedArchive` for an encrypted entry.
@@ -1768,7 +1818,7 @@ trusty-review = "0.15.1"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination, None)
+        let err = assemble(&work, &config(), &report, &[], &[], &destination, None)
             .expect_err("a package carrying the key must not be produced");
         assert!(
             matches!(err, AuditError::CredentialInPackage { .. }),
@@ -1835,6 +1885,7 @@ api_key = "lin_api_do-not-package-me"
             work,
             config,
             &report,
+            &[],
             &[],
             &default_destination(work),
             github_token,
@@ -1940,7 +1991,7 @@ api_key = "lin_api_do-not-package-me"
 
         let package_time = GithubAccess::with_token("ghp_package_time_account_B_token");
         let destination = default_destination(&work);
-        let err = from_checkpoint(&work, &config(), &[], &destination, &package_time)
+        let err = from_checkpoint(&work, &config(), &[], &[], &destination, &package_time)
             .expect_err("a mismatched GitHub credential must refuse packaging");
         assert!(
             matches!(err, AuditError::GithubCredentialChanged),
@@ -1974,7 +2025,7 @@ api_key = "lin_api_do-not-package-me"
 
         let destination = default_destination(&work);
         let same_access = GithubAccess::with_token("ghp_same_account_both_times");
-        from_checkpoint(&work, &config(), &[], &destination, &same_access)
+        from_checkpoint(&work, &config(), &[], &[], &destination, &same_access)
             .expect("a matching credential must not refuse packaging");
         assert!(destination.exists(), "the package must be written");
     }
@@ -1995,6 +2046,7 @@ api_key = "lin_api_do-not-package-me"
         let package = from_checkpoint(
             &work,
             &config(),
+            &[],
             &[],
             &destination,
             &GithubAccess::default(),
@@ -2112,7 +2164,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination, None)
+        let err = assemble(&work, &config(), &report, &[], &[], &destination, None)
             .expect_err("a symlink must not be followed into the package");
         assert!(
             matches!(err, AuditError::UnsafePackageEntry { .. }),
@@ -2137,7 +2189,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination, None)
+        let err = assemble(&work, &config(), &report, &[], &[], &destination, None)
             .expect_err("a hardlink must not carry outside content into the package");
         let AuditError::UnsafePackageEntry { kind, .. } = &err else {
             panic!("expected UnsafePackageEntry, got {err:?}");
@@ -2169,7 +2221,7 @@ api_key = "lin_api_do-not-package-me"
         .expect("hard link");
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination, None)
+        let err = assemble(&work, &config(), &report, &[], &[], &destination, None)
             .expect_err("a hardlink under extract/ must be refused too");
         let AuditError::UnsafePackageEntry { kind, .. } = &err else {
             panic!("expected UnsafePackageEntry, got {err:?}");
@@ -2205,6 +2257,7 @@ api_key = "lin_api_do-not-package-me"
             &config(),
             &report,
             &[],
+            &[],
             &default_destination(&work),
             None,
         )
@@ -2220,7 +2273,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![failed(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination, None)
+        let err = assemble(&work, &config(), &report, &[], &[], &destination, None)
             .expect_err("no audited repository means no package");
         assert!(
             matches!(err, AuditError::NothingToPackage { .. }),
@@ -2243,7 +2296,7 @@ api_key = "lin_api_do-not-package-me"
         let destination = default_destination(&work);
 
         let package =
-            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
         assert_eq!(package.excluded.len(), 1);
         assert!(
             package.excluded[0].contains("acme-web"),
@@ -2291,7 +2344,7 @@ api_key = "lin_api_do-not-package-me"
         .expect("the child left a log");
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         let log = read_entry(&destination, "failures/01-acme-web.log");
         assert!(log.contains("fatal: could not read"), "{log}");
@@ -2316,7 +2369,7 @@ api_key = "lin_api_do-not-package-me"
         ]);
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
         let record = read_entry(&destination, FAILURES_ENTRY);
         assert!(record.contains("no log survived"), "{record}");
         assert!(
@@ -2335,7 +2388,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
         assert!(
             !entries(&destination)
                 .iter()
@@ -2363,7 +2416,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api"), leaking]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination, None)
+        let err = assemble(&work, &config(), &report, &[], &[], &destination, None)
             .expect_err("a generated member carrying the key is refused");
         assert!(
             matches!(err, AuditError::CredentialInPackage { .. }),
@@ -2396,7 +2449,7 @@ api_key = "lin_api_do-not-package-me"
         let destination = tmp.path().join("Desktop/return.zip");
 
         let package =
-            assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+            assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
         assert_eq!(package.path, destination);
         assert!(destination.is_file());
         assert!(!destination.starts_with(work.root()));
@@ -2419,7 +2472,7 @@ api_key = "lin_api_do-not-package-me"
         std::fs::write(work.path(Area::Extract).join("09-other.db"), b"other").expect("write");
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
         let names = entries(&destination);
         assert!(
             names.contains(&"extract/00-acme-api.db".to_owned()),
@@ -2450,7 +2503,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination, None)
+        let err = assemble(&work, &config(), &report, &[], &[], &destination, None)
             .expect_err("a report with no database must not be packaged");
         let AuditError::MissingExtractDatabase { repo, expected } = &err else {
             panic!("expected MissingExtractDatabase, got {err:?}");
@@ -2481,7 +2534,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![run]);
         let destination = default_destination(&work);
 
-        let err = assemble(&work, &config(), &report, &[], &destination, None)
+        let err = assemble(&work, &config(), &report, &[], &[], &destination, None)
             .expect_err("a missing extract/ directory must not be packaged");
         assert!(
             matches!(err, AuditError::MissingExtractDatabase { .. }),
@@ -2570,6 +2623,7 @@ api_key = "lin_api_do-not-package-me"
             &config_with_excerpts(),
             &report,
             &[],
+            &[],
             &destination,
             None,
         )
@@ -2616,6 +2670,7 @@ api_key = "lin_api_do-not-package-me"
             &config_with_excerpts(),
             &report,
             &[],
+            &[],
             &destination,
             None,
         )
@@ -2653,6 +2708,7 @@ api_key = "lin_api_do-not-package-me"
             &work,
             &config_with_excerpts(),
             &report,
+            &[],
             &[],
             &destination,
             None,
@@ -2700,6 +2756,7 @@ api_key = "lin_api_do-not-package-me"
             &work,
             &config_with_excerpts(),
             &report,
+            &[],
             &[],
             &destination,
             None,
@@ -2763,6 +2820,7 @@ api_key = "lin_api_do-not-package-me"
             &config_with_excerpts(),
             &report,
             &[],
+            &[],
             &destination,
             None,
         )
@@ -2813,6 +2871,7 @@ api_key = "lin_api_do-not-package-me"
             &work,
             &config_with_excerpts(),
             &report,
+            &[],
             &[],
             &destination,
             None,
@@ -2879,6 +2938,7 @@ api_key = "lin_api_do-not-package-me"
             &config_with_excerpts(),
             &report,
             &[],
+            &[],
             &destination,
             None,
         )
@@ -2920,6 +2980,7 @@ api_key = "lin_api_do-not-package-me"
             &config_with_excerpts(),
             &report,
             &[],
+            &[],
             &destination,
             None,
         )
@@ -2959,6 +3020,7 @@ api_key = "lin_api_do-not-package-me"
             &work,
             &config_with_excerpts(),
             &report,
+            &[],
             &[],
             &destination,
             None,
@@ -3002,6 +3064,7 @@ api_key = "lin_api_do-not-package-me"
             &config_with_excerpts(),
             &report,
             &[],
+            &[],
             &destination,
             None,
         )
@@ -3030,7 +3093,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
 
         let off = work.root().join("off.zip");
-        assemble(&work, &config(), &report, &[], &off, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &off, None).expect("assembles");
         assert!(
             !entries(&off).contains(&EXCERPTS_ENTRY.to_owned()),
             "{:?}",
@@ -3038,7 +3101,7 @@ api_key = "lin_api_do-not-package-me"
         );
 
         let on = work.root().join("on.zip");
-        assemble(&work, &config_with_excerpts(), &report, &[], &on, None).expect("assembles");
+        assemble(&work, &config_with_excerpts(), &report, &[], &[], &on, None).expect("assembles");
         assert!(
             entries(&on).contains(&EXCERPTS_ENTRY.to_owned()),
             "{:?}",
@@ -3061,6 +3124,7 @@ api_key = "lin_api_do-not-package-me"
             &work,
             &config_with_excerpts(),
             &report,
+            &[],
             &[],
             &destination,
             None,
@@ -3110,7 +3174,7 @@ api_key = "lin_api_do-not-package-me"
         let report = RunReport::of(vec![audited(&work, "00-acme-api", "acme-api")]);
         let destination = default_destination(&work);
 
-        assemble(&work, &config(), &report, &[], &destination, None).expect("assembles");
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
 
         let readme = read_entry(&destination, README_ENTRY);
         assert!(readme.contains("No code excerpts"), "{readme}");

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -103,6 +103,14 @@ struct PackageMetadata {
     /// that requested three extra export families got output byte-identical to
     /// one that requested none, and nothing in either bundle said which.
     config_not_acted_on: Vec<String>,
+    /// #7134: one row per OPTIONAL collector binary (`gitleaks`, `cargo-audit`,
+    /// `cargo-deny`) that was missing at `Phase::Preflight`, in the same words
+    /// the console warning used — so a recipient reading the archive alone
+    /// sees exactly what this run's operator saw before the sweep started.
+    /// Always emitted, for the same reason `not_attempted` is: an empty array
+    /// is a positive claim that every optional collector ran, where an absent
+    /// key leaves the reader to interpret a silence.
+    collector_gaps: Vec<String>,
     tools: Vec<ToolVersion>,
     repositories: Vec<PackagedRepo>,
 }
@@ -342,6 +350,7 @@ pub(super) fn render_metadata(
     report: &RunReport,
     audited: &[&RepoRun],
     unattempted: &[String],
+    collector_gaps: &[String],
 ) -> Result<String, AuditError> {
     let tools = tools::read_record(work)?
         .into_iter()
@@ -372,6 +381,7 @@ pub(super) fn render_metadata(
         repositories_excluded: report.repos.len() - audited.len(),
         not_attempted: unattempted.to_vec(),
         config_not_acted_on: config.unsupported_keys(),
+        collector_gaps: collector_gaps.to_vec(),
         tools,
         repositories,
     };

--- a/crates/trusty-audit/src/progress.rs
+++ b/crates/trusty-audit/src/progress.rs
@@ -57,6 +57,9 @@ pub enum Operation {
     Distribute,
     /// Re-rendering a delivered audit's reports from what shipped with it (#6080).
     Rerender,
+    /// #7134: checking which OPTIONAL collector binaries are on this machine,
+    /// before anything is cloned — see [`crate::chain::Phase::Preflight`].
+    Preflight,
 }
 
 impl Operation {
@@ -69,6 +72,7 @@ impl Operation {
             Self::Package => "assembling the return package",
             Self::Distribute => "assembling the install package",
             Self::Rerender => "re-rendering reports",
+            Self::Preflight => "checking optional collectors",
         }
     }
 
@@ -80,6 +84,7 @@ impl Operation {
             Self::Package => "archive",
             Self::Distribute => "file",
             Self::Rerender => "report",
+            Self::Preflight => "collector",
         }
     }
 
@@ -94,6 +99,7 @@ impl Operation {
             Self::Package => "archives",
             Self::Distribute => "files",
             Self::Rerender => "reports",
+            Self::Preflight => "collectors",
         }
     }
 }

--- a/crates/trusty-audit/src/progress/terminal.rs
+++ b/crates/trusty-audit/src/progress/terminal.rs
@@ -198,6 +198,7 @@ fn verb(operation: Operation) -> &'static str {
         Operation::Sweep => "auditing",
         Operation::Package | Operation::Distribute => "packaging",
         Operation::Rerender => "re-rendering",
+        Operation::Preflight => "checking",
     }
 }
 
@@ -209,6 +210,7 @@ fn done(operation: Operation) -> &'static str {
         Operation::Sweep => "audited",
         Operation::Package | Operation::Distribute => "packaged",
         Operation::Rerender => "re-rendered",
+        Operation::Preflight => "checked",
     }
 }
 

--- a/crates/trusty-audit/src/session.rs
+++ b/crates/trusty-audit/src/session.rs
@@ -982,7 +982,7 @@ impl Session {
         let github_access = run::github_issues::resolve_github_access().await;
         // No unattempted targets: the standalone verb packages whatever the last
         // sweep recorded and knows nothing about a registry (#5824).
-        package::from_checkpoint(&self.work, &config, &[], &destination, &github_access)
+        package::from_checkpoint(&self.work, &config, &[], &[], &destination, &github_access)
     }
 
     /// Drive the whole engagement in one call (#5824).

--- a/crates/trusty-audit/tests/collectors_real_resolve.rs
+++ b/crates/trusty-audit/tests/collectors_real_resolve.rs
@@ -1,0 +1,81 @@
+//! `collectors::missing`/`check` against the REAL `resolve_binary`, in its own
+//! process.
+//!
+//! Why (#7134 fix-round item, code-critic on PR #7170 at `33f27d443`):
+//! `crate::collectors::missing_resolved_by`'s doc comment already names the
+//! hazard — mutating the real, process-global `PATH` to prove "missing" races
+//! every OTHER test in the SAME binary that also resolves a binary
+//! (`crate::run::pins`, `crate::git`, …), and `#[serial_test::serial]` only
+//! orders tests against each other, never against a plain `#[test]` that
+//! never opted in. An earlier version of this proof lived in `collectors.rs`'s
+//! own `#[cfg(test)] mod collectors_tests` — inside the crate's `--lib` test
+//! binary — and intermittently broke
+//! `clone::clone_tests::two_paths_with_one_basename_are_refused_together`
+//! with `"git is on PATH for this suite" … NotFound`. Cargo builds every file
+//! under `tests/` as its OWN process, so a file with exactly one test here has
+//! no sibling in its process to race, ever, at any `--test-threads`.
+//!
+//! What: prepends a directory holding stand-in `gitleaks`/`cargo-audit`/
+//! `cargo-deny` executables to this process's OWN live `PATH` — never
+//! replacing it, so nothing here could hide a binary another process needs —
+//! and confirms the real `trusty_common::bin_resolve::resolve_binary`, reached
+//! through the crate's public `collectors::missing`/`collectors::check`,
+//! finds every one of them. The resolver-injected seam
+//! (`collectors_tests::missing_resolved_by`-backed tests) and the pure
+//! warn/refuse judgement (`collectors_tests::decide_*`) stay in `collectors.rs`
+//! — this file's only job is proving the REAL resolver is actually wired in.
+//!
+//! Test: this is the test.
+
+use trusty_audit::collectors::{self, ALL};
+
+/// Creates an executable file `dir/name` (`chmod +x` on Unix).
+fn touch_executable(dir: &std::path::Path, name: &str) {
+    let path = dir.join(name);
+    std::fs::write(&path, "#!/bin/sh\n").expect("write fake binary");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).expect("chmod +x");
+    }
+}
+
+#[test]
+fn missing_and_check_go_through_the_real_resolve_binary() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for c in ALL {
+        touch_executable(dir.path(), c.binary);
+    }
+    let previous = std::env::var_os("PATH");
+    let mut dirs = vec![dir.path().to_path_buf()];
+    if let Some(p) = &previous {
+        dirs.extend(std::env::split_paths(p));
+    }
+    let prepended = std::env::join_paths(dirs).expect("join_paths");
+    // SAFETY (test-only, sole `#[test]` in this file's own process — see the
+    // module docs for why that makes this safe with no `#[serial]` needed):
+    // restored immediately below, and the change is additive so even a
+    // between-process interleaving (there is none here) could not hide a
+    // binary anything else needs.
+    unsafe {
+        std::env::set_var("PATH", &prepended);
+    }
+    let found = collectors::missing();
+    let checked = collectors::check(false);
+    unsafe {
+        match &previous {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+
+    assert!(
+        found.is_empty(),
+        "the real resolve_binary must find every stand-in on PATH: {found:?}"
+    );
+    assert!(
+        checked
+            .expect("nothing missing, so check does not refuse")
+            .is_empty()
+    );
+}


### PR DESCRIPTION
## Summary

Refs #7134. A 59-repository, 5h03m engagement ran with zero secrets-scan coverage because `gitleaks` was not installed — disclosed correctly per-repository (`[report].gaps`), but only after an hours-long sweep had already cloned and collected everything. Nothing looked before the sweep started.

- New `crates/trusty-audit/src/collectors.rs`: `ALL` (gitleaks/secrets-scan, cargo-audit/cve-scan, cargo-deny/license-review), `OptionalCollector`, `missing()`, `decide(strict, missing)`, and `check(strict)`. `missing()` resolves each binary through the existing `trusty_common::bin_resolve::resolve_binary` — the exact lookup each collector already calls at collection time — so no second PATH lookup exists.
- `chain::audit` runs this first, before Phase 2 clones anything, as the new `Phase::Preflight` (`chain::audit_with_preflight`). Each missing collector is narrated through the existing `Progress` sink as `Operation::Preflight` (visible on stderr before install/materialize/clone_all — not only in the final report). Default (`strict=false`): warns and continues — `ChainReport::collector_gaps` carries one row per missing collector (name, evidence dimension, install hint), rendered first in the CLI's chain output and threaded into the assembled package's `package.toml` (`collector_gaps`), and does **not** change `Outcome::exit_code` — it's informational, distinct from `ChainReport::gaps`. Each repository's own `[report].gaps` line is unaffected either way.
- `--strict-collectors` (new flag on `taudit audit`) refuses with `AuditError::MissingOptionalCollectors` (carrying the same collector/dimension/install-hint detail as the warning rows), attributed to `Phase::Preflight`, before install or materialize ever run.

## Test plan

Rung 3 (localized behavior inside `trusty-audit`), `CARGO_TARGET_DIR` pointed at a worktree-local target dir:

- `cargo fmt --check -p trusty-audit` — clean
- `cargo check -p trusty-audit --all-targets` — clean
- `cargo clippy -p trusty-audit --all-targets -- -D warnings` — clean
- `cargo test -p trusty-audit --no-fail-fast -- --test-threads=4` — `test result: ok. 1057 passed; 0 failed; 5 ignored` (`--lib`) plus `1 passed` in the new integration target, including:
  - `collectors::collectors_tests::{all_names_every_fail_open_collector, missing_finds_a_binary_absent_from_a_fake_resolver, missing_is_empty_when_every_binary_resolves, decide_warns_and_returns_rows_for_every_gap, decide_strict_refuses_on_a_missing_collector, decide_on_an_empty_list_produces_no_rows_either_way, check_composes_missing_and_decide}` — pure, resolver-injected (a closure over a fixed present-binary set) or literal-list tests, never process `PATH`/`HOME`.
  - `crates/trusty-audit/tests/collectors_real_resolve.rs::missing_and_check_go_through_the_real_resolve_binary` — a SEPARATE integration-test process (Cargo always builds a `tests/*.rs` file as its own binary) exercising the real `trusty_common::bin_resolve::resolve_binary`, by prepending a stand-in-binary directory to that process's own live `PATH` and never removing an entry. Moved out of `collectors.rs`'s own `#[cfg(test)]` module in round 2 (code-critic WARN at `33f27d443`): `#[serial_test::serial]` there only ordered serial-tagged tests against each other, so a concurrent non-serial test resolving a binary (`clone::clone_tests::two_paths_with_one_basename_are_refused_together`, which spawns `git`) could still race it under `--test-threads=4` — a different OS process removes that race entirely, at any `--test-threads`.
  - `chain::chain_tests::{strict_collectors_refuses_before_any_repo_is_cloned, a_missing_collector_warns_and_the_sweep_still_proceeds}` — via an `audit_with_preflight` seam that takes the preflight's missing list and decision as parameters (production's one caller, `audit`, always passes the real `collectors::missing`/`collectors::decide` results), so these prove the ordering and reporting deterministically without touching real env. `a_missing_collector_warns_and_the_sweep_still_proceeds` uses a `Recorder` progress sink and asserts the `Operation::Preflight` update's position precedes the `Sweep` operation's start (causally downstream of `clone_all`). The refusal test asserts nothing was installed and no selection was written, proving `Phase::Preflight` stopped the chain before `InstallTools`/`Materialize`.
  - `package::package_tests::a_missing_collector_reaches_package_toml` — a missing collector's row reaches the assembled package's `package.toml`, not only this process's console report.
  - `cli::cli_tests::strict_collectors_is_opt_in`, and `a_chained_run_names_every_phase` extended to assert `Collector gap: …` renders.
- `./scripts/check_line_cap.sh` — 0 violations.
- `./scripts/check_test_pointers.sh` — 0 dangling pointers.
- `./scripts/check_changelog_fragment.sh` — OK, fragment recorded for `trusty-audit`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01ER5DBvGQ54K5sgFLb9G5vz
