### PR TITLE
test(website): assert the Token savings heading after the #7179 rename

### DIFF
--- a/website/src/lib/flagship/content.test.ts
+++ b/website/src/lib/flagship/content.test.ts
@@ -2,9 +2,10 @@
  * Why: the flagship pages are data now, so the failures worth pinning are the
  * ones a build could otherwise ship silently — a page rendering as an empty
  * frame, an include directive that resolved to nothing, or a link into a route
- * that stopped existing. The Cost savings case is asserted by name because it
- * is the whole point of the include mechanism: one `docs/` file publishing at
- * `/docs` and inside `/tools/trusty-mpm` at once.
+ * that stopped existing. The Token savings case (renamed from "Cost savings"
+ * by #7179) is asserted by name because it is the whole point of the include
+ * mechanism: one `docs/` file publishing at `/docs` and inside
+ * `/tools/trusty-mpm` at once.
  *
  * What: one pass over the real corpus in this repository, then a temp-repo
  * fixture per gate — the same shape `../docs/site.test.ts` uses, including its
@@ -19,6 +20,7 @@ import path from 'node:path';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { DocBuildError } from '../docs/errors';
+import { findRepoRoot, readRepoFile } from '../docs/repo';
 import { clearDocSiteCache } from '../docs/site';
 import { TOOLS } from '../tools';
 import { buildFlagshipContent, CONTENT_DIR, clearFlagshipContentCache } from './content';
@@ -107,12 +109,18 @@ describe('the real flagship corpus', () => {
 	/**
 	 * The include mechanism, end to end: the heading comes from a `docs/` file
 	 * this page never names in its own prose, and that file is published at
-	 * `/docs` in its own right.
+	 * `/docs` in its own right. The expected heading text is read from that
+	 * source doc itself (renamed "Cost savings" -> "Token savings" by #7179)
+	 * rather than hardcoded a second time here.
 	 */
-	it('carries the Cost savings section into the trusty-mpm page from docs/', () => {
+	it('carries the Token savings section into the trusty-mpm page from docs/', () => {
+		const source = 'docs/trusty-mpm/statusline-savings.md';
+		const heading = readRepoFile(findRepoRoot(), source).match(/^##\s+(.+)$/m)?.[1];
+		expect(heading, `${source} has no level-2 heading`).toBeDefined();
+
 		const mpm = built.get('trusty-mpm');
-		expect(mpm?.sources).toContain('docs/trusty-mpm/statusline-savings.md');
-		expect(mpm?.html).toContain('>Cost savings</h2>');
+		expect(mpm?.sources).toContain(source);
+		expect(mpm?.html).toContain(`>${heading}</h2>`);
 	});
 
 	/** The included file's own `/docs` page title must not survive the include. */

--- a/website/tests/build-smoke.test.ts
+++ b/website/tests/build-smoke.test.ts
@@ -310,13 +310,15 @@ describe('production build', () => {
 	 * Why: the six markdown-driven flagship pages (#6960) can fail in a way no
 	 * other assertion here sees — the shell prerenders, the hero fills from the
 	 * tool record, and the BODY comes out empty because the markdown was not
-	 * read. The Cost savings section is asserted by name on top of that,
-	 * because it arrives through the include directive from a `docs/` file the
-	 * page's own markdown does not otherwise quote: it is the one piece of copy
-	 * that proves the include ran.
+	 * read. The Token savings section (renamed from "Cost savings" by #7179)
+	 * is asserted by name on top of that, because it arrives through the
+	 * include directive from a `docs/` file the page's own markdown does not
+	 * otherwise quote: it is the one piece of copy that proves the include ran.
 	 * What: for each markdown-driven slug, the rendered body's own prose read
 	 * off the built artifact; then the included section, and the same source
-	 * serving its `/docs` page too.
+	 * serving its `/docs` page too. The expected heading text is read from the
+	 * source doc itself rather than hardcoded a second time, so a future
+	 * rename only needs to happen once.
 	 */
 	it('renders each markdown-driven flagship body from its own source', () => {
 		const opening: Record<string, string> = {
@@ -334,21 +336,28 @@ describe('production build', () => {
 		}
 	});
 
-	it('renders the Cost savings section on /tools/trusty-mpm and at /docs', () => {
+	it('renders the Token savings section on /tools/trusty-mpm and at /docs', () => {
 		const source = 'docs/trusty-mpm/statusline-savings.md';
-		expect(existsSync(path.join(REPO_ROOT, source)), source).toBe(true);
+		const sourcePath = path.join(REPO_ROOT, source);
+		expect(existsSync(sourcePath), source).toBe(true);
+
+		// Read the expected heading text off the doc itself — the single source
+		// of truth for this section's title (renamed "Cost savings" -> "Token
+		// savings" by #7179) — rather than hardcoding it a second time here.
+		const heading = readFileSync(sourcePath, 'utf8').match(/^##\s+(.+)$/m)?.[1];
+		expect(heading, `${source} has no level-2 heading`).toBeDefined();
 
 		const tool = readFileSync(path.join(STATIC, 'tools/trusty-mpm.html'), 'utf8');
-		expect(tool, 'no Cost savings heading on the tool page').toContain('>Cost savings</h2>');
+		expect(tool, `no ${heading} heading on the tool page`).toContain(`>${heading}</h2>`);
 		expect(visibleText(tool), 'the section rendered as a bare heading').toContain(
-			'statusline is an estimate'
+			'still an estimate'
 		);
 		// One <h1> per page: the hero's. An included file's own title is dropped.
 		expect(tool.match(/<h1\b/g) ?? [], 'more than one h1').toHaveLength(1);
 
 		const docs = path.join(STATIC, 'docs/tools/trusty-mpm/statusline-savings.html');
 		expect(existsSync(docs), 'the same source has no /docs page').toBe(true);
-		expect(visibleText(readFileSync(docs, 'utf8'))).toContain('Cost savings');
+		expect(visibleText(readFileSync(docs, 'utf8'))).toContain(heading);
 	});
 
 	// Why: the failure mode a nested route actually has is a dead link — the


### PR DESCRIPTION
## Summary

`docs/trusty-mpm/statusline-savings.md`'s section heading changed from "Cost savings" to "Token savings" in #7183 (the `💸` segment became a percentage, #7179). Two Vitest tests still hardcoded the old heading text, failing on `main`. Both now read the expected heading directly off the source doc rather than hardcoding it a second time, so a future rename needs only one edit.

- `website/tests/build-smoke.test.ts`: renamed the test and derived the expected `<h2>` text (and the "still an estimate" substring, which the #7179 content rewrite also changed) from the doc file instead of a literal.
- `website/src/lib/flagship/content.test.ts`: renamed the test and derived the expected heading the same way.

## Test plan

Run from inside `website/` with the pinned pnpm (`corepack`-resolved 9.15.9):

```
$ pnpm install --frozen-lockfile
$ pnpm test
 Test Files  17 passed (17)
      Tests  308 passed (308)
   Duration  33.73s

$ pnpm run check
svelte-check found 0 errors and 0 warnings
```

`scripts/check_sld.sh` and `scripts/check_public_docs.sh` are not applicable — this PR touches only two test files, no `docs/` or spec content.

No changelog fragment — no crate `src/**` touched.

Refs #7197

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V