### PR TITLE
docs(tga,trusty-audit): resolve the last 5 rustdoc intra-doc links

### DIFF
--- a/crates/trusty-audit/changelog.d/7188-rustdoc-intra-doc-links.md
+++ b/crates/trusty-audit/changelog.d/7188-rustdoc-intra-doc-links.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Resolved the two remaining broken rustdoc intra-doc links in `collectors` — `crate::run::pins` and `crate::chain::audit_with_preflight` are private items, so both mentions are now plain backticks instead of link syntax (#7188).

--- a/crates/trusty-audit/src/collectors.rs
+++ b/crates/trusty-audit/src/collectors.rs
@@ -60,7 +60,7 @@ pub struct OptionalCollector {
 /// [`trusty_common::bin_resolve::resolve_binary`] and fails open with a
 /// named gap line when it is missing. `git`, `tga`, `trusty-search`,
 /// `trusty-analyze` and `trusty-review` are REQUIRED tools with their own
-/// fail-CLOSED preflight ([`crate::run::pins`]) and do not belong here — a
+/// fail-CLOSED preflight (`crate::run::pins`) and do not belong here — a
 /// missing required tool already refuses the run before this module would
 /// ever run.
 pub const ALL: [OptionalCollector; 3] = [
@@ -142,7 +142,7 @@ pub(crate) fn warning_row(c: &OptionalCollector) -> String {
 /// The warn-or-refuse judgement over an already-resolved `missing` list.
 ///
 /// Why: pure and resolver-free, unlike [`missing`] — split out so
-/// [`crate::chain::audit_with_preflight`] can take the missing list as a
+/// `crate::chain::audit_with_preflight` can take the missing list as a
 /// parameter (for progress reporting) and reuse this one decision rather than
 /// re-deriving it, and so a test can drive every branch (empty, some missing,
 /// strict) with a literal list and no PATH/env involved at all.

--- a/crates/trusty-git-analytics/changelog.d/7188-rustdoc-intra-doc-links.md
+++ b/crates/trusty-git-analytics/changelog.d/7188-rustdoc-intra-doc-links.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Resolved the three remaining broken rustdoc intra-doc links in `collect::linear::client` and `collect::linear::sync` — the `unchecked_transaction`/`Connection::transaction` mentions are now plain backticks (external crate item), and `build_jql` now carries a link-reference definition to `crate::collect::jira::sync::build_jql` (#7188).

--- a/crates/trusty-git-analytics/src/collect/linear/client.rs
+++ b/crates/trusty-git-analytics/src/collect/linear/client.rs
@@ -679,8 +679,8 @@ fn parse_issue_node(identifier_fallback: &str, node: &serde_json::Value) -> Line
 /// autocommit `INSERT OR REPLACE` — fine for the old per-commit-reference
 /// callers (a handful of issues), but the new bulk sync can hand this
 /// hundreds or thousands of rows in one call, turning a first-time backfill
-/// into that many individual fsync'd commits. [`unchecked_transaction`] (not
-/// [`Connection::transaction`]) is used because this function's signature
+/// into that many individual fsync'd commits. `unchecked_transaction` (not
+/// `Connection::transaction`) is used because this function's signature
 /// takes `&Database`, not `&mut Database` — widening it would ripple into
 /// every caller (`linear_pipeline`, `commands::linear`, and both modules'
 /// tests) for no behavioral gain: `tga` is single-process and nothing else

--- a/crates/trusty-git-analytics/src/collect/linear/sync.rs
+++ b/crates/trusty-git-analytics/src/collect/linear/sync.rs
@@ -7,8 +7,9 @@
 //! DB writes) lives in `commands::linear::run_sync`.
 //! What: [`SyncScope`], [`resolve_scope`], [`next_cursor`],
 //! [`validate_team_key`], and [`build_issues_filter`] — the Linear
-//! GraphQL-filter counterpart to JIRA's JQL-string [`build_jql`]
-//! (`collect::jira::sync::build_jql`).
+//! GraphQL-filter counterpart to JIRA's JQL-string [`build_jql`].
+//!
+//! [`build_jql`]: crate::collect::jira::sync::build_jql
 
 use chrono::{DateTime, Utc};
 


### PR DESCRIPTION
## Summary

Resolves the last 5 broken rustdoc intra-doc links flagged by CI run 34264700762, closing out the `Rustdoc intra-doc links` check. Rung 1 (doc-only), CLAUDE.md test ladder.

- `crates/trusty-git-analytics/src/collect/linear/client.rs:682-683` — `unchecked_transaction` and `Connection::transaction` are `rusqlite` items; `cargo doc -p trusty-git-analytics --no-deps` builds without `rusqlite`'s own docs in scope, so both mentions become plain backticks.
- `crates/trusty-git-analytics/src/collect/linear/sync.rs:10` — `build_jql` lives in `crate::collect::jira::sync`, a different module than the doc comment; added a `[`build_jql`]: crate::collect::jira::sync::build_jql` link-reference definition so the existing link resolves.
- `crates/trusty-audit/src/collectors.rs:63` (`crate::run::pins`) and `:145` (`crate::chain::audit_with_preflight`) — both targets are private items unreachable from `collectors.rs`; de-linked to plain backticks.

## Evidence

Before (from CI run 34264700762): the 5 rows above, `unresolved link to ...`.

After:

```
$ RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p trusty-git-analytics --no-deps
warning: `tga` (lib doc) generated 81 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 29.66s
EXIT=0

$ RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p trusty-audit --no-deps
warning: `trusty-audit` (lib doc) generated 107 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.42s
EXIT=0

$ bash scripts/check_rustdoc_links.sh
SUMMARY  26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0, 0 diagnostic(s) examined
EXIT=0

$ cargo fmt --check
EXIT=0

$ bash scripts/check_changelog_fragment.sh --staged
OK   trusty-audit: changelog.d fragment present and valid
OK   trusty-git-analytics: changelog.d fragment present and valid

$ bash scripts/check_line_cap.sh
line-cap: measured 4693 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: resolved 32812 Test: citation(s) (floor 5000) — 0 dangling pointers — OK.
```

## Test plan

- [x] Rung 1 (doc-only) per CLAUDE.md test ladder — no Cargo test required beyond the doc gates above
- [x] `cargo doc -p trusty-git-analytics --no-deps` — exit 0
- [x] `cargo doc -p trusty-audit --no-deps` — exit 0
- [x] `bash scripts/check_rustdoc_links.sh` — 0 broken links, both crates absent from any LINK/FAIL rows
- [x] `cargo fmt --check` — exit 0
- [x] Changelog fragments for both crates, `check_changelog_fragment.sh --staged` — OK
- [x] `check_line_cap.sh`, `check_test_pointers.sh` — OK

Refs #7188

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V