### PR TITLE
fix(trusty-common): an opened palace is idle until first access

### DIFF
--- a/crates/trusty-common/changelog.d/7087-open-is-not-access.md
+++ b/crates/trusty-common/changelog.d/7087-open-is-not-access.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `PalaceHandle::open_with_intent` no longer stamps `last_accessed` to the open time — it starts at "never accessed" instead, so a restart's hydration burst (`load_palaces_from_disk` opening every persisted palace) no longer reads as a burst of fresh recalls to `evict_idle`. Every genuine access still calls `PalaceHandle::touch`, which continues to make a handle recent. `PalaceHandle::new` (in-memory / test handles) is unchanged. Slice 0 of #7087.

--- a/crates/trusty-common/src/memory_core/registry_tests.rs
+++ b/crates/trusty-common/src/memory_core/registry_tests.rs
@@ -732,6 +732,112 @@ fn evict_idle_skips_recent_and_respects_zero_threshold() {
     assert_eq!(reg.len(), 2, "no handle should have been evicted");
 }
 
+/// An on-disk open is not an access (#7087): `evict_idle` must be able to
+/// reclaim a handle that was opened but never genuinely touched, on its very
+/// first sweep.
+///
+/// Why: `PalaceHandle::open_with_intent` used to stamp `last_accessed` to the
+/// open time, so a restart burst (every persisted palace opened in a tight
+/// loop by `load_palaces_from_disk`) looked like a burst of fresh recalls to
+/// `evict_idle` and none of them were ever reclaimed — reintroducing the
+/// #6836 memory blowup even through the idle-evict fallback.
+/// What: opens two palaces via `create_palace` (the real disk-hydration path,
+/// not the in-memory `PalaceHandle::new` `make_handle` helper), drops the
+/// caller's reference to each so only the cache holds them
+/// (`Arc::strong_count == 1`), and asserts a 300 s `evict_idle` drops both
+/// immediately even though they were "just opened".
+/// Test: this test itself.
+#[test]
+fn open_does_not_reset_idle_clock() {
+    use crate::memory_core::palace::Palace;
+    use chrono::Utc;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+    let reg = PalaceRegistry::new();
+
+    for name in ["alpha", "beta"] {
+        let palace = Palace {
+            id: PalaceId::new(name),
+            name: name.to_string(),
+            description: None,
+            created_at: Utc::now(),
+            data_dir: data_root.join(name),
+        };
+        let handle = reg.create_palace(data_root, palace).expect("create palace");
+        // Release the caller's clone so only the cache references it —
+        // matching the restart-hydration path, where nothing is ever held
+        // beyond `register_arc`.
+        drop(handle);
+    }
+    assert_eq!(reg.len(), 2, "both palaces opened");
+
+    let evicted = reg.evict_idle(std::time::Duration::from_secs(300));
+    assert_eq!(
+        evicted, 2,
+        "an opened-but-never-accessed handle must read as idle since open"
+    );
+    assert_eq!(reg.len(), 0, "both must have been evicted");
+}
+
+/// A genuine access after open makes a handle recent again — `touch()` still
+/// overrides the "never accessed" open-time sentinel (#7087).
+///
+/// Why: the fix must not make every opened handle permanently look idle;
+/// `PalaceHandle::touch` (called by every real recall/remember/forget path)
+/// has to win over the open-time sentinel the moment a genuine access occurs.
+/// What: opens two palaces, calls `touch()` on only one immediately after
+/// open, and asserts a 300 s `evict_idle` reclaims only the untouched one.
+/// Test: this test itself.
+#[test]
+fn touch_after_open_makes_handle_recent() {
+    use crate::memory_core::palace::Palace;
+    use chrono::Utc;
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+    let reg = PalaceRegistry::new();
+
+    let touched = Palace {
+        id: PalaceId::new("touched"),
+        name: "Touched".to_string(),
+        description: None,
+        created_at: Utc::now(),
+        data_dir: data_root.join("touched"),
+    };
+    let touched_handle = reg
+        .create_palace(data_root, touched)
+        .expect("create touched palace");
+    touched_handle.touch();
+    drop(touched_handle);
+
+    let untouched = Palace {
+        id: PalaceId::new("untouched"),
+        name: "Untouched".to_string(),
+        description: None,
+        created_at: Utc::now(),
+        data_dir: data_root.join("untouched"),
+    };
+    let untouched_handle = reg
+        .create_palace(data_root, untouched)
+        .expect("create untouched palace");
+    drop(untouched_handle);
+
+    let evicted = reg.evict_idle(std::time::Duration::from_secs(300));
+    assert_eq!(
+        evicted, 1,
+        "only the untouched, merely-opened palace should be evicted"
+    );
+    assert!(
+        reg.get(&PalaceId::new("touched")).is_some(),
+        "a touched handle must survive the idle sweep"
+    );
+    assert!(
+        reg.get(&PalaceId::new("untouched")).is_none(),
+        "an untouched handle must not survive the idle sweep"
+    );
+}
+
 /// `PalaceHandle::touch` must be a no-op while a dream cycle holds
 /// `is_compacting`.
 ///

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -32,6 +32,19 @@ use uuid::Uuid;
 
 const RECALL_LOG_FILENAME: &str = "recall.db";
 
+/// Sentinel `last_accessed` value meaning "never genuinely accessed".
+///
+/// Why (#7087): a disk open is bookkeeping, not use. Stamping "now" at open
+/// made a restart burst (`load_palaces_from_disk` opening every persisted
+/// palace) look like a burst of fresh recalls to `evict_idle`, so the idle
+/// sweep left every handle resident regardless of whether anything queried
+/// them afterward.
+/// What: the unix epoch (0). `idle_secs()` then reports the full time since
+/// boot, so an opened-but-never-touched handle reads as idle immediately —
+/// eligible for `evict_idle` on its very first sweep once unreferenced.
+/// Test: `registry_tests::open_does_not_reset_idle_clock`.
+const NEVER_ACCESSED: u64 = 0;
+
 /// Current unix time in whole seconds, saturating to 0 before the epoch.
 ///
 /// Why: `last_accessed` idle tracking (issue: idle-to-disk eviction) needs a
@@ -189,11 +202,18 @@ pub struct PalaceHandle {
     /// all heavy fields) for palaces idle past `TRUSTY_MEMORY_IDLE_EVICT_SECS`;
     /// the durable redb store is the source of truth and the next access
     /// transparently re-opens from disk (`PalaceRegistry::open_palace`).
-    /// What: `Arc<AtomicU64>` initialised to "now" at open so a freshly-opened
-    /// palace is never immediately evicted. Updated by [`PalaceHandle::touch`]
-    /// on every user recall/remember/forget; suppressed during dream cycles
-    /// (see `touch`) so internal consolidation never resets the idle clock.
-    /// Test: `registry_tests::evict_idle_drops_idle_unreferenced_handle`.
+    /// What: `Arc<AtomicU64>`. [`PalaceHandle::new`] (in-memory / test handles
+    /// with no disk-open step) still initialises it to "now". [`Self::open`] /
+    /// [`Self::open_with_intent`] (the disk-hydration path every real daemon
+    /// restart takes) initialise it to `NEVER_ACCESSED` instead (#7087): an
+    /// open is bookkeeping, not use, so a hydrated-but-never-queried handle
+    /// must read as idle since open rather than as freshly touched. Updated by
+    /// [`PalaceHandle::touch`] on every user recall/remember/forget;
+    /// suppressed during dream cycles (see `touch`) so internal consolidation
+    /// never resets the idle clock.
+    /// Test: `registry_tests::evict_idle_drops_idle_unreferenced_handle`,
+    /// `registry_tests::open_does_not_reset_idle_clock`,
+    /// `registry_tests::touch_after_open_makes_handle_recent`.
     pub last_accessed: Arc<AtomicU64>,
 }
 
@@ -357,8 +377,12 @@ impl PalaceHandle {
     /// `KnowledgeGraph::open_with_intent`. When `Writer` and a second live
     /// daemon already holds the lock, this returns `Err` (no handle), so the
     /// daemon process fails to start rather than serving in a broken state.
-    /// Test: `registry_create_and_open` (default read-only path) and
-    /// `writer_intent_open_fails_loud_on_locked_*` in the store tests.
+    /// The returned handle's `last_accessed` starts at `NEVER_ACCESSED`, not
+    /// "now" (#7087) — see the field doc — so a restart's hydration burst
+    /// doesn't read as a burst of fresh use to `evict_idle`.
+    /// Test: `registry_create_and_open` (default read-only path),
+    /// `writer_intent_open_fails_loud_on_locked_*` in the store tests, and
+    /// `registry_tests::open_does_not_reset_idle_clock`.
     pub fn open_with_intent(palace: &Palace, intent: OpenIntent) -> Result<Arc<PalaceHandle>> {
         let data_dir = &palace.data_dir;
         std::fs::create_dir_all(data_dir)
@@ -499,7 +523,8 @@ impl PalaceHandle {
             is_compacting: Arc::new(AtomicBool::new(false)),
             write_mutex: Arc::new(tokio::sync::Mutex::new(())),
             commit_mutex: Arc::new(tokio::sync::Mutex::new(())),
-            last_accessed: Arc::new(AtomicU64::new(now_epoch_secs())),
+            // #7087: an on-disk open is not an access — see the field doc.
+            last_accessed: Arc::new(AtomicU64::new(NEVER_ACCESSED)),
         };
         Ok(Arc::new(handle))
     }

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -447,6 +447,73 @@ async fn load_palaces_from_disk_rehydrates_registry() {
     assert!(ids.contains(&"beta".to_string()));
 }
 
+/// Why (#7087): a restart hydrates every persisted palace through
+/// `load_palaces_from_disk`, which consumes each freshly-opened handle
+/// straight into `register_arc` with no lingering caller-side clone — so
+/// `Arc::strong_count == 1` for every one of them the moment hydration
+/// finishes. Before the fix, `PalaceHandle::open_with_intent` stamped
+/// `last_accessed` to the open time, so this whole burst read as a burst of
+/// fresh recalls and `evict_idle` left every handle resident regardless of
+/// whether anything queried them afterward — reintroducing the #6836
+/// restart-burst memory blowup even through the idle-evict fallback path.
+/// What: persists four palaces to disk (no registry access afterward, so
+/// nothing is ever touched), drops the writer registry, hydrates a fresh
+/// `AppState` via `load_palaces_from_disk`, then runs `evict_idle` with a
+/// 300 s threshold and asserts every hydrated handle was reclaimed — an
+/// opened-but-never-accessed handle must read as idle since open.
+/// Test: this test itself.
+#[tokio::test]
+async fn restart_burst_hydration_is_immediately_idle_evictable() {
+    use trusty_common::memory_core::{Palace, PalaceId, PalaceRegistry};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+
+    // Phase 1: persist four palaces to disk, simulating a prior daemon run.
+    // No `remember`/`recall`/`forget` is ever called on any of them, so none
+    // has a genuine access to record.
+    {
+        let writer = PalaceRegistry::new();
+        for id in ["alpha", "beta", "gamma", "delta"] {
+            let palace = Palace {
+                id: PalaceId::new(id),
+                name: id.to_string(),
+                description: None,
+                created_at: chrono::Utc::now(),
+                data_dir: root.join(id),
+            };
+            writer
+                .create_palace(&root, palace)
+                .expect("persist palace to disk");
+        }
+    }
+
+    // Phase 2: a fresh AppState (a restarted daemon) hydrates all four.
+    let state = AppState::new(root);
+    let count = state
+        .load_palaces_from_disk()
+        .await
+        .expect("load_palaces_from_disk");
+    assert_eq!(count, 4, "all four persisted palaces should be loaded");
+    assert_eq!(state.registry.len(), 4, "registry should hold all four");
+
+    // The idle-evict sweep must reclaim every one of them: none was ever
+    // genuinely accessed, so all must read as idle since open.
+    let evicted = state
+        .registry
+        .evict_idle(std::time::Duration::from_secs(300));
+    assert_eq!(
+        evicted, 4,
+        "an opened-but-never-accessed handle must be evictable on the very \
+         first idle sweep after a restart"
+    );
+    assert_eq!(
+        state.registry.len(),
+        0,
+        "no hydrated-but-untouched handle should remain resident"
+    );
+}
+
 /// Why (issue #1487): the HTTP daemon must open palace redb files as a
 /// writer so a second instance fails loud instead of silently degrading to
 /// read-only snapshot mode. `AppState::with_writer_intent()` is the builder


### PR DESCRIPTION
## Summary

Slice 0 of #7087. `PalaceHandle::open_with_intent` stamped `last_accessed` to the open time, so a restart burst (`load_palaces_from_disk` opening every persisted palace) looked like a burst of fresh recalls to `evict_idle`, and the idle sweep left every hydrated-but-untouched handle resident indefinitely — reintroducing the #6836 restart-burst memory blowup even through the idle-evict fallback path.

An open is bookkeeping, not use: `open_with_intent` now starts `last_accessed` at a `NEVER_ACCESSED` sentinel (epoch 0), so an opened-but-never-queried handle reads as idle since open. `PalaceHandle::new` (in-memory / test handles) is unchanged. Every genuine access still calls `PalaceHandle::touch` (write_pipeline, layers, handle::flush→remember, share/import), which continues to make a handle recent.

The `evict_idle` `Arc::strong_count == 1` guard already protects any handle a caller still holds after open (e.g. `open_palace`/`create_palace` clone the handle before returning it), so this change does not affect in-flight opens.

## Rung

Rung 4 (library + direct consumer: `trusty-common` + `trusty-memory`).

## Gates (raw output)

- `cargo fmt --check` — EXIT=0
- `cargo test -p trusty-common --features memory-core,embedder-test-support --no-fail-fast` — `test result: ok. 1381 passed; 0 failed; 13 ignored` (plus 10 more zero-count/passing targets) — EXIT=0
- `cargo clippy -p trusty-common --features memory-core,embedder-test-support --all-targets -- -D warnings` — EXIT=0
- `cargo check --workspace` — EXIT=0 (no `crates/*/ui/dist` dirt)
- `cargo test -p trusty-memory --no-fail-fast` — `test result: ok. 878 passed; 0 failed; 4 ignored` (plus ~20 more targets, all ok) — EXIT=0
- `bash scripts/check_line_cap.sh` — `4693 tracked .rs file(s) ... 0 violations — OK`
- `bash scripts/check_changelog_fragment.sh --staged` — `OK trusty-common: changelog.d fragment present and valid`
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p trusty-common --no-deps --features memory-core` — exits 101 with 28 `unresolved link` errors, but this is **pre-existing on `origin/main`**: verified byte-identical error set on a stash of this change vs. baseline (all 28 errors point at feature-gated modules — `inference::*`, `update`, `workspace_layout`, `uds::scratch_socket_dir`, `tracing_init::*` — not compiled under `--features memory-core` alone). This PR adds zero new rustdoc errors (66 warnings both before and after this change).

### Before/after: regression tests proven failing pre-fix

`open_does_not_reset_idle_clock`:
```
thread '...open_does_not_reset_idle_clock' panicked at crates/trusty-common/src/memory_core/registry_tests.rs:778:5:
assertion `left == right` failed: an opened-but-never-accessed handle must read as idle since open
  left: 0
 right: 2
test result: FAILED. 0 passed; 1 failed
```

`touch_after_open_makes_handle_recent`: FAILED pre-fix (same file, only the untouched-but-touched pairing was expected to differ; both handles looked equally fresh before the fix).

`restart_burst_hydration_is_immediately_idle_evictable` (trusty-memory): FAILED pre-fix at `crates/trusty-memory/src/lib_tests.rs:503` — hydrated 4 palaces from disk, `evict_idle(300)` evicted 0 instead of the expected 4.

All three pass after the fix (see the full-suite counts above). `lru_evicted_handle_reopens` and `evict_idle_then_reopen_preserves_recall` still pass unmodified.

Refs #7087

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V