### PR TITLE
fix(trusty-mpm): statusline savings percent uses the session-share denominator

### DIFF
--- a/crates/trusty-mpm/README.md
+++ b/crates/trusty-mpm/README.md
@@ -156,11 +156,15 @@ tm telegram pair
 ### Token savings on the statusline
 
 The `tm statusline` bar ends with a 💸 segment showing the whole-number percent
-of tokens this session avoided sending. Two producers write to the ledger it
-folds: instruction sources folded into one compiled prompt, and bulk reads
+of tokens this session avoided sending, as a **session share**: `tokens_saved /
+(session_actual_tokens + tokens_saved)`. Two producers write the saved side to
+a ledger: instruction sources folded into one compiled prompt, and bulk reads
 diverted to a cheap worker. A `divert` row's tokens are the diverted files'
-count minus the returned summary's; each row also carries its own pre-saving
-token count, which is what the percent is measured against. It reads `💸34%`,
+count minus the returned summary's. `session_actual_tokens` is a cumulative
+counter the statusline's compaction tracker keeps per session — it survives
+`total_input_tokens` resetting on every auto-compaction, unlike a raw read of
+that figure would. Before a session's first `statusLine` tick, the percent
+falls back to each row's own pre-saving token count instead. It reads `💸34%`,
 and is absent entirely when nothing has been recorded. It never renders `0%`.
 
 Rows live in `~/.trusty-mpm/usage/savings.jsonl` and are folded at read time.

--- a/crates/trusty-mpm/changelog.d/7179-savings-percent-session-share.md
+++ b/crates/trusty-mpm/changelog.d/7179-savings-percent-session-share.md
@@ -1,0 +1,3 @@
+Changed
+
+- The `💸` statusline savings percent now denominates against the session's own actual token spend — `saved / (session actual tokens + saved)` — instead of the ledger's own before-figure, per owner ruling on #7179. The `tm statusline` compaction tracker (`~/.trusty-mpm/statusline/<session_id>.json`) folds a cumulative actual-tokens counter across every auto-compaction reset of `total_input_tokens`, so the denominator survives any number of resets within a session; `SavingsTotal::percent_saved` falls back to the pre-ruling ledger-only formula only when no compaction tick has landed yet for the session, and that fallback is never distinguished in the rendered `💸<N>%` string.

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/compaction.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/compaction.rs
@@ -3,13 +3,19 @@
 //! Why: Claude Code fires the `statusLine` hook on every render cycle with no
 //! persistent state; this module maintains a tiny JSON file in
 //! `~/.trusty-mpm/statusline/<session_id>.json` so the statusline can show how
-//! much the last auto-compaction shrank the context window.
-//! What: persists a `CompactionState` (running peak + last compaction record)
-//! keyed by `session_id`. All filesystem I/O runs in a detached thread bounded
-//! by a 100 ms wall-clock timeout so it can never stall the render path. Saves
-//! are skipped on no-op ticks. Atomic writes use `NamedTempFile::persist`.
+//! much the last auto-compaction shrank the context window. The same file
+//! also backs the `💸` savings segment's session-share denominator (#7179):
+//! `total_input_tokens` resets on every auto-compaction, so a cumulative
+//! counter has to live somewhere that survives the reset — this store already
+//! does, keyed the same way.
+//! What: persists a `CompactionState` (running peak, last compaction record,
+//! and the cumulative session-actual-tokens base) keyed by `session_id`. All
+//! filesystem I/O runs in a detached thread bounded by a 100 ms wall-clock
+//! timeout so it can never stall the render path. Saves are skipped on no-op
+//! ticks. Atomic writes use `NamedTempFile::persist`.
 //! Test: `humanize_tokens_examples`, `compaction_detection_sequence`,
-//! `state_round_trip`, `rejects_path_traversal_session_id` in inline tests.
+//! `state_round_trip`, `rejects_path_traversal_session_id`,
+//! `session_actual_tokens_accumulate_across_two_compactions` in inline tests.
 
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -47,16 +53,30 @@ pub(crate) struct ContextWindow {
 ///
 /// Why: the statusline binary is invoked fresh on every render tick; this state
 /// file bridges invocations so the segment can show a compaction that happened
-/// several ticks ago.
-/// What: tracks the highest `total_input_tokens` seen (`peak_input_tokens`)
-/// and the most recent compaction record.
-/// Test: `state_round_trip`.
+/// several ticks ago, and (#7179) so the savings segment can read a
+/// session-total token count that survives any number of resets.
+/// What: tracks the highest `total_input_tokens` seen in the current epoch
+/// (`peak_input_tokens`), the most recent compaction record, and the
+/// cumulative-actual-tokens pair (`session_actual_tokens_base`,
+/// `last_seen_input_tokens`) — see [`update_session_actual_tokens`].
+/// Test: `state_round_trip`,
+/// `session_actual_tokens_accumulate_across_two_compactions`.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct CompactionState {
     #[serde(default)]
     pub peak_input_tokens: u64,
     #[serde(default)]
     pub last_compaction: Option<CompactionRecord>,
+    /// #7179: running base of every completed context-window epoch, folded in
+    /// by [`update_session_actual_tokens`] each time `total_input_tokens` is
+    /// observed to drop below the previous tick's reading.
+    #[serde(default)]
+    pub session_actual_tokens_base: u64,
+    /// #7179: the last `total_input_tokens` reading observed. Used only to
+    /// detect the next drop — on its own it is not the session's total; add
+    /// `session_actual_tokens_base` (or call [`session_actual_tokens`]).
+    #[serde(default)]
+    pub last_seen_input_tokens: u64,
 }
 
 /// Record of a detected context-compaction event.
@@ -202,6 +222,92 @@ pub(crate) fn update_state(state: &mut CompactionState, cur: u64) -> bool {
     false
 }
 
+/// Fold one `total_input_tokens` reading into the session's cumulative
+/// actual-token counter; returns `true` when the state changed and a save is
+/// warranted.
+///
+/// Why (#7179, owner ruling 2026-09-08): the `💸` segment's percent needs how
+/// many tokens THIS session actually spent, but `total_input_tokens` resets to
+/// a small number on every auto-compaction — reading it raw after a reset
+/// would understate the session and make the percent swing for reasons
+/// unrelated to anything the harness saved. Folding the pre-reset reading into
+/// a running base makes the session total monotonically non-decreasing across
+/// any number of resets. This drop test is deliberately simpler than
+/// [`update_state`]'s 60%/10k compaction-*display* heuristic: a missed reset
+/// here would silently drop real spend from the denominator (inflating the
+/// percent), while a false positive only folds in a value the next tick would
+/// have superseded anyway — so "any drop" is the safer rule for a running sum.
+/// What: no-op when `cur == 0` (nothing to record, returns `false`).
+/// Otherwise, when `last_seen_input_tokens > 0` and `cur` has dropped below
+/// it, adds `last_seen_input_tokens` to `session_actual_tokens_base` (one
+/// epoch completed). Always then sets `last_seen_input_tokens = cur` when it
+/// changed. Returns `true` whenever `last_seen_input_tokens` changed — that
+/// must persist for the next tick's drop comparison even on a tick that folded
+/// nothing.
+/// Test: `session_actual_tokens_accumulate_across_two_compactions`,
+/// `session_actual_tokens_no_fold_while_rising`,
+/// `session_actual_tokens_ignores_a_zero_reading`,
+/// `session_actual_tokens_unchanged_reading_returns_false`.
+pub(crate) fn update_session_actual_tokens(state: &mut CompactionState, cur: u64) -> bool {
+    if cur == 0 {
+        return false;
+    }
+    if state.last_seen_input_tokens > 0 && cur < state.last_seen_input_tokens {
+        state.session_actual_tokens_base += state.last_seen_input_tokens;
+    }
+    if state.last_seen_input_tokens == cur {
+        return false;
+    }
+    state.last_seen_input_tokens = cur;
+    true
+}
+
+/// The session's cumulative actual-token count: every completed epoch's
+/// folded reading, plus the current epoch's last-seen reading.
+///
+/// Why (#7179): this is the one figure
+/// [`trusty_mpm::core::savings::SavingsTotal::percent_saved`]'s session-share
+/// denominator needs. `None` (rather than `0`) distinguishes "no tick has
+/// landed yet for this session" from a real, if tiny, reading — the caller
+/// falls back to the ledger's own before-total formula on `None` rather than
+/// dividing by a fabricated zero.
+/// What: `None` when no tick has ever been recorded
+/// (`last_seen_input_tokens == 0`); otherwise
+/// `session_actual_tokens_base + last_seen_input_tokens`.
+/// Test: `session_actual_tokens_accumulate_across_two_compactions`,
+/// `session_actual_tokens_is_none_before_the_first_tick`.
+pub(crate) fn session_actual_tokens(state: &CompactionState) -> Option<u64> {
+    if state.last_seen_input_tokens == 0 {
+        return None;
+    }
+    Some(state.session_actual_tokens_base + state.last_seen_input_tokens)
+}
+
+/// Read this session's cumulative actual-token count from its persisted
+/// compaction state, or `None` when the session id is invalid, the state file
+/// is unreadable, or no tick has landed yet.
+///
+/// Why (#7179): the savings segment (`savings.rs`) needs this figure at render
+/// time but must not add a third per-session store — this reuses the exact
+/// file [`compaction_segment`] already keys by `session_id`.
+/// What: validates `session_id`, loads state (`Default` on any I/O error —
+/// see [`load_state_from`]), and returns [`session_actual_tokens`]. A plain
+/// synchronous read, not wrapped in `compaction_segment`'s bounded-thread
+/// timeout: the file is a few dozen bytes, and this runs after
+/// `compaction_segment` has already written the latest tick in the same
+/// render cycle, so it matches the synchronous-read pattern the savings
+/// ledger fold already uses.
+/// Test: covered through [`session_actual_tokens`] and
+/// [`update_session_actual_tokens`], plus `state_file_path`'s and
+/// `load_state_from`'s own tests — this function is their composition.
+pub(crate) fn session_actual_tokens_for(session_id: &str) -> Option<u64> {
+    if !is_valid_session_id(session_id) {
+        return None;
+    }
+    let path = state_file_path(session_id)?;
+    session_actual_tokens(&load_state_from(&path))
+}
+
 /// Return `true` when `s` is a safe session identifier: non-empty and composed
 /// entirely of ASCII alphanumeric characters, underscores, or hyphens.
 ///
@@ -305,8 +411,12 @@ pub(crate) fn compaction_segment(
     std::thread::spawn(move || {
         let mut state = load_state_from(&path);
         if cur > 0 {
-            // update_state returns true only when state actually changed.
-            if update_state(&mut state, cur) {
+            // Both calls run unconditionally (not `||`-short-circuited) so the
+            // #7179 cumulative counter still advances on a tick that the
+            // compaction-display heuristic itself treats as a no-op.
+            let compaction_changed = update_state(&mut state, cur);
+            let actual_changed = update_session_actual_tokens(&mut state, cur);
+            if compaction_changed || actual_changed {
                 save_state_to(&path, &state);
             }
         }
@@ -470,6 +580,85 @@ mod tests {
         assert!(!changed2, "small drop must return false");
     }
 
+    // ── session-actual-tokens (#7179) ─────────────────────────────────────────
+
+    /// Why (#7179): the exact scenario the issue names — a session that grows
+    /// to 100k, gets compacted down to 20k, then grows to 60k — must report an
+    /// actual-tokens figure that adds the pre-compaction reading to the
+    /// current one (100k + 60k = 160k), not the post-compaction reading alone.
+    /// Test: itself.
+    #[test]
+    fn session_actual_tokens_accumulate_across_two_compactions() {
+        let mut state = CompactionState::default();
+
+        assert!(update_session_actual_tokens(&mut state, 100_000));
+        assert_eq!(session_actual_tokens(&state), Some(100_000));
+
+        // First compaction: 100k → 20k.
+        assert!(update_session_actual_tokens(&mut state, 20_000));
+        assert_eq!(state.session_actual_tokens_base, 100_000);
+        assert_eq!(session_actual_tokens(&state), Some(120_000));
+
+        // Grows again, no fold yet.
+        assert!(update_session_actual_tokens(&mut state, 60_000));
+        assert_eq!(state.session_actual_tokens_base, 100_000);
+        assert_eq!(
+            session_actual_tokens(&state),
+            Some(160_000),
+            "100k folded base + 60k current epoch = 160k actual"
+        );
+
+        // Second compaction: 60k → 15k must fold the 60k in too.
+        assert!(update_session_actual_tokens(&mut state, 15_000));
+        assert_eq!(state.session_actual_tokens_base, 160_000);
+        assert_eq!(session_actual_tokens(&state), Some(175_000));
+    }
+
+    /// Why (#7179): a session that only ever rises must never fold anything —
+    /// the base stays zero and the actual figure is just the latest reading.
+    /// Test: itself.
+    #[test]
+    fn session_actual_tokens_no_fold_while_rising() {
+        let mut state = CompactionState::default();
+        update_session_actual_tokens(&mut state, 10_000);
+        update_session_actual_tokens(&mut state, 20_000);
+        update_session_actual_tokens(&mut state, 30_000);
+        assert_eq!(
+            state.session_actual_tokens_base, 0,
+            "no drop was ever observed"
+        );
+        assert_eq!(session_actual_tokens(&state), Some(30_000));
+    }
+
+    /// Why (#7179): `cur == 0` (Claude Code sent no context-window payload)
+    /// must record nothing and must not itself count as a "drop".
+    /// Test: itself.
+    #[test]
+    fn session_actual_tokens_ignores_a_zero_reading() {
+        let mut state = CompactionState::default();
+        assert!(!update_session_actual_tokens(&mut state, 0));
+        assert_eq!(session_actual_tokens(&state), None);
+    }
+
+    /// Why (#7179): before any tick has landed there is nothing to report —
+    /// `None`, not a fabricated `Some(0)`.
+    /// Test: itself.
+    #[test]
+    fn session_actual_tokens_is_none_before_the_first_tick() {
+        assert_eq!(session_actual_tokens(&CompactionState::default()), None);
+    }
+
+    /// Why (#7179): a no-op tick (identical reading) must return `false` so
+    /// `compaction_segment` skips the save, matching `update_state`'s existing
+    /// no-op-tick contract.
+    /// Test: itself.
+    #[test]
+    fn session_actual_tokens_unchanged_reading_returns_false() {
+        let mut state = CompactionState::default();
+        update_session_actual_tokens(&mut state, 50_000);
+        assert!(!update_session_actual_tokens(&mut state, 50_000));
+    }
+
     // ── session_id validation ─────────────────────────────────────────────────
 
     #[test]
@@ -531,6 +720,7 @@ mod tests {
                 after: 58_000,
                 reclaimed_pct: 68.13,
             }),
+            ..Default::default()
         };
         save_state_to(&path, &state);
 
@@ -563,6 +753,7 @@ mod tests {
                 after: 58_000,
                 reclaimed_pct: 68.13,
             }),
+            ..Default::default()
         };
         let cw = ContextWindow {
             total_input_tokens: 60_000,

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs
@@ -1,39 +1,48 @@
 //! The `💸` estimated-savings segment for `tm statusline` (#6958, percent
-//! form since #7179).
+//! form since #7179, session-share denominator since #7179's owner ruling
+//! 2026-09-08).
 //!
 //! Why: the owner asked to see what the harness saves by not sending tokens —
 //! instruction folding today, diverted file reads and compressed gate output as
 //! those producers land. The status bar is where the operator already looks for
-//! the session's cost, so the saving belongs beside it. #7179 (owner ruling
-//! 2026-09-08) replaced the dollar/token figure with a percentage: "how much of
-//! what would have been sent did we avoid" reads at a glance in a way a dollar
-//! amount — which needs the session's spend as context to interpret — does not.
+//! the session's cost, so the saving belongs beside it. #7179 replaced the
+//! dollar/token figure with a percentage, then the owner ruled the percentage
+//! itself must be a *session share* — `saved / (session actual tokens +
+//! saved)` — rather than a ratio scoped only to the ledger's own rows: "how
+//! much of everything this session sent did we avoid" is the number that
+//! actually answers "how much are we saving", where a ledger-only ratio only
+//! answers it for the subset of tokens a savings technique happened to touch.
 //!
-//! What: folds `~/.trusty-mpm/usage/savings.jsonl` for the current session at
-//! render time and renders one segment:
+//! What: folds `~/.trusty-mpm/usage/savings.jsonl` for the current session,
+//! reads that session's cumulative actual-token count from
+//! [`compaction::session_actual_tokens_for`] (the same per-session store
+//! `compaction.rs` already keys by `session_id` — no third store), and renders
+//! one segment:
 //!
 //! | Fold | Renders |
 //! |---|---|
 //! | `tokens_saved > 0` and a percent denominator exists | `💸34%` |
-//! | zero fold, or no denominator (every row predates #7179) | nothing at all |
+//! | zero fold, or no denominator at all (every row predates #7179 and no compaction tick has landed) | nothing at all |
 //!
-//! The percent is [`SavingsTotal::percent_saved`] — `tokens_saved / (this
-//! session's ledger rows' own pre-saving token count)`, folded across every
-//! accepted row, rounded to the nearest whole number. See that method's doc and
-//! the `savings` module header for why this denominator was chosen over the
-//! session's live context-window fill.
+//! The percent is [`SavingsTotal::percent_saved`]: `saved / (actual + saved)`
+//! when a compaction tick has landed for this session, else the pre-ruling
+//! `saved / tokens_before` fallback — see that method's doc for why the
+//! fallback is never distinguished in the rendered string.
 //!
 //! **`0%` is unreachable by construction**, the same way `$0.00` was before
 //! #7179: [`SavingsTotal::is_zero`] gates the whole segment, so a fold with
 //! nothing to show renders nothing rather than a false `0%`.
 //!
 //! Test: `savings_segment_renders_a_percent`,
+//! `savings_segment_uses_the_session_actual_denominator_when_available`,
 //! `savings_segment_is_absent_on_a_zero_fold`,
 //! `savings_segment_never_renders_zero_percent`.
 
 use std::path::{Path, PathBuf};
 
 use trusty_mpm::core::savings::{SavingsTotal, fold_session, savings_log_in};
+
+use super::compaction;
 
 /// Fold the ledger for `session_id` and render the segment, or omit it.
 ///
@@ -42,9 +51,10 @@ use trusty_mpm::core::savings::{SavingsTotal, fold_session, savings_log_in};
 /// and no resolved framework root.
 /// What: resolves the ledger under the operator's framework root — the same
 /// `--root` / `TRUSTY_MPM_ROOT` / XDG-config / `~/.trusty-mpm` chain every other
-/// `tm` command honours — folds it for this session, and renders. An empty
-/// `session_id` (Claude Code sends one only once the session has an id) omits
-/// the segment without touching the disk.
+/// `tm` command honours — folds it for this session, reads this session's
+/// cumulative actual-token count from [`compaction::session_actual_tokens_for`]
+/// (#7179), and renders. An empty `session_id` (Claude Code sends one only
+/// once the session has an id) omits the segment without touching the disk.
 /// Test: `savings_segment_probe_is_absent_without_a_session_id`,
 /// `savings_segment_reads_the_ledger_under_an_explicit_root`.
 pub(crate) fn savings_segment_probe(session_id: &str) -> Option<String> {
@@ -52,18 +62,28 @@ pub(crate) fn savings_segment_probe(session_id: &str) -> Option<String> {
         return None;
     }
     let root = savings_root()?;
-    savings_segment_at(&savings_log_in(&root), session_id)
+    let actual_tokens = compaction::session_actual_tokens_for(session_id);
+    savings_segment_at(&savings_log_in(&root), session_id, actual_tokens)
 }
 
 /// [`savings_segment_probe`] against an explicit ledger path.
 ///
 /// Why: makes the missing-ledger and populated-ledger branches assertable end
-/// to end from a temp directory, with no environment mutation.
-/// What: folds `ledger` for `session_id` and renders the result.
+/// to end from a temp directory, with no environment mutation. Taking
+/// `session_actual_tokens` as a parameter (rather than reading the compaction
+/// state file itself) keeps this function's own I/O to the one ledger path its
+/// tests already control.
+/// What: folds `ledger` for `session_id` and renders the result against
+/// `session_actual_tokens` — the session's cumulative actual-token count, or
+/// `None` when no compaction tick has landed yet (#7179).
 /// Test: `savings_segment_is_absent_when_the_ledger_is_missing`,
 /// `savings_segment_reads_the_ledger_under_an_explicit_root`.
-pub(crate) fn savings_segment_at(ledger: &Path, session_id: &str) -> Option<String> {
-    render_savings_segment(&fold_session(ledger, session_id))
+pub(crate) fn savings_segment_at(
+    ledger: &Path,
+    session_id: &str,
+    session_actual_tokens: Option<u64>,
+) -> Option<String> {
+    render_savings_segment(&fold_session(ledger, session_id), session_actual_tokens)
 }
 
 /// Remember which model this session runs, for the divert producer to price at.
@@ -116,17 +136,25 @@ fn savings_root() -> Option<PathBuf> {
 ///
 /// Why: this is the rule the whole segment exists to get right — never a false
 /// `0%`, never a fabricated figure.
-/// What: `💸<N>%` from [`SavingsTotal::percent_saved`]; `None` on
+/// What: `💸<N>%` from [`SavingsTotal::percent_saved`] against
+/// `session_actual_tokens` (#7179's session-share denominator, or its
+/// pre-ruling `tokens_before` fallback on `None`); `None` on
 /// [`SavingsTotal::is_zero`] or when that method itself returns `None` (no
-/// percent denominator — every accepted row predates #7179's `tokens_before`).
+/// denominator on either path).
 /// Test: `savings_segment_renders_a_percent`,
+/// `savings_segment_uses_the_session_actual_denominator_when_available`,
 /// `savings_segment_is_absent_on_a_zero_fold`,
 /// `savings_segment_never_renders_zero_percent`.
-pub(crate) fn render_savings_segment(total: &SavingsTotal) -> Option<String> {
+pub(crate) fn render_savings_segment(
+    total: &SavingsTotal,
+    session_actual_tokens: Option<u64>,
+) -> Option<String> {
     if total.is_zero() {
         return None;
     }
-    total.percent_saved().map(|pct| format!("\u{1f4b8}{pct}%"))
+    total
+        .percent_saved(session_actual_tokens)
+        .map(|pct| format!("\u{1f4b8}{pct}%"))
 }
 
 #[cfg(test)]
@@ -143,19 +171,32 @@ mod tests {
         }
     }
 
-    /// Why (#7179): the percent is the primary — now only — reading, and
-    /// rounding to the nearest whole number is the exact shape the docs page
-    /// describes.
+    /// Why (#7179): with no actual-tokens reading supplied, the segment falls
+    /// back to the pre-ruling ledger-only formula — pinned here so a
+    /// regression in the fallback path is caught independently of the
+    /// session-share path below.
     /// Test: itself.
     #[test]
     fn savings_segment_renders_a_percent() {
         assert_eq!(
-            render_savings_segment(&total(1, 3)).as_deref(),
+            render_savings_segment(&total(1, 3), None).as_deref(),
             Some("\u{1f4b8}33%")
         );
         assert_eq!(
-            render_savings_segment(&total(5_000, 20_000)).as_deref(),
+            render_savings_segment(&total(5_000, 20_000), None).as_deref(),
             Some("\u{1f4b8}25%")
+        );
+    }
+
+    /// Why (#7179, owner ruling): once a compaction tick has landed for this
+    /// session, the segment must use the session-share denominator —
+    /// `saved / (actual + saved)` — even when `tokens_before` disagrees.
+    /// Test: itself.
+    #[test]
+    fn savings_segment_uses_the_session_actual_denominator_when_available() {
+        assert_eq!(
+            render_savings_segment(&total(40_000, 999_999), Some(160_000)).as_deref(),
+            Some("\u{1f4b8}20%")
         );
     }
 
@@ -164,31 +205,38 @@ mod tests {
     /// Test: itself.
     #[test]
     fn savings_segment_is_absent_on_a_zero_fold() {
-        assert_eq!(render_savings_segment(&SavingsTotal::default()), None);
+        assert_eq!(render_savings_segment(&SavingsTotal::default(), None), None);
         assert_eq!(
-            render_savings_segment(&SavingsTotal {
-                tokens_saved: 0,
-                tokens_before: 0,
-                cost_saved_usd: 0.0,
-                rows: 3,
-            }),
+            render_savings_segment(
+                &SavingsTotal {
+                    tokens_saved: 0,
+                    tokens_before: 0,
+                    cost_saved_usd: 0.0,
+                    rows: 3,
+                },
+                None
+            ),
             None
         );
     }
 
-    /// Why (#7179): a fold with `tokens_saved > 0` but no percent denominator
-    /// (every accepted row predates #7179) must omit the segment, not fabricate
-    /// a percent against nothing.
+    /// Why (#7179): a fold with `tokens_saved > 0` but no denominator on
+    /// either path (no actual-tokens reading, and every accepted row predates
+    /// #7179's `tokens_before`) must omit the segment, not fabricate a percent
+    /// against nothing.
     /// Test: itself.
     #[test]
     fn savings_segment_is_absent_without_a_percent_denominator() {
         assert_eq!(
-            render_savings_segment(&SavingsTotal {
-                tokens_saved: 4_000,
-                tokens_before: 0,
-                cost_saved_usd: 0.01,
-                rows: 1,
-            }),
+            render_savings_segment(
+                &SavingsTotal {
+                    tokens_saved: 4_000,
+                    tokens_before: 0,
+                    cost_saved_usd: 0.01,
+                    rows: 1,
+                },
+                None
+            ),
             None
         );
     }
@@ -202,8 +250,8 @@ mod tests {
     #[test]
     fn savings_segment_never_renders_zero_percent() {
         for (tokens_saved, tokens_before) in [(1_u64, 200), (12_000, 12_000_100), (5, 1_000)] {
-            let rendered =
-                render_savings_segment(&total(tokens_saved, tokens_before)).unwrap_or_default();
+            let rendered = render_savings_segment(&total(tokens_saved, tokens_before), None)
+                .unwrap_or_default();
             assert_ne!(
                 rendered, "\u{1f4b8}0%",
                 "the segment must never render 0% while tokens_saved > 0 \
@@ -219,7 +267,7 @@ mod tests {
     fn savings_segment_is_absent_when_the_ledger_is_missing() {
         let dir = tempfile::tempdir().expect("temp dir");
         let ledger = dir.path().join("usage").join("savings.jsonl");
-        assert_eq!(savings_segment_at(&ledger, "sess-1"), None);
+        assert_eq!(savings_segment_at(&ledger, "sess-1", None), None);
     }
 
     /// Why: proves the whole path — append a row, fold it back for that session
@@ -244,11 +292,11 @@ mod tests {
         )
         .expect("append");
         assert_eq!(
-            savings_segment_at(&ledger, "sess-1").as_deref(),
+            savings_segment_at(&ledger, "sess-1", None).as_deref(),
             Some("\u{1f4b8}20%")
         );
         // A different session's bar reads nothing from the same file.
-        assert_eq!(savings_segment_at(&ledger, "sess-2"), None);
+        assert_eq!(savings_segment_at(&ledger, "sess-2", None), None);
     }
 
     /// Why: before Claude Code assigns a session id there is nothing to fold,

--- a/crates/trusty-mpm/src/core/savings.rs
+++ b/crates/trusty-mpm/src/core/savings.rs
@@ -25,20 +25,24 @@
 //!   A producer bug that undercounts its baseline therefore shows as a missing
 //!   contribution, never as a negative or inflated displayed figure.
 //!
-//! **`tokens_before` and [`SavingsTotal::percent_saved`] (owner ruling
-//! 2026-09-08, #7179).** The `💸` segment shows a whole-number percent of
-//! tokens avoided, not a dollar figure. The percent's denominator is each
-//! row's own pre-saving token count — `tokens_before = tokens_saved + tokens
-//! actually sent` — folded the same way `tokens_saved` is. This was chosen
-//! over pricing the percent against the session's live context-window fill
-//! (`total_input_tokens` from the `statusLine` hook, the only other per-session
-//! token counter available): that figure resets on every auto-compaction, which
-//! would make the percent jump non-monotonically for reasons unrelated to
-//! anything the harness saved, and it counts tokens no savings technique here
-//! ever touched. A ledger-only percent stays stable and scoped to what this
-//! feature actually measures. `#[serde(default)]` so a pre-#7179 row folds
-//! with `tokens_before = 0` and is excluded from the denominator, rather than
-//! failing to parse.
+//! **[`SavingsTotal::percent_saved`] denominator (owner ruling 2026-09-08,
+//! #7179).** The `💸` segment shows a whole-number percent of tokens avoided,
+//! not a dollar figure: `saved / (session actual tokens + saved)` — the
+//! *session share* the owner asked for. "Session actual tokens" is a
+//! cumulative counter `crate::commands::statusline::compaction` (the `tm`
+//! binary) folds across every auto-compaction reset of the `statusLine`
+//! hook's `total_input_tokens`, since that raw figure resets on every
+//! compaction and would otherwise make the percent jump non-monotonically for
+//! reasons unrelated to anything the harness saved. This module has no access
+//! to that counter (it lives in the `tm` binary crate, keyed by session id in
+//! `~/.trusty-mpm/statusline/<session_id>.json`), so `percent_saved` takes it
+//! as an `Option<u64>` argument the statusline binary supplies at render time.
+//! `None` — no compaction tick has landed yet for this session — falls back to
+//! the pre-#7179 formula, `tokens_saved / tokens_before` (each row's own
+//! pre-saving token count, folded the same way `tokens_saved` is).
+//! `#[serde(default)]` on `tokens_before` so a pre-#7179 row folds with
+//! `tokens_before = 0` and is excluded from that fallback denominator, rather
+//! than failing to parse.
 //!
 //! Everything here fails soft: a missing, unreadable, or truncated ledger folds
 //! to zero rather than erroring, because the consumer is a status bar on
@@ -100,14 +104,15 @@ pub struct SavingsRow {
     /// Estimated pre-saving token count for this row — `tokens_saved` plus the
     /// tokens actually sent instead (#7179).
     ///
-    /// Why: [`SavingsTotal::percent_saved`] needs a denominator, and the only
-    /// one that stays stable and scoped to what this feature measures is the
-    /// ledger's own before-figure, folded across every row alongside
-    /// `tokens_saved` — see the module header for why the live context-window
-    /// fill was rejected instead.
+    /// Why: [`SavingsTotal::percent_saved`]'s primary denominator is the
+    /// session's actual-token counter (see the module header), but that value
+    /// is only available once a `statusLine` tick has landed for this session.
+    /// This field folds into the *fallback* denominator used when it has not —
+    /// the ledger's own before-figure, folded across every row alongside
+    /// `tokens_saved`.
     /// What: `u64` (a plain count, never negative by construction).
     /// `#[serde(default)]` so a row written before this field existed folds as
-    /// `0` — excluded from the percent denominator rather than failing to
+    /// `0` — excluded from the fallback denominator rather than failing to
     /// parse. Producers that cannot state a before-figure simply omit it.
     /// Test: `percent_saved_rounds_to_nearest_whole_number`,
     /// `a_row_written_before_tokens_before_existed_still_folds`.
@@ -170,32 +175,61 @@ impl SavingsTotal {
         self.rows == 0 || (self.tokens_saved == 0 && self.cost_saved_usd <= 0.0)
     }
 
-    /// Whole-number percent of tokens the harness avoided sending, folded
-    /// across every accepted row (#7179).
+    /// Whole-number percent of tokens the harness avoided sending, as a share
+    /// of the session (owner ruling 2026-09-08, #7179).
     ///
-    /// Why: the `💸` statusline segment renders one percentage, and the fold is
-    /// the only place `tokens_saved` and `tokens_before` are summed together —
-    /// computing the ratio here, rather than at the render site, means a future
-    /// console consumer gets the identical number from the identical division.
-    /// What: `round(100 * tokens_saved / tokens_before)`, clamped to `[1, 100]`
-    /// whenever the fold accepted at least one row — the lower clamp mirrors
-    /// the pre-#7179 dollar segment's "never render a false zero" rule: a
-    /// sub-0.5% ratio would otherwise round down to a literal `0%`, which reads
-    /// as "we saved nothing" and states a measurement that was never made. The
-    /// upper clamp covers a mixed old/new ledger, where rows written before
-    /// `tokens_before` existed fold their share of the denominator as `0` (see
-    /// the module header) and can otherwise push the raw ratio above 100.
-    /// `None` when there is nothing to divide: [`Self::is_zero`], or a
-    /// `tokens_before` sum of `0` (every accepted row predates #7179).
-    /// Test: `percent_saved_rounds_to_nearest_whole_number`,
+    /// Why: the `💸` statusline segment renders one percentage — how much of
+    /// what this session actually spent plus what it avoided did the harness
+    /// avoid. `session_actual_tokens` is the caller-supplied cumulative token
+    /// count from `crate::commands::statusline::compaction` (see the module
+    /// header for why that counter, rather than a raw `total_input_tokens`
+    /// read, is what survives an auto-compaction). This method has no
+    /// filesystem access of its own — it is a pure function of the fold plus
+    /// whatever the caller already read — which is what keeps it unit-testable
+    /// against hand-built totals with no I/O.
+    /// What: primary path, `session_actual_tokens = Some(actual)`:
+    /// `round(100 * tokens_saved / (actual + tokens_saved))`. Fallback path,
+    /// `None` — no compaction tick has landed yet for this session:
+    /// `round(100 * tokens_saved / tokens_before)`, the pre-#7179 formula.
+    /// This fallback is never distinguished in the rendered string — both
+    /// paths produce the identical `💸<N>%` shape; only this doc comment
+    /// records which formula ran. Either path clamps to `[1, 100]` whenever
+    /// the fold accepted at least one row and the denominator is nonzero — the
+    /// lower clamp mirrors the pre-#7179 dollar segment's "never render a
+    /// false zero" rule: a sub-0.5% ratio would otherwise round down to a
+    /// literal `0%`, which reads as "we saved nothing" and states a
+    /// measurement that was never made. The upper clamp covers a mixed
+    /// old/new ledger on the fallback path, where rows written before
+    /// `tokens_before` existed fold their share of that denominator as `0`
+    /// (see the module header) and can otherwise push the raw ratio above 100.
+    /// `None` when there is nothing to divide: [`Self::is_zero`], or (on the
+    /// fallback path only) a `tokens_before` sum of `0` — every accepted row
+    /// predates #7179 and no compaction tick has landed either.
+    /// Test: `percent_saved_uses_the_session_actual_denominator_when_given`,
+    /// `percent_saved_falls_back_to_tokens_before_when_actual_is_unknown`,
+    /// `percent_saved_rounds_to_nearest_whole_number`,
     /// `percent_saved_is_none_on_a_zero_fold`,
     /// `percent_saved_clamps_a_legacy_mixed_fold`,
     /// `percent_saved_never_rounds_down_to_zero`.
-    pub fn percent_saved(&self) -> Option<u32> {
-        if self.is_zero() || self.tokens_before == 0 {
+    pub fn percent_saved(&self, session_actual_tokens: Option<u64>) -> Option<u32> {
+        if self.is_zero() {
             return None;
         }
-        let ratio = self.tokens_saved as f64 / self.tokens_before as f64;
+        let ratio = match session_actual_tokens {
+            Some(actual) => {
+                let denominator = actual + self.tokens_saved;
+                if denominator == 0 {
+                    return None;
+                }
+                self.tokens_saved as f64 / denominator as f64
+            }
+            None => {
+                if self.tokens_before == 0 {
+                    return None;
+                }
+                self.tokens_saved as f64 / self.tokens_before as f64
+            }
+        };
         let pct = (ratio * 100.0).round();
         // A true zero is already excluded by the checks above, so any ratio
         // reaching here is a real (if tiny) measurement — round it up to the

--- a/crates/trusty-mpm/src/core/savings_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_tests.rs
@@ -81,7 +81,7 @@ fn a_row_written_before_tokens_before_existed_still_folds() {
         "an absent tokens_before must read back as 0, not fail the parse"
     );
     assert_eq!(
-        total.percent_saved(),
+        total.percent_saved(None),
         None,
         "a fold with no tokens_before has no percent to report"
     );
@@ -194,7 +194,7 @@ fn percent_saved_rounds_to_nearest_whole_number() {
             cost_saved_usd: 0.01,
             rows: 1,
         }
-        .percent_saved(),
+        .percent_saved(None),
         Some(33)
     );
     assert_eq!(
@@ -204,7 +204,7 @@ fn percent_saved_rounds_to_nearest_whole_number() {
             cost_saved_usd: 0.05,
             rows: 1,
         }
-        .percent_saved(),
+        .percent_saved(None),
         Some(25)
     );
 }
@@ -215,7 +215,7 @@ fn percent_saved_rounds_to_nearest_whole_number() {
 /// Test: itself.
 #[test]
 fn percent_saved_is_none_on_a_zero_fold() {
-    assert_eq!(SavingsTotal::default().percent_saved(), None);
+    assert_eq!(SavingsTotal::default().percent_saved(None), None);
 }
 
 /// Why (#7179): the one output this method may never produce while it accepted
@@ -232,7 +232,7 @@ fn percent_saved_never_rounds_down_to_zero() {
             cost_saved_usd: 0.000_01,
             rows: 1,
         }
-        .percent_saved(),
+        .percent_saved(None),
         Some(1)
     );
 }
@@ -250,9 +250,42 @@ fn percent_saved_clamps_a_legacy_mixed_fold() {
             cost_saved_usd: 0.01,
             rows: 1,
         }
-        .percent_saved(),
+        .percent_saved(None),
         None
     );
+}
+
+/// Why (#7179, owner ruling): the session-share denominator is the primary
+/// reading now — `actual + saved`, not the ledger's own before-figure — and
+/// this pins the exact division against the scenario the issue named: 40 000
+/// tokens saved of a session that actually spent 160 000.
+/// Test: itself.
+#[test]
+fn percent_saved_uses_the_session_actual_denominator_when_given() {
+    let total = SavingsTotal {
+        tokens_saved: 40_000,
+        // Deliberately different from the actual-tokens path so the test
+        // fails if the fallback formula runs instead.
+        tokens_before: 999_999,
+        cost_saved_usd: 0.5,
+        rows: 3,
+    };
+    assert_eq!(total.percent_saved(Some(160_000)), Some(20));
+}
+
+/// Why (#7179): a brand-new session (or a state file that could not be read)
+/// has no compaction tick yet — the percent must still render, falling back
+/// to the ledger's own before-total rather than omitting the segment.
+/// Test: itself.
+#[test]
+fn percent_saved_falls_back_to_tokens_before_when_actual_is_unknown() {
+    let total = SavingsTotal {
+        tokens_saved: 5_000,
+        tokens_before: 20_000,
+        cost_saved_usd: 0.05,
+        rows: 1,
+    };
+    assert_eq!(total.percent_saved(None), Some(25));
 }
 
 /// Why (#6958, required acceptance): a producer that crashes mid-write, or a

--- a/docs/trusty-mpm/statusline-savings.md
+++ b/docs/trusty-mpm/statusline-savings.md
@@ -21,18 +21,30 @@ It has one form and one absence:
 
 ### How the percent is computed
 
-Every ledger row already knows two figures: `tokens_saved` (what it avoided
-sending) and `tokens_before` (what it would have sent without the technique).
-The segment sums both across every row this session wrote, then reports
-`round(100 × tokens_saved / tokens_before)`.
+The percent is a **session share**: how much of everything this session sent —
+what it actually spent, plus what the harness avoided — did the harness avoid.
 
-This denominator was chosen over the session's live context-window fill (the
-`total_input_tokens` figure behind the `ctx 41%` segment) deliberately: that
-figure resets on every auto-compaction, which would make the percent jump for
-reasons that have nothing to do with anything the harness saved, and it counts
-tokens no savings technique here ever touches. The ledger-only percent stays
-scoped to exactly what `instruction-compression` and `divert` measure, and it
-only grows as more of those write rows.
+```
+percent = tokens_saved / (session_actual_tokens + tokens_saved)
+```
+
+`tokens_saved` is every accepted ledger row's `tokens_saved`, summed across the
+session. `session_actual_tokens` is a cumulative counter the `tm statusline`
+compaction tracker keeps per session, alongside the `ctx 41%` segment's own
+state, in `~/.trusty-mpm/statusline/<session_id>.json`. It exists because the
+`statusLine` hook's raw `total_input_tokens` figure resets to a small number on
+every auto-compaction — reading it directly would understate the session and
+make the percent swing for reasons that have nothing to do with anything the
+harness saved. The tracker instead folds each pre-reset reading into a running
+base the moment it detects a drop, so `session_actual_tokens` only grows,
+across any number of compactions in the session.
+
+Before the first `statusLine` tick lands for a session — no compaction tracker
+state yet — the segment falls back to the ledger-only ratio this feature
+originally shipped with: `round(100 × tokens_saved / tokens_before)`, where
+`tokens_before` is each row's own pre-saving token count. That fallback
+produces the identical `💸<N>%` shape; nothing in the rendered segment
+distinguishes which formula ran.
 
 It is still an estimate, for the same two reasons as before:
 


### PR DESCRIPTION
## Summary
- Owner ruling on #7179: the `💸` statusline percent's denominator changes from the ledger's own `tokens_before` to the session's actual token spend — `saved / (session_actual_tokens + saved)`.
- Adds a cumulative actual-tokens counter (`session_actual_tokens_base`, `last_seen_input_tokens`) to `CompactionState` in `crates/trusty-mpm/src/bin/tm/commands/statusline/compaction.rs`, persisted in the same per-session state file (`~/.trusty-mpm/statusline/<session_id>.json`) the compaction tracker already owns — no third store. On each tick, a drop below the last-seen reading folds that reading into the running base, so the total survives any number of auto-compaction resets.
- `SavingsTotal::percent_saved` (`crates/trusty-mpm/src/core/savings.rs`) now takes `session_actual_tokens: Option<u64>`. `Some(actual)` uses the session-share formula; `None` (no compaction tick yet) falls back to the pre-ruling `tokens_saved / tokens_before` formula — the fallback is documented but never distinguished in the rendered `💸<N>%` string. Still clamped `[1, 100]`, still hidden when nothing was saved.
- `crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs` wires the two: `savings_segment_probe` reads `compaction::session_actual_tokens_for(session_id)` and passes it through.
- Docs updated: `docs/trusty-mpm/statusline-savings.md` and `crates/trusty-mpm/README.md` now describe the session-share definition (the mpm flagship page includes the former via `<!-- include: -->`).
- Changelog fragment: `crates/trusty-mpm/changelog.d/7179-savings-percent-session-share.md`.

## Test plan (rung 3)
- `cargo fmt --check` — clean.
- `cargo check -p trusty-mpm` — clean.
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean.
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — 55 test binaries, all `test result: ok`, 0 failed. New tests: `compaction::tests::session_actual_tokens_accumulate_across_two_compactions` (100k → 20k → 60k gives 160k, plus a second compaction), `session_actual_tokens_no_fold_while_rising`, `session_actual_tokens_ignores_a_zero_reading`, `session_actual_tokens_is_none_before_the_first_tick`, `session_actual_tokens_unchanged_reading_returns_false`; `core::savings::tests::percent_saved_uses_the_session_actual_denominator_when_given` (40k saved / 160k actual → 20%), `percent_saved_falls_back_to_tokens_before_when_actual_is_unknown`; `statusline::savings::tests::savings_segment_uses_the_session_actual_denominator_when_available`.
- `bash scripts/check_line_cap.sh` — 4686 files scanned, 0 violations.
- `bash scripts/check_changelog_fragment.sh --staged` — fragment present and valid.
- `bash scripts/check_doc_paths.sh` — 62 files scanned, all path citations resolve.
- `./scripts/check_test_pointers.sh` — 0 dangling pointers.

Refs #7179

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V