### PR TITLE
fix(trusty-mpm): managed launches also disable Claude Code mouse capture

### DIFF
--- a/crates/trusty-mpm/changelog.d/7160-disable-mouse-capture.md
+++ b/crates/trusty-mpm/changelog.d/7160-disable-mouse-capture.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Every tm-managed Claude Code launch (`tm launch`, `tm connect`, `tm run`, in-place resume/relaunch) now also provisions `CLAUDE_CODE_DISABLE_MOUSE=1` alongside `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1`, so tmux's per-pane `mouse_any_flag` no longer captures the wheel under the classic renderer. Yields to an operator-exported value, decided independently per variable (#7160).

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -659,16 +659,19 @@ pub(crate) async fn run_inplace_relaunch(
 /// The scrub runs BEFORE the deliberate assignments below so it can never
 /// clobber `CLAUDE_CONFIG_DIR` (#4455) even if the marker list grew wrongly.
 ///
-/// Issue #6495: the same reasoning applies to the classic-renderer default —
-/// the `env NAME=VALUE` operand the tmux-pane paths carry cannot reach an exec,
-/// so [`trusty_mpm::core::alt_screen::apply_default_to_command`] sets it here.
-/// It runs last and sets nothing when this pane already exports a value.
+/// Issues #6495/#7160: the same reasoning applies to the classic-renderer and
+/// mouse-capture defaults — the `env NAME=VALUE` operands the tmux-pane paths
+/// carry cannot reach an exec, so
+/// [`trusty_mpm::core::alt_screen::apply_default_to_command`] sets both here.
+/// It runs last and, for each variable independently, sets nothing when this
+/// pane already exports a value.
 /// Test: `inplace_exec_command_forwards_every_arg_in_order`,
 /// `inplace_exec_command_scrubs_api_key_and_sets_auth_env`,
 /// `inplace_exec_command_scrubs_inherited_session_markers`,
 /// `inplace_exec_command_carries_a_non_empty_mcp_env`,
 /// `inplace_exec_command_carries_isolation_flags_and_persona_end_to_end`,
-/// `inplace_exec_command_defaults_the_alternate_screen_off`.
+/// `inplace_exec_command_defaults_the_alternate_screen_off`,
+/// `inplace_exec_command_defaults_the_mouse_capture_off`.
 pub(crate) fn build_inplace_exec_command(
     resume: &trusty_mpm::runtime::InPlaceResumeCommand,
     cwd: &std::path::Path,

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -928,6 +928,26 @@ fn inplace_exec_command_defaults_the_alternate_screen_off() {
     );
 }
 
+/// #7160: the mouse-capture counterpart of
+/// `inplace_exec_command_defaults_the_alternate_screen_off`.
+#[test]
+fn inplace_exec_command_defaults_the_mouse_capture_off() {
+    use trusty_mpm::core::alt_screen::{MOUSE_DEFAULT, MOUSE_ENV_VAR};
+
+    let resume = synthetic_resume(&["--dangerously-skip-permissions"]);
+    let cmd = build_inplace_exec_command(&resume, std::path::Path::new("/fake/cwd"));
+
+    let carried_by_the_launch = std::env::var_os(MOUSE_ENV_VAR).is_some();
+    let provisioned = cmd.get_envs().any(|(k, v)| {
+        k == MOUSE_ENV_VAR && v.is_some_and(|v| v == std::ffi::OsStr::new(MOUSE_DEFAULT))
+    });
+    assert_eq!(
+        provisioned, !carried_by_the_launch,
+        "tm must provision {MOUSE_ENV_VAR}={MOUSE_DEFAULT} when the launch \
+         carries no value, and leave an operator value untouched when it does"
+    );
+}
+
 #[serial_test::serial]
 #[test]
 fn inplace_exec_command_carries_isolation_flags_and_persona_end_to_end() {

--- a/crates/trusty-mpm/src/core/alt_screen.rs
+++ b/crates/trusty-mpm/src/core/alt_screen.rs
@@ -1,45 +1,66 @@
-//! Start every tm-managed Claude Code session on the classic renderer (issue
-//! #6495).
+//! Start every tm-managed Claude Code session on the classic renderer, with
+//! its mouse capture off (issues #6495, #7160).
 //!
 //! Why: Claude Code's fullscreen renderer takes the alternate screen and
 //! captures the mouse wheel, so a managed pane scrolls only the one live window
 //! — the terminal's native scrollback and tmux's copy-mode history both stop
 //! responding, which operators report as "everything is one window that will not
 //! scroll". Claude Code names the escape hatch in its own failure text:
-//! `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 forces that any time`. Setting it by
-//! hand in `~/.claude/settings.json` fixes the session; tm now provisions it so
-//! nobody has to find it.
+//! `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 forces that any time`. #7160 found
+//! the fix incomplete: even under the classic renderer, Claude Code still sets
+//! tmux's per-pane `mouse_any_flag` via its own escape sequence, so the wheel
+//! still reaches the app instead of tmux copy-mode — `CLAUDE_CODE_DISABLE_MOUSE`
+//! is the documented opt-out for that half. Setting either by hand in
+//! `~/.claude/settings.json` fixes a session; tm now provisions both so nobody
+//! has to find them.
 //!
-//! What: one variable name, one default value, and the two carriers the launch
-//! paths need — a shell `NAME=VALUE` operand for the builders that emit an
-//! `env …` prefix string, and a [`std::process::Command`] mutation for the
-//! builders that exec `claude` directly. Both carriers YIELD to a value the
-//! launch already carries; neither forces one.
+//! What: [`MANAGED_DEFAULTS`] is the one table — variable name, default value,
+//! and pinned shell operand — that drives every carrier below, so a third
+//! variable is a one-line addition to the table rather than a change repeated
+//! at each launch site:
+//!   * [`managed_shell_assignments`] composes the `env NAME="${NAME-default}"`
+//!     operands, space-joined in table order, for the builders that emit an
+//!     `env …` prefix string.
+//!   * [`apply_default_to_command`] (and its hermetic core,
+//!     [`apply_default_when_unset`]) mutates a [`std::process::Command`] for the
+//!     builders that exec `claude` directly, applying each table entry
+//!     independently.
+//!
+//! Both carriers YIELD to a value the launch already carries; neither forces
+//! one, and each variable is decided independently — an operator who exported
+//! only one of the two still gets the tm default for the other.
 //!
 //! Operator precedence, and where it comes from:
-//!   * launch environment — the shell operand expands `${NAME-1}`, so the pane
-//!     shell substitutes the default only when the variable is UNSET. A value
-//!     the pane already exports reaches `claude` unchanged, including an empty
-//!     one (`-`, not `:-`). [`apply_default_when_unset`] makes the same decision
-//!     in Rust for the exec paths, reading the environment the child would
-//!     otherwise inherit.
+//!   * launch environment — the shell operand expands `${NAME-default}`, so the
+//!     pane shell substitutes the default only when the variable is UNSET. A
+//!     value the pane already exports reaches `claude` unchanged, including an
+//!     empty one (`-`, not `:-`). [`apply_default_when_unset`] makes the same
+//!     decision in Rust for the exec paths, reading the environment the child
+//!     would otherwise inherit.
 //!   * settings `env` block — Claude Code applies an allowlisted settings `env`
-//!     entry ON TOP of the process environment, and this variable is on that
+//!     entry ON TOP of the process environment, and both variables are on that
 //!     allowlist, so an operator entry in any settings tier already outranks
-//!     whatever tm exports. tm writes this variable into no settings file, so
-//!     there is nothing here for an operator entry to fight.
+//!     whatever tm exports. tm writes neither variable into any settings file,
+//!     so there is nothing here for an operator entry to fight.
 //!
 //! Switching renderers from inside a session still works: Claude Code's own
-//! switch re-execs with this variable dropped.
+//! switch re-execs with these variables dropped.
 //!
-//! Test: this module's `tests`, plus one per launch path —
-//! `spawn_command_defaults_the_alternate_screen_off`,
-//! `resume_command_defaults_the_alternate_screen_off`,
-//! `claude_command_defaults_the_alternate_screen_off`,
-//! `inplace_session_command_defaults_the_alternate_screen_off`,
-//! `client_session_command_defaults_the_alternate_screen_off`,
-//! `test_build_launch_command_defaults_the_alternate_screen_off`,
-//! `inplace_exec_command_defaults_the_alternate_screen_off`.
+//! Test: this module's `tests`, plus one per launch path for each variable —
+//! `spawn_command_defaults_the_alternate_screen_off` /
+//! `spawn_command_defaults_the_mouse_capture_off`,
+//! `resume_command_defaults_the_alternate_screen_off` /
+//! `resume_command_defaults_the_mouse_capture_off`,
+//! `claude_command_defaults_the_alternate_screen_off` /
+//! `claude_command_defaults_the_mouse_capture_off`,
+//! `inplace_session_command_defaults_the_alternate_screen_off` /
+//! `inplace_session_command_defaults_the_mouse_capture_off`,
+//! `client_session_command_defaults_the_alternate_screen_off` /
+//! `client_session_command_defaults_the_mouse_capture_off`,
+//! `test_build_launch_command_defaults_the_alternate_screen_off` /
+//! `test_build_launch_command_defaults_the_mouse_capture_off`,
+//! `inplace_exec_command_defaults_the_alternate_screen_off` /
+//! `inplace_exec_command_defaults_the_mouse_capture_off`.
 
 /// The Claude Code variable that selects the classic (non-fullscreen) renderer.
 pub const ALT_SCREEN_ENV_VAR: &str = "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN";
@@ -67,12 +88,96 @@ pub const ALT_SCREEN_DEFAULT: &str = "1";
 pub const ALT_SCREEN_SHELL_ASSIGNMENT: &str =
     "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=\"${CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN-1}\"";
 
-/// Provision the classic-renderer default on a `claude` [`std::process::Command`].
+/// The Claude Code variable that opts the pane out of the app's own mouse
+/// capture (#7160).
+///
+/// Why: tmux's per-pane `mouse_any_flag` is set by the application running in
+/// the pane, via an escape sequence — independent of tmux's own `mouse`
+/// server option and independent of [`ALT_SCREEN_ENV_VAR`]. Claude Code sets
+/// it even under the classic renderer, so #6495's fix alone leaves the wheel
+/// captured. Claude Code documents this variable as the opt-out.
+pub const MOUSE_ENV_VAR: &str = "CLAUDE_CODE_DISABLE_MOUSE";
+
+/// The value tm provisions when the launch carries none.
+pub const MOUSE_DEFAULT: &str = "1";
+
+/// The `env` operand every shell-string launch line carries (#7160) — the
+/// mouse-capture counterpart to [`ALT_SCREEN_SHELL_ASSIGNMENT`], same form and
+/// same reason for being a pinned literal rather than a composed one.
+/// Test: `mouse_shell_assignment_pins_the_defaulting_form`,
+/// `mouse_shell_assignment_names_the_variable_and_the_default`.
+pub const MOUSE_SHELL_ASSIGNMENT: &str =
+    "CLAUDE_CODE_DISABLE_MOUSE=\"${CLAUDE_CODE_DISABLE_MOUSE-1}\"";
+
+/// One variable tm provisions a default for on every managed launch.
+///
+/// Why: pairs each variable's name, default, and pinned shell operand so
+/// [`MANAGED_DEFAULTS`] can drive every carrier from one table instead of the
+/// table's shape being re-derived at each carrier (#7160).
+/// What: three fields, all `&'static str` so the table itself can be a `const`.
+struct ManagedDefault {
+    /// The environment variable name.
+    env_var: &'static str,
+    /// The value tm provisions when the launch carries none.
+    default: &'static str,
+    /// The pinned `NAME="${NAME-default}"` shell operand — see
+    /// [`ALT_SCREEN_SHELL_ASSIGNMENT`]'s doc for why this is a literal rather
+    /// than composed from the other two fields.
+    shell_assignment: &'static str,
+}
+
+/// Every variable tm provisions a default for on a managed launch, in the
+/// order every carrier emits them (#6495, #7160).
+///
+/// Why: the single source of truth [`managed_shell_assignments`] and
+/// [`apply_default_when_unset`] both drive off, so a third variable is a
+/// one-line addition here rather than a change repeated at every launch site
+/// this module has callers in.
+/// Test: `managed_shell_assignments_joins_both_operands_in_order`.
+const MANAGED_DEFAULTS: &[ManagedDefault] = &[
+    ManagedDefault {
+        env_var: ALT_SCREEN_ENV_VAR,
+        default: ALT_SCREEN_DEFAULT,
+        shell_assignment: ALT_SCREEN_SHELL_ASSIGNMENT,
+    },
+    ManagedDefault {
+        env_var: MOUSE_ENV_VAR,
+        default: MOUSE_DEFAULT,
+        shell_assignment: MOUSE_SHELL_ASSIGNMENT,
+    },
+];
+
+/// The `env` operand text carrying every managed default, space-joined in
+/// [`MANAGED_DEFAULTS`] order — what a shell-command launch line splices in
+/// ahead of `claude` (#6495 alternate-screen, #7160 mouse capture).
+///
+/// Why: every shell-string builder previously spliced in
+/// [`ALT_SCREEN_SHELL_ASSIGNMENT`] alone; adding the mouse default without a
+/// second call at every one of those sites would silently miss one the next
+/// time a variable is added. One function, driven by the table, is the single
+/// place a launch line's defaulted-env text is assembled.
+/// What: each entry's `shell_assignment`, joined with a single space — the
+/// same separator every builder already places between the scrub flags and
+/// the assignment, and between one assignment and the next (see
+/// [`crate::core::model_inject::build_claude_command_with`]'s per-assignment
+/// `cmd.push(' ')`).
+/// Test: `managed_shell_assignments_joins_both_operands_in_order`.
+pub fn managed_shell_assignments() -> String {
+    MANAGED_DEFAULTS
+        .iter()
+        .map(|d| d.shell_assignment)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Provision every managed default (#6495, #7160) on a `claude`
+/// [`std::process::Command`].
 ///
 /// Why: the exec launch paths (the bare-`tm` in-place relaunch, `tm run`) build
-/// a `Command` with no shell in between, so [`ALT_SCREEN_SHELL_ASSIGNMENT`] and
-/// its `${NAME-1}` expansion cannot apply to them — but they inherit the same
-/// pane environment and need the same default and the same operator precedence.
+/// a `Command` with no shell in between, so [`managed_shell_assignments`] and
+/// its `${NAME-default}` expansion cannot apply to them — but they inherit the
+/// same pane environment and need the same defaults and the same operator
+/// precedence, decided independently per variable.
 /// What: delegates to [`apply_default_when_unset`] with a real-environment
 /// lookup. The parent's environment is what the child inherits, so "already set
 /// here" is exactly "the launch already carries a value".
@@ -85,21 +190,28 @@ pub fn apply_default_to_command(cmd: &mut std::process::Command) {
     apply_default_when_unset(cmd, |name| std::env::var_os(name).is_some());
 }
 
-/// Pure core of [`apply_default_to_command`]: set the default only when `is_set`
-/// reports the variable absent.
+/// Pure core of [`apply_default_to_command`]: for every table entry, set its
+/// default only when `is_set` reports that variable absent.
 ///
 /// Why: [`std::process::Command::env`] overrides the inherited value
 /// unconditionally, so an unguarded call would defeat an operator who exported
-/// the variable in the pane — the exact override #6495 must not perform.
-/// What: no-op when `is_set(ALT_SCREEN_ENV_VAR)` is true; otherwise
-/// `cmd.env(ALT_SCREEN_ENV_VAR, ALT_SCREEN_DEFAULT)`.
-/// Test: `command_default_applies_when_the_variable_is_unset`,
-/// `command_default_yields_to_an_operator_value`.
+/// the variable in the pane — the exact override #6495/#7160 must not perform.
+/// Each variable is decided independently: an operator who exported only one
+/// of the two must still get the tm default for the other, never both-or-
+/// neither.
+/// What: for each entry in [`MANAGED_DEFAULTS`], no-op when
+/// `is_set(entry.env_var)` is true; otherwise
+/// `cmd.env(entry.env_var, entry.default)`.
+/// Test: `command_defaults_apply_when_every_variable_is_unset`,
+/// `command_defaults_yield_to_an_operator_value`,
+/// `command_defaults_yield_per_variable_independently`.
 pub fn apply_default_when_unset(cmd: &mut std::process::Command, is_set: impl Fn(&str) -> bool) {
-    if is_set(ALT_SCREEN_ENV_VAR) {
-        return;
+    for entry in MANAGED_DEFAULTS {
+        if is_set(entry.env_var) {
+            continue;
+        }
+        cmd.env(entry.env_var, entry.default);
     }
-    cmd.env(ALT_SCREEN_ENV_VAR, ALT_SCREEN_DEFAULT);
 }
 
 #[cfg(test)]
@@ -131,6 +243,40 @@ mod tests {
         );
     }
 
+    /// #7160: the mouse-capture counterpart of `shell_assignment_pins_the_defaulting_form`.
+    #[test]
+    fn mouse_shell_assignment_pins_the_defaulting_form() {
+        assert_eq!(
+            MOUSE_SHELL_ASSIGNMENT,
+            "CLAUDE_CODE_DISABLE_MOUSE=\"${CLAUDE_CODE_DISABLE_MOUSE-1}\""
+        );
+        assert!(
+            !MOUSE_SHELL_ASSIGNMENT.contains(":-"),
+            "`:-` would override an operator value of empty string"
+        );
+    }
+
+    /// #7160: the mouse-capture counterpart of
+    /// `shell_assignment_names_the_variable_and_the_default`.
+    #[test]
+    fn mouse_shell_assignment_names_the_variable_and_the_default() {
+        assert_eq!(
+            MOUSE_SHELL_ASSIGNMENT,
+            format!("{MOUSE_ENV_VAR}=\"${{{MOUSE_ENV_VAR}-{MOUSE_DEFAULT}}}\"")
+        );
+    }
+
+    /// #7160: one function must carry both operands, in table order, so a
+    /// caller that splices its result in ahead of `claude` gets both defaults
+    /// from a single call site.
+    #[test]
+    fn managed_shell_assignments_joins_both_operands_in_order() {
+        assert_eq!(
+            managed_shell_assignments(),
+            format!("{ALT_SCREEN_SHELL_ASSIGNMENT} {MOUSE_SHELL_ASSIGNMENT}")
+        );
+    }
+
     /// Read the explicit overrides a `Command` carries: `get_envs` reports a set
     /// value as `(key, Some(value))` and an `env_remove` as `(key, None)`.
     fn override_for(cmd: &std::process::Command, name: &str) -> Option<Option<String>> {
@@ -140,24 +286,53 @@ mod tests {
     }
 
     #[test]
-    fn command_default_applies_when_the_variable_is_unset() {
+    fn command_defaults_apply_when_every_variable_is_unset() {
         let mut cmd = std::process::Command::new("claude");
         apply_default_when_unset(&mut cmd, |_| false);
         assert_eq!(
             override_for(&cmd, ALT_SCREEN_ENV_VAR),
             Some(Some(ALT_SCREEN_DEFAULT.to_string())),
-            "an unset variable must be provisioned with the tm default"
+            "an unset alternate-screen variable must be provisioned with the tm default"
+        );
+        assert_eq!(
+            override_for(&cmd, MOUSE_ENV_VAR),
+            Some(Some(MOUSE_DEFAULT.to_string())),
+            "an unset mouse-capture variable must be provisioned with the tm default"
         );
     }
 
     #[test]
-    fn command_default_yields_to_an_operator_value() {
+    fn command_defaults_yield_to_an_operator_value() {
+        let mut cmd = std::process::Command::new("claude");
+        apply_default_when_unset(&mut cmd, |_| true);
+        assert_eq!(
+            override_for(&cmd, ALT_SCREEN_ENV_VAR),
+            None,
+            "a value the launch already carries must reach claude untouched"
+        );
+        assert_eq!(
+            override_for(&cmd, MOUSE_ENV_VAR),
+            None,
+            "a value the launch already carries must reach claude untouched"
+        );
+    }
+
+    /// #7160: the two variables must be decided INDEPENDENTLY — an operator who
+    /// exported only the alternate-screen variable must still get the tm
+    /// default for mouse capture, never both-or-neither.
+    #[test]
+    fn command_defaults_yield_per_variable_independently() {
         let mut cmd = std::process::Command::new("claude");
         apply_default_when_unset(&mut cmd, |name| name == ALT_SCREEN_ENV_VAR);
         assert_eq!(
             override_for(&cmd, ALT_SCREEN_ENV_VAR),
             None,
-            "a value the launch already carries must reach claude untouched"
+            "the variable the launch already carries must reach claude untouched"
+        );
+        assert_eq!(
+            override_for(&cmd, MOUSE_ENV_VAR),
+            Some(Some(MOUSE_DEFAULT.to_string())),
+            "the variable the launch does NOT carry must still be provisioned"
         );
     }
 }

--- a/crates/trusty-mpm/src/core/claude_env_scrub.rs
+++ b/crates/trusty-mpm/src/core/claude_env_scrub.rs
@@ -230,8 +230,9 @@ pub fn scrub_command(cmd: &mut std::process::Command) {
 /// [`crate::core::model_inject::build_inplace_session_command`] and
 /// `build_client_session_command`, which were assignment-free until then — the
 /// unconditional
-/// [`crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT`] operand, so the
-/// assignment stop now fires on all of them. `daemon::spawn_command`'s
+/// [`crate::core::alt_screen::managed_shell_assignments`] operand text (#7160
+/// added a second variable to it), so the assignment stop now fires on all of
+/// them. `daemon::spawn_command`'s
 /// `relaunch_command` is the one that stays assignment-free, which is what keeps
 /// the COMMAND stop reachable.
 /// Test: `parse_env_unset_vars_reads_the_real_spawn_prefix`,

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -302,13 +302,13 @@ pub fn build_claude_command(
 /// bypasses the Keychain entirely. `runtime::claude_code::env_bin_prefix` closes
 /// the same hole the same way for the daemon path; this is that mechanism, not a
 /// second one.
-/// #6495: the line also carries
-/// [`crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT`] unconditionally, so
+/// #6495/#7160: the line also carries
+/// [`crate::core::alt_screen::managed_shell_assignments`] unconditionally, so
 /// a `tm launch` / `tm connect` pane starts on Claude Code's classic renderer
-/// and keeps its scrollback. Its `${NAME-1}` expansion yields to a value the
-/// pane already exports.
+/// with its own mouse capture off and keeps its scrollback. Each `${NAME-1}`
+/// expansion yields independently to a value the pane already exports.
 /// What: composes `env`, the [`crate::core::claude_env_scrub::env_unset_flags`]
-/// `-u` operands, the alternate-screen operand, then the optional
+/// `-u` operands, the alt-screen/mouse operands, then the optional
 /// `CLAUDE_CONFIG_DIR` and
 /// [`crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR`] assignments (both
 /// single-quoted via [`crate::core::spawn_disclaim::pane::shell_single_quote`],
@@ -321,7 +321,8 @@ pub fn build_claude_command(
 /// `claude_command_relocated_isolates_by_relocation_not_exclusion`,
 /// `claude_command_carries_a_non_empty_mcp_env`,
 /// `claude_command_scrubs_inherited_session_markers` (the non-relocated shape),
-/// `claude_command_defaults_the_alternate_screen_off`.
+/// `claude_command_defaults_the_alternate_screen_off`,
+/// `claude_command_defaults_the_mouse_capture_off`.
 pub fn build_claude_command_with(
     model: Option<&str>,
     prompt_file: Option<&Path>,
@@ -335,10 +336,11 @@ pub fn build_claude_command_with(
     // `tm connect` / delegations keep native --resume/--continue/rewind. These
     // `-u` flags MUST precede every assignment below (POSIX `env` grammar).
     let mut cmd = format!("env{}", crate::core::claude_env_scrub::env_unset_flags());
-    // #6495: start on the classic renderer so the pane keeps native and tmux
-    // scrollback; `${NAME-1}` yields to a value the pane already exports.
+    // #6495/#7160: start on the classic renderer with mouse capture off, so
+    // the pane keeps native and tmux scrollback; each `${NAME-1}` yields
+    // independently to a value the pane already exports.
     cmd.push(' ');
-    cmd.push_str(crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT);
+    cmd.push_str(&crate::core::alt_screen::managed_shell_assignments());
     if let Some(dir) = config_dir {
         // #4181: point the session at the tm-owned config home so the `user`
         // settings tier resolves there instead of the operator's `~/.claude`.
@@ -399,24 +401,28 @@ pub fn build_claude_command_with(
 /// tier is the operator's own `~/.claude` — dropping it would change which
 /// settings and agents an in-place session loads. This fix scrubs the markers
 /// and changes nothing else.
-/// What: `env <-u marker…> CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN="${…-1}" claude
-/// --dangerously-skip-permissions`. The scrub flags lead the line and the one
-/// `NAME=VALUE` assignment follows them, as POSIX `env` grammar requires.
+/// What: `env <-u marker…> CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN="${…-1}"
+/// CLAUDE_CODE_DISABLE_MOUSE="${…-1}" claude --dangerously-skip-permissions`.
+/// The scrub flags lead the line and the two `NAME=VALUE` assignments follow
+/// them, as POSIX `env` grammar requires.
 ///
-/// #6495 added that assignment. It does not disturb the settings-tier reasoning
-/// above: it is an environment default, not a `--setting-sources` flag, so this
-/// path still loads the operator's own `user` tier.
+/// #6495 added the alt-screen assignment; #7160 added the mouse-capture one.
+/// Neither disturbs the settings-tier reasoning above: both are environment
+/// defaults, not `--setting-sources` flags, so this path still loads the
+/// operator's own `user` tier.
 /// Test: `inplace_session_command_scrubs_inherited_session_markers`,
 /// `inplace_session_command_keeps_the_permission_flag_and_nothing_else`,
-/// `inplace_session_command_defaults_the_alternate_screen_off`.
+/// `inplace_session_command_defaults_the_alternate_screen_off`,
+/// `inplace_session_command_defaults_the_mouse_capture_off`.
 pub fn build_inplace_session_command() -> String {
     // #4467: same shared scrub every other launch line uses — never a second
     // mechanism.
     format!(
         "env{} {} claude {}",
         crate::core::claude_env_scrub::env_unset_flags(),
-        // #6495: classic renderer by default, yielding to the pane's own value.
-        crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT,
+        // #6495/#7160: classic renderer + mouse capture off by default, each
+        // yielding independently to the pane's own value.
+        crate::core::alt_screen::managed_shell_assignments(),
         PERMISSION_MODE_FLAG
     )
 }
@@ -436,22 +442,26 @@ pub fn build_inplace_session_command() -> String {
 /// as [`build_inplace_session_command`]: that would add [`SETTING_SOURCES_FLAG`]
 /// and drop the `user` settings tier on a path that does not relocate
 /// `CLAUDE_CONFIG_DIR`. This scrubs the markers and changes nothing else.
-/// What: `env <-u marker…> CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN="${…-1}" claude`
-/// plus `--append-system-prompt-file <path>` when `prompt_file` is `Some`. The
+/// What: `env <-u marker…> CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN="${…-1}"
+/// CLAUDE_CODE_DISABLE_MOUSE="${…-1}" claude` plus
+/// `--append-system-prompt-file <path>` when `prompt_file` is `Some`. The
 /// caller falls back to `None` when writing the prompt file failed, which is why
-/// the argument is optional. #6495 added the assignment so a `/connect` pane
-/// starts on the classic renderer and keeps its scrollback.
+/// the argument is optional. #6495 added the alt-screen assignment so a
+/// `/connect` pane starts on the classic renderer and keeps its scrollback;
+/// #7160 added the mouse-capture one.
 /// Test: `client_session_command_scrubs_inherited_session_markers`,
 /// `client_session_command_appends_the_prompt_file`,
-/// `client_session_command_defaults_the_alternate_screen_off`.
+/// `client_session_command_defaults_the_alternate_screen_off`,
+/// `client_session_command_defaults_the_mouse_capture_off`.
 pub fn build_client_session_command(prompt_file: Option<&Path>) -> String {
     // #4467: same shared scrub every other launch line uses — never a second
     // mechanism.
     let mut cmd = format!(
         "env{} {} claude",
         crate::core::claude_env_scrub::env_unset_flags(),
-        // #6495: classic renderer by default, yielding to the pane's own value.
-        crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT
+        // #6495/#7160: classic renderer + mouse capture off by default, each
+        // yielding independently to the pane's own value.
+        crate::core::alt_screen::managed_shell_assignments()
     );
     if let Some(p) = prompt_file {
         cmd.push_str(" --append-system-prompt-file ");
@@ -497,19 +507,20 @@ mod tests {
     /// The isolation + unattended suffix every command now carries (#1269).
     const FLAGS: &str = "--setting-sources project,local --dangerously-skip-permissions";
 
-    /// The `env <-u marker…> <alt-screen operand> claude` head every command now
-    /// carries (#4467, #6495).
+    /// The `env <-u marker…> <alt-screen operand> <mouse operand> claude` head
+    /// every command now carries (#4467, #6495, #7160).
     ///
     /// Interpolated from production so these pins assert each segment's
     /// POSITION; the marker CONTENT is pinned by literal name in
     /// `core::claude_env_scrub`'s `every_marker_is_pinned_by_literal_name`, and
-    /// the alternate-screen operand's literal text in `core::alt_screen`'s
-    /// `shell_assignment_pins_the_defaulting_form`.
+    /// each operand's literal text in `core::alt_screen`'s
+    /// `shell_assignment_pins_the_defaulting_form` /
+    /// `mouse_shell_assignment_pins_the_defaulting_form`.
     fn head() -> String {
         format!(
             "env{} {} claude",
             crate::core::claude_env_scrub::env_unset_flags(),
-            crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT
+            crate::core::alt_screen::managed_shell_assignments()
         )
     }
 
@@ -603,7 +614,7 @@ mod tests {
                  CLAUDE_CODE_OAUTH_TOKEN='tok-abc' claude \
                  --setting-sources user,project,local --dangerously-skip-permissions",
                 crate::core::claude_env_scrub::env_unset_flags(),
-                crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT
+                crate::core::alt_screen::managed_shell_assignments()
             )
         );
         // POSIX `env` stops parsing options at the first NAME=VALUE, so a
@@ -769,8 +780,8 @@ mod tests {
     /// `CLAUDE_CONFIG_DIR`, so that tier is the operator's own `~/.claude`.
     /// Pinned as a full string so a flag cannot creep in.
     ///
-    /// #6495 changed the expected string by adding an `env` operand
-    /// (`ALT_SCREEN_SHELL_ASSIGNMENT`) ahead of `claude`. That is deliberate and
+    /// #6495/#7160 changed the expected string by adding `env` operands
+    /// (`managed_shell_assignments()`) ahead of `claude`. That is deliberate and
     /// does not weaken what this test asserts: the guard is about which SETTINGS
     /// TIERS the line loads, an environment default changes none of them, and
     /// `--dangerously-skip-permissions` is still the only flag. The
@@ -782,7 +793,7 @@ mod tests {
             format!(
                 "env{} {} claude {PERMISSION_MODE_FLAG}",
                 crate::core::claude_env_scrub::env_unset_flags(),
-                crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT
+                crate::core::alt_screen::managed_shell_assignments()
             )
         );
         assert!(
@@ -844,6 +855,36 @@ mod tests {
         }
     }
 
+    /// #7160: the mouse-capture counterpart of
+    /// `claude_command_defaults_the_alternate_screen_off` — same launch lines,
+    /// same operand-form assertion, the other variable.
+    #[test]
+    fn claude_command_defaults_the_mouse_capture_off() {
+        let operand = crate::core::alt_screen::MOUSE_SHELL_ASSIGNMENT;
+        for cmd in [
+            build_claude_command(None, None, None, &[]),
+            build_claude_command(Some("claude-opus-4-5"), None, None, &[]),
+            build_claude_command_with(
+                None,
+                None,
+                Some(Path::new("/tm/claude-config")),
+                Some("tok"),
+                &[],
+            ),
+        ] {
+            assert!(
+                cmd.contains(operand),
+                "the launch line must default mouse capture off: {cmd}"
+            );
+            let first_assignment = cmd.find('=').expect("the line carries an assignment");
+            let last_unset = cmd.rfind("-u ").expect("the line carries scrub flags");
+            assert!(
+                last_unset < first_assignment,
+                "the operand must follow every -u flag: {cmd}"
+            );
+        }
+    }
+
     /// #6495: the two builders that were assignment-free until now. Kept
     /// separate from the pins above so a regression names the path it broke.
     #[test]
@@ -855,9 +896,32 @@ mod tests {
         );
     }
 
+    /// #7160: the mouse-capture counterpart of
+    /// `inplace_session_command_defaults_the_alternate_screen_off`.
+    #[test]
+    fn inplace_session_command_defaults_the_mouse_capture_off() {
+        let cmd = build_inplace_session_command();
+        assert!(
+            cmd.contains(crate::core::alt_screen::MOUSE_SHELL_ASSIGNMENT),
+            "the in-place session line must default mouse capture off: {cmd}"
+        );
+    }
+
     #[test]
     fn client_session_command_defaults_the_alternate_screen_off() {
         let operand = crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT;
+        assert!(build_client_session_command(None).contains(operand));
+        assert!(
+            build_client_session_command(Some(Path::new("/tmp/p.txt"))).contains(operand),
+            "the prompt-file shape must carry it too"
+        );
+    }
+
+    /// #7160: the mouse-capture counterpart of
+    /// `client_session_command_defaults_the_alternate_screen_off`.
+    #[test]
+    fn client_session_command_defaults_the_mouse_capture_off() {
+        let operand = crate::core::alt_screen::MOUSE_SHELL_ASSIGNMENT;
         assert!(build_client_session_command(None).contains(operand));
         assert!(
             build_client_session_command(Some(Path::new("/tmp/p.txt"))).contains(operand),

--- a/crates/trusty-mpm/src/core/standalone/run.rs
+++ b/crates/trusty-mpm/src/core/standalone/run.rs
@@ -52,16 +52,19 @@ use super::registry::ManagedRegistry;
 /// returns false immediately and an inherited `CLAUDE_CODE_CHILD_SESSION` always
 /// wins.
 ///
-/// Issue #6495: also provisions the classic-renderer default via
-/// [`crate::core::alt_screen::apply_default_to_command`] — `tm run` is an
-/// interactive session and the fullscreen renderer costs it terminal
-/// scrollback. Nothing is set when the launching shell already exports a value.
+/// Issues #6495/#7160: also provisions the classic-renderer and mouse-capture
+/// defaults via [`crate::core::alt_screen::apply_default_to_command`] —
+/// `tm run` is an interactive session, the fullscreen renderer costs it
+/// terminal scrollback, and Claude Code sets tmux's per-pane `mouse_any_flag`
+/// even under the classic renderer. Nothing is set for a variable the
+/// launching shell already exports; the two are decided independently.
 /// Test: `test_build_launch_command_sets_env_and_cwd`,
 /// `test_build_launch_command_adds_bare_with_api_key`,
 /// `test_build_launch_command_no_bare_without_api_key`,
 /// `test_build_launch_command_includes_bypass_permissions`,
 /// `test_build_launch_command_scrubs_inherited_session_markers`,
-/// `test_build_launch_command_defaults_the_alternate_screen_off`.
+/// `test_build_launch_command_defaults_the_alternate_screen_off`,
+/// `test_build_launch_command_defaults_the_mouse_capture_off`.
 pub fn build_launch_command(
     repo_path: &Path,
     claude_config_dir: &Path,
@@ -443,6 +446,26 @@ mod tests {
         assert_eq!(
             provisioned, !carried_by_the_launch,
             "tm run must provision {ALT_SCREEN_ENV_VAR}={ALT_SCREEN_DEFAULT} when the \
+             launch carries no value, and leave an operator value untouched when it does"
+        );
+    }
+
+    /// #7160: the mouse-capture counterpart of
+    /// `test_build_launch_command_defaults_the_alternate_screen_off`.
+    #[test]
+    fn test_build_launch_command_defaults_the_mouse_capture_off() {
+        use crate::core::alt_screen::{MOUSE_DEFAULT, MOUSE_ENV_VAR};
+
+        let tmp = TempDir::new().unwrap();
+        let cmd = build_launch_command(&tmp.path().join("repo"), &tmp.path().join("cfg"), None);
+
+        let carried_by_the_launch = std::env::var_os(MOUSE_ENV_VAR).is_some();
+        let provisioned = cmd.get_envs().any(|(k, v)| {
+            k == MOUSE_ENV_VAR && v.is_some_and(|v| v == std::ffi::OsStr::new(MOUSE_DEFAULT))
+        });
+        assert_eq!(
+            provisioned, !carried_by_the_launch,
+            "tm run must provision {MOUSE_ENV_VAR}={MOUSE_DEFAULT} when the \
              launch carries no value, and leave an operator value untouched when it does"
         );
     }

--- a/crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs
@@ -121,10 +121,11 @@ const ALLOWLISTED_CLAUDE_SITES: &[(&str, usize, &str)] = &[
     ),
     (
         "core/alt_screen.rs",
-        2,
-        "test fixtures for apply_default_when_unset (#6495) — not launch lines. The \
-         module emits no command of its own: it supplies the alternate-screen default \
-         that the real builders carry, as a shell operand or a Command mutation",
+        3,
+        "test fixtures for apply_default_when_unset (#6495, #7160) — not launch lines. \
+         The module emits no command of its own: it supplies the alt-screen and \
+         mouse-capture defaults the real builders carry, as a shell operand or a \
+         Command mutation",
     ),
     (
         "core/spawn_disclaim/pane.rs",

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -158,14 +158,17 @@ fn cd_and_group(cwd: &Path, body: &str) -> String {
 /// `--resume` / `--continue` / `/rewind` recovery. The scrub list deliberately
 /// EXCLUDES `CLAUDE_CONFIG_DIR` — see that module's `DELIBERATE_SPAWN_ENV`, and
 /// #4455/#4451 for why removing it would re-break the bundled agent roster.
-/// (5) Issue #6495: the line always assigns
-/// [`crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT`], which starts the
-/// pane on Claude Code's classic renderer. The fullscreen renderer captures the
-/// mouse wheel, so a managed pane loses both native and tmux scrollback. The
-/// operand's `${NAME-1}` expansion means a value the pane already exports wins.
-/// What: `env -u ANTHROPIC_API_KEY <-u marker…> CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN="${…-1}" [CLAUDE_CONFIG_DIR='<dir>'] [CLAUDE_CODE_OAUTH_TOKEN='<token>'] <claude_bin>`
-/// — each bracketed assignment appears only when its value is `Some`; the
-/// alternate-screen operand is unconditional. The
+/// (5) Issues #6495/#7160: the line always assigns
+/// [`crate::core::alt_screen::managed_shell_assignments`], which starts the
+/// pane on Claude Code's classic renderer with its own mouse capture off. The
+/// fullscreen renderer captures the mouse wheel, and Claude Code sets tmux's
+/// per-pane `mouse_any_flag` via escape sequence even under the classic
+/// renderer, so either half alone still costs a managed pane native and tmux
+/// scrollback. Each operand's `${NAME-1}` expansion means a value the pane
+/// already exports wins, decided independently per variable.
+/// What: `env -u ANTHROPIC_API_KEY <-u marker…> CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN="${…-1}" CLAUDE_CODE_DISABLE_MOUSE="${…-1}" [CLAUDE_CONFIG_DIR='<dir>'] [CLAUDE_CODE_OAUTH_TOKEN='<token>'] <claude_bin>`
+/// — each bracketed assignment appears only when its value is `Some`; the two
+/// managed-default operands are unconditional. The
 /// `-u NAME` option MUST precede any
 /// `NAME=VALUE` assignment per POSIX `env` grammar (`env [OPTION]...
 /// [NAME=VALUE]... [COMMAND]...`); putting an assignment before `-u` makes
@@ -184,7 +187,9 @@ fn cd_and_group(cwd: &Path, body: &str) -> String {
 /// `spawn_command_keeps_config_dir_out_of_the_scrub`,
 /// `env_bin_prefix_orders_scrub_flags_before_assignments`,
 /// `spawn_command_defaults_the_alternate_screen_off`,
-/// `resume_command_defaults_the_alternate_screen_off`.
+/// `resume_command_defaults_the_alternate_screen_off`,
+/// `spawn_command_defaults_the_mouse_capture_off`,
+/// `resume_command_defaults_the_mouse_capture_off`.
 ///
 /// `GH_TOKEN`/`GH_USER` (issue #3025) are deliberately NOT assignments on
 /// this prefix — see [`claude_code_gh_env::gh_env_source_prefix`], applied
@@ -199,11 +204,12 @@ pub(crate) fn env_bin_prefix(
     mcp_env: &[(String, String)],
 ) -> String {
     let mut assignments = String::new();
-    // #6495: default the pane to Claude Code's classic renderer so native and
-    // tmux scrollback keep working; the `${NAME-1}` form yields to a value the
-    // pane already exports.
+    // #6495/#7160: default the pane to Claude Code's classic renderer with
+    // mouse capture off, so native and tmux scrollback keep working; each
+    // `${NAME-1}` form yields independently to a value the pane already
+    // exports.
     assignments.push(' ');
-    assignments.push_str(crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT);
+    assignments.push_str(&crate::core::alt_screen::managed_shell_assignments());
     if let Some(dir) = config_dir {
         let quoted = shell_single_quote(&dir.display().to_string());
         assignments.push_str(&format!(" CLAUDE_CONFIG_DIR={quoted}"));

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -349,20 +349,22 @@ fn spawn_command_without_token_pins_the_exact_command() {
         &[],
     );
     let scrub = crate::core::claude_env_scrub::env_unset_flags();
-    // #6495 added the alternate-screen operand; interpolated for the same reason
-    // the scrub segment is — this pins its POSITION, while its literal text is
-    // pinned in `core::alt_screen`'s `shell_assignment_pins_the_defaulting_form`.
-    let alt = crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT;
+    // #6495/#7160 added the alt-screen and mouse-capture operands; interpolated
+    // for the same reason the scrub segment is — this pins their POSITION,
+    // while their literal text is pinned in `core::alt_screen`'s
+    // `shell_assignment_pins_the_defaulting_form` /
+    // `mouse_shell_assignment_pins_the_defaulting_form`.
+    let managed = crate::core::alt_screen::managed_shell_assignments();
     // #6766 replaced the unconditional `; echo '<hint>'` with a status/elapsed
     // branch, and added the launch clock that feeds it. Both are interpolated
-    // from production code for the same reason the scrub and alt-screen
+    // from production code for the same reason the scrub and managed-defaults
     // segments are — this test pins their POSITION; their literal text is
     // pinned by `claude_code_exit_hint`'s own executing tests.
     let clock = super::claude_code_exit_hint::launch_clock_prefix();
     let dispatch = super::claude_code_exit_hint::exit_dispatch_suffix();
     let expected = format!(
         "cd '/tmp/ws' && {{ export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; \
-             {clock}env -u ANTHROPIC_API_KEY{scrub} {alt} claude \
+             {clock}env -u ANTHROPIC_API_KEY{scrub} {managed} claude \
              --setting-sources project,local --dangerously-skip-permissions{dispatch}; }}"
     );
     assert_eq!(cmd, expected, "no-token command shape must stay pinned");
@@ -620,13 +622,13 @@ fn resume_command_without_token_pins_the_exact_command() {
         &[],
     );
     let scrub = crate::core::claude_env_scrub::env_unset_flags();
-    let alt = crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT;
+    let managed = crate::core::alt_screen::managed_shell_assignments();
     // #6766: see the spawn-path pin above for why these two are interpolated.
     let clock = super::claude_code_exit_hint::launch_clock_prefix();
     let dispatch = super::claude_code_exit_hint::exit_dispatch_suffix();
     let expected = format!(
         "cd '/tmp/ws' && {{ export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; \
-             {clock}env -u ANTHROPIC_API_KEY{scrub} {alt} claude \
+             {clock}env -u ANTHROPIC_API_KEY{scrub} {managed} claude \
              --setting-sources project,local --dangerously-skip-permissions --resume abc-123\
              {dispatch}; }}"
     );
@@ -681,6 +683,46 @@ fn spawn_command_defaults_the_alternate_screen_off() {
     }
 }
 
+/// #7160: the mouse-capture counterpart of
+/// `spawn_command_defaults_the_alternate_screen_off` — same launch lines,
+/// same operand-form assertion, the other variable.
+#[test]
+fn spawn_command_defaults_the_mouse_capture_off() {
+    let operand = crate::core::alt_screen::MOUSE_SHELL_ASSIGNMENT;
+    let dir = Path::new("/tm/claude-config");
+    for cmd in [
+        spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            None,
+            TEST_SESSION_ID,
+            None,
+            None,
+            None,
+            &[],
+        ),
+        spawn_command(
+            Path::new(TEST_CWD),
+            "claude",
+            Some(dir),
+            TEST_SESSION_ID,
+            None,
+            Some("tok"),
+            None,
+            &[],
+        ),
+    ] {
+        let at = cmd
+            .find(operand)
+            .unwrap_or_else(|| panic!("the spawn line must default mouse capture off: {cmd}"));
+        let last_unset = cmd.rfind("-u ").expect("the line carries scrub flags");
+        assert!(
+            last_unset < at,
+            "the operand must follow every -u flag: {cmd}"
+        );
+    }
+}
+
 /// #6495, resume-path counterpart: a resumed session gets the same default as a
 /// fresh one, or the fix would evaporate on the first reconnect.
 #[test]
@@ -699,6 +741,28 @@ fn resume_command_defaults_the_alternate_screen_off() {
     assert!(
         cmd.contains(crate::core::alt_screen::ALT_SCREEN_SHELL_ASSIGNMENT),
         "the resume line must default the alternate screen off: {cmd}"
+    );
+}
+
+/// #7160, resume-path counterpart: a resumed session gets the same mouse-
+/// capture default as a fresh one, or the fix would evaporate on the first
+/// reconnect.
+#[test]
+fn resume_command_defaults_the_mouse_capture_off() {
+    let cmd = resume_command(
+        Path::new(TEST_CWD),
+        "claude",
+        None,
+        Some("abc-123"),
+        TEST_SESSION_ID,
+        None,
+        None,
+        None,
+        &[],
+    );
+    assert!(
+        cmd.contains(crate::core::alt_screen::MOUSE_SHELL_ASSIGNMENT),
+        "the resume line must default mouse capture off: {cmd}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Refs #7160. `crates/trusty-mpm/src/core/alt_screen.rs` (issue #6495) now provisions `CLAUDE_CODE_DISABLE_MOUSE=1` alongside `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` on every tm-managed Claude Code launch path, with the same yield-to-existing-value semantics — `${NAME-1}` shell operand for the env-prefix builders, `apply_default_when_unset` for the exec builders. Neither variable is written to any settings file.
- Generalized the module around one table (`MANAGED_DEFAULTS`) driving both a shell-operand composer (`managed_shell_assignments()`) and the `Command`-mutation path (`apply_default_when_unset`), so a third variable is a one-line table addition rather than a change repeated at every launch site.
- Every launch-path builder updated: `runtime::claude_code::{spawn_command, resume_command}` (via `env_bin_prefix`), `core::model_inject::{build_claude_command, build_inplace_session_command, build_client_session_command}`, `core::standalone::run::build_launch_command` (`tm run`), `bin/tm/commands/guided_inplace::build_inplace_exec_command` (in-place relaunch).
- Doc comments (Why/What/Test) updated on `alt_screen.rs` and every call site to cover both variables; `// #7160:` markers at each change site.
- `tm doctor`'s `tmux_options` check (38) was **not** extended to read `#{mouse_any_flag}` per tm-* pane — see "Doctor check" below.

## Test plan (rung 3, `trusty-mpm`)

- `cargo fmt --check` — clean
- `cargo check -p trusty-mpm` — EXIT=0
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — EXIT=0, zero warnings
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — EXIT=0, `6259 passed; 0 failed; 8 ignored` (plus every other target `ok`, 0 failed)
- `bash scripts/check_line_cap.sh` — OK, 0 violations
- `bash scripts/check_changelog_fragment.sh` — OK, fragment present and valid

New tests, mirroring each existing `*_defaults_the_alternate_screen_off` test:
`spawn_command_defaults_the_mouse_capture_off`, `resume_command_defaults_the_mouse_capture_off`, `claude_command_defaults_the_mouse_capture_off`, `inplace_session_command_defaults_the_mouse_capture_off`, `client_session_command_defaults_the_mouse_capture_off`, `test_build_launch_command_defaults_the_mouse_capture_off`, `inplace_exec_command_defaults_the_mouse_capture_off` — plus the module's own unit tests: `mouse_shell_assignment_pins_the_defaulting_form`, `mouse_shell_assignment_names_the_variable_and_the_default`, `managed_shell_assignments_joins_both_operands_in_order`, `command_defaults_apply_when_every_variable_is_unset`, `command_defaults_yield_to_an_operator_value`, `command_defaults_yield_per_variable_independently`. All pass.

## Doctor check — deferred, not added

The issue's closure conditions ask for a `tm doctor` check reading `#{mouse_any_flag}` per tm-* pane. The tmux argv building blocks already exist (`TmuxCommand::ListSessions`, `TmuxCommand::ListPanes`, `core::tmux::display_message_argv`, `trusty_common::session_naming::is_managed_session_name`), but wiring them into `daemon::doctor_tmux_options` is not the "cheap" addition the issue allows for: unlike the three existing global `show-options` probes (fixed, O(1) subprocess calls), a per-pane check requires enumerating every live session, listing panes per session, then one `display-message` subprocess per pane — O(sessions × panes) — plus new decision/message logic and its own tests. That's a real feature addition, not a one-line extension of check 38, so I left it out per the task's explicit "leave it out and say so" allowance rather than rush it into this PR. A follow-up issue can pick it up using the plumbing named above.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01ER5DBvGQ54K5sgFLb9G5vz