### PR TITLE
test(trusty-common): bound the push_client no-socket test by behaviour, not wall-clock

### DIFF
--- a/crates/trusty-common/changelog.d/7168-push-client-flake.md
+++ b/crates/trusty-common/changelog.d/7168-push-client-flake.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second` no longer flakes under CI/CPU contention: it now asserts the deterministic buffer-state outcome of 10,000 sends (`buffered_len` and `dropped` against the default capacity) as the primary check, with the wall-clock budget widened 10x (1s to 10s) as a secondary regression guard against `send` reverting to per-call I/O (#7168).

--- a/crates/trusty-common/src/control_bus/push_client.rs
+++ b/crates/trusty-common/src/control_bus/push_client.rs
@@ -608,9 +608,26 @@ mod tests {
         );
     }
 
-    /// Acceptance criterion (issue #6847): `send` never touches the network,
-    /// so 10,000 calls with no socket present complete in well under a
-    /// second.
+    /// Why: Acceptance criterion (issue #6847) — `send` never touches the
+    ///      network, so it must stay cheap under load. `send` takes no
+    ///      argument and holds no state that distinguishes "no socket" from
+    ///      "socket present" (it never dials either way, see `send`'s own
+    ///      `What` above), so there is no separate completion flag to assert
+    ///      on instead of timing — the wall clock is the only observable
+    ///      signal that the hot path stayed pure buffer manipulation and did
+    ///      not regress into doing I/O per call.
+    /// What: Asserts the run completes and the buffer state is exactly what
+    ///       10,000 sends against the default limits produce —
+    ///       `buffered_len() == DEFAULT_PUSH_BUFFER_CAPACITY` and
+    ///       `dropped() == 10_000 - DEFAULT_PUSH_BUFFER_CAPACITY` — which is
+    ///       deterministic and proves every call actually ran the eviction
+    ///       loop rather than exiting early. The wall-clock budget is then a
+    ///       secondary, generous (10x the original 1s) guard against a
+    ///       regression back to per-call I/O, not the primary correctness
+    ///       check; widened after this test flaked at 1.08-1.48s under
+    ///       concurrent-worktree CPU contention (issue #7168) with zero
+    ///       algorithmic change in scope.
+    /// Test: this test.
     #[test]
     fn ten_thousand_sends_with_no_socket_complete_under_one_second() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -623,9 +640,27 @@ mod tests {
         }
         let elapsed = start.elapsed();
 
+        // Deterministic behavioral bound: every one of the 10,000 sends ran
+        // to completion through the count-cap eviction loop. This does not
+        // depend on wall-clock at all.
+        assert_eq!(
+            client.buffered_len(),
+            DEFAULT_PUSH_BUFFER_CAPACITY,
+            "10,000 sends against the default capacity must leave the buffer \
+             exactly full, not partially drained or short-circuited"
+        );
+        assert_eq!(
+            client.dropped(),
+            10_000 - DEFAULT_PUSH_BUFFER_CAPACITY as u64,
+            "every eviction beyond the default capacity must be counted"
+        );
+
+        // #7168: 10x the original 1s budget — generous headroom for
+        // concurrent-worktree CI contention — kept as a secondary guard
+        // against `send` regressing into per-call network I/O.
         assert!(
-            elapsed < Duration::from_secs(1),
-            "10,000 no-socket sends took {elapsed:?}, expected under 1s"
+            elapsed < Duration::from_secs(10),
+            "10,000 no-socket sends took {elapsed:?}, expected under 10s"
         );
     }
 


### PR DESCRIPTION
Refs #7168

## Rung

Rung 2 (test-only stabilization) per docs/reference/test-ladder-baseline.md.

## What changed

`control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second` in `crates/trusty-common/src/control_bus/push_client.rs` asserted a 1s wall-clock budget as its only check. `send()` never touches the network regardless of feature or environment, so there is no separate completion flag to assert instead of timing — but the test can still assert the buffer's exact deterministic state (`buffered_len() == DEFAULT_PUSH_BUFFER_CAPACITY`, `dropped() == 10_000 - DEFAULT_PUSH_BUFFER_CAPACITY`) as its primary check, proving every one of the 10,000 sends ran the eviction loop to completion. The wall-clock assertion is kept as a secondary regression guard against `send` reverting to per-call I/O, widened 10x (1s to 10s) per the flaky-test guidance.

## Reproduction

Reproduced by running the compiled test binary directly under artificial CPU contention (14 parallel copies x 48 background `yes` processes, matching "several agent worktrees building at once"):

```
thread 'control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second' (90565264) panicked at crates/trusty-common/src/control_bus/push_client.rs:626:9:
10,000 no-socket sends took 1.008690459s, expected under 1s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 646 filtered out; finished in 1.01s

thread 'control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second' (90565227) panicked at crates/trusty-common/src/control_bus/push_client.rs:626:9:
10,000 no-socket sends took 1.066964208s, expected under 1s
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 646 filtered out; finished in 1.07s
```

(14 of 14 parallel runs in that batch failed at 1.43-1.64s, squarely inside the reported 1.08-1.48s flake range.)

## Verification

Same contention setup (140 runs: 10 batches x 14 parallel) against the fixed test — 140/140 passed, max observed 2.11s, comfortably inside the new 10s budget:

```
140  (count of "test result: ok")
0    (count of "FAILED")
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 2.11s
...
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 1.97s
```

10 consecutive `cargo test` runs of just the target test, no artificial load:

```
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.15s
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.15s
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.14s
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.15s
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.15s
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.15s
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.14s
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.14s
test control_bus::push_client::tests::ten_thousand_sends_with_no_socket_complete_under_one_second ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 646 filtered out; finished in 0.15s
```

Note: the `uds` feature gates `push_client` (not `memory-core,embedder-test-support`, which does not compile this module — confirmed by a 0-tests-matched run first).

## Gates run

- `cargo fmt --check` — EXIT=0
- `bash scripts/check_line_cap.sh` — `measured 4693 tracked .rs file(s) (floor 500); 4 allowlisted, 0 violations — OK`
- `bash scripts/check_changelog_fragment.sh --staged` — `OK trusty-common: changelog.d fragment present and valid`
- `bash scripts/check_test_pointers.sh` — `resolved 32812 Test: citation(s) (floor 5000) — 0 dangling pointers — OK`
- `cargo test -p trusty-common --features uds --no-fail-fast` — `test result: ok. 641 passed; 0 failed; 6 ignored` (unit tests; 6 ignored are the pre-existing `#[ignore]`d ONNX embedder tests), plus every integration/doctest target green
- `cargo clippy -p trusty-common --features uds --all-targets -- -D warnings` — EXIT=0, zero warnings

## Changelog

`crates/trusty-common/changelog.d/7168-push-client-flake.md` (category: Fixed)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V
