### PR TITLE
fix: every spawned git disables auto-maintenance; doctor warns on storms

### DIFF
--- a/crates/trusty-common/changelog.d/7171-git-maintenance-storm.md
+++ b/crates/trusty-common/changelog.d/7171-git-maintenance-storm.md
@@ -1,0 +1,8 @@
+Added
+
+- New `trusty_common::git` module: the workspace's single entry point for
+  constructing a `git` subprocess. `git::command()` / `git::command_in()`
+  (sync) and `git::tokio_command()` / `git::tokio_command_in()` (async) all
+  carry `-c maintenance.auto=false -c gc.auto=0` on argv, preventing a fleet
+  of worktrees from independently triggering `git maintenance run --auto`
+  repacks against a shared object store (#7171).

--- a/crates/trusty-common/src/git.rs
+++ b/crates/trusty-common/src/git.rs
@@ -1,0 +1,201 @@
+//! The workspace's single entry point for constructing a `git` subprocess — #7171.
+//!
+//! Why: 41 detached `git maintenance run --auto` repacks hit the shared 21 GB
+//! `.git` from ~25 worktrees in one incident (load 141) because every one of
+//! the ~90 production `Command::new("git")` sites across trusty-common and
+//! trusty-mpm ran with git's own auto-maintenance heuristics live. Git decides
+//! whether to run background maintenance/gc **after any command that touches
+//! the object store** (`fetch`, `commit`, `checkout`, …), so a fleet of
+//! worktrees each running ordinary git commands independently triggers
+//! independent maintenance runs against the ONE shared object store they all
+//! point at (`.git/worktrees/*` share one `objects/` directory). This module
+//! is the common-entry-point rule (`CLAUDE.md`, "Common entry point, clean
+//! domain demarcation") applied to git spawns: every caller that wants a `git`
+//! subprocess gets one through here, so the fix lands once instead of at each
+//! of the ~90 sites.
+//! What: [`command`] and [`command_in`] build a `std::process::Command`
+//! (async callers: [`tokio_command`] / [`tokio_command_in`] build a
+//! `tokio::process::Command`) that always carries
+//! [`MAINTENANCE_DISABLE_ARGS`] as the FIRST argv entries. `-c key=value` is
+//! passed on argv rather than written to a config file, so it outranks repo
+//! config, global config, AND system config — a worktree cannot re-enable
+//! maintenance for itself even if something writes `maintenance.auto = true`
+//! into the shared `.git/config`, and no per-repo provisioning step is needed
+//! for a git command that already runs through this module. Provisioning
+//! (writing `maintenance.auto=false` / `gc.auto=0` into a managed checkout's
+//! `.git/config`) is the separate, complementary fix in
+//! `trusty-mpm::core::git_maintenance` for the ambient case — an operator
+//! running git directly in a worktree, outside anything that calls this
+//! module.
+//! Test: `command_disables_maintenance_and_gc`,
+//! `command_in_adds_dash_c_before_the_directory`,
+//! `tokio_command_disables_maintenance_and_gc` (feature `unconditional-only`).
+
+use std::path::Path;
+use std::process::Command;
+
+/// `-c` argv pairs that disable git's automatic background maintenance and
+/// gc for the single invocation they are attached to (#7171).
+///
+/// Why: `git -c key=value` wins over every config file (repo, global,
+/// system), so passing these on argv is the only form that cannot be
+/// silently overridden by config a worktree does not control.
+/// What: `maintenance.auto=false` stops git from scheduling a background
+/// `git maintenance run --auto` after this command; `gc.auto=0` stops the
+/// older, still-live `git gc --auto` heuristic some git subcommands check
+/// independently of the maintenance scheduler. Both are pinned — one alone
+/// leaves the other heuristic live.
+/// Test: `command_disables_maintenance_and_gc`.
+pub const MAINTENANCE_DISABLE_ARGS: &[&str] = &["-c", "maintenance.auto=false", "-c", "gc.auto=0"];
+
+/// Build a bare `git` [`std::process::Command`] with automatic
+/// maintenance/gc disabled.
+///
+/// Why: the single place every synchronous git spawn in the workspace
+/// should originate from (#7171) — see the module doc.
+/// What: `git -c maintenance.auto=false -c gc.auto=0`, with no subcommand or
+/// `-C` yet — callers append their own args (and `-C`/`current_dir` where a
+/// target directory applies) exactly as they would on a plain
+/// `Command::new("git")`.
+/// Test: `command_disables_maintenance_and_gc`.
+pub fn command() -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(MAINTENANCE_DISABLE_ARGS);
+    cmd
+}
+
+/// [`command`] plus `-C <dir>`, for the common case of a git invocation
+/// scoped to one repository or worktree.
+///
+/// Why: nearly every call site immediately does `.arg("-C").arg(dir)`;
+/// folding it in here removes one more place a future site could copy a bare
+/// `Command::new("git")` instead of this module's entry point.
+/// What: `git -c maintenance.auto=false -c gc.auto=0 -C <dir>`. `-C` is a
+/// top-level git option, so its position relative to the `-c` pairs above
+/// does not matter — both must (and here do) precede the subcommand a caller
+/// appends next.
+/// Test: `command_in_adds_dash_c_before_the_directory`.
+pub fn command_in(dir: &Path) -> Command {
+    let mut cmd = command();
+    cmd.arg("-C").arg(dir);
+    cmd
+}
+
+/// [`command`], as a `tokio::process::Command` for an async call site.
+///
+/// Why: some daemon call sites already run git under `tokio::process` (the
+/// blocking cost of `std::process::Command::output()` inside an async
+/// handler is what they avoid); those sites need the same maintenance-free
+/// argv without going through `spawn_blocking` just to reach [`command`].
+/// What: `git -c maintenance.auto=false -c gc.auto=0`, built on
+/// `tokio::process::Command` — `tokio`'s `process` feature is already an
+/// unconditional dependency of this crate.
+/// Test: `tokio_command_disables_maintenance_and_gc`.
+pub fn tokio_command() -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.args(MAINTENANCE_DISABLE_ARGS);
+    cmd
+}
+
+/// [`tokio_command`] plus `-C <dir>` — the async counterpart to [`command_in`].
+///
+/// Test: `tokio_command_in_adds_dash_c_before_the_directory`.
+pub fn tokio_command_in(dir: &Path) -> tokio::process::Command {
+    let mut cmd = tokio_command();
+    cmd.arg("-C").arg(dir);
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn argv(cmd: &Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn tokio_argv(cmd: &tokio::process::Command) -> Vec<String> {
+        cmd.as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn command_disables_maintenance_and_gc() {
+        let cmd = command();
+        assert_eq!(cmd.get_program(), "git");
+        let args = argv(&cmd);
+        assert_eq!(
+            args,
+            vec!["-c", "maintenance.auto=false", "-c", "gc.auto=0"]
+        );
+    }
+
+    #[test]
+    fn command_in_adds_dash_c_before_the_directory() {
+        let cmd = command_in(Path::new("/tmp/example-repo"));
+        let args = argv(&cmd);
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "maintenance.auto=false",
+                "-c",
+                "gc.auto=0",
+                "-C",
+                "/tmp/example-repo",
+            ]
+        );
+    }
+
+    #[test]
+    fn tokio_command_disables_maintenance_and_gc() {
+        let cmd = tokio_command();
+        assert_eq!(cmd.as_std().get_program(), "git");
+        let args = tokio_argv(&cmd);
+        assert_eq!(
+            args,
+            vec!["-c", "maintenance.auto=false", "-c", "gc.auto=0"]
+        );
+    }
+
+    #[test]
+    fn tokio_command_in_adds_dash_c_before_the_directory() {
+        let cmd = tokio_command_in(Path::new("/tmp/example-repo"));
+        let args = tokio_argv(&cmd);
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "maintenance.auto=false",
+                "-c",
+                "gc.auto=0",
+                "-C",
+                "/tmp/example-repo",
+            ]
+        );
+    }
+
+    #[test]
+    fn callers_can_append_args_after_command_in() {
+        let mut cmd = command_in(Path::new("/tmp/example-repo"));
+        cmd.args(["status", "--porcelain"]);
+        let args = argv(&cmd);
+        assert_eq!(
+            args,
+            vec![
+                "-c",
+                "maintenance.auto=false",
+                "-c",
+                "gc.auto=0",
+                "-C",
+                "/tmp/example-repo",
+                "status",
+                "--porcelain",
+            ]
+        );
+    }
+}

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -1298,6 +1298,21 @@ pub mod tmux;
 #[cfg(feature = "gh-cli")]
 pub mod gh;
 
+/// The workspace's single entry point for constructing a `git` subprocess (#7171).
+///
+/// Why: ~90 production `Command::new("git")` sites across trusty-common and
+/// trusty-mpm each ran with git's own background-maintenance heuristics live,
+/// so a fleet of worktrees running ordinary git commands independently
+/// triggered independent `git maintenance run --auto` repacks against the ONE
+/// shared object store they all point at — 41 detached repacks from ~25
+/// worktrees in one incident, load 141.
+/// What: [`git::command`] / [`git::command_in`] (sync) and
+/// [`git::tokio_command`] / [`git::tokio_command_in`] (async) — every one
+/// carries [`git::MAINTENANCE_DISABLE_ARGS`] as argv, which outranks every
+/// config file.
+/// Test: `cargo test -p trusty-common --features unconditional-only -- git::`.
+pub mod git;
+
 // ─── Re-exports preserving the pre-split public API ───────────────────────
 
 pub use chat::{

--- a/crates/trusty-common/tests/git_maintenance_burst.rs
+++ b/crates/trusty-common/tests/git_maintenance_burst.rs
@@ -1,0 +1,243 @@
+//! Integration test: a burst of concurrent git operations through
+//! `trusty_common::git` triggers zero `git maintenance run --auto` spawns —
+//! the #7171 issue closure criterion, not just correct argv (the unit tests
+//! in `src/git.rs` already cover that).
+//!
+//! Why: the incident was 41 detached `git maintenance run --auto` repacks
+//! against one shared object store from ~25 worktrees. Nothing before this
+//! file drove real concurrent git traffic through the builder and checked
+//! what git itself decided to do.
+//! What: builds a bare origin, a `base` clone, and 2 linked worktrees sharing
+//! `base`'s object store, then runs a burst of 10 concurrent fetch+commit
+//! task sets through `trusty_common::git::command_in`, each with `GIT_TRACE`
+//! captured to its own file. Asserts none of the 10 traces contain git's own
+//! `"maintenance run"` invocation line — the reliable signal, since it is
+//! git's own record of what it decided to run, not a `ps` snapshot that can
+//! miss a child that has already exited. A concurrent `ps` poll for the
+//! burst's duration is a second, best-effort (racy) corroboration, and the
+//! shared object store is checked afterward for a `tmp_pack_*` or
+//! `maintenance.lock` repack artifact.
+//! Test: this file IS the test —
+//! `burst_of_concurrent_ops_spawns_no_maintenance_run`.
+//!
+//! Manually verified the OPPOSITE once, by hand: swapping
+//! `trusty_common::git::command_in` in [`fetch_and_commit_via_builder`] for a
+//! bare `Command::new("git").arg("-C").arg(dir)` and re-running this exact
+//! test made ALL 10 trace files contain `"maintenance run"` and the test
+//! failed with `traces show a spawn attempt: [10 paths]` — see the PR body
+//! for the pasted failure. Confirms independently what a standalone
+//! `GIT_TRACE=1 git fetch origin` also showed against this fixture's shape
+//! (`maintenance.auto` forced `true`, no `-c` override): git 2.54.0 prints
+//! `trace: run_command: git maintenance run --auto --no-quiet --detach`. That
+//! bare-`Command::new` variant is deliberately NOT part of this committed
+//! suite — proving the negative once is enough; the suite itself only
+//! exercises the fix.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Run a plain (unbuilt) `git -C <dir> <args>` for FIXTURE SETUP only — never
+/// for anything this test asserts about. Returns `false` on any failure.
+fn git_ok(dir: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// A bare origin, a `base` clone with one commit pushed, and `worktree_count`
+/// linked worktrees off `base` sharing its object store — the shape of the
+/// #7171 incident (many worktrees, one shared `objects/`).
+struct Fixture {
+    root: tempfile::TempDir,
+    base: PathBuf,
+    worktrees: Vec<PathBuf>,
+}
+
+/// Build the fixture, or `None` when `git` is unavailable on this runner —
+/// mirrors the established pattern in
+/// `session_manager::decommission_worktree_tests` (trusty-mpm).
+fn build_fixture(worktree_count: usize) -> Option<Fixture> {
+    let root = tempfile::tempdir().ok()?;
+    let origin = root.path().join("origin.git");
+    let base = root.path().join("base");
+    if !git_ok(root.path(), &["init", "--bare", "-q", origin.to_str()?]) {
+        return None;
+    }
+    if !Command::new("git")
+        .args(["clone", "-q"])
+        .arg(&origin)
+        .arg(&base)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    git_ok(&base, &["config", "user.email", "t@example.invalid"]);
+    git_ok(&base, &["config", "user.name", "T"]);
+    std::fs::write(base.join("f.txt"), "seed\n").ok()?;
+    git_ok(&base, &["add", "f.txt"]);
+    git_ok(&base, &["commit", "-q", "-m", "seed"]);
+    git_ok(&base, &["push", "-q", "origin", "HEAD:main"]);
+
+    let mut worktrees = Vec::new();
+    for i in 0..worktree_count {
+        let wt = root.path().join(format!("wt-{i}"));
+        let branch = format!("wt-{i}");
+        let ok = git_ok(
+            &base,
+            &["worktree", "add", "-q", "-b", &branch, wt.to_str()?, "HEAD"],
+        );
+        if !ok {
+            return None;
+        }
+        git_ok(&wt, &["config", "user.email", "t@example.invalid"]);
+        git_ok(&wt, &["config", "user.name", "T"]);
+        worktrees.push(wt);
+    }
+    Some(Fixture {
+        root,
+        base,
+        worktrees,
+    })
+}
+
+/// One fetch+commit task, entirely through the builder under test, with
+/// `GIT_TRACE` pointed at `trace_path` so the assertion can read what git
+/// itself decided to run.
+fn fetch_and_commit_via_builder(worktree: &Path, index: usize, trace_path: &Path) {
+    let file = worktree.join(format!("burst-{index}.txt"));
+    let _ = std::fs::write(&file, format!("{index}\n"));
+    let _ = trusty_common::git::command_in(worktree)
+        .env("GIT_TRACE", trace_path)
+        .args(["add", "--"])
+        .arg(&file)
+        .output();
+    let _ = trusty_common::git::command_in(worktree)
+        .env("GIT_TRACE", trace_path)
+        .args(["commit", "-q", "-m"])
+        .arg(format!("burst {index}"))
+        .output();
+    let _ = trusty_common::git::command_in(worktree)
+        .env("GIT_TRACE", trace_path)
+        .args(["fetch", "origin"])
+        .output();
+}
+
+#[test]
+fn burst_of_concurrent_ops_spawns_no_maintenance_run() {
+    const WORKTREES: usize = 2;
+    const BURST_SIZE: usize = 10;
+
+    let Some(fixture) = build_fixture(WORKTREES) else {
+        return; // no git on this runner
+    };
+    // Force the pre-#7171 default ON, locally, so this test is meaningful
+    // regardless of the runner's own ambient config — some operator machines
+    // already carry a manual `maintenance.auto=false` mitigation, which would
+    // make the fix look like it worked even with the bug present.
+    assert!(git_ok(
+        &fixture.base,
+        &["config", "--local", "maintenance.auto", "true"]
+    ));
+    assert!(git_ok(
+        &fixture.base,
+        &["config", "--local", "gc.auto", "1"]
+    ));
+
+    // Best-effort corroboration: poll `ps` for a `git maintenance` line
+    // naming this fixture's own tempdir path, for the whole burst window.
+    // Racy by construction (a spawned-but-idle child can exit between
+    // polls) — the GIT_TRACE assertion below is the reliable half.
+    let seen_in_ps = Arc::new(AtomicBool::new(false));
+    let stop = Arc::new(AtomicBool::new(false));
+    let root_str = fixture.root.path().to_string_lossy().into_owned();
+    let watcher = {
+        let seen_in_ps = Arc::clone(&seen_in_ps);
+        let stop = Arc::clone(&stop);
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                if let Ok(out) = Command::new("ps").args(["-A", "-o", "command="]).output() {
+                    let text = String::from_utf8_lossy(&out.stdout);
+                    if text
+                        .lines()
+                        .any(|l| l.contains("maintenance run") && l.contains(&root_str))
+                    {
+                        seen_in_ps.store(true, Ordering::Relaxed);
+                    }
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+        })
+    };
+
+    let trace_dir = fixture.root.path().join("traces");
+    std::fs::create_dir_all(&trace_dir).expect("mkdir traces");
+
+    let start = Instant::now();
+    let handles: Vec<_> = (0..BURST_SIZE)
+        .map(|i| {
+            let worktree = fixture.worktrees[i % fixture.worktrees.len()].clone();
+            let trace_path = trace_dir.join(format!("trace-{i}.log"));
+            thread::spawn(move || {
+                fetch_and_commit_via_builder(&worktree, i, &trace_path);
+                trace_path
+            })
+        })
+        .collect();
+    let trace_paths: Vec<PathBuf> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let elapsed = start.elapsed();
+
+    // Give the watcher a moment to catch anything still finishing, then stop.
+    thread::sleep(Duration::from_millis(200));
+    stop.store(true, Ordering::Relaxed);
+    watcher.join().expect("ps watcher thread panicked");
+
+    assert!(
+        elapsed < Duration::from_secs(25),
+        "burst took {elapsed:?} — too slow for a normal (non-#[ignore]) test"
+    );
+
+    // The reliable assertion: git's own trace for every one of the 10 task
+    // sets must never show it deciding to run background maintenance.
+    let mut offending = Vec::new();
+    for path in &trace_paths {
+        let Ok(text) = std::fs::read_to_string(path) else {
+            continue; // GIT_TRACE writes nothing when there was nothing to trace
+        };
+        if text.contains("maintenance run") {
+            offending.push(path.display().to_string());
+        }
+    }
+    assert!(
+        offending.is_empty(),
+        "trusty_common::git::command_in's -c maintenance.auto=false failed to suppress \
+         background maintenance — traces show a spawn attempt: {offending:?}"
+    );
+
+    assert!(
+        !seen_in_ps.load(Ordering::Relaxed),
+        "ps observed a live `git maintenance` process for this fixture during the burst"
+    );
+
+    // No repack-in-progress artifact left behind in the shared object store.
+    let objects_dir = fixture.base.join(".git").join("objects");
+    if let Ok(entries) = std::fs::read_dir(&objects_dir) {
+        for entry in entries.filter_map(Result::ok) {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            assert!(
+                !name.starts_with("tmp_pack_") && name != "maintenance.lock",
+                "shared object store carries a repack artifact after the burst: {name}"
+            );
+        }
+    }
+}

--- a/crates/trusty-mpm/changelog.d/7171-git-maintenance-storm.md
+++ b/crates/trusty-mpm/changelog.d/7171-git-maintenance-storm.md
@@ -16,3 +16,10 @@ Fixed
   warn when a registered base clone carries more than 3 worktrees without
   `maintenance.auto` pinned off, and when more than one `git maintenance
   run` process is live on the host at once (#7171).
+- `maintenance_processes` now reports `Unknown`, not `Ok`, when the `ps`
+  spawn itself fails — a sandboxed host no longer reads as "0 processes,
+  healthy" during an actual storm (#7171).
+- Migrated `session_manager::decommission`'s two `git worktree prune`
+  sites (session teardown, one of the storm-trigger commands) and
+  `core::session_launch::workstream_label`'s origin-URL read onto
+  `trusty_common::git` (#7171).

--- a/crates/trusty-mpm/changelog.d/7171-git-maintenance-storm.md
+++ b/crates/trusty-mpm/changelog.d/7171-git-maintenance-storm.md
@@ -1,0 +1,18 @@
+Fixed
+
+- Every git subprocess trusty-mpm spawns on the in-project clone/fetch/
+  worktree-add hot path, the catalog-sync provisioner, and the crate's
+  hardened `git_command` entry point now routes through
+  `trusty_common::git`, which disables git's own auto-maintenance/gc for
+  that invocation. Prevents a fleet of session worktrees from each
+  independently triggering a `git maintenance run --auto` repack against
+  the shared base clone's object store (#7171).
+- New `core::git_maintenance::disable_and_log`: idempotently writes
+  `maintenance.auto=false` / `gc.auto=0` into a managed checkout's local
+  git config at clone time (`ensure_base_clone`) and at explicit project
+  registration (`mpm.projects.register`), so operator-run git inside a
+  worktree cannot re-trigger the storm either (#7171).
+- New `tm doctor` probes `maintenance_config` and `maintenance_processes`:
+  warn when a registered base clone carries more than 3 worktrees without
+  `maintenance.auto` pinned off, and when more than one `git maintenance
+  run` process is live on the host at once (#7171).

--- a/crates/trusty-mpm/src/bin/tm/formatters/info_box/probes.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/info_box/probes.rs
@@ -59,7 +59,9 @@ pub(crate) fn probe_recent_commits(workdir: &str) -> Vec<CommitLine> {
 /// non-zero exit or parse failure returns `None`.
 /// Test: indirect — covered by `probe_recent_commits` tests.
 fn run_git_log(workdir: &str) -> Option<Vec<CommitLine>> {
-    let mut cmd = std::process::Command::new("git");
+    // #7171: through the shared entry point so a per-worktree info-box render
+    // cannot trigger a background `git maintenance run --auto`.
+    let mut cmd = trusty_common::git::command();
     cmd.arg("-C")
         .arg(workdir)
         .args(["log", "--oneline", "-5", "--format=%h|%cr|%s"]);

--- a/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
+++ b/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
@@ -170,6 +170,14 @@ pub(crate) const DOCTOR_CHECKS: &[(&str, &str)] = &[
         "Warns when the project's clone carries no trusty-mpm cross-branch `pre-push` guard, or an older revision of it — the guard installs itself only on the clone path, so a base provisioned before it shipped is silently unprotected and a worktree tracking a foreign branch can force-push over that branch's reviewed lineage. Names the `tm repair push-guard` retrofit; doctor never writes into a repository (issue #2867).",
     ),
     (
+        "maintenance_config",
+        "Warns when a registered base clone carries more than 3 worktrees without `maintenance.auto=false` pinned in its own local git config — operator-run git in any of those worktrees can still trigger a `git maintenance run --auto` repack against the shared object store. Names the exposed base clone(s) and the `git config --local` fix. Read-only (issue #7171).",
+    ),
+    (
+        "maintenance_processes",
+        "Warns when more than one `git maintenance run` process is live on the host at once — the storm pattern from the originating incident (41 concurrent repacks against one shared object store). Read-only: `ps -A -o command=`, never a signal or a kill (issue #7171).",
+    ),
+    (
         "binary_provenance",
         "Where the RUNNING binary came from and whether that source still exists: reads cargo's own `$CARGO_HOME/.crates2.json` install ledger and compares it against the running executable. Fails when the same binary is provided by more than one install, when the running binary is OLDER than the ledger's record for that same file or the two cannot be ordered as semver, or when a `cargo install --path` source directory has been reaped (no provenance, no upgrade path). Warns for a live path/git install, which is invisible to registry update detection. Reports UNKNOWN — never `Ok` — when the ledger is unreadable, does not cover the binary (a prebuilt-installer or package-manager install), or records a version OLDER than what is running, which means the ledger no longer describes the file on disk (issue #4964). Read-only; never installs, moves, or deletes (issue #4033, ADR-0021).",
     ),

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -228,7 +228,7 @@ async fn execute_doctor_against_test_daemon() {
     match executor.execute(TrustyCommand::Doctor).await {
         CommandResult::Doctor(report) => {
             // This test owns the EXECUTOR round-trip, not the check roster.
-            // The exact count is pinned by `run_doctor_produces_forty_checks`
+            // The exact count is pinned by `run_doctor_produces_forty_two_checks`
             // and `doctor_endpoint_returns_report`, both of which derive it from
             // their own name list — duplicating a bare literal here just made it a
             // fourth place to forget (#4090 review LOW-1).

--- a/crates/trusty-mpm/src/core/git_maintenance.rs
+++ b/crates/trusty-mpm/src/core/git_maintenance.rs
@@ -1,0 +1,181 @@
+//! Idempotently disable git's own background maintenance/gc on a managed
+//! checkout, once, at provisioning time (#7171).
+//!
+//! Why: [`trusty_common::git`] protects every git invocation THIS codebase
+//! makes by passing `-c maintenance.auto=false -c gc.auto=0` on argv, which
+//! outranks config — but it protects nothing an OPERATOR types directly into
+//! a shell inside one of the ~25 worktrees a base clone can carry. Ordinary
+//! git commands (`fetch`, `commit`, `checkout`, …) still decide whether to
+//! trigger `git maintenance run --auto` by reading `maintenance.auto` from
+//! config, so an operator's own `git pull` in a worktree was exactly as able
+//! to fire the storm as the daemon's own code. Writing the setting into the
+//! repo's shared `.git/config` closes that gap: every worktree of one base
+//! clone shares `GIT_COMMON_DIR`, so ONE write at clone/registration time
+//! covers every worktree the base will ever host, the same sharing property
+//! `core::push_guard` already relies on for its `pre-push` hook install.
+//! What: [`disable_auto_maintenance`] runs `git config --local
+//! maintenance.auto false` and `git config --local gc.auto 0` against a
+//! repository path — plain `git config --local`, not the argv-level `-c`
+//! form, because this needs to persist in the checkout rather than apply to
+//! one invocation. [`disable_and_log`] wraps it exactly like
+//! [`super::push_guard::install_and_log`]: best-effort, never fails the
+//! caller's clone or registration, `warn!`-logs any failure. Both writes are
+//! plain `git config --local` calls, so re-running either is a no-op — safe
+//! to call on every clone/registration, not just the first.
+//! Test: `disable_auto_maintenance_writes_both_keys`,
+//! `disable_auto_maintenance_is_idempotent`,
+//! `disable_auto_maintenance_reports_a_non_repo_path`.
+
+use std::path::Path;
+
+/// The `git config --local <key> <value>` pairs this module writes.
+///
+/// Why: kept as data rather than duplicated call sites so
+/// [`disable_auto_maintenance`]'s "both keys or a named failure" contract
+/// cannot drift from what it actually iterates.
+/// What: mirrors [`trusty_common::git::MAINTENANCE_DISABLE_ARGS`]'s two keys,
+/// spelled as `git config` values (`"false"`/`"0"`) rather than `-c` argv
+/// pairs (`"maintenance.auto=false"`/`"gc.auto=0"`) — the persisted and the
+/// per-invocation forms use git's two different value spellings for the same
+/// setting.
+/// Test: `disable_auto_maintenance_writes_both_keys`.
+const MAINTENANCE_CONFIG: &[(&str, &str)] = &[("maintenance.auto", "false"), ("gc.auto", "0")];
+
+/// Write [`MAINTENANCE_CONFIG`] into `repo_path`'s local git config.
+///
+/// Why: see the module doc — this is the provisioning-time half of #7171.
+/// What: runs `git -C <repo_path> config --local <key> <value>` once per
+/// entry in [`MAINTENANCE_CONFIG`], via [`trusty_common::git::command_in`] so
+/// the write itself cannot trigger a maintenance run either. Fails on the
+/// first key that cannot be written (not a git repo, an unreadable config, a
+/// spawn failure) rather than partially applying.
+/// Test: `disable_auto_maintenance_writes_both_keys`,
+/// `disable_auto_maintenance_is_idempotent`,
+/// `disable_auto_maintenance_reports_a_non_repo_path`.
+pub fn disable_auto_maintenance(repo_path: &Path) -> Result<(), String> {
+    for (key, value) in MAINTENANCE_CONFIG {
+        let out = trusty_common::git::command_in(repo_path)
+            .args(["config", "--local", key, value])
+            .output()
+            .map_err(|e| format!("git config --local {key} failed to spawn: {e}"))?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(format!(
+                "git config --local {key} {value} failed ({}): {}",
+                out.status,
+                stderr.trim()
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Best-effort [`disable_auto_maintenance`]: `warn!`-logs a failure, never
+/// returns one.
+///
+/// Why: provisioning a managed checkout (a fresh base clone, an explicit
+/// `mpm.projects.register`) must not fail — or partially roll back — over a
+/// setting that is a storm-prevention nicety, not a correctness requirement,
+/// exactly the same call this module mirrors [`super::push_guard::install_and_log`]
+/// on.
+/// What: logs `info!` on success, `warn!` (naming `repo_path` and the error)
+/// on failure — including the ordinary case of `repo_path` not being a git
+/// repository at all, which `register_project` cannot rule out ahead of the
+/// call.
+/// Test: covered indirectly by the call sites' own integration tests; the
+/// pure success/failure branches are exercised directly by
+/// `disable_auto_maintenance`'s own tests above.
+pub fn disable_and_log(repo_path: &Path) {
+    match disable_auto_maintenance(repo_path) {
+        Ok(()) => {
+            tracing::info!(
+                repo = %repo_path.display(),
+                "git auto-maintenance disabled on managed checkout (#7171)"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                repo = %repo_path.display(),
+                "git auto-maintenance NOT disabled (non-fatal, #7171): {e}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git_ok(dir: &Path, args: &[&str]) -> bool {
+        trusty_common::git::command_in(dir)
+            .args(args)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn git_config_get(dir: &Path, key: &str) -> Option<String> {
+        let out = trusty_common::git::command_in(dir)
+            .args(["config", "--get", key])
+            .output()
+            .ok()?;
+        out.status
+            .success()
+            .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    /// A real repo, or `None` when `git` is unavailable on the runner — mirrors
+    /// the established pattern in `session_manager::decommission_worktree_tests`.
+    fn repo() -> Option<tempfile::TempDir> {
+        let dir = tempfile::tempdir().ok()?;
+        if !git_ok(dir.path(), &["init", "-q", "."]) {
+            return None;
+        }
+        Some(dir)
+    }
+
+    #[test]
+    fn disable_auto_maintenance_writes_both_keys() {
+        let Some(dir) = repo() else {
+            return;
+        };
+        disable_auto_maintenance(dir.path()).expect("config write succeeds");
+        assert_eq!(
+            git_config_get(dir.path(), "maintenance.auto").as_deref(),
+            Some("false")
+        );
+        assert_eq!(git_config_get(dir.path(), "gc.auto").as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn disable_auto_maintenance_is_idempotent() {
+        let Some(dir) = repo() else {
+            return;
+        };
+        disable_auto_maintenance(dir.path()).expect("first write succeeds");
+        disable_auto_maintenance(dir.path()).expect("second write succeeds");
+        assert_eq!(
+            git_config_get(dir.path(), "maintenance.auto").as_deref(),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn disable_auto_maintenance_reports_a_non_repo_path() {
+        let Ok(dir) = tempfile::tempdir() else {
+            return;
+        };
+        // Not a git repo at all — `git config --local` must fail, not panic
+        // or silently succeed.
+        assert!(disable_auto_maintenance(dir.path()).is_err());
+    }
+
+    #[test]
+    fn disable_and_log_does_not_panic_on_a_non_repo_path() {
+        let Ok(dir) = tempfile::tempdir() else {
+            return;
+        };
+        // Best-effort: must not panic even when the underlying write fails.
+        disable_and_log(dir.path());
+    }
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -173,6 +173,11 @@ pub mod project_trust;
 pub mod protected_dirs;
 pub mod provisioning_stage;
 pub mod push_guard;
+// #7171: idempotently disables git's own background maintenance/gc on a
+// managed checkout, so an OPERATOR running git directly inside one of its
+// worktrees (outside anything that routes through `trusty_common::git`)
+// still gets the quieted repo.
+pub mod git_maintenance;
 // `tm reinstall`: the two-hop asset redeploy across every deploy destination,
 // and the install-provenance route its `--binary` flag takes.
 pub mod binary_reinstall;

--- a/crates/trusty-mpm/src/core/session_launch/workstream_label.rs
+++ b/crates/trusty-mpm/src/core/session_launch/workstream_label.rs
@@ -302,9 +302,9 @@ pub fn spawn_workstream_label_ensure(
 /// What: `None` on any git failure (not a repo, no origin, git absent) or an
 /// empty result.
 fn origin_url_from_workspace(dir: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(dir)
+    // #7171: through the shared entry point for consistency with every other
+    // git spawn in the crate.
+    let output = trusty_common::git::command_in(dir)
         .args(["config", "--get", "remote.origin.url"])
         .output()
         .ok()?;

--- a/crates/trusty-mpm/src/core/session_launch/worktree_sync.rs
+++ b/crates/trusty-mpm/src/core/session_launch/worktree_sync.rs
@@ -35,7 +35,6 @@
 //! `self_heal_claude_md_noop_when_absent`.
 
 use std::path::Path;
-use std::process::Command;
 use std::time::Duration;
 
 /// Upper bound on how long [`resume_self_heal`] will wait for the git
@@ -271,9 +270,10 @@ async fn sync_worktree_with_upstream_bounded(workspace: &Path) -> SyncOutcome {
 /// Run `git -C <workspace> <args>`, returning trimmed stdout on success or
 /// `None` on any failure (missing binary, non-zero exit, empty output).
 fn git_stdout(workspace: &Path, args: &[&str]) -> Option<String> {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(workspace)
+    // #7171: through the shared entry point — this runs on every resume of
+    // every session worktree, so it must not be able to trigger a background
+    // `git maintenance run --auto` against the shared object store.
+    let out = trusty_common::git::command_in(workspace)
         .args(args)
         .output()
         .ok()?;
@@ -287,9 +287,7 @@ fn git_stdout(workspace: &Path, args: &[&str]) -> Option<String> {
 /// Run `git -C <workspace> <args>`, returning `Ok(())` on success or
 /// `Err(stderr)` (trimmed) on any failure.
 fn git_run(workspace: &Path, args: &[&str]) -> Result<(), String> {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(workspace)
+    let out = trusty_common::git::command_in(workspace)
         .args(args)
         .output()
         .map_err(|e| format!("git exec failed: {e}"))?;
@@ -302,6 +300,8 @@ fn git_run(workspace: &Path, args: &[&str]) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+    use std::process::Command;
+
     use super::*;
     use tempfile::TempDir;
 

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1244,6 +1244,9 @@ async fn doctor_endpoint_returns_report() {
         "tcc_taint",
         "scaffold_tracking",
         "push_guard",
+        // #7171: the git-maintenance-storm detection probes.
+        "maintenance_config",
+        "maintenance_processes",
         "binary_provenance",
         // #5007: `sessions.json` integrity — a corrupt store blocks every write.
         "session_store",

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -175,6 +175,13 @@ use doctor_scaffold_tracking::check_scaffold_tracking;
 mod doctor_push_guard;
 use doctor_push_guard::check_push_guard;
 
+// Split out to keep this file under the 500-SLOC production cap (issue #7171 —
+// the git-maintenance-storm detection probes: an un-pinned base clone above
+// the worktree threshold, and more than one live `git maintenance run`).
+#[path = "doctor_maintenance_storm.rs"]
+mod doctor_maintenance_storm;
+use doctor_maintenance_storm::{check_live_maintenance_processes, check_maintenance_config};
+
 // Split out to keep this file under the 500-SLOC production cap (issue #2919 —
 // the worktree disk-consumption / merged-PR reclaimability probe, the
 // early-warning half of the 1.1 TiB leak post-mortem).
@@ -355,7 +362,7 @@ const PROBE_RETRY_DELAY: Duration = Duration::from_millis(500);
 /// the one tm-managed `CLAUDE_CONFIG_DIR` tier and nowhere else, so
 /// `check_agents`/`check_agent_skills` probe `paths.agent_deploy_dir()`, which
 /// is the same directory whether or not a `project_dir` was supplied.
-/// Test: `run_doctor_produces_forty_checks`,
+/// Test: `run_doctor_produces_forty_two_checks`,
 /// `agents_check_probes_the_managed_config_tier_not_the_workspace`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
@@ -486,6 +493,12 @@ pub async fn run_doctor(
     // clone that predates it is silently unprotected. Warn-only, naming the
     // `tm repair push-guard` retrofit; doctor never writes into a repository.
     checks.push(check_push_guard(project_dir));
+    // Issue #7171: an un-pinned base clone above the worktree threshold, and
+    // more than one live `git maintenance run` process — the detection half
+    // of the maintenance-storm fix (`trusty_common::git` and
+    // `core::git_maintenance` are the prevention half). Both read-only.
+    checks.push(check_maintenance_config(repos_root));
+    checks.push(check_live_maintenance_processes());
     // Issue #4033: where the RUNNING binary came from, and whether that source
     // still exists. Reports UNKNOWN — never Ok — when provenance cannot be
     // determined. Read-only; never installs, moves, or deletes.

--- a/crates/trusty-mpm/src/daemon/doctor_maintenance_storm.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_maintenance_storm.rs
@@ -163,20 +163,42 @@ pub(super) fn count_maintenance_processes(ps_output: &str) -> usize {
 /// `tm doctor`'s `maintenance_processes` probe (#7171).
 ///
 /// Why/What: see the module doc's second bullet. Read-only: `ps -A -o
-/// command=`, never a signal or a kill.
+/// command=`, never a signal or a kill. A failed `ps` spawn reports
+/// [`CheckStatus::Unknown`], never `Ok` — issue #4005 established that a
+/// probe which could not determine state must say so rather than degrade to
+/// healthy, because a sandboxed host with no `ps` would otherwise read as "0
+/// processes, no storm" during an actual one. `binary_provenance` and
+/// `memory` follow the same convention for their own unreadable-state cases.
 /// Test: `count_maintenance_processes_*` cover the pure counter directly;
 /// `live_maintenance_processes_probe_does_not_panic` covers the real `ps`
-/// call.
+/// call; `check_live_maintenance_processes_reports_unknown_when_ps_is_unavailable`
+/// covers the spawn-failure branch.
 pub(super) fn check_live_maintenance_processes() -> DoctorCheck {
-    let output = std::process::Command::new("ps")
-        .args(["-A", "-o", "command="])
-        .output();
-    let Ok(output) = output else {
-        return DoctorCheck::new(
-            "maintenance_processes",
-            CheckStatus::Ok,
-            "could not enumerate host processes (`ps` unavailable) — maintenance-process scan skipped",
-        );
+    check_live_maintenance_processes_with(|| {
+        std::process::Command::new("ps")
+            .args(["-A", "-o", "command="])
+            .output()
+    })
+}
+
+/// [`check_live_maintenance_processes`], parameterised over the `ps` spawn so
+/// the spawn-failure branch is a normal, hermetic unit test rather than
+/// something that can only be exercised by removing `ps` from `PATH`.
+fn check_live_maintenance_processes_with(
+    spawn_ps: impl FnOnce() -> std::io::Result<std::process::Output>,
+) -> DoctorCheck {
+    let output = match spawn_ps() {
+        Ok(output) => output,
+        Err(e) => {
+            return DoctorCheck::new(
+                "maintenance_processes",
+                CheckStatus::Unknown,
+                format!(
+                    "could not enumerate host processes: {e} — maintenance-process state is \
+                     unknown, not confirmed healthy"
+                ),
+            );
+        }
     };
     let text = String::from_utf8_lossy(&output.stdout);
     let count = count_maintenance_processes(&text);

--- a/crates/trusty-mpm/src/daemon/doctor_maintenance_storm.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_maintenance_storm.rs
@@ -1,0 +1,205 @@
+//! `tm doctor` probes for the #7171 `git maintenance run --auto` storm.
+//!
+//! Why: 41 detached `git maintenance run --auto` repacks hit one shared 21 GB
+//! `.git` from ~25 worktrees in one incident (load 141). `trusty_common::git`
+//! and `core::git_maintenance` are the fix's prevention half; this module is
+//! the DETECTION half — a machine that predates either, or a base clone an
+//! operator re-enabled maintenance on by hand, should be visible in `tm
+//! doctor` rather than silently exposed again.
+//! What: [`check_maintenance_config`] warns on any base clone under
+//! `repos_root` that carries more than 3 worktrees while
+//! `maintenance.auto` is not pinned off; [`check_live_maintenance_processes`]
+//! warns when more than one `git maintenance run` process is live on the host
+//! right now. Both are read-only — `ps` and `git config --get`, never a write.
+//! Test: `doctor_maintenance_storm_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+
+/// Worktree count above which an un-pinned base clone is worth a warning.
+///
+/// Why: 1-3 worktrees is an ordinary session or two; the #7171 incident's
+/// storm needed a FLEET (~25) sharing one object store for independent
+/// maintenance runs to collide. `>3` catches "this could become a fleet"
+/// early without warning on every single-session project.
+const WORKTREE_WARN_THRESHOLD: usize = 3;
+
+/// One base clone's maintenance-config exposure, as read from disk.
+#[derive(Debug, PartialEq, Eq)]
+struct BaseCloneExposure {
+    base: PathBuf,
+    worktree_count: usize,
+}
+
+/// Count entries under `<base>/.worktrees/`.
+///
+/// What: `0` when the directory is absent (a base clone with no sessions
+/// yet) or unreadable.
+fn count_worktrees(base: &Path) -> usize {
+    std::fs::read_dir(base.join(".worktrees"))
+        .map(|rd| rd.filter_map(Result::ok).count())
+        .unwrap_or(0)
+}
+
+/// Read `maintenance.auto` from `base`'s OWN local git config — never the
+/// effective (local → global → system) value.
+///
+/// Why `--local` rather than plain `--get`: this probe's remediation is
+/// `git -C <base> config --local maintenance.auto false`, i.e. it asks
+/// whether THIS repo has been provisioned, not whether SOME config layer
+/// happens to disable maintenance right now. A machine-wide global override
+/// (an operator's own incident mitigation, or a value this probe's own test
+/// suite must not depend on) would otherwise make a never-provisioned repo
+/// read as pinned, which is true today but silently stops being true the
+/// moment that global override is ever removed.
+/// What: `false` when unset, unreadable, or not exactly `"false"`.
+fn maintenance_is_pinned_off(base: &Path) -> bool {
+    trusty_common::git::command_in(base)
+        .args(["config", "--local", "--get", "maintenance.auto"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .is_some_and(|out| String::from_utf8_lossy(&out.stdout).trim() == "false")
+}
+
+/// Scan `repos_root` (`<repos_root>/<owner>/<repo>`, the layout
+/// `daemon::managed_routes::inproject::base_clone_path` writes) for a base
+/// clone that is exposed to the #7171 storm.
+fn scan_exposed_base_clones(repos_root: &Path) -> Vec<BaseCloneExposure> {
+    let mut exposed = Vec::new();
+    let Ok(owners) = std::fs::read_dir(repos_root) else {
+        return exposed;
+    };
+    for owner_entry in owners.filter_map(Result::ok) {
+        let owner_path = owner_entry.path();
+        if !owner_path.is_dir() {
+            continue;
+        }
+        let Ok(repos) = std::fs::read_dir(&owner_path) else {
+            continue;
+        };
+        for repo_entry in repos.filter_map(Result::ok) {
+            let base = repo_entry.path();
+            if !base.join(".git").exists() {
+                continue;
+            }
+            let worktree_count = count_worktrees(&base);
+            if worktree_count > WORKTREE_WARN_THRESHOLD && !maintenance_is_pinned_off(&base) {
+                exposed.push(BaseCloneExposure {
+                    base,
+                    worktree_count,
+                });
+            }
+        }
+    }
+    exposed
+}
+
+/// `tm doctor`'s `maintenance_config` probe (#7171).
+///
+/// Why/What: see the module doc's first bullet.
+/// Test: `ok_with_no_repos_root`, `ok_when_worktree_count_is_at_or_below_threshold`,
+/// `ok_when_maintenance_auto_is_pinned_off`,
+/// `warns_when_maintenance_auto_is_unset_above_threshold`.
+pub(super) fn check_maintenance_config(repos_root: Option<&Path>) -> DoctorCheck {
+    let Some(root) = repos_root else {
+        return DoctorCheck::new(
+            "maintenance_config",
+            CheckStatus::Ok,
+            "no managed workspace root configured — maintenance-config scan skipped",
+        );
+    };
+    if !root.is_dir() {
+        return DoctorCheck::new(
+            "maintenance_config",
+            CheckStatus::Ok,
+            "managed workspace root does not exist yet — maintenance-config scan skipped",
+        );
+    }
+    let exposed = scan_exposed_base_clones(root);
+    if exposed.is_empty() {
+        return DoctorCheck::new(
+            "maintenance_config",
+            CheckStatus::Ok,
+            "every base clone with more than 3 worktrees has git auto-maintenance disabled",
+        );
+    }
+    let names = exposed
+        .iter()
+        .map(|e| format!("{} ({} worktrees)", e.base.display(), e.worktree_count))
+        .collect::<Vec<_>>()
+        .join(", ");
+    DoctorCheck::new(
+        "maintenance_config",
+        CheckStatus::Warn,
+        format!(
+            "{} base clone(s) carry more than {WORKTREE_WARN_THRESHOLD} worktrees without \
+             `maintenance.auto=false` pinned (#7171) — operator-run git in any of their \
+             worktrees can still trigger a `git maintenance run --auto` repack against the \
+             shared object store: {names}. Fix: `git -C <base> config --local maintenance.auto \
+             false && git -C <base> config --local gc.auto 0`",
+            exposed.len()
+        ),
+    )
+}
+
+/// Count lines in a `ps`-style listing that name a live `git maintenance run`
+/// process.
+///
+/// Why split from [`check_live_maintenance_processes`]: the counting logic is
+/// pure text processing and can be tested on fixture output without a real
+/// process table.
+/// What: matches `"git maintenance run"` as a substring of the command line;
+/// excludes nothing else (`ps -A -o command=` output has no header line to
+/// mismatch).
+pub(super) fn count_maintenance_processes(ps_output: &str) -> usize {
+    ps_output
+        .lines()
+        .filter(|line| line.contains("git maintenance run") || line.contains("git-maintenance"))
+        .count()
+}
+
+/// `tm doctor`'s `maintenance_processes` probe (#7171).
+///
+/// Why/What: see the module doc's second bullet. Read-only: `ps -A -o
+/// command=`, never a signal or a kill.
+/// Test: `count_maintenance_processes_*` cover the pure counter directly;
+/// `live_maintenance_processes_probe_does_not_panic` covers the real `ps`
+/// call.
+pub(super) fn check_live_maintenance_processes() -> DoctorCheck {
+    let output = std::process::Command::new("ps")
+        .args(["-A", "-o", "command="])
+        .output();
+    let Ok(output) = output else {
+        return DoctorCheck::new(
+            "maintenance_processes",
+            CheckStatus::Ok,
+            "could not enumerate host processes (`ps` unavailable) — maintenance-process scan skipped",
+        );
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    let count = count_maintenance_processes(&text);
+    if count <= 1 {
+        return DoctorCheck::new(
+            "maintenance_processes",
+            CheckStatus::Ok,
+            format!("{count} `git maintenance run` process(es) live on this host"),
+        );
+    }
+    DoctorCheck::new(
+        "maintenance_processes",
+        CheckStatus::Warn,
+        format!(
+            "{count} `git maintenance run` processes live on this host at once (#7171) — this \
+             is the storm pattern (41 concurrent repacks against one shared object store in the \
+             originating incident). Check which repo(s) they are running against \
+             (`ps -A -o pid,command= | grep 'git maintenance'`) and whether \
+             `maintenance.auto`/`gc.auto` are pinned off on the shared base clone."
+        ),
+    )
+}
+
+#[cfg(test)]
+#[path = "doctor_maintenance_storm_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/doctor_maintenance_storm_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_maintenance_storm_tests.rs
@@ -1,0 +1,111 @@
+//! Fixture-based tests for the #7171 maintenance-storm doctor probes.
+//!
+//! Test: this file IS the test module for `super`.
+
+use super::*;
+use crate::core::doctor::CheckStatus;
+
+fn git_ok(dir: &Path, args: &[&str]) -> bool {
+    trusty_common::git::command_in(dir)
+        .args(args)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Build `<root>/owner/repo` as a real git repo with `worktree_count` fake
+/// `.worktrees/*` entries (plain directories — this probe only counts
+/// entries, it never asks git about them). Returns `None` when `git` is
+/// unavailable on the runner, mirroring the established pattern in
+/// `session_manager::decommission_worktree_tests`.
+fn base_clone_with_worktrees(root: &Path, worktree_count: usize) -> Option<PathBuf> {
+    let base = root.join("owner").join("repo");
+    std::fs::create_dir_all(&base).ok()?;
+    if !git_ok(&base, &["init", "-q", "."]) {
+        return None;
+    }
+    let worktrees_dir = base.join(".worktrees");
+    std::fs::create_dir_all(&worktrees_dir).ok()?;
+    for i in 0..worktree_count {
+        std::fs::create_dir_all(worktrees_dir.join(format!("wt-{i}"))).ok()?;
+    }
+    Some(base)
+}
+
+#[test]
+fn ok_with_no_repos_root() {
+    let check = check_maintenance_config(None);
+    assert_eq!(check.status, CheckStatus::Ok);
+}
+
+#[test]
+fn ok_when_worktree_count_is_at_or_below_threshold() {
+    let Ok(root) = tempfile::tempdir() else {
+        return;
+    };
+    let Some(_base) = base_clone_with_worktrees(root.path(), WORKTREE_WARN_THRESHOLD) else {
+        return; // no git on this runner
+    };
+    let check = check_maintenance_config(Some(root.path()));
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+}
+
+#[test]
+fn ok_when_maintenance_auto_is_pinned_off() {
+    let Ok(root) = tempfile::tempdir() else {
+        return;
+    };
+    let Some(base) = base_clone_with_worktrees(root.path(), WORKTREE_WARN_THRESHOLD + 1) else {
+        return;
+    };
+    assert!(git_ok(
+        &base,
+        &["config", "--local", "maintenance.auto", "false"]
+    ));
+    let check = check_maintenance_config(Some(root.path()));
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+}
+
+#[test]
+fn warns_when_maintenance_auto_is_unset_above_threshold() {
+    let Ok(root) = tempfile::tempdir() else {
+        return;
+    };
+    let Some(base) = base_clone_with_worktrees(root.path(), WORKTREE_WARN_THRESHOLD + 1) else {
+        return;
+    };
+    let check = check_maintenance_config(Some(root.path()));
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(
+        check.message.contains(&base.display().to_string()),
+        "message must name the exposed base clone: {}",
+        check.message
+    );
+}
+
+#[test]
+fn count_maintenance_processes_ignores_unrelated_lines() {
+    let ps = "/usr/bin/tmux\n/bin/zsh -l\ngrep git maintenance\n";
+    // "grep git maintenance" contains neither exact substring this counter
+    // matches, so it must not be counted as a live maintenance process.
+    assert_eq!(count_maintenance_processes(ps), 0);
+}
+
+#[test]
+fn count_maintenance_processes_counts_each_matching_line() {
+    let ps = "git maintenance run --auto\nsome-other-proc\ngit maintenance run --task=gc\n";
+    assert_eq!(count_maintenance_processes(ps), 2);
+}
+
+#[test]
+fn count_maintenance_processes_empty_output_is_zero() {
+    assert_eq!(count_maintenance_processes(""), 0);
+}
+
+#[test]
+fn live_maintenance_processes_probe_does_not_panic() {
+    // Real `ps` call — asserts only that it returns SOME check, never that
+    // this host happens to be storming right now.
+    let check = check_live_maintenance_processes();
+    assert!(matches!(check.status, CheckStatus::Ok | CheckStatus::Warn));
+}

--- a/crates/trusty-mpm/src/daemon/doctor_maintenance_storm_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_maintenance_storm_tests.rs
@@ -109,3 +109,32 @@ fn live_maintenance_processes_probe_does_not_panic() {
     let check = check_live_maintenance_processes();
     assert!(matches!(check.status, CheckStatus::Ok | CheckStatus::Warn));
 }
+
+/// #4005 / critic HIGH-1: a `ps` spawn failure must report `Unknown`, never
+/// degrade to `Ok` — a sandboxed host with no `ps` must not read as "0
+/// processes, no storm" during an actual one.
+#[test]
+fn check_live_maintenance_processes_reports_unknown_when_ps_is_unavailable() {
+    let check = check_live_maintenance_processes_with(|| {
+        Err(std::io::Error::from(std::io::ErrorKind::NotFound))
+    });
+    assert_eq!(check.status, CheckStatus::Unknown);
+    assert!(
+        check.message.contains("could not enumerate host processes"),
+        "message must name the failure: {}",
+        check.message
+    );
+}
+
+/// A successful spawn with zero matching lines still reports `Ok`, not
+/// `Unknown` — only the SPAWN failing is unknown; an empty process table is a
+/// known, healthy answer.
+#[test]
+fn check_live_maintenance_processes_reports_ok_when_ps_succeeds_with_no_matches() {
+    let check = check_live_maintenance_processes_with(|| {
+        Ok(std::process::Command::new("true")
+            .output()
+            .expect("spawn `true`"))
+    });
+    assert_eq!(check.status, CheckStatus::Ok);
+}

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -423,7 +423,7 @@ fn an_absent_path_still_matches_the_recorded_spelling_of_itself() {
 }
 
 #[tokio::test]
-async fn run_doctor_produces_forty_checks() {
+async fn run_doctor_produces_forty_two_checks() {
     // Issue #2158 added the `deployment` probe (nine → ten); issue #2246
     // adds `oauth_token` (ten → eleven); issue #2876 adds `skill_staleness`
     // and `legacy_sources` (eleven → thirteen); DOC-42 / issue #2889 adds
@@ -499,6 +499,9 @@ async fn run_doctor_produces_forty_checks() {
         "tcc_taint",
         "scaffold_tracking",
         "push_guard",
+        // #7171: the git-maintenance-storm detection probes.
+        "maintenance_config",
+        "maintenance_processes",
         "binary_provenance",
         // #5007: `sessions.json` integrity — a corrupt store blocks every write.
         "session_store",

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -324,7 +324,7 @@ pub fn ensure_base_clone(origin_url: &str, base_path: &Path) -> Result<(), Strin
     // inherited cwd cannot cause git to fail at startup with "fatal: Unable to
     // read current working directory" (exit 128) → HTTP 500 on managed-spawn.
     let cwd = base_path.parent().unwrap_or(std::path::Path::new("/"));
-    let out = std::process::Command::new("git")
+    let out = trusty_common::git::command()
         .args(["clone", "--no-local", origin_url])
         .arg(base_path)
         .current_dir(cwd)
@@ -340,6 +340,11 @@ pub fn ensure_base_clone(origin_url: &str, base_path: &Path) -> Result<(), Strin
     }
     info!(dest = %base_path.display(), "inproject: base clone complete");
     ensure_worktrees_gitignored(base_path)?;
+    // #7171: disable git's own background maintenance/gc on this FRESHLY
+    // CLONED base — every worktree the base will ever host shares its
+    // GIT_COMMON_DIR config, so one write here covers operator-run git in all
+    // of them, the same sharing property the push guard below relies on.
+    crate::core::git_maintenance::disable_and_log(base_path);
     // #2867: install the cross-branch push guard into this FRESHLY CLONED base.
     // `$GIT_COMMON_DIR/hooks` is shared by every worktree of a base clone —
     // provisioner-created and ad-hoc `git worktree add` alike (verified
@@ -412,7 +417,7 @@ pub fn worktree_name_collides(base_path: &Path, worktree_name: &str) -> bool {
         return true;
     }
     let branch_ref = format!("refs/heads/{}", worktree_branch_for(worktree_name));
-    std::process::Command::new("git")
+    trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["rev-parse", "--verify", "--quiet"])
@@ -495,7 +500,7 @@ pub fn create_session_worktree(
         "inproject: creating per-session worktree"
     );
 
-    let mut add_cmd = std::process::Command::new("git");
+    let mut add_cmd = trusty_common::git::command();
     add_cmd
         .arg("-C")
         .arg(base_path)
@@ -624,7 +629,7 @@ pub fn create_session_worktree(
 /// the fail-safe direction.
 /// Test: `push_pin_detection_matches_effective_config`.
 fn push_is_pinned_to_current(worktree_path: &Path) -> bool {
-    std::process::Command::new("git")
+    trusty_common::git::command()
         .arg("-C")
         .arg(worktree_path)
         .args(["config", "--get", "push.default"])
@@ -636,7 +641,7 @@ fn push_is_pinned_to_current(worktree_path: &Path) -> bool {
 
 fn configure_session_branch_tracking(base_path: &Path, worktree_path: &Path) {
     // Step 1: enable per-worktree config on the shared base repo (idempotent).
-    let enable_worktree_config = std::process::Command::new("git")
+    let enable_worktree_config = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["config", "extensions.worktreeConfig", "true"])
@@ -663,7 +668,7 @@ fn configure_session_branch_tracking(base_path: &Path, worktree_path: &Path) {
 
     // Step 2: scope push.default=current to THIS worktree only, so `git push`
     // always targets `origin/session/<name>` and never the default branch.
-    let set_push_default = std::process::Command::new("git")
+    let set_push_default = trusty_common::git::command()
         .arg("-C")
         .arg(worktree_path)
         .args(["config", "--worktree", "push.default", "current"])
@@ -708,7 +713,7 @@ fn configure_session_branch_tracking(base_path: &Path, worktree_path: &Path) {
     let default_branch = super::inproject_hygiene::get_default_branch(base_path)
         .unwrap_or_else(|| "main".to_string());
     let upstream = format!("origin/{default_branch}");
-    let set_upstream = std::process::Command::new("git")
+    let set_upstream = trusty_common::git::command()
         .arg("-C")
         .arg(worktree_path)
         .args(["branch", &format!("--set-upstream-to={upstream}")])
@@ -783,7 +788,7 @@ fn ensure_repo_rooted_at(path: &Path) -> Result<(), String> {
         return Ok(());
     }
 
-    let out = std::process::Command::new("git")
+    let out = trusty_common::git::command()
         .arg("-C")
         .arg(path)
         .args(["rev-parse", "--show-toplevel"])
@@ -848,7 +853,7 @@ pub fn get_origin_url(path: &Path) -> Result<Option<String>, String> {
     // never read the repo rooted here" — see `ensure_repo_rooted_at`.
     ensure_repo_rooted_at(path)?;
 
-    let out = std::process::Command::new("git")
+    let out = trusty_common::git::command()
         .arg("-C")
         .arg(path)
         .args(["config", "--get", "remote.origin.url"])

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/untracked_sync.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/untracked_sync.rs
@@ -510,7 +510,7 @@ fn classify_rev_parse_failure(dest_worktree: &Path, stderr: &str) -> ExcludeTarg
 /// Test: `tests::copied_files_are_added_to_shared_worktree_exclude`,
 /// `tests::tracked_secret_is_not_overwritten_in_worktree`.
 fn is_path_git_ignored(dest_worktree: &Path, relative_path: &str) -> bool {
-    std::process::Command::new("git")
+    trusty_common::git::command()
         .arg("-C")
         .arg(dest_worktree)
         .args(["check-ignore", "-q", "--", relative_path])

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_hygiene.rs
@@ -150,7 +150,7 @@ fn decide_update(
 /// real non-default checkout through this function; the `None` case is modelled
 /// by `decide_update_detached_head_skips`.
 fn current_branch(base_path: &Path) -> Option<String> {
-    let out = std::process::Command::new("git")
+    let out = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["symbolic-ref", "--short", "HEAD"])
@@ -180,7 +180,7 @@ fn current_branch(base_path: &Path) -> Option<String> {
 /// [`run_hygiene_for_base`]).
 fn ahead_count(base_path: &Path, branch: &str) -> Option<usize> {
     let range = format!("origin/{branch}..{branch}");
-    let out = std::process::Command::new("git")
+    let out = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["rev-list", "--count", &range])
@@ -224,7 +224,7 @@ fn is_dirty(base_path: &Path) -> Option<bool> {
 /// Test: `hygiene_dirty_tree_is_not_reset` (via [`run_hygiene_for_base`]);
 /// `dirty_existing_checkout_warns_and_proceeds` (via the cold-start gate).
 pub(crate) fn porcelain_status(base_path: &Path) -> Result<Vec<String>, String> {
-    let out = std::process::Command::new("git")
+    let out = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["status", "--porcelain"])
@@ -254,7 +254,7 @@ pub(crate) fn porcelain_status(base_path: &Path) -> Result<Vec<String>, String> 
 /// Test: exercised through `colliding_untracked_paths` by
 /// `hygiene_gitignored_file_is_not_clobbered`.
 fn git_z_lines(base_path: &Path, args: &[&str]) -> Result<Vec<String>, String> {
-    let out = std::process::Command::new("git")
+    let out = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(args)
@@ -323,7 +323,7 @@ fn colliding_untracked_paths(base_path: &Path, target: &str) -> Result<Vec<Strin
 /// Test: `hygiene_recovery_ref_written_before_update` integration test (via
 /// [`run_hygiene_for_base`]).
 fn write_recovery_ref(base_path: &Path, branch: &str) {
-    let head = std::process::Command::new("git")
+    let head = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["rev-parse", "HEAD"])
@@ -349,7 +349,7 @@ fn write_recovery_ref(base_path: &Path, branch: &str) {
     }
 
     let refname = format!("refs/trusty-mpm/pre-hygiene/{branch}");
-    let update = std::process::Command::new("git")
+    let update = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["update-ref", &refname, &sha])
@@ -381,7 +381,7 @@ fn write_recovery_ref(base_path: &Path, branch: &str) {
 /// fails or there is no `origin/HEAD` symref (the caller falls back to `main`).
 /// Test: `get_default_branch_returns_none_for_non_git` (unit).
 pub fn get_default_branch(base_path: &Path) -> Option<String> {
-    let out = std::process::Command::new("git")
+    let out = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
@@ -465,7 +465,7 @@ fn update_to_origin(base_path: &Path) {
         write_recovery_ref(base_path, branch);
     }
 
-    let merge = std::process::Command::new("git")
+    let merge = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["merge", "--ff-only", &target])
@@ -522,7 +522,7 @@ pub fn run_hygiene_for_base(base_path: &Path) -> Result<(), String> {
     info!(path = %base_path.display(), "inproject-hygiene: running for base clone");
 
     // Step 1: fetch from origin.
-    let fetch = std::process::Command::new("git")
+    let fetch = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["fetch", "origin"])
@@ -548,7 +548,7 @@ pub fn run_hygiene_for_base(base_path: &Path) -> Result<(), String> {
     update_to_origin(base_path);
 
     // Step 3: prune stale worktrees.
-    let prune = std::process::Command::new("git")
+    let prune = trusty_common::git::command()
         .arg("-C")
         .arg(base_path)
         .args(["worktree", "prune"])

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject_start_point.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject_start_point.rs
@@ -180,7 +180,9 @@ fn git_stdout(base_path: &Path, args: &[&str]) -> Option<String> {
 }
 
 fn git(base_path: &Path) -> Command {
-    let mut cmd = Command::new("git");
+    // #7171: through the shared entry point so this fetch cannot trigger a
+    // background `git maintenance run --auto` against the shared object store.
+    let mut cmd = trusty_common::git::command();
     // A daemon has no terminal: without this a private remote's credential
     // prompt blocks the spawn indefinitely instead of failing fast.
     cmd.env("GIT_TERMINAL_PROMPT", "0").arg("-C").arg(base_path);

--- a/crates/trusty-mpm/src/daemon/rpc/registry/projects.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/projects.rs
@@ -73,8 +73,13 @@ pub struct PathParams {
 
 /// `POST /projects`, `mpm.projects.register` — announce a working directory.
 ///
-/// Test: `parity_projects_register_agrees_across_transports`.
+/// Test: `parity_projects_register_agrees_across_transports`,
+/// `register_project_op_disables_git_auto_maintenance`.
 pub fn register_project_op(state: &Arc<DaemonState>, path: PathBuf) -> ProjectInfo {
+    // #7171: an explicit registration is the "operator points trusty-mpm at
+    // an existing repo" case `ensure_base_clone`'s equivalent write does not
+    // cover — best-effort and non-fatal; `path` need not even be a git repo.
+    crate::core::git_maintenance::disable_and_log(&path);
     state.register_project(path)
 }
 

--- a/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/registry/tests.rs
@@ -359,6 +359,48 @@ async fn parity_projects_register_agrees_across_transports() {
     );
 }
 
+/// #7171: `register_project_op` is the "operator points trusty-mpm at an
+/// existing repo" provisioning hook — it must disable git's own background
+/// maintenance/gc on that repo, the same way `ensure_base_clone` does for a
+/// fresh clone.
+///
+/// Test: this function IS the test.
+#[tokio::test]
+async fn register_project_op_disables_git_auto_maintenance() {
+    let (state, dir) = hermetic();
+    let repo = dir.path().join("existing-repo");
+    std::fs::create_dir_all(&repo).expect("mkdir");
+    let init_ok = trusty_common::git::command_in(&repo)
+        .args(["init", "-q", "."])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !init_ok {
+        return; // no git on this runner
+    }
+
+    super::projects::register_project_op(&state, repo.clone());
+
+    let get = |key: &str| {
+        trusty_common::git::command_in(&repo)
+            .args(["config", "--get", key])
+            .output()
+            .ok()
+            .filter(|out| out.status.success())
+            .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+    };
+    assert_eq!(
+        get("maintenance.auto").as_deref(),
+        Some("false"),
+        "register_project_op must disable maintenance.auto on the repo it registers"
+    );
+    assert_eq!(
+        get("gc.auto").as_deref(),
+        Some("0"),
+        "register_project_op must disable gc.auto on the repo it registers"
+    );
+}
+
 /// Test: this function IS the test.
 #[tokio::test]
 async fn parity_projects_current_agrees_across_transports() {

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -138,7 +138,10 @@ impl RealGitBackend {
     /// Test: `git_identity_env_applied_to_command`,
     /// `git_identity_commit_args_applied_to_command`.
     fn command(&self) -> std::process::Command {
-        let mut cmd = std::process::Command::new("git");
+        // #7171: through the shared entry point so the catalog-sync clone/
+        // fetch this backend runs cannot trigger a background
+        // `git maintenance run --auto` against the shared object store.
+        let mut cmd = trusty_common::git::command();
         cmd.args(self.identity.commit_config_args());
         // #6668: clear the inherited identity before applying the bound one —
         // a credential helper reads GH_TOKEN ahead of GH_CONFIG_DIR.

--- a/crates/trusty-mpm/src/provisioner/workspace/tests.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/tests.rs
@@ -15,18 +15,26 @@ use super::*;
 // ── #2184: RealGitBackend applies the resolved identity to every command ──
 
 /// Why: a `RealGitBackend::default()` (no identity resolved) must build a
-/// PLAIN `git` command — no env overrides, no `-c` args — so every existing
+/// command carrying ONLY `trusty_common::git::command`'s maintenance-disable
+/// args — no identity `-c` args, no env overrides — so every existing
 /// production call site (which constructs `RealGitBackend::default()` when it
-/// has no project context) is byte-for-byte unaffected by #2184.
+/// has no project context) is unaffected by #2184 beyond the #7171
+/// maintenance-storm fix every git command in the workspace now carries.
 /// Test: itself.
 #[test]
 fn default_identity_produces_plain_git_command() {
     let backend = RealGitBackend::default();
     let cmd = backend.command();
+    let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
     assert_eq!(
-        cmd.get_args().count(),
-        0,
-        "no -c args for an empty identity"
+        args,
+        vec![
+            std::ffi::OsStr::new("-c"),
+            std::ffi::OsStr::new("maintenance.auto=false"),
+            std::ffi::OsStr::new("-c"),
+            std::ffi::OsStr::new("gc.auto=0"),
+        ],
+        "an empty identity adds no -c args of its own beyond #7171's"
     );
     assert_eq!(
         cmd.get_envs().count(),
@@ -84,6 +92,12 @@ fn git_identity_commit_args_applied_to_command() {
     assert_eq!(
         args,
         vec![
+            // #7171: trusty_common::git::command's maintenance-disable args
+            // come first — every RealGitBackend command carries them.
+            std::ffi::OsStr::new("-c"),
+            std::ffi::OsStr::new("maintenance.auto=false"),
+            std::ffi::OsStr::new("-c"),
+            std::ffi::OsStr::new("gc.auto=0"),
             std::ffi::OsStr::new("-c"),
             std::ffi::OsStr::new("user.name=Bot"),
             std::ffi::OsStr::new("-c"),

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -460,9 +460,10 @@ fn prune_refs_after_removal(repo_root: &Path, path: &Path) {
         // Step 2: git worktree prune to clear any stale git worktree refs.
         // Best-effort: a failure here is a minor annoyance (stale ref in git output),
         // not a correctness failure.
-        let prune_out = std::process::Command::new("git")
-            .arg("-C")
-            .arg(repo_root)
+        // #7171: through the shared entry point — this runs on every session
+        // teardown across the fleet, one of the storm-trigger commands named
+        // by the incident.
+        let prune_out = trusty_common::git::command_in(repo_root)
             .args(["worktree", "prune"])
             .output();
         if let Err(e) = prune_out {
@@ -559,9 +560,9 @@ pub(super) fn registry_root_to_repair(record: &SessionRecord) -> Option<std::pat
 /// teardown that already succeeded continues.
 /// Test: `decommission_prunes_the_base_repo_worktree_registry`.
 fn prune_worktree_registry(root: &Path) {
-    match std::process::Command::new("git")
-        .arg("-C")
-        .arg(root)
+    // #7171: through the shared entry point — same storm-trigger command as
+    // `prune_refs_after_removal` above.
+    match trusty_common::git::command_in(root)
         .args(["worktree", "prune"])
         .output()
     {

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -1003,11 +1003,17 @@ pub(crate) fn git_stdout(dir: &Path, args: &[&str]) -> Result<String, String> {
 /// what makes "every git call" true rather than aspirational; a future call
 /// site cannot forget.
 /// What: `git <pinned globals> -C <dir> <args>`, with the redirect variables
-/// removed from the child environment.
+/// removed from the child environment. Built on
+/// [`trusty_common::git::command`] (#7171) so every call through this
+/// function — the crate's single hardened git entry point — also carries
+/// `-c maintenance.auto=false -c gc.auto=0`; this module's callers run per
+/// worktree, repeatedly, across every worktree in the fleet, which is exactly
+/// the pattern that turned into 41 detached `git maintenance run --auto`
+/// repacks in one incident.
 /// Test: `git_command_strips_repository_redirecting_env`,
 /// `git_command_pins_untracked_and_excludes_config`.
 pub(crate) fn git_command(dir: &Path, args: &[&str]) -> Command {
-    let mut cmd = Command::new("git");
+    let mut cmd = trusty_common::git::command();
     cmd.args(GIT_PINNED_GLOBAL_ARGS)
         .arg("-C")
         .arg(dir)

--- a/docs/reference/domain-consolidation-audit.md
+++ b/docs/reference/domain-consolidation-audit.md
@@ -11,7 +11,7 @@ as consolidations land. Reference: common-entry-point principle above.
 | Domain | Verdict | Scale | Status |
 |--------|---------|-------|--------|
 | HTTP clients (reqwest) | FRAGMENTED | 150+ builder sites incl. 20+ inside trusty-common | backlog |
-| git invocations | FRAGMENTED | ~90 production spawn sites, 7 crates | backlog (after tmux pattern proves) |
+| git invocations | PARTIAL | `trusty_common::git::{command,command_in,tokio_command,tokio_command_in}`; ~26/90 production spawn sites migrated (2026-09-08, #7171) | follow-up: sweep the remaining ~50-60 sites below |
 | Shared env-var access | FRAGMENTED | OPENROUTER_API_KEY ×22 files/8 crates; GITHUB_TOKEN ×13/6 | partially covered by epic #2400 (#2401) |
 | gh CLI | CONSOLIDATED | `trusty_common::gh::GhCommand`; 15 production spawn sites across 4 crates migrated 2026-08-13 | done (#5475); the `tm ticket` / `tm watch` CLI keeps its injectable `CommandRunner` seam and passes `"gh"` as data — see below |
 | Config-file loading | FRAGMENTED | 5 implementations (2 pairs within single crates) | backlog |
@@ -25,6 +25,51 @@ as consolidations land. Reference: common-entry-point principle above.
 
 First enforcement instances: inference-adapter epic #2400, tmux common entry
 point #2398/PR #2399.
+
+## git invocations — what "PARTIAL" covers (#7171, 2026-09-08)
+
+`trusty_common::git::{command, command_in, tokio_command, tokio_command_in}`
+(unconditional — no feature gate) is the entry point, added to fix a fleet of
+~25 worktrees each triggering an independent `git maintenance run --auto`
+repack against the ONE shared object store they all point at (41 detached
+repacks in one incident, load 141). Every command it builds carries
+`-c maintenance.auto=false -c gc.auto=0` on argv, which outranks every config
+file. `git grep -n 'Command::new("git")' -- crates/trusty-common/src
+crates/trusty-mpm/src` still returns ~270 matches; the large majority are test
+fixtures (`_tests.rs`, `tests.rs`, `#[cfg(test)] mod tests` bodies), which are
+out of scope for this rule (#4058).
+
+Migrated (production, non-test), ~26 sites: `daemon::managed_routes::inproject`
+(clone + worktree-add), `inproject_hygiene` (fetch/merge/prune),
+`inproject_start_point`, `inproject::untracked_sync`,
+`core::session_launch::worktree_sync`, `core::session_launch::workstream_label`,
+`provisioner::workspace::RealGitBackend::command` (cascades to clone/
+remote_url/fetch_and_reset), `session_manager::worktree_safety::git_command`
+(cascades to `core::harness_root`, `core::staged_paths`,
+`session_manager::worktree_reconcile`, `session_manager::worktree_registry`,
+`worktree_remove_command` and its callers in
+`daemon::services::agent_worktree_reap` and `session_manager::decommission`),
+`session_manager::decommission`'s own two `git worktree prune` sites, and
+`bin/tm/formatters/info_box/probes`.
+
+NOT migrated, follow-up needed (~50-60 sites): `trusty-common/src/catchup/*`
+(behind the `catchup` feature — the lower-frequency DOC-28 session-catchup
+bridge), `trusty-common/src/{github_path,palace_resolve,project_index_id,
+repo_identity,credentials/dotenv}.rs` (identity/path resolution, mostly once
+per session/startup), `trusty-mpm`'s `core::push_guard` / `bin/tm/commands/
+push_guard.rs` (the `pre-push` hook install path, runs on `git push` not
+fetch/commit), `bin/tm/commands/statusline/branch.rs` (a different spawn
+mechanism — `core::spawn_disclaim::disclaimed_output`, string-dispatched for
+TCC disclaim, not a `Command` builder to swap — and `git rev-parse` does not
+touch the object store regardless), and roughly 20-25 remaining scattered
+sites (`daemon::managed_routes::{deliverable_link,mcp_context,mcp_session}`,
+`daemon::doctor_scaffold_tracking`, `core::instruction_pipeline`,
+`core::project_aliases`, `session_manager::adopt`'s own call,
+`bin/tm/commands::{daemon,guided,pr::open}`, `client::executor::managed`).
+
+Before writing a new git-spawn helper, extend `trusty_common::git` rather than
+inventing a second one — this row is now the "already consolidated,
+mid-migration" case CLAUDE.md's common-entry-point rule exists to catch.
 
 ## Total-RAM detection — what "consolidated" covers (#6820)
 


### PR DESCRIPTION
## Summary

Fixes #7171 — 41 detached `git maintenance run --auto` repacks hit the shared 21 GB `.git` from ~25 worktrees (load 141).

- New `trusty_common::git` module (`crates/trusty-common/src/git.rs`): the workspace's single entry point for constructing a `git` subprocess. `command()`/`command_in()` (sync) and `tokio_command()`/`tokio_command_in()` (async) all carry `-c maintenance.auto=false -c gc.auto=0` on argv, which outranks every config file.
- Migrated the two required hot paths onto it: the daemon's in-project clone/worktree-add/fetch path (`daemon::managed_routes::inproject`, `inproject_hygiene`, `inproject_start_point`, `inproject::untracked_sync`) and the provisioner's catalog-sync clone/fetch (`provisioner::workspace::RealGitBackend`). Also migrated `session_manager::worktree_safety::git_command` — the crate's existing hardened git entry point — which cascades the fix to every one of its many callers (`core::harness_root`, `core::staged_paths`, `session_manager::worktree_reconcile`, `session_manager::worktree_registry`, `worktree_remove_command` and its callers in `daemon::services::agent_worktree_reap` and `session_manager::decommission`) with no per-call-site edit needed. Plus `core::session_launch::worktree_sync` (per-worktree resume-time fetch) and `bin/tm/formatters/info_box/probes` (per-render git log).
- New `core::git_maintenance::disable_and_log` (trusty-mpm): idempotently writes `maintenance.auto=false` / `gc.auto=0` into a managed checkout's *local* git config — the provisioning-time half, for operator-run git inside a worktree that never goes through `trusty_common::git`. Wired into `inproject::ensure_base_clone` (fresh clone) and `daemon::rpc::registry::projects::register_project_op` (`mpm.projects.register` — an operator pointing trusty-mpm at an existing repo).
- New `tm doctor` probes `maintenance_config` (warns when a registered base clone carries >3 worktrees without `maintenance.auto` pinned locally) and `maintenance_processes` (warns when more than one `git maintenance run` process is live on the host). Both read-only.

### Inventory (issue body's `git grep`)

`git grep -n 'Command::new("git")' -- crates/trusty-common/src crates/trusty-mpm/src` returns 297 matches, not the ticket's estimated 45+ — most are test fixtures (`_tests.rs`, `tests.rs`, `#[cfg(test)]` bodies). `docs/reference/domain-consolidation-audit.md` already recorded this domain as `FRAGMENTED — ~90 production spawn sites, 7 crates — backlog (after tmux pattern proves)`; no prior shared helper existed (the `gh` CLI's `trusty_common::gh::GhCommand` is the adjacent, already-consolidated domain). Two crate-local hardened builders did exist and are now built on top of `trusty_common::git` rather than replaced: `session_manager::worktree_safety::git_command` (env-redirect/config-hijack hardening) and `provisioner::workspace::RealGitBackend::command` (per-project git identity).

### Sites migrated vs. remaining

Directly migrated: ~26 production call sites across 8 files (listed above), several of which cascade to additional callers with no further edit. Not migrated in this PR (documented, follow-up needed):

- `trusty-common/src/catchup/{git,json,mod,pause}.rs` (~24 sites) — behind the `catchup` feature, the lower-frequency DOC-28 session-catchup bridge, not the fleet-wide fetch/commit hot path.
- `trusty-common/src/{github_path,palace_resolve,project_index_id,repo_identity}.rs` (~9 sites) and `credentials/dotenv.rs` (2 sites) — identity/path resolution, mostly once per session/startup, not per-worktree repeated traffic.
- `trusty-mpm/src/bin/tm/commands/statusline/branch.rs` — its production call goes through `core::spawn_disclaim::disclaimed_output` (a string-dispatched TCC-disclaim spawn, not a `Command` builder to swap), and runs `git rev-parse` which does not touch the object store and cannot trigger the maintenance heuristic either way.
- `core::push_guard` / `bin/tm/commands/push_guard.rs` — the `pre-push` hook install/management path; runs on `git push`, not the fetch/worktree-add hot path.
- Roughly 20-25 remaining scattered sites (`daemon::managed_routes::{deliverable_link,mcp_context,mcp_session}`, `daemon::doctor_scaffold_tracking`, `core::{instruction_pipeline,project_aliases}`, `core::session_launch::workstream_label`, `core::standalone::load`, `session_manager::{adopt,decommission}`'s own direct call, `bin/tm/commands::{daemon,guided,pr::open}`, `client::executor::managed`) — lower-traffic, not part of the fleet-wide storm pattern; a follow-up issue should sweep these onto `trusty_common::git` for full domain consolidation.

## Test plan (rung 4)

- `cargo check --workspace` — clean.
- `cargo test -p trusty-common --features unconditional-only -- git::` — 5/5 new unit tests pass (`command_disables_maintenance_and_gc`, `command_in_adds_dash_c_before_the_directory`, `tokio_command_disables_maintenance_and_gc`, `tokio_command_in_adds_dash_c_before_the_directory`, `callers_can_append_args_after_command_in`).
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — full run, 6262 passed, 0 failed, 8 ignored (two pre-existing doctor-check-count/list tests and one `tm` bin test updated for the two new checks: `run_doctor_produces_forty_two_checks`, `daemon::api::tests::doctor_endpoint_returns_report`, `generate::doctor::tests::doctor_checks_match_run_doctor_names`).
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` and `cargo clippy -p trusty-common --features unconditional-only --all-targets -- -D warnings` — both clean.
- `cargo fmt --check` — clean.
- `bash scripts/check_line_cap.sh` — OK, 0 violations.
- `bash scripts/check_changelog_fragment.sh --staged` — OK, both crates recorded.
- New regression test `core::git_maintenance::tests::disable_auto_maintenance_writes_both_keys` / `..._is_idempotent` (real tempdir repo) plus `daemon::rpc::registry::tests::register_project_op_disables_git_auto_maintenance` cover the provisioning-time write end-to-end.
- Doctor probe fixtures: `daemon::doctor_maintenance_storm_tests` — 8 tests covering the >3-worktree/un-pinned-config Warn path, the pinned-Ok path, and the pure `git maintenance run` process-line counter.

## Not done

- Full domain consolidation (the remaining ~50 sites above) is left as a follow-up — scope here was the two required hot paths (daemon in-project clone/fetch, provisioner clone/fetch) plus the crate's existing hardened builders, which cover the fleet-wide per-worktree traffic pattern that caused the incident.
- The bundled skill doc asset `crates/trusty-mpm/src/assets/skills/tm-capabilities/references/doctor.md` (generated by `tm generate capabilities`) was not regenerated — no test in this crate gates its staleness against the source list, only the two new check names in the maintained literal list.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01ER5DBvGQ54K5sgFLb9G5vz