### PR TITLE
feat(trusty-audit): surface package.toml per-repo collector gaps in reports/index.md

### DIFF
--- a/crates/trusty-audit/changelog.d/7135-index-collector-gaps.md
+++ b/crates/trusty-audit/changelog.d/7135-index-collector-gaps.md
@@ -1,0 +1,9 @@
+Added
+
+- `reports/index.md` (and the sweep's own `out/index.md`) now carries a `##
+  Gaps` section listing, per repository, every gap its `package.toml`/manifest
+  recorded — a skipped secrets scan, a JIRA sync that never ran, a lost
+  search-evidence tier — rendered verbatim and silent when a run recorded none.
+  Previously that data existed only inside a 59-entry TOML array with no
+  heading, table, or grep match anywhere in the file the package's own README
+  calls "start here".

--- a/crates/trusty-audit/src/index_report.rs
+++ b/crates/trusty-audit/src/index_report.rs
@@ -229,6 +229,23 @@ pub struct IndexEntry {
     /// line the report itself leads with — one fact with one source, rather than
     /// a flag that can disagree with the prose beside it.
     pub search_evidence: bool,
+    /// Every gap this unit's `package.toml`/manifest recorded, verbatim (#7135).
+    ///
+    /// Why: [`Self::stale`] already promotes ONE kind of gap (a stale fetch) into
+    /// the index because a caveat buried in a report's own Gaps section is read
+    /// too late, if at all — but every other kind (a skipped secrets scan, a
+    /// JIRA sync that never ran) stayed exactly there, buried, with nothing
+    /// naming it in the file the README calls "start here". This field is the
+    /// same promotion applied to the whole list rather than one marker.
+    /// What: a straight copy of the unit's recorded gaps, in the order they were
+    /// recorded. Rendered by this module's own `gaps_section` as one bullet list
+    /// per unit that has any, and silent for a unit that has none. This crate
+    /// does not reword
+    /// or redact a gap's text here — it renders exactly the string the collector
+    /// wrote. // See #7137
+    /// Test: `index_tests::the_gaps_section_lists_only_units_that_recorded_one`,
+    /// `index_tests::a_clean_run_renders_no_gaps_section`.
+    pub gaps: Vec<String>,
 }
 
 /// Everything the index states, before it is rendered against a directory.
@@ -399,6 +416,9 @@ pub fn render(report: &IndexReport, dir: &Path) -> String {
     out.push_str(&crate::grounding::coverage_rollup::index_section(
         report.coverage.as_ref(),
     ));
+    // #7135: same placement as the two roll-ups above and for the same reason —
+    // a finding about the run, before the description of the directory.
+    gaps_section(report, &mut out);
     contents(report.producer, &mut out);
     out
 }
@@ -549,6 +569,49 @@ fn reports(report: &IndexReport, dir: &Path, out: &mut String) {
     if report.entries.is_empty() {
         out.push_str("This run produced no reports.\n\n");
     }
+}
+
+/// A roll-up of every unit's recorded gaps, one bullet list per unit (#7135).
+///
+/// Why: `## Reports` already states each unit's gaps in its own `### <name>`
+/// subsection, but a reader following the "start here" path reads this file
+/// top to bottom and stops well before the 59th subsection — which is exactly
+/// how a run can lose search evidence for 57 of 59 repositories, secrets
+/// scanning for all 59, and JIRA data for all 59, with nothing surfaced before
+/// the reader has already opened most of them one at a time. The OSV and
+/// coverage roll-ups above already give their own findings this treatment; this
+/// section is the same treatment applied to every OTHER collector's gaps.
+/// What: silent — no heading, no line — when no unit recorded a gap, so a clean
+/// run's index states nothing extra. Otherwise one `## Gaps` section, a summary
+/// line, and one bullet list per unit that recorded at least one, each gap
+/// rendered verbatim (never reworded, never redacted — see the wording note on
+/// [`IndexEntry::gaps`], // See #7137).
+/// Test: `index_tests::the_gaps_section_lists_only_units_that_recorded_one`,
+/// `index_tests::a_clean_run_renders_no_gaps_section`.
+fn gaps_section(report: &IndexReport, out: &mut String) {
+    let with_gaps: Vec<&IndexEntry> = report
+        .entries
+        .iter()
+        .filter(|entry| !entry.gaps.is_empty())
+        .collect();
+    if with_gaps.is_empty() {
+        return;
+    }
+    out.push_str("## Gaps\n\n");
+    out.push_str(&format!(
+        "{} of {} {} recorded at least one gap in its `package.toml`; each is stated \
+         verbatim below.\n\n",
+        with_gaps.len(),
+        report.entries.len(),
+        report.producer.unit(report.entries.len())
+    ));
+    for entry in with_gaps {
+        out.push_str(&format!("- **{}**\n", entry.name));
+        for gap in &entry.gaps {
+            out.push_str(&format!("  - {gap}\n"));
+        }
+    }
+    out.push('\n');
 }
 
 /// What each file and directory here is.
@@ -883,6 +946,9 @@ pub fn write_sweep(
             // #6783: read off the gaps this repository actually stated, which a
             // resumed entry carries forward with the rest of its record.
             search_evidence: !crate::grounding::search_tier_degraded(&run.gaps),
+            // #7135: the full list this repository's manifest recorded, not only
+            // the stale-fetch subset promoted above.
+            gaps: run.gaps.clone(),
         })
         .collect();
     // #6781: one read of each repository's manifest, feeding both the index's
@@ -978,6 +1044,8 @@ pub fn write_render(
             // #6783: a re-render indexes any checkout present on this machine,
             // so it loses the tier the same way a sweep does and says so here.
             search_evidence: !crate::grounding::search_tier_degraded(&rendered.gaps),
+            // #7135: the full list the source manifest recorded.
+            gaps: rendered.gaps.clone(),
         })
         .collect();
     // #6781: read from the manifest each report was rendered FROM — the
@@ -1039,6 +1107,7 @@ mod index_tests {
             carried_over: false,
             duration: Some(Duration::from_millis(1_500)),
             search_evidence: true,
+            gaps: Vec::new(),
         }
     }
 
@@ -1072,6 +1141,70 @@ mod index_tests {
             text.matches("git history is stale").count(),
             1,
             "the clean repository picked up a stale line:\n{text}"
+        );
+    }
+
+    /// Regression for #7135: against the pre-fix code this fails, because
+    /// `render` never read a unit's gaps at all — `grep -c` over its output for
+    /// any of "secrets-scan", "jira sync" or "## Gaps" was always zero,
+    /// regardless of what a repository's manifest recorded.
+    ///
+    /// Why this is worth a test: two collector gaps recorded against ONE
+    /// repository must both render, in the order they were recorded, and a
+    /// SECOND repository with an empty gap list must not add a bullet of its
+    /// own — the section is opt-in per unit, not a blanket list of every unit.
+    /// What: exact section text, not a substring check on one gap line, so a
+    /// stray heading level, missing bullet or wrong count regresses this test
+    /// rather than passing unnoticed.
+    /// Test: this is the test.
+    #[test]
+    fn the_gaps_section_lists_only_units_that_recorded_one() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("01-acme");
+        std::fs::create_dir_all(&dir).expect("create dir");
+
+        let mut degraded = entry("acme/api", dir.clone());
+        degraded.gaps = vec![
+            "secrets-scan: gitleaks binary not found".to_owned(),
+            "jira sync skipped: no project configured for acme/api".to_owned(),
+        ];
+        let clean = entry("acme/web", dir);
+
+        let text = render(&report(Producer::Sweep, vec![degraded, clean]), tmp.path());
+
+        let expected = "## Gaps\n\n\
+             1 of 2 repositories recorded at least one gap in its `package.toml`; each is \
+             stated verbatim below.\n\n\
+             - **acme/api**\n\
+             \x20\x20- secrets-scan: gitleaks binary not found\n\
+             \x20\x20- jira sync skipped: no project configured for acme/api\n\n";
+        assert!(
+            text.contains(expected),
+            "the Gaps section did not render as expected:\n{text}"
+        );
+        assert!(
+            !text.contains("acme/web**"),
+            "the clean repository picked up a Gaps bullet of its own:\n{text}"
+        );
+    }
+
+    /// The counterpart to the test above: a run where every unit's gap list is
+    /// empty renders no `## Gaps` heading at all, rather than an empty one — the
+    /// same silent-when-clean shape `osv_rollup::index_section` and
+    /// `coverage_rollup::index_section` already give their own findings.
+    /// Test: this is the test.
+    #[test]
+    fn a_clean_run_renders_no_gaps_section() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("01-acme");
+        std::fs::create_dir_all(&dir).expect("create dir");
+        let clean = entry("acme/web", dir);
+
+        let text = render(&report(Producer::Sweep, vec![clean]), tmp.path());
+
+        assert!(
+            !text.contains("## Gaps"),
+            "a run with no recorded gaps rendered a Gaps section:\n{text}"
         );
     }
 

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -198,6 +198,10 @@ pub(super) fn render_index(
                 // #6783: the recipient's copy of the coverage count, read off
                 // the same gaps the sweep's own index reads.
                 search_evidence: !crate::grounding::search_tier_degraded(&run.gaps),
+                // #7135: the recipient's copy of the full gap list — the same
+                // rows `package.toml`'s own `repositories[].gaps` carries for
+                // this repository, so the two members cannot disagree.
+                gaps: run.gaps.clone(),
             }
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

`reports/index.md` never surfaced the per-repo `gaps` a manifest recorded (secrets-scan skipped, JIRA sync skipped, search-index failures) — they existed only inside `package.toml`'s `repositories[].gaps` array with no heading, table, or grep match anywhere in the file the package's own README calls "start here".

- Added `IndexEntry::gaps: Vec<String>` (`crates/trusty-audit/src/index_report.rs`), populated at all three producer sites — `write_sweep`, `write_render`, and `crate::package::generated::render_index` (`crates/trusty-audit/src/package/generated.rs`) — from the same `RepoRun`/`RenderedReport` gaps list each already reads for `stale` and `search_evidence`.
- Added `gaps_section` in `index_report.rs`, rendered in `render()` beside the OSV and coverage roll-ups (before the contents table): a `## Gaps` heading, a one-line summary, and one bullet list per unit that recorded at least one gap, verbatim. Silent — no heading at all — when no unit recorded a gap, matching `osv_rollup::index_section` / `coverage_rollup::index_section`.
- Gap TEXT is rendered exactly as recorded — no rewording, no redaction. Left `// See #7137` at the render site for the follow-up (home-directory path redaction in gap text).

## Test plan

Rung 3 (localized behavior inside `trusty-audit`).

- `cargo fmt --check` — clean
- `cargo check -p trusty-audit --all-targets` — clean
- `cargo clippy -p trusty-audit --all-targets -- -D warnings` — clean (pre-existing unrelated `main.rs` multi-target warnings only)
- `cargo test -p trusty-audit --no-fail-fast` — `test result: ok. 1059 passed; 0 failed; 5 ignored` (lib), plus every integration test binary green; two new regression tests: `index_report::index_tests::the_gaps_section_lists_only_units_that_recorded_one` (fixture: two repos, one with two gaps, one with none — asserts the exact rendered section, and that the clean repo gets no bullet) and `index_report::index_tests::a_clean_run_renders_no_gaps_section` (asserts no `## Gaps` heading at all when nothing recorded a gap). Both fail against pre-fix code — `render` never read a unit's gaps at all.
- `bash scripts/check_line_cap.sh crates/trusty-audit/src/index_report.rs crates/trusty-audit/src/package/generated.rs` — `0 violations — OK`
- `bash scripts/check_changelog_fragment.sh --staged` — `OK trusty-audit: changelog.d fragment present and valid`
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p trusty-audit --no-deps` — exit 0, no new warnings
- `bash scripts/check_test_pointers.sh` — `0 dangling pointers — OK`

Refs #7135

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V