### PR TITLE
chore(trusty-mpm): bump to 1.5.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11911,7 +11911,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.18"
+version = "1.5.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -25,7 +25,7 @@ name = "trusty-mpm"
 # changes in the test suite under an already-published version.
 # 1.5.18 (refs #6892): patch — 1.5.17 is published and this PR edits `src/**`.
 # The edits are doc comments only, so no public item changed signature.
-version = "1.5.18"
+version = "1.5.19"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Every tm reinstall carries a patch bump (owner ruling 2026-09-08) so `tm --version` identifies the installed build.
- Installed from main at 5a0c8730b as 1.5.18; this bump makes the next install identifiable as 1.5.19.

## Gates
- `bash scripts/check_workspace_dep_versions.sh` — PASS (trusty-mpm's workspace req `1.0.0` already accepts `1.5.19`; 1.x PATCH needs no row change)
- `bash scripts/check_semver.sh --crate trusty-mpm` — SKIP (trusty-mpm is binary-only, excluded via `scripts/semver-checks-crate-exclusions.tsv`; 0 checked, 1 skipped, verdict OK)
- `bash scripts/check_changelog_fragment.sh --staged` — OK, 0 crate-source paths attributed (only Cargo.toml/Cargo.lock version lines changed, no `src/**` touched — no fragment owed)
- `bash scripts/check-pr-version-bump.sh` — OK, 2 changed paths examined, none under `crates/<crate>/src/**`

Bump-only PR, not a release cut — no tag, no `cargo publish`, changelog fragments left untouched per `docs/reference/changelog-fragments.md` (assembly happens at release time via `bump-version.sh`, not here).

## Test plan
- [x] `check_workspace_dep_versions.sh` passes
- [x] `check_semver.sh --crate trusty-mpm` passes (SKIP, expected)
- [x] `check_changelog_fragment.sh --staged` passes (no fragment owed)
- [x] `check-pr-version-bump.sh` passes post-commit

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V