### PR TITLE
chore(trusty-code,trusty-agents): patch bumps for reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11282,7 +11282,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -11376,7 +11376,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-common"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11400,7 +11400,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-local"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "tokio",
@@ -11551,7 +11551,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-code"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # ── Internal crates (path deps so the monorepo builds without publish cycles) ──
 # trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
 # First published to crates.io at version 0.1.0.
-trusty-code = { path = "crates/trusty-code", version = "0.5.0" }
+trusty-code = { path = "crates/trusty-code", version = "0.6" }
 # trusty-code-tui: engine-agnostic terminal-UI seam (`TuiEngine` trait + `ReplEvent`)
 # shared by trusty-code's `tcode tui` and trusty-agents' tagent REPL (DOC-50,
 # epic #3411). Published as of #4713 so `trusty-code` can publish again; 0.1.0

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -27,7 +27,10 @@ name = "trusty-agents-common"
 # src/assets/agents/version-control.md (prose only — no item signature changed),
 # which scripts/check-pr-version-bump.sh requires be bumped in the same PR
 # (#4421).
-version = "0.7.1"
+# 0.7.2: patch bump for the trusty-code/trusty-agents reinstall carrying
+# #6537/#7158 for live verification (owner ruling 2026-09-08); src has moved
+# since 0.7.1 but no public item signature changed.
+version = "0.7.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-agents-local/Cargo.toml
+++ b/crates/trusty-agents-local/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "trusty-agents-local"
-version = "0.1.3"
+# 0.1.4: patch bump for the trusty-code/trusty-agents reinstall carrying
+# #6537/#7158 for live verification (owner ruling 2026-09-08); src (main.rs)
+# has moved since 0.1.3. publish = false — internal only, no semver gate.
+version = "0.1.4"
 edition = "2024"
 publish = false
 description = "Private launcher: thin pass-through to trusty-agents::run()"

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -5,7 +5,10 @@ name = "trusty-agents"
 # `MemoryBackend::auto_detect_with_url` take a socket path rather than a base
 # URL, and the workstream helpers thread a `&Path`. Cargo's 0.x rule puts a
 # breaking change in the MINOR position.
-version = "0.39.0"
+# 0.39.1: patch bump for a reinstall carrying #6537/#7158 for live verification
+# (owner ruling 2026-09-08 — every reinstall carries a patch bump so
+# `--version` identifies the build); no public API change.
+version = "0.39.1"
 edition = "2024"
 description = "Trusty Agents: Rust-native agentic harness with multi-model routing, tool execution, and subprocess delegation."
 license.workspace = true

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -9,7 +9,14 @@ name = "trusty-code"
 # 0.5.1 (#6657): patch — `fs_browse::mpm_registry::parse_owner_repo` (a
 # private fn) now delegates to `trusty_common::github_path::parse_remote_url`
 # instead of its own split logic; no public item changed shape.
-version = "0.5.2"
+# 0.6.0: minor bump. Triggered by a reinstall carrying #6537/#7158 for live
+# verification (owner ruling 2026-09-08 — every reinstall carries a version
+# bump so `--version` identifies the build), but `check_semver.sh` found a
+# real break versus the 0.5.1 baseline live on crates.io: `Session` (a
+# publicly-constructible struct) gained a new pub field `result`
+# (src/session/model.rs:180), which is `constructible_struct_adds_field` —
+# breaking under Cargo's 0.x rule, so this lands in MINOR rather than PATCH.
+version = "0.6.0"
 edition = "2024"
 rust-version.workspace = true
 # license.workspace resolves to "MIT"; LICENSE is kept in-crate for correctness.


### PR DESCRIPTION
## Summary
- Bump trusty-code 0.5.2 -> 0.6.0 (minor: `check_semver.sh` found `Session` gained a new pub field `result`, breaking under Cargo's 0.x rule versus the 0.5.1 crates.io baseline; widened the root `[workspace.dependencies]` row to `0.6` accordingly)
- Bump trusty-agents 0.39.0 -> 0.39.1 (patch)
- Bump trusty-agents-common 0.7.1 -> 0.7.2 and trusty-agents-local 0.1.3 -> 0.1.4 (both had src changes since their last version bump; both are trusty-code/trusty-agents dependencies or in the same crate family)
- Reinstall carries a version bump (owner ruling 2026-09-08) so `--version` identifies the build; ships #6537 and #7158 for live verification

## Test plan
- [x] `cargo check -p trusty-code -p trusty-agents -p trusty-agents-common -p trusty-agents-local` — clean
- [x] `bash scripts/check_workspace_dep_versions.sh` — all rows OK
- [x] `bash scripts/check_semver.sh --crate trusty-code` — exit 0 (break permitted at minor position)
- [x] `bash scripts/check_semver.sh --crate trusty-agents` — exit 0 (skip, never published)
- [x] `bash scripts/check-pr-version-bump.sh` — OK
- [x] `bash scripts/check_changelog_fragment.sh` — OK (no crate source changed, Cargo.toml/lock only)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V