### PR TITLE
feat(trusty-mpm): statusline savings segment shows percent of tokens saved

### DIFF
--- a/crates/trusty-mpm/README.md
+++ b/crates/trusty-mpm/README.md
@@ -153,15 +153,15 @@ tm tui
 tm telegram pair
 ```
 
-### Cost savings on the statusline
+### Token savings on the statusline
 
-The `tm statusline` bar ends with a 💸 segment estimating what the harness
-saved this session by not sending tokens. Two producers write to it: instruction
-sources folded into one compiled prompt, and bulk reads diverted to a cheap
-worker. A `divert` row is the diverted files' token count minus the returned
-summary's, priced at the parent session's input rate, less what the worker
-itself billed. It reads `💸~$0.36`, or `💸~5k tok` below a cent, and is absent
-entirely when nothing has been recorded. It never renders `$0.00`.
+The `tm statusline` bar ends with a 💸 segment showing the whole-number percent
+of tokens this session avoided sending. Two producers write to the ledger it
+folds: instruction sources folded into one compiled prompt, and bulk reads
+diverted to a cheap worker. A `divert` row's tokens are the diverted files'
+count minus the returned summary's; each row also carries its own pre-saving
+token count, which is what the percent is measured against. It reads `💸34%`,
+and is absent entirely when nothing has been recorded. It never renders `0%`.
 
 Rows live in `~/.trusty-mpm/usage/savings.jsonl` and are folded at read time.
 The figure is an estimate, and it is NOT subtractable from the cost segment

--- a/crates/trusty-mpm/changelog.d/7179-statusline-savings-percent.md
+++ b/crates/trusty-mpm/changelog.d/7179-statusline-savings-percent.md
@@ -1,0 +1,3 @@
+Changed
+
+- The `💸` statusline segment now shows the whole-number percent of tokens the session avoided sending (`💸34%`), replacing the prior dollar/token-count figure. The percent is folded from the savings ledger's own `tokens_saved`/`tokens_before` sums, never from the session's live context-window fill. `0%` is never rendered; the segment is omitted when nothing was saved.

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs
@@ -1,43 +1,39 @@
-//! The `💸` estimated-savings segment for `tm statusline` (#6958).
+//! The `💸` estimated-savings segment for `tm statusline` (#6958, percent
+//! form since #7179).
 //!
 //! Why: the owner asked to see what the harness saves by not sending tokens —
 //! instruction folding today, diverted file reads and compressed gate output as
 //! those producers land. The status bar is where the operator already looks for
-//! the session's cost, so the saving belongs beside it.
+//! the session's cost, so the saving belongs beside it. #7179 (owner ruling
+//! 2026-09-08) replaced the dollar/token figure with a percentage: "how much of
+//! what would have been sent did we avoid" reads at a glance in a way a dollar
+//! amount — which needs the session's spend as context to interpret — does not.
 //!
 //! What: folds `~/.trusty-mpm/usage/savings.jsonl` for the current session at
-//! render time and renders one segment. Two forms, one absence:
+//! render time and renders one segment:
 //!
 //! | Fold | Renders |
 //! |---|---|
-//! | `>= $0.01` | `💸~$0.42` |
-//! | `> $0` but `< $0.01` | `💸~5k tok` |
-//! | no ledger, unreadable, or zero | nothing at all |
+//! | `tokens_saved > 0` and a percent denominator exists | `💸34%` |
+//! | zero fold, or no denominator (every row predates #7179) | nothing at all |
 //!
-//! The leading `~` is the estimate marker. It is what keeps this segment
-//! visually distinct from the exact `<cost>` segment two positions earlier,
-//! which carries Claude Code's own billed total. The two are NOT subtractable —
-//! a saving is measured against tokens never sent, not against the session's
-//! bill — and the docs page says so.
+//! The percent is [`SavingsTotal::percent_saved`] — `tokens_saved / (this
+//! session's ledger rows' own pre-saving token count)`, folded across every
+//! accepted row, rounded to the nearest whole number. See that method's doc and
+//! the `savings` module header for why this denominator was chosen over the
+//! session's live context-window fill.
 //!
-//! **`$0.00` is unreachable by construction.** A rendered `$0.00` is
-//! indistinguishable from "no savings" and states a measurement that was never
-//! made, so a sub-cent fold falls back to the token form and an empty fold
-//! omits the segment entirely.
+//! **`0%` is unreachable by construction**, the same way `$0.00` was before
+//! #7179: [`SavingsTotal::is_zero`] gates the whole segment, so a fold with
+//! nothing to show renders nothing rather than a false `0%`.
 //!
-//! Test: `savings_segment_renders_dollars_above_a_cent`,
-//! `savings_segment_renders_tokens_below_a_cent`,
+//! Test: `savings_segment_renders_a_percent`,
 //! `savings_segment_is_absent_on_a_zero_fold`,
-//! `savings_segment_never_renders_zero_dollars`.
+//! `savings_segment_never_renders_zero_percent`.
 
 use std::path::{Path, PathBuf};
 
 use trusty_mpm::core::savings::{SavingsTotal, fold_session, savings_log_in};
-
-/// The floor below which the dollar form would round to `$0.00`.
-///
-/// Test: `savings_segment_never_renders_zero_dollars`.
-const CENT: f64 = 0.01;
 
 /// Fold the ledger for `session_id` and render the segment, or omit it.
 ///
@@ -118,31 +114,19 @@ fn savings_root() -> Option<PathBuf> {
 
 /// Render a folded total as the segment text, or `None` to omit it.
 ///
-/// Why: this is the rule the whole segment exists to get right — never `$0.00`,
-/// never a fabricated figure, and a visible estimate marker on everything it
-/// does show.
-/// What: `💸~$X.XX` at or above one cent; `💸~<N>k tok` / `💸~<N> tok` for a
-/// positive sub-cent fold; `None` when [`SavingsTotal::is_zero`].
-/// Test: `savings_segment_renders_dollars_above_a_cent`,
-/// `savings_segment_renders_tokens_below_a_cent`,
+/// Why: this is the rule the whole segment exists to get right — never a false
+/// `0%`, never a fabricated figure.
+/// What: `💸<N>%` from [`SavingsTotal::percent_saved`]; `None` on
+/// [`SavingsTotal::is_zero`] or when that method itself returns `None` (no
+/// percent denominator — every accepted row predates #7179's `tokens_before`).
+/// Test: `savings_segment_renders_a_percent`,
 /// `savings_segment_is_absent_on_a_zero_fold`,
-/// `savings_segment_never_renders_zero_dollars`.
+/// `savings_segment_never_renders_zero_percent`.
 pub(crate) fn render_savings_segment(total: &SavingsTotal) -> Option<String> {
     if total.is_zero() {
         return None;
     }
-    if total.cost_saved_usd >= CENT {
-        return Some(format!("\u{1f4b8}~${:.2}", total.cost_saved_usd));
-    }
-    let tokens = total.tokens_saved;
-    if tokens == 0 {
-        return None;
-    }
-    Some(if tokens >= 1_000 {
-        format!("\u{1f4b8}~{}k tok", tokens / 1_000)
-    } else {
-        format!("\u{1f4b8}~{tokens} tok")
-    })
+    total.percent_saved().map(|pct| format!("\u{1f4b8}{pct}%"))
 }
 
 #[cfg(test)]
@@ -150,42 +134,28 @@ mod tests {
     use super::*;
     use trusty_mpm::core::savings::{SavingsRow, append_row, now_ts};
 
-    fn total(tokens: u64, usd: f64) -> SavingsTotal {
+    fn total(tokens_saved: u64, tokens_before: u64) -> SavingsTotal {
         SavingsTotal {
-            tokens_saved: tokens,
-            cost_saved_usd: usd,
+            tokens_saved,
+            tokens_before,
+            cost_saved_usd: 0.01,
             rows: 1,
         }
     }
 
-    /// Why: the dollar form is the primary reading, and two decimals with the
-    /// `~` estimate marker is the exact shape the docs page describes.
+    /// Why (#7179): the percent is the primary — now only — reading, and
+    /// rounding to the nearest whole number is the exact shape the docs page
+    /// describes.
     /// Test: itself.
     #[test]
-    fn savings_segment_renders_dollars_above_a_cent() {
+    fn savings_segment_renders_a_percent() {
         assert_eq!(
-            render_savings_segment(&total(140_000, 0.42)).as_deref(),
-            Some("\u{1f4b8}~$0.42")
+            render_savings_segment(&total(1, 3)).as_deref(),
+            Some("\u{1f4b8}33%")
         );
         assert_eq!(
-            render_savings_segment(&total(4_000_000, 12.005)).as_deref(),
-            Some("\u{1f4b8}~$12.01")
-        );
-    }
-
-    /// Why (#6958): a sub-cent fold rendered as dollars is `$0.00`, which reads
-    /// as "we saved nothing" — the opposite of what the row says. The token
-    /// form is approximate but true.
-    /// Test: itself.
-    #[test]
-    fn savings_segment_renders_tokens_below_a_cent() {
-        assert_eq!(
-            render_savings_segment(&total(5_400, 0.0009)).as_deref(),
-            Some("\u{1f4b8}~5k tok")
-        );
-        assert_eq!(
-            render_savings_segment(&total(320, 0.0004)).as_deref(),
-            Some("\u{1f4b8}~320 tok")
+            render_savings_segment(&total(5_000, 20_000)).as_deref(),
+            Some("\u{1f4b8}25%")
         );
     }
 
@@ -198,6 +168,7 @@ mod tests {
         assert_eq!(
             render_savings_segment(&SavingsTotal {
                 tokens_saved: 0,
+                tokens_before: 0,
                 cost_saved_usd: 0.0,
                 rows: 3,
             }),
@@ -205,24 +176,38 @@ mod tests {
         );
     }
 
-    /// Why (#6958): the one output this segment may never produce, asserted
-    /// directly rather than inferred from the two format tests. A naive
-    /// implementation that formatted every fold as `${:.2}` passes both of
-    /// those and fails this.
+    /// Why (#7179): a fold with `tokens_saved > 0` but no percent denominator
+    /// (every accepted row predates #7179) must omit the segment, not fabricate
+    /// a percent against nothing.
     /// Test: itself.
     #[test]
-    fn savings_segment_never_renders_zero_dollars() {
-        for (tokens, usd) in [
-            (500_u64, 0.0),
-            (500, 0.000_001),
-            (1, 0.004_9),
-            (0, 0.0),
-            (12_000, 0.009_9),
-        ] {
-            let rendered = render_savings_segment(&total(tokens, usd)).unwrap_or_default();
-            assert!(
-                !rendered.contains("$0.00"),
-                "the segment must never render $0.00 (tokens={tokens}, usd={usd}): {rendered:?}"
+    fn savings_segment_is_absent_without_a_percent_denominator() {
+        assert_eq!(
+            render_savings_segment(&SavingsTotal {
+                tokens_saved: 4_000,
+                tokens_before: 0,
+                cost_saved_usd: 0.01,
+                rows: 1,
+            }),
+            None
+        );
+    }
+
+    /// Why (#7179): the one output this segment may never produce, asserted
+    /// directly rather than inferred from the format test. A naive
+    /// implementation that let the ratio exceed 1.0 (a mixed old/new ledger,
+    /// see [`SavingsTotal::percent_saved`]) would print `💸0%` on the wrong
+    /// side or a percent above 100 without the clamp this pins.
+    /// Test: itself.
+    #[test]
+    fn savings_segment_never_renders_zero_percent() {
+        for (tokens_saved, tokens_before) in [(1_u64, 200), (12_000, 12_000_100), (5, 1_000)] {
+            let rendered =
+                render_savings_segment(&total(tokens_saved, tokens_before)).unwrap_or_default();
+            assert_ne!(
+                rendered, "\u{1f4b8}0%",
+                "the segment must never render 0% while tokens_saved > 0 \
+                 (tokens_saved={tokens_saved}, tokens_before={tokens_before})"
             );
         }
     }
@@ -251,6 +236,7 @@ mod tests {
                 session_id: "sess-1".to_string(),
                 technique: "instruction-compression".to_string(),
                 tokens_saved: 12_000,
+                tokens_before: 60_000,
                 cost_saved_usd: 0.18,
                 basis: "sources 60000 B - compiled 12000 B".to_string(),
                 model_source: "launch-config".to_string(),
@@ -259,7 +245,7 @@ mod tests {
         .expect("append");
         assert_eq!(
             savings_segment_at(&ledger, "sess-1").as_deref(),
-            Some("\u{1f4b8}~$0.18")
+            Some("\u{1f4b8}20%")
         );
         // A different session's bar reads nothing from the same file.
         assert_eq!(savings_segment_at(&ledger, "sess-2"), None);

--- a/crates/trusty-mpm/src/core/savings.rs
+++ b/crates/trusty-mpm/src/core/savings.rs
@@ -9,10 +9,10 @@
 //! later, the console) renders.
 //!
 //! What: `~/.trusty-mpm/usage/savings.jsonl` — one JSON object per line,
-//! `{ts, session_id, technique, tokens_saved, cost_saved_usd, basis}`.
-//! [`append_row`] is the single writer, [`fold_session`] and [`fold_all`] the
-//! single readers. `technique` is an open string, so a new producer needs no
-//! schema change here.
+//! `{ts, session_id, technique, tokens_saved, tokens_before, cost_saved_usd,
+//! basis}`. [`append_row`] is the single writer, [`fold_session`] and
+//! [`fold_all`] the single readers. `technique` is an open string, so a new
+//! producer needs no schema change here.
 //!
 //! Two properties the rest of the feature depends on:
 //!
@@ -25,6 +25,21 @@
 //!   A producer bug that undercounts its baseline therefore shows as a missing
 //!   contribution, never as a negative or inflated displayed figure.
 //!
+//! **`tokens_before` and [`SavingsTotal::percent_saved`] (owner ruling
+//! 2026-09-08, #7179).** The `💸` segment shows a whole-number percent of
+//! tokens avoided, not a dollar figure. The percent's denominator is each
+//! row's own pre-saving token count — `tokens_before = tokens_saved + tokens
+//! actually sent` — folded the same way `tokens_saved` is. This was chosen
+//! over pricing the percent against the session's live context-window fill
+//! (`total_input_tokens` from the `statusLine` hook, the only other per-session
+//! token counter available): that figure resets on every auto-compaction, which
+//! would make the percent jump non-monotonically for reasons unrelated to
+//! anything the harness saved, and it counts tokens no savings technique here
+//! ever touched. A ledger-only percent stays stable and scoped to what this
+//! feature actually measures. `#[serde(default)]` so a pre-#7179 row folds
+//! with `tokens_before = 0` and is excluded from the denominator, rather than
+//! failing to parse.
+//!
 //! Everything here fails soft: a missing, unreadable, or truncated ledger folds
 //! to zero rather than erroring, because the consumer is a status bar on
 //! Claude Code's hot render path.
@@ -32,7 +47,7 @@
 //! Test: the inline suite in `savings_tests.rs` — `append_then_fold_round_trips`,
 //! `fold_skips_a_malformed_line_and_keeps_the_valid_total`,
 //! `a_negative_row_cannot_raise_the_total`, `fold_ignores_other_sessions`,
-//! `fold_of_a_missing_ledger_is_zero`.
+//! `fold_of_a_missing_ledger_is_zero`, `percent_saved_rounds_to_nearest_whole_number`.
 
 use std::path::{Path, PathBuf};
 
@@ -82,6 +97,22 @@ pub struct SavingsRow {
     pub technique: String,
     /// Estimated tokens not sent. Rows at or below zero are skipped.
     pub tokens_saved: i64,
+    /// Estimated pre-saving token count for this row — `tokens_saved` plus the
+    /// tokens actually sent instead (#7179).
+    ///
+    /// Why: [`SavingsTotal::percent_saved`] needs a denominator, and the only
+    /// one that stays stable and scoped to what this feature measures is the
+    /// ledger's own before-figure, folded across every row alongside
+    /// `tokens_saved` — see the module header for why the live context-window
+    /// fill was rejected instead.
+    /// What: `u64` (a plain count, never negative by construction).
+    /// `#[serde(default)]` so a row written before this field existed folds as
+    /// `0` — excluded from the percent denominator rather than failing to
+    /// parse. Producers that cannot state a before-figure simply omit it.
+    /// Test: `percent_saved_rounds_to_nearest_whole_number`,
+    /// `a_row_written_before_tokens_before_existed_still_folds`.
+    #[serde(default)]
+    pub tokens_before: u64,
     /// Estimated USD not spent. Rows at or below zero are skipped.
     pub cost_saved_usd: f64,
     /// Free text stating how the two figures above were arrived at.
@@ -107,16 +138,19 @@ pub struct SavingsRow {
 
 /// The folded total of every accepted row in one read.
 ///
-/// Why: the statusline needs both figures — it renders dollars above a cent and
-/// tokens below it — and `rows` is what lets a caller distinguish "the ledger
-/// held nothing" from "every row was rejected", which read very differently in
-/// a bug report.
+/// Why: the statusline needs `tokens_saved` and `tokens_before` together to
+/// compute a percent, and `cost_saved_usd` for `tm`'s own dollar-denominated
+/// reporting commands (the ledger stays the one source both surfaces read).
+/// `rows` is what lets a caller distinguish "the ledger held nothing" from
+/// "every row was rejected", which read very differently in a bug report.
 /// What: sums of the accepted rows only; skipped rows contribute nothing.
 /// Test: `fold_skips_a_malformed_line_and_keeps_the_valid_total`.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct SavingsTotal {
     /// Sum of `tokens_saved` across accepted rows.
     pub tokens_saved: u64,
+    /// Sum of `tokens_before` across accepted rows — the percent denominator.
+    pub tokens_before: u64,
     /// Sum of `cost_saved_usd` across accepted rows.
     pub cost_saved_usd: f64,
     /// How many rows were accepted.
@@ -134,6 +168,40 @@ impl SavingsTotal {
     /// Test: `zero_fold_is_zero`, `savings_segment_is_absent_on_a_zero_fold`.
     pub fn is_zero(&self) -> bool {
         self.rows == 0 || (self.tokens_saved == 0 && self.cost_saved_usd <= 0.0)
+    }
+
+    /// Whole-number percent of tokens the harness avoided sending, folded
+    /// across every accepted row (#7179).
+    ///
+    /// Why: the `💸` statusline segment renders one percentage, and the fold is
+    /// the only place `tokens_saved` and `tokens_before` are summed together —
+    /// computing the ratio here, rather than at the render site, means a future
+    /// console consumer gets the identical number from the identical division.
+    /// What: `round(100 * tokens_saved / tokens_before)`, clamped to `[1, 100]`
+    /// whenever the fold accepted at least one row — the lower clamp mirrors
+    /// the pre-#7179 dollar segment's "never render a false zero" rule: a
+    /// sub-0.5% ratio would otherwise round down to a literal `0%`, which reads
+    /// as "we saved nothing" and states a measurement that was never made. The
+    /// upper clamp covers a mixed old/new ledger, where rows written before
+    /// `tokens_before` existed fold their share of the denominator as `0` (see
+    /// the module header) and can otherwise push the raw ratio above 100.
+    /// `None` when there is nothing to divide: [`Self::is_zero`], or a
+    /// `tokens_before` sum of `0` (every accepted row predates #7179).
+    /// Test: `percent_saved_rounds_to_nearest_whole_number`,
+    /// `percent_saved_is_none_on_a_zero_fold`,
+    /// `percent_saved_clamps_a_legacy_mixed_fold`,
+    /// `percent_saved_never_rounds_down_to_zero`.
+    pub fn percent_saved(&self) -> Option<u32> {
+        if self.is_zero() || self.tokens_before == 0 {
+            return None;
+        }
+        let ratio = self.tokens_saved as f64 / self.tokens_before as f64;
+        let pct = (ratio * 100.0).round();
+        // A true zero is already excluded by the checks above, so any ratio
+        // reaching here is a real (if tiny) measurement — round it up to the
+        // smallest displayable percent rather than down to a false zero.
+        let pct = if pct < 1.0 { 1.0 } else { pct };
+        Some(pct.clamp(1.0, 100.0) as u32)
     }
 }
 
@@ -269,6 +337,7 @@ fn fold(ledger: &Path, session_id: Option<&str>) -> SavingsTotal {
             continue;
         }
         total.tokens_saved += row.tokens_saved as u64;
+        total.tokens_before += row.tokens_before;
         total.cost_saved_usd += row.cost_saved_usd;
         total.rows += 1;
     }

--- a/crates/trusty-mpm/src/core/savings_divert.rs
+++ b/crates/trusty-mpm/src/core/savings_divert.rs
@@ -233,6 +233,10 @@ fn divert_row(
         session_id: session_id.to_string(),
         technique: TECHNIQUE_DIVERT.to_string(),
         tokens_saved,
+        // #7179: the percent segment's denominator — the diverted files'
+        // token count before the worker ever ran. `file_tokens` is a floor of
+        // a non-negative byte count, so it is never negative.
+        tokens_before: file_tokens as u64,
         cost_saved_usd,
         basis: format!(
             "files {file_tokens} tok - summary {summary_tokens} tok, \

--- a/crates/trusty-mpm/src/core/savings_divert_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_divert_tests.rs
@@ -54,6 +54,9 @@ fn a_hand_computed_delta_matches_the_row() {
     let row = divert_row("sess-a", 400_000, 4_000, 0.02, sonnet_price).expect("a row");
     assert_eq!(row.session_id, "sess-a");
     assert_eq!(row.tokens_saved, 99_000);
+    // #7179: the percent denominator is the diverted files' own token count —
+    // 400,000 bytes at four bytes per token is 100,000 tokens.
+    assert_eq!(row.tokens_before, 100_000);
     assert!(
         (row.cost_saved_usd - 0.277).abs() < 1e-9,
         "cost was {}",

--- a/crates/trusty-mpm/src/core/savings_instructions.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions.rs
@@ -159,6 +159,9 @@ fn instruction_compression_row(
         session_id: session_id.to_string(),
         technique: TECHNIQUE_INSTRUCTION_COMPRESSION.to_string(),
         tokens_saved,
+        // #7179: the percent segment's denominator — the folded source set's
+        // own token count. Floor of a non-negative byte count: never negative.
+        tokens_before: (source_bytes as f64 / BYTES_PER_TOKEN).floor() as u64,
         cost_saved_usd,
         basis: format!(
             "sources {source_bytes} B - compiled {compiled_bytes} B, \

--- a/crates/trusty-mpm/src/core/savings_instructions_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions_tests.rs
@@ -48,6 +48,9 @@ fn a_folded_source_set_produces_a_row() {
     let row = instruction_compression_row("sess-a", 60_000, 20_000, sonnet_price).expect("a row");
     assert_eq!(row.session_id, "sess-a");
     assert_eq!(row.tokens_saved, 10_000);
+    // #7179: the percent denominator is the folded source set's own token
+    // count — 60,000 bytes at four bytes per token is 15,000 tokens.
+    assert_eq!(row.tokens_before, 15_000);
     assert!((row.cost_saved_usd - 0.03).abs() < 1e-9);
     assert!(
         row.basis.contains("60000") && row.basis.contains("20000"),

--- a/crates/trusty-mpm/src/core/savings_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_tests.rs
@@ -24,6 +24,10 @@ fn row(session: &str, tokens: i64, usd: f64) -> SavingsRow {
         session_id: session.to_string(),
         technique: TECHNIQUE_INSTRUCTION_COMPRESSION.to_string(),
         tokens_saved: tokens,
+        // Twice the saved figure — a plausible "before" for a row this test
+        // helper builds. Callers that need a specific before/saved ratio for a
+        // percent assertion build their own `SavingsRow` instead.
+        tokens_before: tokens.max(0) as u64 * 2,
         cost_saved_usd: usd,
         basis: "sources 1000 B - compiled 400 B".to_string(),
         model_source: crate::core::session_model::MODEL_SOURCE_LAUNCH_CONFIG.to_string(),
@@ -52,6 +56,34 @@ fn a_row_written_before_the_model_source_field_still_folds() {
     assert_eq!(
         parsed.model_source, "",
         "an absent model_source must read back as empty, not fail the parse"
+    );
+}
+
+/// Why (#7179): the ledger carries rows written before `tokens_before`
+/// existed. A field without `#[serde(default)]` would make every such line
+/// unparseable — zeroing the operator's fold, not just the percent, on the
+/// first render after the upgrade.
+/// Test: itself.
+#[test]
+fn a_row_written_before_tokens_before_existed_still_folds() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let ledger = ledger_with(
+        &dir,
+        &[
+            r#"{"ts":"2026-09-07T02:41:00Z","session_id":"sess-a","technique":"divert","tokens_saved":5300,"cost_saved_usd":0.0159,"basis":"files 5000 tok - summary 200 tok"}"#,
+        ],
+    );
+    let total = fold_session(&ledger, "sess-a");
+    assert_eq!(total.rows, 1, "a pre-#7179 row must still count");
+    assert_eq!(total.tokens_saved, 5300);
+    assert_eq!(
+        total.tokens_before, 0,
+        "an absent tokens_before must read back as 0, not fail the parse"
+    );
+    assert_eq!(
+        total.percent_saved(),
+        None,
+        "a fold with no tokens_before has no percent to report"
     );
 }
 
@@ -131,6 +163,7 @@ fn zero_fold_is_zero() {
     assert!(
         SavingsTotal {
             tokens_saved: 0,
+            tokens_before: 0,
             cost_saved_usd: 0.0,
             rows: 4,
         }
@@ -139,10 +172,86 @@ fn zero_fold_is_zero() {
     assert!(
         !SavingsTotal {
             tokens_saved: 1,
+            tokens_before: 2,
             cost_saved_usd: 0.0,
             rows: 1,
         }
         .is_zero()
+    );
+}
+
+/// Why (#7179): the percent is what the `💸` segment renders, so its rounding
+/// rule is pinned directly against hand-built totals rather than inferred from
+/// the ledger round trip.
+/// Test: itself.
+#[test]
+fn percent_saved_rounds_to_nearest_whole_number() {
+    // 1/3 rounds to the nearest whole percent, not truncates.
+    assert_eq!(
+        SavingsTotal {
+            tokens_saved: 1,
+            tokens_before: 3,
+            cost_saved_usd: 0.01,
+            rows: 1,
+        }
+        .percent_saved(),
+        Some(33)
+    );
+    assert_eq!(
+        SavingsTotal {
+            tokens_saved: 5_000,
+            tokens_before: 20_000,
+            cost_saved_usd: 0.05,
+            rows: 1,
+        }
+        .percent_saved(),
+        Some(25)
+    );
+}
+
+/// Why (#7179): a zero fold has nothing to divide, and `None` — not `Some(0)`
+/// — is what tells the render layer to omit the segment rather than print a
+/// false `0%`.
+/// Test: itself.
+#[test]
+fn percent_saved_is_none_on_a_zero_fold() {
+    assert_eq!(SavingsTotal::default().percent_saved(), None);
+}
+
+/// Why (#7179): the one output this method may never produce while it accepted
+/// at least one row — a naive `round()` with no floor lets a sub-0.5% ratio
+/// print `0%`, which reads as "the harness saved nothing" and states a
+/// measurement that was never made.
+/// Test: itself.
+#[test]
+fn percent_saved_never_rounds_down_to_zero() {
+    assert_eq!(
+        SavingsTotal {
+            tokens_saved: 1,
+            tokens_before: 10_000,
+            cost_saved_usd: 0.000_01,
+            rows: 1,
+        }
+        .percent_saved(),
+        Some(1)
+    );
+}
+
+/// Why (#7179): a ledger with only pre-#7179 rows (no `tokens_before`) folds
+/// `tokens_saved > 0` beside `tokens_before == 0` — nothing to divide by, so
+/// the segment must omit the percent rather than report a fabricated one.
+/// Test: itself.
+#[test]
+fn percent_saved_clamps_a_legacy_mixed_fold() {
+    assert_eq!(
+        SavingsTotal {
+            tokens_saved: 4_000,
+            tokens_before: 0,
+            cost_saved_usd: 0.01,
+            rows: 1,
+        }
+        .percent_saved(),
+        None
     );
 }
 

--- a/docs/trusty-mpm/statusline-savings.md
+++ b/docs/trusty-mpm/statusline-savings.md
@@ -1,53 +1,61 @@
-# Statusline cost savings
+# Statusline token savings
 
-## Cost savings
+## Token savings
 
 trusty-mpm spends real effort *not* sending tokens: it folds several instruction
 sources into one compiled prompt, it diverts a bulk file read to a cheap worker
 and brings back a summary, and it compresses gate output before an agent reads
-it. The `💸` segment on the `tm` statusline is an estimate of what all of that
-adds up to for the session you are looking at.
+it. The `💸` segment on the `tm` statusline shows what percentage of tokens
+that would otherwise have been sent, this session avoided sending.
 
 ```
-TM 1.5.18 ● | trusty-tools ⎇ main | @bobmatnyc | ✻you@example.com | Opus | ctx 41% | $12.40 | ⏳24% 📅41% | 💸~$0.36
+TM 1.5.18 ● | trusty-tools ⎇ main | @bobmatnyc | ✻you@example.com | Opus | ctx 41% | $12.40 | ⏳24% 📅41% | 💸34%
 ```
 
-It has two forms and one absence:
+It has one form and one absence:
 
 | Folded total | Segment |
 |---|---|
-| At or above one cent | `💸~$0.36` |
-| Above zero, below one cent | `💸~5k tok` |
-| Nothing recorded for this session | *the segment is not rendered at all* |
+| At least one accepted row, with a percent to report | `💸34%` |
+| Nothing recorded for this session, or every accepted row predates #7179 | *the segment is not rendered at all* |
 
-The leading `~` is the estimate marker. It is there to keep this figure visually
-apart from the `$12.40` cost segment two positions earlier, which is Claude
-Code's own billed total for the session.
+### How the percent is computed
 
-### The two numbers are not subtractable
+Every ledger row already knows two figures: `tokens_saved` (what it avoided
+sending) and `tokens_before` (what it would have sent without the technique).
+The segment sums both across every row this session wrote, then reports
+`round(100 × tokens_saved / tokens_before)`.
 
-The cost segment counts dollars actually spent. The savings segment counts
-dollars *not* spent on tokens that were never sent. Netting one against the
-other produces a number that means nothing: the counterfactual session — the one
-that read every file in full and carried every instruction source verbatim —
-never ran. Read the savings figure as "this is roughly what the harness avoided",
-not as a discount on the bill.
+This denominator was chosen over the session's live context-window fill (the
+`total_input_tokens` figure behind the `ctx 41%` segment) deliberately: that
+figure resets on every auto-compaction, which would make the percent jump for
+reasons that have nothing to do with anything the harness saved, and it counts
+tokens no savings technique here ever touches. The ledger-only percent stays
+scoped to exactly what `instruction-compression` and `divert` measure, and it
+only grows as more of those write rows.
 
-Two further reasons it is an estimate, both stated so you can discount it
-yourself:
+It is still an estimate, for the same two reasons as before:
 
 - **Bytes are converted to tokens at four bytes per token.** That is the
   conventional English-prose approximation, not a tokenizer run.
 - **Cache reads are not distinguished from fresh input.** Some of the tokens a
   technique avoided would have been cache reads, which bill at a tenth of the
-  input rate. On a cache-heavy session the figure overstates.
+  input rate — irrelevant to the *percent of tokens avoided*, but relevant if
+  you convert the figure to a dollar estimate yourself.
 
-### `$0.00` is never rendered
+### `0%` is never rendered
 
-A rendered `$0.00` cannot be told apart from "nothing was saved", and it states
-a measurement that was never made. So a sub-cent total falls back to the token
-form, and a session with no recorded savings omits the segment entirely. If you
-do not see a `💸`, no producer has written anything for that session.
+A rendered `0%` cannot be told apart from "nothing was saved", and it states a
+measurement that was never made. So a fold with `tokens_saved > 0` always
+reports at least `1%` — even a true sub-0.5% ratio rounds up rather than down
+— and a session with no recorded savings omits the segment entirely. If you do
+not see a `💸`, no producer has written anything for that session.
+
+Dollar figures have not gone away — they still live in the ledger's
+`cost_saved_usd` field and in `tm`'s own reporting commands. The statusline
+just no longer surfaces one, because a percentage reads at a glance in a way a
+bare dollar amount does not: it needs no context about the session's spend to
+interpret.
 
 ## The techniques, and what each one measures
 
@@ -138,7 +146,7 @@ under whatever framework root your `--root` flag, `TRUSTY_MPM_ROOT`, or
 `[standalone] root` config key resolves to. One object per line:
 
 ```json
-{"ts":"2026-09-07T02:41:00Z","session_id":"trusty-tools-ec","technique":"instruction-compression","tokens_saved":5300,"cost_saved_usd":0.0159,"basis":"sources 47000 B - compiled 25800 B, at 4 B/token, priced at claude-sonnet-4-6 input $3/Mtok","model_source":"launch-config"}
+{"ts":"2026-09-07T02:41:00Z","session_id":"trusty-tools-ec","technique":"instruction-compression","tokens_saved":5300,"tokens_before":11750,"cost_saved_usd":0.0159,"basis":"sources 47000 B - compiled 25800 B, at 4 B/token, priced at claude-sonnet-4-6 input $3/Mtok","model_source":"launch-config"}
 ```
 
 `model_source` names where the model the row was priced at came from. For a


### PR DESCRIPTION
## Summary

Replaces the 💸 statusline segment's dollar/token-count figure with a whole-number percent of tokens avoided (`💸34%`), per owner ruling 2026-09-08 (#7179).

## Denominator decision

The task specified two options: price against the session's real token consumption ("actual_session_tokens"), or fall back to `saved / before_total`. The only per-session token counter the `statusLine` hook payload exposes is `context_window.total_input_tokens` — the live context-window fill behind the `ctx%` segment. I rejected it as the denominator: it resets on every auto-compaction, which would make the percent jump for reasons unrelated to anything the harness saved, and it counts tokens no savings technique here ever touches.

I used the fallback formula instead, made structurally available rather than a rare edge case: `SavingsRow` gains a `tokens_before` field (`#[serde(default)]`, u64 — the row's own pre-saving token count), populated by both producers (`savings_divert.rs`'s `file_tokens`, `savings_instructions.rs`'s `source_bytes` in tokens). `SavingsTotal` sums it alongside `tokens_saved`, and `SavingsTotal::percent_saved()` computes `round(100 * tokens_saved / tokens_before)`, clamped to `[1, 100]` — floored at 1 so a true nonzero ratio never displays a false `0%` (mirroring the old "never `$0.00`" rule), capped at 100 to absorb a mixed ledger where legacy rows (predating this field) fold their `tokens_before` share as `0`.

This keeps the percent self-contained in the ledger fold — stable, technique-scoped, and consistent whether the statusline or a future console reads it — documented in the `savings` module header and `percent_saved`'s doc comment.

## Changes

- `crates/trusty-mpm/src/core/savings.rs`: `SavingsRow.tokens_before`, `SavingsTotal.tokens_before`, `SavingsTotal::percent_saved()`.
- `crates/trusty-mpm/src/core/savings_divert.rs`, `savings_instructions.rs`: producers populate `tokens_before`.
- `crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs`: `render_savings_segment` renders `💸<N>%`, hides on `is_zero()` or no percent denominator.
- `docs/trusty-mpm/statusline-savings.md`, `crates/trusty-mpm/README.md`: updated to percent language, kept prominent per the #6958 owner directive.
- `crates/trusty-mpm/changelog.d/7179-statusline-savings-percent.md`.

## Tests replaced

The four dollar/token-format tests in `statusline/savings.rs` (`savings_segment_renders_dollars_above_a_cent`, `savings_segment_renders_tokens_below_a_cent`, `savings_segment_never_renders_zero_dollars`, plus the `$0.18` assertion in `savings_segment_reads_the_ledger_under_an_explicit_root`) are replaced by `savings_segment_renders_a_percent`, `savings_segment_is_absent_without_a_percent_denominator`, `savings_segment_never_renders_zero_percent`, and the same round-trip test now asserting `💸20%`. New tests in `savings.rs`/`savings_tests.rs`: `percent_saved_rounds_to_nearest_whole_number`, `percent_saved_is_none_on_a_zero_fold`, `percent_saved_clamps_a_legacy_mixed_fold`, `percent_saved_never_rounds_down_to_zero`, `a_row_written_before_tokens_before_existed_still_folds`. Producer tests gained `tokens_before` assertions.

## Test plan (rung 3, trusty-mpm)

- `cargo fmt --check` — clean after `cargo fmt -p trusty-mpm`.
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — exit 0, no warnings.
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — every target ran (`--no-fail-fast`): lib `6254 passed; 0 failed`, bin (`tm`) `2276 passed; 0 failed` (×2 for the `tm`/`trusty-mpm` binary aliases), all remaining integration/doctest targets `0 failed`.
- `bash scripts/check_line_cap.sh` — 0 violations.
- `bash scripts/check_changelog_fragment.sh --staged` — fragment present and valid.
- `bash scripts/check_doc_paths.sh` — all citations resolve.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01ER5DBvGQ54K5sgFLb9G5vz