### PR TITLE
docs(trusty-code,trusty-agents): resolve the log-drain intra-doc links

### DIFF
--- a/crates/trusty-agents/changelog.d/7164-rustdoc-intra-doc-links.md
+++ b/crates/trusty-agents/changelog.d/7164-rustdoc-intra-doc-links.md
@@ -1,0 +1,7 @@
+Fixed
+
+- **`log_drain` module docs resolve their own links again (#7164).** The four
+  intra-doc links in the module header (`LogDrainConfig`, `resolve_log_drain`,
+  `LogDrainSetting`, `spawn`) are now backed by `crate::log_drain::…`
+  reference definitions, so rustdoc resolves them instead of failing the
+  intra-doc link gate.

--- a/crates/trusty-agents/src/log_drain/mod.rs
+++ b/crates/trusty-agents/src/log_drain/mod.rs
@@ -22,6 +22,11 @@
 //! `trusty_common::log_drain`; nothing here reimplements it.
 //!
 //! Test: `resolve::tests`, `scheduler::tests`.
+//!
+//! [`LogDrainConfig`]: crate::log_drain::LogDrainConfig
+//! [`resolve_log_drain`]: crate::log_drain::resolve_log_drain
+//! [`LogDrainSetting`]: crate::log_drain::LogDrainSetting
+//! [`spawn`]: crate::log_drain::spawn
 
 mod resolve;
 mod scheduler;

--- a/crates/trusty-code/changelog.d/7164-rustdoc-intra-doc-links.md
+++ b/crates/trusty-code/changelog.d/7164-rustdoc-intra-doc-links.md
@@ -1,0 +1,7 @@
+Fixed
+
+- **`log_drain` module docs resolve their own links again (#7164).** The four
+  intra-doc links in the module header (`config::LogDrainConfig`,
+  `resolve::resolve_log_drain`, `resolve::LogDrainSetting`, `scheduler::spawn`)
+  are now backed by `crate::log_drain::…` reference definitions, so rustdoc
+  resolves them instead of failing the intra-doc link gate.

--- a/crates/trusty-code/src/log_drain/mod.rs
+++ b/crates/trusty-code/src/log_drain/mod.rs
@@ -21,6 +21,11 @@
 //! `trusty_common::log_drain`; nothing here reimplements it.
 //!
 //! Test: `config::tests`, `resolve::tests`, `scheduler::tests`.
+//!
+//! [`config::LogDrainConfig`]: crate::log_drain::LogDrainConfig
+//! [`resolve::resolve_log_drain`]: crate::log_drain::resolve_log_drain
+//! [`resolve::LogDrainSetting`]: crate::log_drain::LogDrainSetting
+//! [`scheduler::spawn`]: crate::log_drain::spawn
 
 mod config;
 mod resolve;


### PR DESCRIPTION
## Summary

Fixes the 8 broken intra-doc links introduced by #7155's log-drain adoption (`crates/trusty-code/src/lib.rs:274`, `crates/trusty-agents/src/lib.rs:108`). Same root-cause pattern as #7157/#7162: each `log_drain` module declares an outer doc at its `pub mod log_drain;` line AND its own inner `//!` doc; both merge onto one rustdoc page, and the inner doc's bare `[`name`]` links resolve against the declaring (lib.rs) scope instead of the module's own scope. Fixed with `[`name`]: crate::log_drain::name` reference-style link definitions in each module's own `//!` doc, preserving the original link text.

- `crates/trusty-code/src/log_drain/mod.rs` — 4 link-reference definitions for `config::LogDrainConfig`, `resolve::resolve_log_drain`, `resolve::LogDrainSetting`, `scheduler::spawn`.
- `crates/trusty-agents/src/log_drain/mod.rs` — 4 link-reference definitions for `LogDrainConfig`, `resolve_log_drain`, `LogDrainSetting`, `spawn`.

Rung 1 (docs only, no `src` behavior change — doc-comment text only).

## Test plan

- [x] `bash scripts/check_rustdoc_links.sh` — `SUMMARY 24 crate(s) examined by rustdoc, 11 broken link(s), baseline 0, 11 diagnostic(s) examined`; zero of those 11 attribute to `trusty-code` or `trusty-agents` (remaining 11 are pre-existing in `trusty-common`, `trusty-audit`, `trusty-git-analytics` — out of scope, `trusty-common` handled by #7186).
- [x] `cargo fmt --check` — exit 0.
- [x] `cargo check -p trusty-code` — `Finished`, exit 0.
- [x] `cargo check -p trusty-agents` — `Finished`, exit 0.
- [x] `bash scripts/check_changelog_fragment.sh --staged` — both crates OK.
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations.
- [x] `bash scripts/check_test_pointers.sh` — OK, 0 dangling pointers.

Refs #7164

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V