### PR TITLE
fix(trusty-mpm): tm issue standard falls back on a read:project scope wall; audit hardened against the real projectItems shape

### DIFF
--- a/crates/trusty-mpm/changelog.d/7169-issue-audit-project-detection.md
+++ b/crates/trusty-mpm/changelog.d/7169-issue-audit-project-detection.md
@@ -1,0 +1,7 @@
+Fixed
+
+- `tm issue standard` no longer reports the projects section "unavailable"
+  when a token lacks `read:project` scope for the owner-qualified
+  `gh project list --owner <login>` query but the same token's bare
+  `gh project list` (the viewer's own projects) succeeds — it now falls back
+  to the bare call on a scope-shaped failure before giving up (#7169).

--- a/crates/trusty-mpm/src/bin/tm/commands/issue/standard_live.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/issue/standard_live.rs
@@ -145,10 +145,30 @@ const PROJECT_LIST_LIMIT: &str = "200";
 /// working directory the milestone call reads.
 /// What: `gh repo view --json owner`, then
 /// `gh project list --owner <login> -L 200 --format json`, dropping closed
-/// projects.
+/// projects. #7169: an owner-qualified list can hit a scope wall a bare
+/// `gh project list` (the viewer's own projects) does not — see
+/// [`fetch_projects_owner_scoped`]'s doc — so a scope-shaped failure there
+/// retries with the bare form rather than reporting the section unavailable
+/// on a call that a plain `gh project list` would have satisfied.
 /// Test: `filing_targets_skip_closed_projects`,
-/// `project_list_carries_an_explicit_limit`.
+/// `project_list_carries_an_explicit_limit`,
+/// `filing_targets_fall_back_to_the_bare_project_list_on_a_scope_error`,
+/// `a_non_scope_project_failure_does_not_fall_back`.
 fn fetch_projects(runner: &dyn CommandRunner) -> anyhow::Result<Vec<(u64, String)>> {
+    match fetch_projects_owner_scoped(runner) {
+        Ok(projects) => Ok(projects),
+        // #7169: the bare fallback also failed — surface the ORIGINAL error,
+        // which names the owner-scoped call the operator actually needs
+        // explained.
+        Err(e) if is_scope_shaped_failure(&e) => fetch_projects_bare(runner).map_err(|_| e),
+        Err(e) => Err(e),
+    }
+}
+
+/// The owner-qualified `gh project list --owner <login> -L 200 --format json`
+/// half of [`fetch_projects`], split out so the fallback in the caller can
+/// retry independently.
+fn fetch_projects_owner_scoped(runner: &dyn CommandRunner) -> anyhow::Result<Vec<(u64, String)>> {
     let owner_out = runner.run(
         "gh",
         &["repo", "view", "--json", "owner", "--jq", ".owner.login"],
@@ -173,14 +193,61 @@ fn fetch_projects(runner: &dyn CommandRunner) -> anyhow::Result<Vec<(u64, String
         ],
     )?;
     let text = list_out.ok_or_stderr("gh project list")?;
-    let parsed: GhProjectList = serde_json::from_str(&text)
-        .with_context(|| format!("could not parse `gh project list --owner {owner}` output"))?;
+    parse_project_list(&text, &format!("`gh project list --owner {owner}`"))
+}
+
+/// The bare `gh project list -L 200 --format json` fallback — the viewer's own
+/// projects, with no `--owner` qualification.
+///
+/// Why (#7169): `gh project list --owner <login>` queries GitHub's
+/// `user(login:)`/`organization(login:)` GraphQL object, which GitHub gates on
+/// the `read:project` scope even when `<login>` is the token's own account; the
+/// bare form queries `viewer`, which the same token can read without that
+/// scope. A token missing `read:project` therefore fails the owner-qualified
+/// call while `gh project list` alone — "the same token", per #7169's report —
+/// succeeds.
+/// Test: `filing_targets_fall_back_to_the_bare_project_list_on_a_scope_error`.
+fn fetch_projects_bare(runner: &dyn CommandRunner) -> anyhow::Result<Vec<(u64, String)>> {
+    let list_out = runner.run(
+        "gh",
+        &[
+            "project",
+            "list",
+            "-L",
+            PROJECT_LIST_LIMIT,
+            "--format",
+            "json",
+        ],
+    )?;
+    let text = list_out.ok_or_stderr("gh project list")?;
+    parse_project_list(&text, "`gh project list`")
+}
+
+fn parse_project_list(text: &str, source: &str) -> anyhow::Result<Vec<(u64, String)>> {
+    let parsed: GhProjectList =
+        serde_json::from_str(text).with_context(|| format!("could not parse {source} output"))?;
     Ok(parsed
         .projects
         .into_iter()
         .filter(|p| !p.closed)
         .map(|p| (p.number, p.title))
         .collect())
+}
+
+/// Whether an error from [`fetch_projects_owner_scoped`] looks like a missing
+/// `project`/`read:project` OAuth scope rather than some other failure (`gh`
+/// missing, unauthenticated entirely, network outage).
+///
+/// Why (#7169): only a scope-shaped failure should trigger the bare-list
+/// fallback — any other failure means the bare call would fail identically,
+/// so retrying it would just mask the real error with a confusing second one.
+/// What: a case-insensitive substring match on the phrasing GitHub's GraphQL
+/// API and `gh` itself use for this class of failure.
+/// Test: `filing_targets_fall_back_to_the_bare_project_list_on_a_scope_error`,
+/// `a_non_scope_project_failure_does_not_fall_back`.
+fn is_scope_shaped_failure(err: &anyhow::Error) -> bool {
+    let text = err.to_string().to_lowercase();
+    (text.contains("scope") && text.contains("project")) || text.contains("read:project")
 }
 
 #[cfg(test)]
@@ -315,6 +382,48 @@ mod tests {
         assert!(text.contains("project"), "{text}");
         // The milestone half still rendered.
         assert!(text.contains("open milestones (1):"), "{text}");
+    }
+
+    /// #7169: a real `gh` scope error names `read:project` this way when a
+    /// classic PAT lacks the `project` scope.
+    const SCOPE_ERROR: &str = "gh: your token has not been granted the required scopes: \
+        the 'read:project' scope is required";
+
+    #[test]
+    fn filing_targets_fall_back_to_the_bare_project_list_on_a_scope_error() {
+        // #7169: the owner-scoped call fails on a missing `read:project`
+        // scope; the bare call (same token, no `--owner`) succeeds and its
+        // result must reach the report instead of "unavailable".
+        let runner = FakeRunner::new(vec![
+            ok_out("Backlog · mpm/core\n"),
+            ok_out("bobmatnyc"),
+            fail_out(SCOPE_ERROR),
+            ok_out(PROJECTS_JSON),
+        ]);
+        let text = render_filing_targets(&runner);
+        assert!(text.contains("open projects (1):"), "{text}");
+        assert!(text.contains("#3  trusty-mpm"), "{text}");
+        assert!(!text.contains("projects: unavailable"), "{text}");
+        // The fallback call carries no `--owner`.
+        let calls = runner.calls.borrow();
+        let fallback = calls.last().expect("a fallback call was made");
+        assert!(!fallback.contains(&"--owner".to_string()), "{fallback:?}");
+    }
+
+    #[test]
+    fn a_non_scope_project_failure_does_not_fall_back() {
+        // #7169: an unrelated failure (offline, unauthenticated) must not
+        // trigger a second `gh` call that would just fail the same way — the
+        // original error is what the operator needs to see.
+        let runner = FakeRunner::new(vec![
+            ok_out("Backlog · mpm/core\n"),
+            ok_out("bobmatnyc"),
+            fail_out("gh: not authenticated"),
+        ]);
+        let text = render_filing_targets(&runner);
+        assert!(text.contains("projects: unavailable ("), "{text}");
+        assert!(text.contains("not authenticated"), "{text}");
+        assert_eq!(runner.calls.borrow().len(), 3, "no fallback call was made");
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/issue_audit_tests.rs
+++ b/crates/trusty-mpm/src/core/issue_audit_tests.rs
@@ -63,6 +63,29 @@ fn facts_parse_a_live_view_payload() {
     assert_eq!(facts.created_at, "2026-09-08T00:30:20Z");
 }
 
+/// A real `gh issue view 7166 --json projectItems` payload, captured live on
+/// 2026-09-08 (#7169). Unlike [`COMPLIANT`]'s simplified
+/// `{"title": "trusty-mpm"}`, a live project item carries a sibling `status`
+/// object — `gh`'s actual wire shape for a ProjectV2 item, not the minimal
+/// shape prior fixtures exercised.
+const LIVE_PROJECT_ITEM_WITH_STATUS: &str = r#"{"projectItems":[
+    {"status":{"optionId":"f75ad846","name":"Todo"},"title":"trusty-mpm"}
+]}"#;
+
+#[test]
+fn a_project_item_with_a_status_sibling_field_still_parses() {
+    // #7169: `tm issue audit 7166` was reported to FAIL "no project" despite
+    // `gh issue view 7166 --json projectItems` showing the item attached.
+    // `TitleRef` has no `deny_unknown_fields`, so the extra `status` object
+    // must be ignored rather than rejected — this fixture is the exact live
+    // shape, captured directly from #7166, that a stricter deserializer would
+    // break on.
+    let facts: IssueFacts =
+        serde_json::from_str(LIVE_PROJECT_ITEM_WITH_STATUS).expect("the live shape parses");
+    assert_eq!(facts.project_items.len(), 1);
+    assert_eq!(facts.project_items[0].title, "trusty-mpm");
+}
+
 #[test]
 fn facts_parse_a_list_payload() {
     // #7097: `gh issue list --json` returns an ARRAY of the same objects, so


### PR DESCRIPTION
## Summary

Refs #7169. Rung 3.

**Defect 2 (`tm issue standard` / `read:project` scope) — root-caused and fixed.**
`fetch_projects` in `standard_live.rs` queried `gh project list --owner <login>`.
GitHub's GraphQL API gates the owner-qualified `user(login:)`/`organization(login:)`
project lookup on the `read:project` scope even when `<login>` is the token's own
account, while the bare `gh project list` (the `viewer` object) does not need it —
so a token missing `read:project` fails the owner-qualified call while `gh project
list` alone, the same token, succeeds (exactly #7169's report). `fetch_projects`
now tries the owner-qualified call first and falls back to the bare call only when
the failure text looks scope-shaped (`is_scope_shaped_failure`); a non-scope
failure (offline, unauthenticated) is left alone so the operator sees the real
error instead of a second, identically-failing call.

**Defect 1 (`tm issue audit` false `project FAIL` on #7166) — could not reproduce; hardened.**
Live re-run against #7166 today, and code review of `project_row`/`IssueFacts`
(`core/issue_audit.rs`, `core/issue_audit_gh.rs`), shows current `main` parses the
real live `gh issue view 7166 --json projectItems` payload correctly and reports
PASS — `TitleRef` has no `deny_unknown_fields`, so the real wire shape's sibling
`status` object (absent from the existing `COMPLIANT`/`NO_PROJECT` test fixtures)
is already ignored correctly. No shape or logic difference was found between
#7166 (reported FAIL) and #7188 (confirmed PASS). The best-supported explanation
is a per-account visibility/scope difference at read time — `gh_account.rs`'s own
test fixtures document one real local account (`bobmatnyc`) with no `project`
scope and another (`bob-duetto`) with it — not a parsing defect in this code.
Added `a_project_item_with_a_status_sibling_field_still_parses` locking in the
real captured #7166 wire shape (with `status`) as defense-in-depth. Recommend
closing defect 1 as "cannot reproduce" unless a future report captures the exact
`gh`-bound identity/scopes at audit time.

## Test plan (rung 3, raw output)

- `cargo fmt --check` — clean
- `cargo check -p trusty-mpm --all-targets` — clean
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — `11266` total passed across every target, 0 failed (new: `filing_targets_fall_back_to_the_bare_project_list_on_a_scope_error`, `a_non_scope_project_failure_does_not_fall_back`, `a_project_item_with_a_status_sibling_field_still_parses`)
- `bash scripts/check_line_cap.sh` — OK, 0 violations
- `bash scripts/check_changelog_fragment.sh --staged` — OK
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p trusty-mpm --no-deps` — exit 0 (only pre-existing redundant-link warnings, unrelated)
- `bash scripts/check_capabilities.sh` — pre-existing drift on `origin/main` (doctor check count 40→42, unrelated to this change — not touched here, left for a separate PR)
- Live: `tm issue audit 7166` → all PASS; `tm issue standard` → projects section renders normally (30 open projects), no "unavailable"

## Closes

- [x] `tm issue standard` no longer errors/reports unavailable on a `read:project` scope wall when the same token's bare `gh project list` succeeds
- [ ] `tm issue audit`'s false FAIL on #7166 — not reproduced; hardened with a real-shape regression fixture; recommend follow-up only if it recurs with captured identity/scope evidence

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V