### PR TITLE
docs: ignore target-worktree/ and say so in the worktree discipline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
 **/target/
+# #7177: worktree build output isolation
+**/target-worktree/
 **/*.rs.bk
 .env
 .env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,6 +459,9 @@ independently reviewable PR outcome, subagent confinement, cleanup — lives in
   from a checkout with an empty `git status --porcelain` at a known commit —
   check it, don't assume it. A fresh worktree off `origin/main` satisfies that by
   construction and stays the default.
+  When staging worktree changes with git, always name files explicitly: `git add <file>` or `git add -p`.
+  Never use `git add -A` in a worktree, as it stages untracked build directories like `target-worktree/`.
+  Verify the ignored name with `git check-ignore -v target-worktree/` from the worktree root.
 - The main checkout is not automatically disqualified: the write boundary
   restricts SOURCE writes only, so docs and configuration (`.md` included) stay
   writable and committable there

--- a/docs/reference/worktree-discipline.md
+++ b/docs/reference/worktree-discipline.md
@@ -113,3 +113,9 @@ partway through leaves that session's uncommitted work exactly where it was.
 The old form of this recipe stashed the dirty checkout instead, which meant an
 interrupted run left the work in a stash entry someone had to find and restore
 by hand (#4730).
+
+## Git Staging in Worktrees
+
+When staging changes in a worktree, always name files explicitly: `git add <file>` or `git add -p`.
+Never use `git add -A` in a worktree, as it stages untracked build directories.
+The ignored directory name is `target-worktree/`, verified with `git check-ignore -v target-worktree/` from the worktree root.


### PR DESCRIPTION
## Summary

Adds `.gitignore` entry for `target-worktree/` and documents the caution about `git add -A` in worktrees. Prevents accidental staging of build output when agents commit changes in worktrees.

## Test plan

**Rung 1 (docs/config only):**

```bash
bash scripts/check_sld.sh
bash scripts/check_doc_paths.sh
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools