### PR TITLE
fix(trusty-common): qualify unresolved intra-doc links in residency.rs

### DIFF
--- a/crates/trusty-common/src/residency.rs
+++ b/crates/trusty-common/src/residency.rs
@@ -11,10 +11,12 @@
 //! set and pinning it is cheaper and more honest than teaching two unrelated
 //! eviction policies to each re-derive "active" on their own.
 //!
-//! What: [`ActiveProjectSet`] / [`ActiveProject`] are the wire shape a
-//! producer (trusty-mpm, slice 1b) publishes and every consumer (trusty-memory,
-//! trusty-search; slices 2 and 3) decodes. [`ResidencySnapshot`] is the
-//! injected-clock state machine a consumer's pull ticker drives:
+//! What: [`crate::residency::ActiveProjectSet`] /
+//! [`crate::residency::ActiveProject`] are the wire shape a producer
+//! (trusty-mpm, slice 1b) publishes and every consumer (trusty-memory,
+//! trusty-search; slices 2 and 3) decodes.
+//! [`crate::residency::ResidencySnapshot`] is the injected-clock state
+//! machine a consumer's pull ticker drives:
 //! [`crate::residency::ResidencySnapshot::observe`] on a successful pull,
 //! [`crate::residency::ResidencySnapshot::on_pull_failure`] on a failed one,
 //! [`crate::residency::ResidencySnapshot::pinned`] to read the currently-trusted set (or `None`


### PR DESCRIPTION
Follow-up to #7194, which merged (23a6cb1) before this fix landed — the "Rustdoc intra-doc links" check is not a required context, so the merge went through with main red on it.

## Root cause
`crates/trusty-common/src/residency.rs`'s module-level `//!` doc had three unqualified intra-doc links left over from the review round on #7194 — `[`ActiveProjectSet`]`, `[`ActiveProject`]`, `[`ResidencySnapshot`]` in the opening "What:" paragraph. My earlier verification ran `cargo doc -p trusty-common --features uds` and grepped human-readable output for `residency.rs`/`mpm_rpc.rs` filenames — but rustdoc attributes a `//!` block's unresolved-link diagnostic to the parent `lib.rs` mod-declaration span, with no `-->` file:line header in the human-rendered text, so the grep silently missed it.

Fixed by fully qualifying the three links (`crate::residency::ActiveProjectSet` etc.), matching the pattern already used elsewhere in the same doc comment.

## Verification
Ran CI's actual invocation, `scripts/check_rustdoc_links.sh` (`cargo doc --workspace --no-deps --locked --keep-going`), not a single-package `-p` build:
```
SUMMARY	26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0, 0 diagnostic(s) examined
```

CI job that caught the original break: https://github.com/bobmatnyc/trusty-tools/actions/runs/34272452949/job/102217779303

## Test plan
- `cargo fmt --check` — clean
- `cargo test -p trusty-common --features uds,unconditional-only --no-fail-fast` — `665 passed; 0 failed; 6 ignored`
- `cargo clippy -p trusty-common --features uds --all-targets -- -D warnings` — clean
- `bash scripts/check_rustdoc_links.sh` — `26 crate(s) examined, 0 broken link(s), baseline 0`

Docs-only change (doc comments only, no code/behavior change) — no changelog fragment per the test-only/docs-only exemption.

Refs #7087

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V