### PR TITLE
fix(trusty-mpm): tm issue audit derives crate labels instead of enumerating them

### DIFF
--- a/crates/trusty-mpm/changelog.d/7123-component-label-any-crate.md
+++ b/crates/trusty-mpm/changelog.d/7123-component-label-any-crate.md
@@ -1,0 +1,5 @@
+Fixed
+- `tm issue audit` widens the accepted component-label set with the repository's
+  own live `gh` labels (any label whose description reads `Crate: <name>`), not
+  only the local `Cargo.toml` derivation #7123 shipped. A `gh` failure leaves
+  the Cargo.toml-derived set unchanged rather than failing the audit. Refs #7123.

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/audit.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/audit.rs
@@ -15,16 +15,45 @@
 //! windowed mode, prints, and returns `Err` when anything FAILED (which is how
 //! `tm` exits 1).
 //!
+//! # The accepted component labels — two independent sources (#7123, #7182)
+//!
+//! [`trusty_mpm::core::component_labels::ComponentLabels::resolve`] derives the
+//! accepted set from the audited repository's own `Cargo.toml` — no network,
+//! bounded and fail-closed. #7123 shipped that alone and it is correct against
+//! a checkout that actually holds the crate in question. #7182 (recurrence of
+//! #7123 against `trusty-audit` in isolation) could not be reproduced against
+//! this repository's HEAD — a live probe confirms `resolve` already accepts
+//! `trusty-audit` — which points at the ONE thing a local Cargo.toml read can
+//! never see: a stale or wrong working directory at the point `tm issue audit`
+//! actually ran. [`widen_with_live_crate_labels`] closes that gap with a second,
+//! independent source: the repository's OWN `gh label list`, which answers from
+//! GitHub rather than the local checkout, so it is right even when the
+//! filesystem read is not. A label whose description names a crate
+//! (`Crate: <name>`, the convention `tm issue seed-labels` writes) widens the
+//! accepted set; a `gh` failure (offline, unauthenticated) leaves the
+//! Cargo.toml-derived set untouched rather than failing the audit.
+//!
 //! Test: `single_issue_output_is_the_per_requirement_report`,
 //! `a_failing_audit_exits_nonzero`, `a_window_prints_the_summary_table`,
-//! `an_empty_window_is_not_a_failure`, and `cli_parses_issue_audit_*` in
-//! `tests.rs`.
+//! `an_empty_window_is_not_a_failure`, `widen_adds_a_crate_described_label`,
+//! `widen_ignores_a_non_crate_label`, `widen_on_gh_failure_keeps_the_set`, and
+//! `cli_parses_issue_audit_*` in `tests.rs`.
 
 use trusty_mpm::core::component_labels::ComponentLabels;
 use trusty_mpm::core::gh_identity::GhEnv;
 use trusty_mpm::core::issue_audit::{IssueAudit, audit_issue, render_audit, render_summary};
 use trusty_mpm::core::issue_audit_gh::{AuditWindow, list_open_issues, view_issue};
 use trusty_mpm::core::trusty_tools_config::ResolvedTicketing;
+
+use crate::commands::ticket::labels::gh_list_repo_labels;
+use crate::commands::ticket::runner::CommandRunner;
+
+/// Prefix a live `gh` label's description carries when it names a crate.
+///
+/// Why: `tm issue seed-labels` and manual seeding both write `Crate: <name>` —
+/// naming it once keeps [`widen_with_live_crate_labels`] and any future reader
+/// of the convention in agreement.
+const CRATE_LABEL_DESCRIPTION_PREFIX: &str = "Crate:";
 
 /// Run `tm issue audit`.
 ///
@@ -35,11 +64,12 @@ use trusty_mpm::core::trusty_tools_config::ResolvedTicketing;
 /// prints the summary table. With none of the three, errors rather than
 /// guessing a default window. `gh` runs in the current directory, which is what
 /// selects the repository — and, since #7123, also what selects the crate
-/// labels that satisfy the owning-component rule.
+/// labels that satisfy the owning-component rule (widened per the module doc).
 /// Test: see the module doc; the pure halves are unit-tested in the library.
 pub(crate) fn run(
     ticketing: &ResolvedTicketing,
     gh_env: &GhEnv,
+    runner: &dyn CommandRunner,
     issue: Option<u64>,
     recent: Option<usize>,
     since: Option<String>,
@@ -48,6 +78,9 @@ pub(crate) fn run(
     // crate labels, not just the ones the harness seeds.
     let cwd = std::env::current_dir().ok();
     let components = ComponentLabels::resolve(ticketing, cwd.as_deref());
+    // #7182: widen from the live `gh` label set, which is right even when the
+    // Cargo.toml read above was not (see the module doc).
+    let components = widen_with_live_crate_labels(components, runner);
     let audits = match (issue, recent, since) {
         (Some(number), _, _) => {
             let facts = view_issue(number, None, gh_env)?;
@@ -65,6 +98,37 @@ pub(crate) fn run(
     };
     print!("{}", render_report(&audits));
     exit_result(&audits)
+}
+
+/// Widen `components` with every live `gh` label whose description names a
+/// crate (`Crate: <name>`).
+///
+/// Why: see the module doc's "two independent sources" section (#7182) — a
+/// stale or wrong working directory defeats the Cargo.toml-derived set with no
+/// visible error, while `gh label list` answers from GitHub regardless of what
+/// the local checkout holds.
+/// What: `gh_list_repo_labels` on success unions every matching label's `name`
+/// into `components`; a `gh` failure (offline, unauthenticated, a truncated
+/// page) returns `components` unchanged — an ADDITIONAL source failing closed,
+/// never turning an audit itself into a hard error.
+/// Test: `widen_adds_a_crate_described_label`, `widen_ignores_a_non_crate_label`,
+/// `widen_on_gh_failure_keeps_the_set`.
+fn widen_with_live_crate_labels(
+    components: ComponentLabels,
+    runner: &dyn CommandRunner,
+) -> ComponentLabels {
+    let Ok(labels) = gh_list_repo_labels(runner) else {
+        return components;
+    };
+    let extra = labels
+        .into_iter()
+        .filter(|l| {
+            l.description
+                .trim_start()
+                .starts_with(CRATE_LABEL_DESCRIPTION_PREFIX)
+        })
+        .map(|l| l.name);
+    ComponentLabels::from_names(components.names().iter().cloned().chain(extra))
 }
 
 /// Audit every issue in a window.
@@ -117,12 +181,87 @@ fn exit_result(audits: &[IssueAudit]) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
     use super::*;
+    use crate::commands::ticket::runner::CommandOutput;
     use trusty_mpm::core::issue_audit::IssueFacts;
     use trusty_mpm::core::trusty_tools_config::{TrustyToolsConfig, resolve_ticketing};
 
     fn standard() -> ResolvedTicketing {
         resolve_ticketing(&TrustyToolsConfig::default()).expect("the defaults resolve")
+    }
+
+    /// A scripted [`CommandRunner`] returning one queued `gh label list`
+    /// result.
+    struct FakeRunner(RefCell<Option<anyhow::Result<CommandOutput>>>);
+
+    impl CommandRunner for FakeRunner {
+        fn run(&self, _program: &str, _args: &[&str]) -> anyhow::Result<CommandOutput> {
+            self.0
+                .borrow_mut()
+                .take()
+                .unwrap_or_else(|| anyhow::bail!("FakeRunner called more than once"))
+        }
+    }
+
+    fn ok_out(stdout: &str) -> FakeRunner {
+        FakeRunner(RefCell::new(Some(Ok(CommandOutput {
+            success: true,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }))))
+    }
+
+    fn fail_out() -> FakeRunner {
+        FakeRunner(RefCell::new(Some(Ok(CommandOutput {
+            success: false,
+            stdout: String::new(),
+            stderr: "gh: not authenticated".to_string(),
+        }))))
+    }
+
+    #[test]
+    fn widen_adds_a_crate_described_label() {
+        // #7182: `trusty-audit` in isolation — the exact shape the recurrence
+        // was filed against, sourced from GitHub rather than the checkout.
+        let runner = ok_out(
+            r#"[{"name": "trusty-audit", "color": "", "description": "Crate: trusty-audit"}]"#,
+        );
+        let widened = widen_with_live_crate_labels(
+            ComponentLabels::from_names(["trusty-mpm".into()]),
+            &runner,
+        );
+        assert!(
+            widened.accepts("trusty-audit"),
+            "set was {:?}",
+            widened.names()
+        );
+        assert!(widened.accepts("trusty-mpm"), "the original set is kept");
+    }
+
+    #[test]
+    fn widen_ignores_a_non_crate_label() {
+        let runner = ok_out(
+            r#"[{"name": "enhancement", "color": "", "description": "New feature or request"}]"#,
+        );
+        let widened = widen_with_live_crate_labels(
+            ComponentLabels::from_names(["trusty-mpm".into()]),
+            &runner,
+        );
+        assert!(
+            !widened.accepts("enhancement"),
+            "set was {:?}",
+            widened.names()
+        );
+    }
+
+    #[test]
+    fn widen_on_gh_failure_keeps_the_set() {
+        let runner = fail_out();
+        let original = ComponentLabels::from_names(["trusty-mpm".into()]);
+        let widened = widen_with_live_crate_labels(original.clone(), &runner);
+        assert_eq!(widened, original, "a gh failure must not change the set");
     }
 
     fn facts(json: &str) -> IssueFacts {

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/mod.rs
@@ -137,7 +137,7 @@ fn dispatch<S: TicketSystem>(
             recent,
             since,
         } => {
-            audit::run(&ticketing, gh_env, issue, recent, since)?;
+            audit::run(&ticketing, gh_env, runner, issue, recent, since)?;
         }
         IssueCmd::Repair { issue, config } => {
             let model = load_model(config.as_deref(), lifecycle)?;

--- a/crates/trusty-mpm/src/bin/tm/commands/ticket/labels.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/ticket/labels.rs
@@ -63,7 +63,9 @@ pub(crate) enum AssigneeTarget {
 /// Test: `gh_list_repo_labels_parses`, `gh_list_repo_labels_errors`,
 /// `gh_list_repo_labels_reads_past_the_default_page`,
 /// `gh_list_repo_labels_rejects_a_truncated_page`.
-pub(crate) fn gh_list_repo_labels<R: CommandRunner>(runner: &R) -> anyhow::Result<Vec<RepoLabel>> {
+pub(crate) fn gh_list_repo_labels<R: CommandRunner + ?Sized>(
+    runner: &R,
+) -> anyhow::Result<Vec<RepoLabel>> {
     // #6914: the probe asked for gh's default 30-label page and read a partial
     // label set as if it were the whole repo.
     let limit = trusty_mpm::core::policy_labels::LABEL_LIST_LIMIT;

--- a/crates/trusty-mpm/src/core/component_labels_tests.rs
+++ b/crates/trusty-mpm/src/core/component_labels_tests.rs
@@ -1,14 +1,17 @@
 //! Tests for [`super`] — the accepted component-label set (#7123).
 //!
-//! Every test builds a throwaway workspace in a `TempDir`, so nothing here
-//! depends on the checkout it runs in.
+//! Every test but one builds a throwaway workspace in a `TempDir`, so it does
+//! not depend on the checkout it runs in.
+//! `resolve_accepts_every_live_workspace_crate` is the exception (#7182): it
+//! runs the real derivation against THIS checkout's actual `crates/*`
+//! listing, so a drift a synthetic fixture could not see still fails CI.
 
 use std::fs;
 use std::path::Path;
 
 use tempfile::TempDir;
 
-use super::{ComponentLabels, cargo_workspace_root, expand_member};
+use super::{ComponentLabels, cargo_workspace_root, expand_member, package_name};
 use crate::core::trusty_tools_config::ResolvedTicketing;
 
 /// Write a crate directory with a `[package] name`.
@@ -183,4 +186,39 @@ fn member_literal_path_is_kept() {
 fn member_pattern_that_matches_nothing_yields_nothing() {
     let tmp = workspace();
     assert!(expand_member(tmp.path(), "services/*").is_empty());
+}
+
+/// #7182 (recurrence of #7123): every OTHER test in this file resolves
+/// against a synthetic fixture, so nothing here would notice `resolve` ever
+/// drifting from THIS checkout's actual `crates/*` listing — the exact gap a
+/// hand-maintained allow-list would also have had. This runs the real
+/// derivation against the real repository: every directory `crates/*`
+/// contains (this checkout's ground truth, walked fresh — never a hardcoded
+/// name) must resolve to an accepted package-name label, `trusty-audit`
+/// included.
+#[test]
+fn resolve_accepts_every_live_workspace_crate() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("crates/trusty-mpm/src/core is 3 levels under the workspace root");
+    let labels = ComponentLabels::resolve(&ResolvedTicketing::default(), Some(root));
+    let crates_dir = root.join("crates");
+    let entries = fs::read_dir(&crates_dir)
+        .unwrap_or_else(|e| panic!("read_dir({}): {e}", crates_dir.display()));
+    for entry in entries {
+        let dir = entry.unwrap().path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let Some(name) = package_name(&dir) else {
+            continue;
+        };
+        assert!(
+            labels.accepts(&name),
+            "crates/{} declares package `{name}`, not accepted; set was {:?}",
+            dir.file_name().unwrap().to_string_lossy(),
+            labels.names()
+        );
+    }
 }

--- a/crates/trusty-mpm/src/core/issue_audit.rs
+++ b/crates/trusty-mpm/src/core/issue_audit.rs
@@ -369,7 +369,8 @@ fn no_milestone_reason(comments: &[CommentRef]) -> Option<String> {
 /// now [`ComponentLabels`]'s, and the FAIL line names every label in it so the
 /// fix is a label the reader can copy rather than a guess.
 /// Test: `a_missing_component_label_fails`,
-/// `a_non_mpm_crate_component_label_passes`.
+/// `a_non_mpm_crate_component_label_passes`,
+/// `trusty_audit_alone_passes_the_component_label_check`.
 fn component_row(facts: &IssueFacts, components: &ComponentLabels) -> AuditRow {
     let present: Vec<&str> = facts
         .labels

--- a/crates/trusty-mpm/src/core/issue_audit_tests.rs
+++ b/crates/trusty-mpm/src/core/issue_audit_tests.rs
@@ -290,6 +290,30 @@ fn a_non_mpm_crate_component_label_passes() {
 }
 
 #[test]
+fn trusty_audit_alone_passes_the_component_label_check() {
+    // #7182: the recurrence of #7123 — `a_non_mpm_crate_component_label_passes`
+    // above carries `tga` AND `trusty-audit` together, so it passed via `tga`
+    // and never isolated `trusty-audit` as the deciding label (the exact gap
+    // the recurrence comment named). This fixture carries `trusty-audit` alone.
+    let tmp = workspace_fixture();
+    let resolved = ComponentLabels::resolve(&standard(), Some(tmp.path()));
+    let json = COMPLIANT.replace(
+        r#"[{"name": "enhancement"}, {"name": "trusty-mpm"}]"#,
+        r#"[{"name": "enhancement"}, {"name": "trusty-audit"}]"#,
+    );
+    let audit = audit_issue(&parse(&json), &standard(), &resolved);
+    let component = row(&audit, "component label");
+    assert_eq!(
+        component.verdict,
+        Verdict::Pass,
+        "detail was: {}",
+        component.detail
+    );
+    assert_eq!(component.detail, "trusty-audit");
+    assert!(!audit.failed());
+}
+
+#[test]
 fn an_issue_with_no_crate_label_still_fails_against_the_widened_set() {
     // #7123 widened the accepted set; it did not weaken the rule to "any label
     // present". An issue carrying only a type and a priority still FAILs, and


### PR DESCRIPTION
## Summary

Refs #7123 (recurrence #7182: `tm issue audit 7156` FAILed component-label on an issue carrying `trusty-audit` alone).

- #7123 (PR #7143, squash `201d34b9b`) already made `ComponentLabels::resolve` derive the accepted set from the workspace's own `Cargo.toml` rather than a hand-maintained list. A live test in this PR (`resolve_accepts_every_live_workspace_crate`) runs that derivation against THIS checkout's real `crates/*` and confirms it already accepts `trusty-audit` — the recurrence could not be reproduced against `origin/main`'s HEAD.
- That points at the one failure mode a local `Cargo.toml` read can never see: a stale or wrong working directory at the point `tm issue audit` actually ran. `tm issue audit` now widens the accepted set with a second, independent source — the repository's own live `gh label list`, filtered to labels whose description names a crate (`Crate: <name>`, the convention `tm issue seed-labels` already writes). GitHub's label list is correct regardless of local checkout staleness. A `gh` failure (offline, unauthenticated) leaves the Cargo.toml-derived set unchanged rather than failing the audit.
- Added the regression test the recurrence explicitly asked for: an issue carrying `trusty-audit` ALONE now has a dedicated test (`trusty_audit_alone_passes_the_component_label_check`) isolating it as the deciding label — the prior test (`a_non_mpm_crate_component_label_passes`) carried it alongside `tga`, which is exactly why the gap went unnoticed in the #7123 live verification.

## Test plan

Rung 3 (localized behavior inside one crate), all `-p trusty-mpm`:

- `cargo fmt --check` — clean.
- `cargo check -p trusty-mpm --all-targets` — clean.
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean (0 errors; 3 pre-existing, unrelated multi-bin-target manifest warnings).
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — `EXIT=0`, every target ran, 0 failed. New tests, all `ok`: `resolve_accepts_every_live_workspace_crate`, `trusty_audit_alone_passes_the_component_label_check`, `widen_adds_a_crate_described_label`, `widen_ignores_a_non_crate_label`, `widen_on_gh_failure_keeps_the_set`.
- `bash scripts/check_line_cap.sh` — OK, 0 violations.
- `bash scripts/check_changelog_fragment.sh` — OK, fragment present.
- `bash scripts/check_test_pointers.sh` — OK, 0 dangling pointers.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01ER5DBvGQ54K5sgFLb9G5vz