### PR TITLE
feat(trusty-mpm): serve the active-project set over UDS as mpm.residency.active

### DIFF
--- a/crates/trusty-mpm/changelog.d/7087-residency-producer.md
+++ b/crates/trusty-mpm/changelog.d/7087-residency-producer.md
@@ -7,11 +7,11 @@ Added
   `trusty_common::residency::ActiveProjectSet`. A `tmux` probe failure fails
   closed — every persisted `Active`/`Provisioning` record is served rather
   than the set collapsing to empty.
-- The residency generation now moves on every transition that changes which
-  sessions `mpm.residency.active` serves — `resume`, `mark_reactivated`, the
-  runtime-exit reaper's `Stopped` transition, a forced record delete, and the
-  boot reconcile's leaked-test-adoption sweep — so a consumer polling the set
-  can no longer be handed a stale generation across any of them (#7087). A
-  session reaching a terminal state also drops its cached palace/index
-  derivation, bounding that cache by live records rather than by every session
-  the daemon has served.
+- The residency generation now moves on `resume`, `mark_reactivated`,
+  `mark_errored`, the runtime-exit reaper's `Stopped` transition, a forced
+  record delete, and the boot reconcile's leaked-test-adoption sweep, joining
+  the create/stop/adopt/decommission bumps already there — so a consumer
+  polling `mpm.residency.active` can no longer be handed a stale generation
+  across any of them (#7087). A session reaching a terminal state also drops
+  its cached palace/index derivation, bounding that cache by live records
+  rather than by every session the daemon has served.

--- a/crates/trusty-mpm/changelog.d/7087-residency-producer.md
+++ b/crates/trusty-mpm/changelog.d/7087-residency-producer.md
@@ -1,0 +1,9 @@
+Added
+
+- trusty-mpm now serves the active-project set over its Unix socket as
+  `mpm.residency.active` (#7087 slice 1b): every managed session in state
+  `Active`/`Provisioning` whose tmux pane a live `tmux list-sessions` still
+  confirms, grouped by project root into a
+  `trusty_common::residency::ActiveProjectSet`. A `tmux` probe failure fails
+  closed — every persisted `Active`/`Provisioning` record is served rather
+  than the set collapsing to empty.

--- a/crates/trusty-mpm/changelog.d/7087-residency-producer.md
+++ b/crates/trusty-mpm/changelog.d/7087-residency-producer.md
@@ -7,3 +7,11 @@ Added
   `trusty_common::residency::ActiveProjectSet`. A `tmux` probe failure fails
   closed — every persisted `Active`/`Provisioning` record is served rather
   than the set collapsing to empty.
+- The residency generation now moves on every transition that changes which
+  sessions `mpm.residency.active` serves — `resume`, `mark_reactivated`, the
+  runtime-exit reaper's `Stopped` transition, a forced record delete, and the
+  boot reconcile's leaked-test-adoption sweep — so a consumer polling the set
+  can no longer be handed a stale generation across any of them (#7087). A
+  session reaching a terminal state also drops its cached palace/index
+  derivation, bounding that cache by live records rather than by every session
+  the daemon has served.

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -53,6 +53,8 @@ pub mod proxy;
 pub mod prune;
 pub mod reactivate;
 pub mod reconcile;
+// #7087: the `mpm.residency.active` producer route.
+pub(crate) mod residency;
 // #6497: the explicit ownership transfer for a dead owner's worktree.
 pub mod adopt_worktree;
 pub mod rename;

--- a/crates/trusty-mpm/src/daemon/managed_routes/residency.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/residency.rs
@@ -1,0 +1,178 @@
+//! The `mpm.residency.active` route: trusty-mpm as the active-project
+//! producer (#7087 slice 1b).
+//!
+//! Why: slice 1a defined the wire contract
+//! ([`trusty_common::residency::ActiveProjectSet`]) and the consumer-side
+//! freshness state machine but shipped no producer — nothing yet answers
+//! [`trusty_common::mpm_rpc::METHOD_RESIDENCY_ACTIVE`]. This is that producer:
+//! it reads the SAME managed-session store every other route reads, so
+//! "active" here means exactly what `tm session ls` already shows, not a
+//! second derivation that can drift from it.
+//! What: [`active_projects_core`] lists every managed session, keeps the ones
+//! whose persisted state is `Active` or `Provisioning` AND whose `tmux_name`
+//! a live `tmux list-sessions` still recognizes, groups the survivors by
+//! project root (`workspace_path` if set, else `cwd`), and derives each
+//! group's palace id / trusty-search index id(s) through
+//! [`SessionManager::residency_cache_lookup`] /
+//! [`SessionManager::residency_cache_store`] so a session whose root has not
+//! changed since the last poll never re-touches the filesystem or `git`.
+//! **Fail-closed, never fail-empty:** a `tmux list_sessions` error is logged
+//! and every persisted `Active`/`Provisioning` record is treated as active
+//! rather than the set collapsing to empty — an empty answer would evict
+//! every consumer's pinned project at once (#6836), which is exactly what
+//! this producer exists to prevent.
+//! Test: `residency_tests` (sibling file).
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use trusty_common::residency::{ACTIVE_PROJECT_SET_SCHEMA, ActiveProject, ActiveProjectSet};
+
+use crate::daemon::rpc::managed::outcome::RouteOutcome;
+use crate::daemon::state::DaemonState;
+use crate::session_manager::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+/// Per-root accumulator while grouping the active sessions.
+struct ProjectAccum {
+    root: PathBuf,
+    repo_url: Option<String>,
+    session_ids: Vec<ManagedSessionId>,
+    session_id_strings: Vec<String>,
+    last_activity_unix: Option<u64>,
+}
+
+/// The transport-neutral body of `mpm.residency.active`.
+///
+/// Test: `residency_tests`.
+pub(crate) async fn active_projects_core(state: &Arc<DaemonState>) -> RouteOutcome {
+    let mgr = state.session_manager().await;
+    let sessions: Vec<SessionRecord> = mgr.list().await;
+
+    // Fail closed (#6836): a probe failure must never be read as "nothing is
+    // active" — it degrades to trusting the PERSISTED state instead.
+    let live_tmux_names: Option<HashSet<String>> = match mgr.tmux_driver().list_sessions() {
+        Ok(names) => Some(names.into_iter().collect()),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "mpm.residency.active: tmux list_sessions failed; treating every \
+                 persisted Active/Provisioning session as active (fail closed)"
+            );
+            None
+        }
+    };
+
+    let mut groups: HashMap<PathBuf, ProjectAccum> = HashMap::new();
+    for record in &sessions {
+        let persisted_active = matches!(
+            record.state,
+            ManagedSessionState::Active | ManagedSessionState::Provisioning
+        );
+        if !persisted_active {
+            continue;
+        }
+        let tmux_confirmed = live_tmux_names
+            .as_ref()
+            .is_none_or(|names| names.contains(&record.tmux_name));
+        if !tmux_confirmed {
+            continue;
+        }
+
+        let root = record
+            .workspace_path
+            .clone()
+            .unwrap_or_else(|| record.cwd.clone());
+        let last_activity_unix = record
+            .last_activity_at
+            .map(|dt| dt.timestamp().max(0) as u64);
+
+        let accum = groups.entry(root.clone()).or_insert_with(|| ProjectAccum {
+            root: root.clone(),
+            repo_url: None,
+            session_ids: Vec::new(),
+            session_id_strings: Vec::new(),
+            last_activity_unix: None,
+        });
+        if accum.repo_url.is_none() {
+            accum.repo_url = record.repo_url.clone();
+        }
+        accum.session_ids.push(record.id);
+        accum.session_id_strings.push(record.id.to_string());
+        accum.last_activity_unix = match (accum.last_activity_unix, last_activity_unix) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) => Some(a),
+            (None, b) => b,
+        };
+    }
+
+    let mut projects = Vec::with_capacity(groups.len());
+    for accum in groups.into_values() {
+        let (palace_id, index_ids) = derive_for_group(&mgr, &accum).await;
+        // `ActiveProject` is `#[non_exhaustive]`: struct-literal syntax (even
+        // with `..Default::default()`) is refused outside its defining crate,
+        // so build the default and assign fields.
+        let mut project = ActiveProject::default();
+        project.root = accum.root;
+        project.palace_id = palace_id;
+        project.index_ids = index_ids;
+        project.session_ids = accum.session_id_strings;
+        project.last_activity_unix = accum.last_activity_unix;
+        projects.push(project);
+    }
+
+    let published_at_unix = chrono::Utc::now().timestamp().max(0) as u64;
+    let mut set = ActiveProjectSet::default();
+    set.schema = ACTIVE_PROJECT_SET_SCHEMA;
+    set.generation = mgr.residency_generation();
+    set.published_at_unix = published_at_unix;
+    set.projects = projects;
+    RouteOutcome::ok(&set)
+}
+
+/// Derive `(palace_id, index_ids)` for one project group, once — reusing the
+/// manager's per-session cache when the group's representative session's
+/// cached root still matches.
+///
+/// Why one representative rather than deriving per session in the group: two
+/// sessions sharing a root always resolve to the same palace/index ids (both
+/// are functions of `root` alone), so deriving once per GROUP is correct and
+/// cheaper. The result is still cached under EVERY session id in the group,
+/// so a later poll hits regardless of which session in the group survives.
+async fn derive_for_group(
+    mgr: &crate::session_manager::SessionManager,
+    accum: &ProjectAccum,
+) -> (Option<String>, Vec<String>) {
+    let representative = accum.session_ids[0];
+    if let Some(cached) = mgr
+        .residency_cache_lookup(&representative, &accum.root)
+        .await
+    {
+        return cached;
+    }
+
+    let palace_id =
+        crate::core::session_launch::resolve_palace_slug(&accum.root, accum.repo_url.as_deref());
+
+    let mut index_ids = vec![trusty_common::project_index_id::derive_project_index_id(
+        &accum.root,
+    )];
+    if crate::core::worktree_index::is_git_worktree(&accum.root)
+        && let Some(base) = crate::core::base_facet_index::base_checkout_of(&accum.root)
+    {
+        index_ids.push(trusty_common::project_index_id::derive_project_index_id(
+            &base,
+        ));
+    }
+
+    for &id in &accum.session_ids {
+        mgr.residency_cache_store(id, accum.root.clone(), palace_id.clone(), index_ids.clone())
+            .await;
+    }
+
+    (palace_id, index_ids)
+}
+
+#[cfg(test)]
+#[path = "residency_tests.rs"]
+mod residency_tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/residency_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/residency_tests.rs
@@ -286,3 +286,212 @@ async fn generation_increments_across_create_and_stop() {
         "stop must bump the generation: after_create={after_create} after_stop={after_stop}"
     );
 }
+
+/// (f) `resume` takes `Stopped` -> `Active`, which is exactly the persisted
+/// state this route filters on, so the served set changes and the generation
+/// must move with it. It did not before this test existed.
+#[tokio::test]
+async fn generation_increments_across_resume() {
+    let (state, driver, dir) = test_state().await;
+    let mgr = state.session_manager().await;
+
+    let mut record = make_record(None);
+    record.tmux_name = "tm-resume-gen".into();
+    record.state = ManagedSessionState::Stopped;
+    // `resume` resolves and existence-checks its workdir, so this must be a
+    // real directory.
+    record.cwd = dir.path().to_path_buf();
+    let id = record.id;
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("upsert stopped session");
+    driver.set_live(&["tm-resume-gen"]);
+
+    let before = decode(&active_projects_core(&state).await).generation;
+    assert_eq!(
+        decode(&active_projects_core(&state).await).projects.len(),
+        0,
+        "a Stopped session is not in the served set"
+    );
+
+    mgr.resume(&id).await.expect("resume");
+
+    let after = decode(&active_projects_core(&state).await);
+    assert_eq!(
+        after.projects.len(),
+        1,
+        "resume put the session back in the served set: {:?}",
+        after.projects
+    );
+    assert!(
+        after.generation > before,
+        "resume must bump the generation: before={before} after={}",
+        after.generation
+    );
+}
+
+/// (g) `mark_reactivated` takes `Stopped` OR `Decommissioned` -> `Active`.
+/// The tombstone case is the sharper one: the project was absent from the set
+/// entirely one call earlier.
+#[tokio::test]
+async fn generation_increments_across_mark_reactivated() {
+    let (state, driver, dir) = test_state().await;
+    let mgr = state.session_manager().await;
+
+    let mut record = make_record(None);
+    record.tmux_name = "tm-reactivate-gen".into();
+    record.state = ManagedSessionState::Decommissioned;
+    // `mark_reactivated` refuses when the resolved workspace is gone.
+    record.cwd = dir.path().to_path_buf();
+    let id = record.id;
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("upsert tombstone");
+    driver.set_live(&["tm-reactivate-gen"]);
+
+    let before = decode(&active_projects_core(&state).await).generation;
+
+    mgr.mark_reactivated(&id).await.expect("mark_reactivated");
+
+    let after = decode(&active_projects_core(&state).await);
+    assert_eq!(
+        after.projects.len(),
+        1,
+        "the revived tombstone rejoins the served set: {:?}",
+        after.projects
+    );
+    assert!(
+        after.generation > before,
+        "mark_reactivated must bump the generation: before={before} after={}",
+        after.generation
+    );
+}
+
+/// (h) `mark_runtime_exited_stopped` takes `Active` -> `Stopped` from the
+/// periodic runtime-exit reaper and the `SessionEnd` reconcile — neither of
+/// which routes through `stop`, so this is the only place that path can bump.
+#[tokio::test]
+async fn generation_increments_across_mark_runtime_exited_stopped() {
+    let (state, driver, _dir) = test_state().await;
+    let mgr = state.session_manager().await;
+
+    let mut record = make_record(None);
+    record.tmux_name = "tm-reap-gen".into();
+    record.state = ManagedSessionState::Active;
+    record.workspace_path = Some(PathBuf::from("/repo/reaped"));
+    let id = record.id;
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("upsert active session");
+    driver.set_live(&["tm-reap-gen"]);
+
+    let before = decode(&active_projects_core(&state).await).generation;
+
+    mgr.mark_runtime_exited_stopped(&id)
+        .await
+        .expect("mark_runtime_exited_stopped");
+
+    let after = decode(&active_projects_core(&state).await);
+    assert_eq!(
+        after.projects.len(),
+        0,
+        "a runtime-exited session leaves the served set: {:?}",
+        after.projects
+    );
+    assert!(
+        after.generation > before,
+        "mark_runtime_exited_stopped must bump the generation: \
+         before={before} after={}",
+        after.generation
+    );
+}
+
+/// (i) `delete_record(force = true)` reaches `Deleted` straight from `Active`
+/// without passing through `stop`, so nothing else on that path can bump.
+#[tokio::test]
+async fn generation_increments_across_forced_delete() {
+    let (state, driver, _dir) = test_state().await;
+    let mgr = state.session_manager().await;
+
+    let mut record = make_record(None);
+    record.tmux_name = "tm-force-delete-gen".into();
+    record.state = ManagedSessionState::Active;
+    record.workspace_path = Some(PathBuf::from("/repo/force-deleted"));
+    let id = record.id;
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("upsert active session");
+    // Live in tmux — the un-forced probe would refuse, so this only reaches
+    // `Deleted` because `force` is true.
+    driver.set_live(&["tm-force-delete-gen"]);
+
+    let before = decode(&active_projects_core(&state).await).generation;
+
+    mgr.delete_record(&id, true).await.expect("force delete");
+
+    let after = decode(&active_projects_core(&state).await);
+    assert_eq!(
+        after.projects.len(),
+        0,
+        "a deleted session leaves the served set: {:?}",
+        after.projects
+    );
+    assert!(
+        after.generation > before,
+        "a forced delete must bump the generation: before={before} after={}",
+        after.generation
+    );
+}
+
+/// (j) A terminal transition also drops the session's derivation-cache entry,
+/// so the map is bounded by live records rather than by every session the
+/// daemon has ever served.
+#[tokio::test]
+async fn forced_delete_evicts_the_residency_cache_entry() {
+    let (state, driver, _dir) = test_state().await;
+    let mgr = state.session_manager().await;
+
+    let root = PathBuf::from("/repo/evicted");
+    let mut record = make_record(None);
+    record.tmux_name = "tm-evict-cache".into();
+    record.state = ManagedSessionState::Active;
+    record.workspace_path = Some(root.clone());
+    let id = record.id;
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("upsert active session");
+    driver.set_live(&["tm-evict-cache"]);
+
+    // One poll derives and caches this session's (palace_id, index_ids).
+    assert_eq!(
+        decode(&active_projects_core(&state).await).projects.len(),
+        1
+    );
+    assert!(
+        mgr.residency_cache_lookup(&id, &root).await.is_some(),
+        "the route must cache the derivation it just made"
+    );
+
+    mgr.delete_record(&id, true).await.expect("force delete");
+
+    assert_eq!(
+        mgr.residency_cache_lookup(&id, &root).await,
+        None,
+        "a deleted session's cache entry must not outlive its record"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/residency_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/residency_tests.rs
@@ -1,0 +1,288 @@
+//! Unit tests for `mpm.residency.active` (#7087 slice 1b).
+//!
+//! Why a sibling file rather than an inline `#[cfg(test)] mod`: keeps
+//! `residency.rs` itself small, matching the `tests.rs`/`staleness_bench_tests.rs`
+//! precedent already established in this directory.
+//! What: exercises [`active_projects_core`] directly against a
+//! `DaemonState::with_root_isolated_managed_and_driver` fixture — no HTTP, no
+//! real tmux, no real daemon process.
+//! Test: this file.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use trusty_common::residency::ActiveProjectSet;
+
+use super::active_projects_core;
+use crate::daemon::managed_routes::tests::make_record;
+use crate::daemon::rpc::managed::outcome::{RouteBody, RouteOutcome};
+use crate::daemon::state::DaemonState;
+use crate::session_manager::{ManagedError, ManagedSessionState, ManagedTmuxDriver, StopCause};
+
+/// A tmux driver whose `list_sessions` answer is set by the test — `Ok(names)`
+/// by default, switchable to a failure mid-test (test (d) needs sessions
+/// created while the driver still answers `Ok`, then a failure for the actual
+/// route call).
+struct ControllableTmux {
+    live: Mutex<Result<Vec<String>, String>>,
+}
+
+impl ControllableTmux {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            live: Mutex::new(Ok(Vec::new())),
+        })
+    }
+
+    fn set_live(&self, names: &[&str]) {
+        *self.live.lock().unwrap() = Ok(names.iter().map(|s| s.to_string()).collect());
+    }
+
+    fn set_failing(&self, message: &str) {
+        *self.live.lock().unwrap() = Err(message.to_string());
+    }
+}
+
+impl ManagedTmuxDriver for ControllableTmux {
+    fn create_session(&self, _name: &str, _workdir: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn kill_session(&self, _name: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn send_line(&self, _name: &str, _text: &str) -> Result<(), ManagedError> {
+        Ok(())
+    }
+    fn capture(&self, _name: &str, _lines: usize) -> Result<String, ManagedError> {
+        Ok(String::new())
+    }
+    fn list_sessions(&self) -> Result<Vec<String>, ManagedError> {
+        match &*self.live.lock().unwrap() {
+            Ok(names) => Ok(names.clone()),
+            Err(e) => Err(ManagedError::TmuxUnavailable(e.clone())),
+        }
+    }
+}
+
+/// Build a `DaemonState` over a fresh temp dir with a caller-controlled tmux
+/// driver, returning the state alongside the driver handle (for `set_live`/
+/// `set_failing`) and the temp dir (kept alive for the test's lifetime).
+async fn test_state() -> (Arc<DaemonState>, Arc<ControllableTmux>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let driver = ControllableTmux::new();
+    let state = DaemonState::with_root_isolated_managed_and_driver(
+        dir.path().to_path_buf(),
+        driver.clone(),
+    )
+    .await;
+    (Arc::new(state), driver, dir)
+}
+
+/// Decode a `RouteOutcome`'s JSON body into `ActiveProjectSet`, panicking on
+/// anything else (every test here expects a 200).
+fn decode(outcome: &RouteOutcome) -> ActiveProjectSet {
+    assert_eq!(
+        outcome.status, 200,
+        "expected 200, body: {:?}",
+        outcome.body
+    );
+    match &outcome.body {
+        RouteBody::Json(v) => serde_json::from_value(v.clone()).expect("decode ActiveProjectSet"),
+        RouteBody::Text(t) => panic!("expected JSON body, got text: {t}"),
+    }
+}
+
+/// (a) 2 Active-with-tmux + 1 Active-without-tmux + 1 Stopped → exactly 2
+/// projects — the persisted-state filter AND the tmux-liveness filter both
+/// gate inclusion, and a filtered-out record must not silently sneak in.
+#[tokio::test]
+async fn active_with_tmux_counted_others_excluded() {
+    let (state, driver, _dir) = test_state().await;
+    driver.set_live(&["tm-proj-a", "tm-proj-b"]);
+    let mgr = state.session_manager().await;
+
+    let mut active_a = make_record(None);
+    active_a.tmux_name = "tm-proj-a".into();
+    active_a.state = ManagedSessionState::Active;
+    active_a.workspace_path = Some(PathBuf::from("/repo/a"));
+    mgr.store
+        .write()
+        .await
+        .upsert(active_a)
+        .await
+        .expect("upsert a");
+
+    let mut active_b = make_record(None);
+    active_b.tmux_name = "tm-proj-b".into();
+    active_b.state = ManagedSessionState::Active;
+    active_b.workspace_path = Some(PathBuf::from("/repo/b"));
+    mgr.store
+        .write()
+        .await
+        .upsert(active_b)
+        .await
+        .expect("upsert b");
+
+    // Persisted Active, but tmux does not confirm it — excluded.
+    let mut active_no_tmux = make_record(None);
+    active_no_tmux.tmux_name = "tm-proj-ghost".into();
+    active_no_tmux.state = ManagedSessionState::Active;
+    active_no_tmux.workspace_path = Some(PathBuf::from("/repo/ghost"));
+    mgr.store
+        .write()
+        .await
+        .upsert(active_no_tmux)
+        .await
+        .expect("upsert ghost");
+
+    // Stopped, even though tmux would confirm it if asked — excluded.
+    let mut stopped = make_record(None);
+    stopped.tmux_name = "tm-proj-stopped".into();
+    stopped.state = ManagedSessionState::Stopped;
+    stopped.workspace_path = Some(PathBuf::from("/repo/stopped"));
+    mgr.store
+        .write()
+        .await
+        .upsert(stopped)
+        .await
+        .expect("upsert stopped");
+
+    let set = decode(&active_projects_core(&state).await);
+    assert_eq!(set.projects.len(), 2, "projects: {:?}", set.projects);
+}
+
+/// (b) Two sessions on one root → one project, two `session_ids`.
+#[tokio::test]
+async fn two_sessions_on_one_root_group_into_one_project() {
+    let (state, driver, _dir) = test_state().await;
+    driver.set_live(&["tm-shared-1", "tm-shared-2"]);
+    let mgr = state.session_manager().await;
+
+    let root = PathBuf::from("/repo/shared");
+    let mut s1 = make_record(None);
+    s1.tmux_name = "tm-shared-1".into();
+    s1.state = ManagedSessionState::Active;
+    s1.workspace_path = Some(root.clone());
+    let id1 = s1.id;
+    mgr.store.write().await.upsert(s1).await.expect("upsert s1");
+
+    let mut s2 = make_record(None);
+    s2.tmux_name = "tm-shared-2".into();
+    s2.state = ManagedSessionState::Provisioning;
+    s2.workspace_path = Some(root.clone());
+    let id2 = s2.id;
+    mgr.store.write().await.upsert(s2).await.expect("upsert s2");
+
+    let set = decode(&active_projects_core(&state).await);
+    assert_eq!(set.projects.len(), 1, "projects: {:?}", set.projects);
+    let project = &set.projects[0];
+    assert_eq!(project.root, root);
+    let mut ids = project.session_ids.clone();
+    ids.sort();
+    let mut expected = vec![id1.to_string(), id2.to_string()];
+    expected.sort();
+    assert_eq!(ids, expected);
+}
+
+/// (c) A worktree root resolves to two `index_ids` (the worktree's own, plus
+/// its base checkout's).
+#[tokio::test]
+async fn worktree_root_yields_two_index_ids() {
+    let fixture = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
+    let worktree = fixture.add_worktree("wt-residency");
+
+    let (state, driver, _dir) = test_state().await;
+    driver.set_live(&["tm-wt"]);
+    let mgr = state.session_manager().await;
+
+    let mut record = make_record(None);
+    record.tmux_name = "tm-wt".into();
+    record.state = ManagedSessionState::Active;
+    record.workspace_path = Some(worktree.clone());
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("upsert worktree session");
+
+    let set = decode(&active_projects_core(&state).await);
+    assert_eq!(set.projects.len(), 1, "projects: {:?}", set.projects);
+    assert_eq!(
+        set.projects[0].index_ids.len(),
+        2,
+        "index_ids: {:?}",
+        set.projects[0].index_ids
+    );
+}
+
+/// (d) A `list_sessions` failure serves the PERSISTED state rather than
+/// collapsing to empty (#6836) — fail closed, never fail empty.
+#[tokio::test]
+async fn tmux_list_failure_serves_persisted_state() {
+    let (state, driver, _dir) = test_state().await;
+    driver.set_live(&["tm-during-create"]);
+    let mgr = state.session_manager().await;
+
+    let mut record = make_record(None);
+    record.tmux_name = "tm-during-create".into();
+    record.state = ManagedSessionState::Active;
+    record.workspace_path = Some(PathBuf::from("/repo/failclosed"));
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("upsert");
+
+    // Now the producer's OWN list_sessions call fails.
+    driver.set_failing("enumeration failed");
+
+    let set = decode(&active_projects_core(&state).await);
+    assert_eq!(
+        set.projects.len(),
+        1,
+        "a tmux probe failure must still serve persisted Active/Provisioning \
+         records: {:?}",
+        set.projects
+    );
+}
+
+/// (e) The residency generation increments across `create`/`stop`, and the
+/// route reflects the CURRENT value without recomputing it from scratch.
+#[tokio::test]
+async fn generation_increments_across_create_and_stop() {
+    let (state, driver, _dir) = test_state().await;
+    let mgr = state.session_manager().await;
+
+    let before = decode(&active_projects_core(&state).await).generation;
+
+    let record = mgr
+        .create(
+            "residency generation test".into(),
+            Some(PathBuf::from("/tmp/residency-gen")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    driver.set_live(&[record.tmux_name.as_str()]);
+
+    let after_create = decode(&active_projects_core(&state).await).generation;
+    assert!(
+        after_create > before,
+        "create must bump the generation: before={before} after={after_create}"
+    );
+
+    mgr.stop_with_cause(&record.id, StopCause::Deliberate)
+        .await
+        .expect("stop");
+
+    let after_stop = decode(&active_projects_core(&state).await).generation;
+    assert!(
+        after_stop > after_create,
+        "stop must bump the generation: after_create={after_create} after_stop={after_stop}"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/residency_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/residency_tests.rs
@@ -455,6 +455,48 @@ async fn generation_increments_across_forced_delete() {
     );
 }
 
+/// (k) `mark_errored` takes `Active`/`Provisioning` -> `Errored`, which is
+/// outside the set this route serves. Six production callers reach it — a
+/// failed spawn, a failed resume, a failed launch verification and a parked
+/// auto-resume — and none of them passes through `stop`.
+#[tokio::test]
+async fn generation_increments_across_mark_errored() {
+    let (state, driver, _dir) = test_state().await;
+    let mgr = state.session_manager().await;
+
+    let mut record = make_record(None);
+    record.tmux_name = "tm-errored-gen".into();
+    record.state = ManagedSessionState::Active;
+    record.workspace_path = Some(PathBuf::from("/repo/errored"));
+    let id = record.id;
+    mgr.store
+        .write()
+        .await
+        .upsert(record)
+        .await
+        .expect("upsert active session");
+    driver.set_live(&["tm-errored-gen"]);
+
+    let before = decode(&active_projects_core(&state).await).generation;
+
+    mgr.mark_errored(&id, "spawn failed")
+        .await
+        .expect("mark_errored");
+
+    let after = decode(&active_projects_core(&state).await);
+    assert_eq!(
+        after.projects.len(),
+        0,
+        "an errored session leaves the served set: {:?}",
+        after.projects
+    );
+    assert!(
+        after.generation > before,
+        "mark_errored must bump the generation: before={before} after={}",
+        after.generation
+    );
+}
+
 /// (j) A terminal transition also drops the session's derivation-cache entry,
 /// so the map is bounded by live records rather than by every session the
 /// daemon has ever served.

--- a/crates/trusty-mpm/src/daemon/rpc/managed/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed/sessions.rs
@@ -18,6 +18,7 @@
 //! | `mpm.managed.prune_worktrees` | `POST /api/v1/sessions/managed/prune-worktrees` |
 //! | `mpm.managed.reconcile_worktrees` | `GET /api/v1/sessions/managed/reconcile-worktrees` |
 //! | `mpm.managed.fleet` | `GET /api/v1/sessions/managed/fleet` |
+//! | `mpm.residency.active` | none — socket-only (#7087 slice 1b) |
 //! | `mpm.managed.get` | `GET /api/v1/sessions/managed/{id}` |
 //! | `mpm.managed.stop` | `DELETE /api/v1/sessions/managed/{id}` |
 //! | `mpm.managed.rename` | `PATCH /api/v1/sessions/managed/{id}` |
@@ -49,7 +50,7 @@ use crate::daemon::managed_routes::prune::{PruneRequest, PruneWorktreesRequest};
 use crate::daemon::managed_routes::{
     AdoptExistingRequest, AnswerRequest, ReactivateQuery, RenameRequest, SendInputRequest,
     SpawnRequest, activity, cores, delete, fleet, provision_status, prune, reactivate, reconcile,
-    rename, sync_assets,
+    rename, residency, sync_assets,
 };
 use crate::daemon::state::DaemonState;
 
@@ -165,6 +166,7 @@ fn register_fleet_wide(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter
     }
     let (spawn_s, list_s, adopt_s, prune_s, eph_s) = (st!(), st!(), st!(), st!(), st!());
     let (pw_s, rw_s, fleet_s, sa_s) = (st!(), st!(), st!(), st!());
+    let residency_s = st!();
 
     router
         .typed("mpm.managed.spawn", move |req: SpawnRequest| {
@@ -213,6 +215,13 @@ fn register_fleet_wide(router: RpcRouter, state: &Arc<DaemonState>) -> RpcRouter
             let state = Arc::clone(&fleet_s);
             async move { fleet::fleet_core(&state).await.into_rpc() }
         })
+        .typed(
+            trusty_common::mpm_rpc::METHOD_RESIDENCY_ACTIVE,
+            move |_: NoParams| {
+                let state = Arc::clone(&residency_s);
+                async move { residency::active_projects_core(&state).await.into_rpc() }
+            },
+        )
         .typed("mpm.managed.sync_assets_all", move |_: NoParams| {
             let state = Arc::clone(&sa_s);
             async move {

--- a/crates/trusty-mpm/src/daemon/rpc/managed_tests.rs
+++ b/crates/trusty-mpm/src/daemon/rpc/managed_tests.rs
@@ -195,6 +195,7 @@ async fn every_scoped_route_has_a_method() {
         "mpm.managed.prune_worktrees",
         "mpm.managed.reconcile_worktrees",
         "mpm.managed.fleet",
+        "mpm.residency.active",
         "mpm.managed.get",
         "mpm.managed.stop",
         "mpm.managed.runtime_stop",
@@ -1584,4 +1585,48 @@ async fn proxy_summary_parity() {
     .await;
     assert_eq!(http.status, 200);
     assert_parity("mpm.proxy.summary", &http, &rpc);
+}
+
+/// `mpm.residency.active` round-trips over a REAL Unix socket, through the
+/// REAL `managed::register` router — not just `RpcRouter::dispatch` in memory
+/// (#7087 slice 1b). Proves the method is reachable by the same client
+/// trusty-memory/trusty-search will use:
+/// [`trusty_common::mpm_rpc::fetch_active_projects_at`].
+#[tokio::test]
+async fn residency_active_round_trips_over_the_real_socket() {
+    use tokio::sync::oneshot;
+
+    let (state, _dir) = test_state().await;
+    let router = Arc::new(managed::register(RpcRouter::new(), &state));
+
+    let socket_dir = tempfile::tempdir().expect("socket tempdir");
+    let socket = socket_dir.path().join("trusty-mpm.sock");
+    let listener = trusty_common::uds::bind_hardened(&socket).expect("bind");
+
+    let (stop, shutdown) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        trusty_common::uds::server::serve_until(
+            &listener,
+            router,
+            trusty_common::uds::server::RpcServeOptions::default(),
+            async {
+                let _ = shutdown.await;
+            },
+        )
+        .await;
+    });
+
+    let set = trusty_common::mpm_rpc::fetch_active_projects_at(
+        &socket,
+        std::time::Duration::from_secs(5),
+    )
+    .await
+    .expect("fetch_active_projects_at");
+    assert_eq!(
+        set.schema,
+        trusty_common::residency::ACTIVE_PROJECT_SET_SCHEMA
+    );
+    assert_eq!(set.projects.len(), 0, "no managed sessions seeded");
+
+    let _ = stop.send(());
 }

--- a/crates/trusty-mpm/src/session_manager/adopt.rs
+++ b/crates/trusty-mpm/src/session_manager/adopt.rs
@@ -465,6 +465,9 @@ impl SessionManager {
             }
         };
 
+        // #7087: an adopted session can join the active-project set.
+        self.bump_residency_generation();
+
         info!(
             id = %record.id,
             name = %record.tmux_name,

--- a/crates/trusty-mpm/src/session_manager/create.rs
+++ b/crates/trusty-mpm/src/session_manager/create.rs
@@ -363,6 +363,10 @@ impl SessionManager {
             return Err(ManagedError::from(e));
         }
 
+        // #7087: a new session can join the active-project set; bump so a
+        // residency consumer polling `mpm.residency.active` notices.
+        self.bump_residency_generation();
+
         // The record is durably persisted; the store/registry now owns the
         // session's lifetime. Disarm so the guard's drop is a no-op and the
         // tracked session is NOT reaped at the end of this request scope (#1453).

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -712,6 +712,8 @@ impl SessionManager {
         // starts here, not at `created_at`.
         record.set_lifecycle_state(ManagedSessionState::Decommissioned, Utc::now());
         self.store.write().await.upsert(record.clone()).await?;
+        // #7087: a record-only tombstone leaves the active-project set.
+        self.bump_residency_generation();
         info!(id = %id, name = %record.tmux_name, "managed session record tombstoned (record-only)");
         Ok((record, false))
     }
@@ -1120,6 +1122,8 @@ impl SessionManager {
         // starts here, not at `created_at`.
         record.set_lifecycle_state(ManagedSessionState::Decommissioned, Utc::now());
         self.store.write().await.upsert(record.clone()).await?;
+        // #7087: a full teardown leaves the active-project set.
+        self.bump_residency_generation();
         info!(id = %id, name = %record.tmux_name, "managed session decommissioned");
         Ok((record, workspace_removed))
     }

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -714,6 +714,9 @@ impl SessionManager {
         self.store.write().await.upsert(record.clone()).await?;
         // #7087: a record-only tombstone leaves the active-project set.
         self.bump_residency_generation();
+        // #7087: and a tombstone is terminal — drop its derivation entry so the
+        // cache tracks live records, not every session the daemon has served.
+        self.residency_cache_evict(id).await;
         info!(id = %id, name = %record.tmux_name, "managed session record tombstoned (record-only)");
         Ok((record, false))
     }
@@ -1124,6 +1127,9 @@ impl SessionManager {
         self.store.write().await.upsert(record.clone()).await?;
         // #7087: a full teardown leaves the active-project set.
         self.bump_residency_generation();
+        // #7087: and a tombstone is terminal — drop its derivation entry so the
+        // cache tracks live records, not every session the daemon has served.
+        self.residency_cache_evict(id).await;
         info!(id = %id, name = %record.tmux_name, "managed session decommissioned");
         Ok((record, workspace_removed))
     }

--- a/crates/trusty-mpm/src/session_manager/delete.rs
+++ b/crates/trusty-mpm/src/session_manager/delete.rs
@@ -65,7 +65,10 @@ impl SessionManager {
     /// `delete_record_force_bypasses_running_guard`,
     /// `delete_record_never_touches_workspace_dir`,
     /// `delete_record_stale_active_deletable_when_tmux_dead` (#2022) in
-    /// `super::delete_tests`.
+    /// `super::delete_tests`; the #7087 residency bump and cache eviction by
+    /// `generation_increments_across_forced_delete` and
+    /// `forced_delete_evicts_the_residency_cache_entry` in
+    /// `daemon::managed_routes::residency`'s route tests.
     pub async fn delete_record(
         &self,
         id: &ManagedSessionId,
@@ -101,6 +104,13 @@ impl SessionManager {
         updated.pending_decision = None;
         updated.proposed_default = None;
         self.store.write().await.upsert(updated).await?;
+        // #7087: a soft-delete leaves the active-project set — `--force`
+        // reaches `Deleted` straight from `Active`/`Provisioning`, without
+        // passing through `stop`, so this is the only bump on that path.
+        self.bump_residency_generation();
+        // #7087: `Deleted` is terminal, so nothing will ask the residency
+        // route about this session again — drop its derivation entry.
+        self.residency_cache_evict(id).await;
         Ok(record)
     }
 }

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -711,7 +711,10 @@ impl SessionManager {
     /// `stop_runtime_exited_does_not_kill_pane` (same module) asserts
     /// `kill_session` is never invoked on the fake driver;
     /// `mark_runtime_exited_stopped_rejects_concurrently_decommissioned`
-    /// (this module's tests) asserts the CAS guard below.
+    /// (this module's tests) asserts the CAS guard below;
+    /// `generation_increments_across_mark_runtime_exited_stopped` in
+    /// `daemon::managed_routes::residency`'s route tests asserts the #7087
+    /// residency bump.
     ///
     /// CAS guard (#2453 review finding 3): the pre-fix implementation read
     /// the record via [`Self::get`] (which acquires and releases the store's
@@ -793,6 +796,9 @@ impl SessionManager {
         record.stop_cause = Some(self.runtime_exit_stop_cause(id, &record.tmux_name).await);
         guard.upsert(record.clone()).await?;
         drop(guard);
+        // #7087: Active -> Stopped leaves the active-project set, exactly as
+        // `stop` does — the reaper reaches it without going through `stop`.
+        self.bump_residency_generation();
         info!(
             id = %id,
             name = %record.tmux_name,
@@ -876,7 +882,9 @@ impl SessionManager {
     /// through to a session-scoped reuse or a session-wide kill/recreate;
     /// `liveness_tests.rs`'s `resume_refuses_when_the_tmux_probe_fails` —
     /// asserts an unobservable probe refuses instead of killing the pane
-    /// (#5859).
+    /// (#5859); `generation_increments_across_resume` in
+    /// `daemon::managed_routes::residency`'s route tests — asserts the #7087
+    /// residency bump.
     ///
     /// #6568: this is the OPERATOR entry point. It forgives the auto-resume flap
     /// streak, because a person resuming a session by hand is saying the cause
@@ -986,6 +994,8 @@ impl SessionManager {
         // this resume followed a deliberate stop.
         record.stop_cause = None;
         self.store.write().await.upsert(record.clone()).await?;
+        // #7087: Stopped/Errored -> Active re-enters the active-project set.
+        self.bump_residency_generation();
         Ok(record)
     }
 

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -21,8 +21,10 @@
 //! `manager_resume_respawns`, `manager_decommission_removes_workspace`,
 //! `manager_reconcile_gone_tmux_yields_stopped` in tests.rs.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use chrono::Utc;
 use thiserror::Error;
@@ -36,6 +38,10 @@ use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::resume_workdir;
 use super::slots::SlotRegistry;
 use super::store::{SessionStore, StoreError};
+
+/// One session's cached `(root, palace_id, index_ids)` residency derivation.
+/// See `residency_state.rs`.
+type ResidencyCacheEntry = (PathBuf, Option<String>, Vec<String>);
 
 /// Errors produced by the session manager.
 ///
@@ -250,6 +256,18 @@ pub struct SessionManager {
     pub(crate) resume_breaker: RwLock<super::resume_breaker::ResumeBreakerStore>,
     /// #6568: the breaker's window/threshold, read once at construction.
     pub(crate) resume_breaker_cfg: super::resume_breaker::ResumeBreakerConfig,
+    /// #7087: monotonic residency-set version. In-memory only, like `slots` —
+    /// a fresh daemon process has nothing to compare a first pull against, so
+    /// there is nothing to persist. Bumped by `create`/`stop`/`adopt`/
+    /// `decommission`; read (never bumped) by `mpm.residency.active`. See
+    /// `residency_state.rs`.
+    pub(crate) residency_generation: AtomicU64,
+    /// #7087: per-session `(root, palace_id, index_ids)` derivation cache the
+    /// residency route reuses across polls, avoiding a repeat
+    /// `resolve_palace_slug`/`derive_project_index_id` (both filesystem/`git`
+    /// touching) for a session whose root has not changed. In-memory only,
+    /// like `slots` and `residency_generation` above. See `residency_state.rs`.
+    pub(crate) residency_cache: RwLock<HashMap<ManagedSessionId, ResidencyCacheEntry>>,
 }
 
 impl std::fmt::Debug for SessionManager {
@@ -289,6 +307,8 @@ impl SessionManager {
                 super::resume_breaker::ResumeBreakerStore::load(data_dir).await,
             ),
             resume_breaker_cfg: super::resume_breaker::ResumeBreakerConfig::from_env(),
+            residency_generation: AtomicU64::new(0),
+            residency_cache: RwLock::new(HashMap::new()),
         })
     }
 

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -9,9 +9,12 @@
 //! `mark_runtime_exited_stopped` (non-destructive counterpart to `stop`,
 //! #2023 A), `resume`, and `decommission`.
 //! `mark_reactivated` (the in-place counterpart to `resume`, #2023 C) lives in
-//! the sibling `reactivate.rs`, and `reconcile_on_boot` lives in the sibling
-//! `reconcile.rs` (#2379) — both extracted to keep this file under the
-//! 500-SLOC cap.
+//! the sibling `reactivate.rs`, `reconcile_on_boot` lives in the sibling
+//! `reconcile.rs` (#2379), and the post-creation field setters
+//! (`mark_errored`, `set_workspace`, `set_pending_decision`, `set_source_id`,
+//! `set_deliverable_id`, `clear_pending_decision`) live in the sibling
+//! `setters.rs` (#7087) — all extracted to keep this file under the 500-SLOC
+//! cap.
 //! [`ReconcileReport`] describes what the reconciliation pass found.
 //! [`ManagedError`] is the module's error type.
 //! Test: `manager_create_record`, `manager_stop_keeps_workspace`,
@@ -24,7 +27,7 @@ use std::sync::Arc;
 use chrono::Utc;
 use thiserror::Error;
 use tokio::sync::RwLock;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 
 use crate::core::names::SessionNameError;
 use crate::core::sm::control::Submit;
@@ -1145,190 +1148,5 @@ impl SessionManager {
             None => self.tmux.capture(tmux_name, lines).ok()?,
         };
         (!text.is_empty()).then_some(text)
-    }
-
-    /// Mark a session as errored with a message.
-    ///
-    /// Why: when provisioning or spawning fails the session must not remain in
-    /// `Provisioning`; marking it errored surfaces the failure to `tm session ls`.
-    /// What: transitions the record to `ManagedSessionState::Errored` and appends
-    /// the error message to the task field for observability, then persists.
-    /// Test: covered by handler_spawn_wires_provision_and_spawn error path.
-    pub async fn mark_errored(
-        &self,
-        id: &ManagedSessionId,
-        error_msg: &str,
-    ) -> Result<(), ManagedError> {
-        let mut record = self.get(id).await?;
-        record.state = ManagedSessionState::Errored;
-        record.task = format!("{} [error: {}]", record.task, error_msg);
-        self.store.write().await.upsert(record).await?;
-        Ok(())
-    }
-
-    /// Update a session's workspace path and transition to a new state.
-    ///
-    /// Why: after the workspace path is resolved
-    /// must be persisted so `tm session ls` shows it and `activity` can infer
-    /// context.
-    /// What: looks up the record, sets `workspace_path` and `state`, and persists.
-    /// Test: covered by handler_spawn_wires_provision_and_spawn.
-    pub async fn set_workspace(
-        &self,
-        id: &ManagedSessionId,
-        workspace_path: std::path::PathBuf,
-        new_state: ManagedSessionState,
-    ) -> Result<(), ManagedError> {
-        let mut record = self.get(id).await?;
-        record.workspace_path = Some(workspace_path);
-        record.state = new_state;
-        self.store.write().await.upsert(record).await?;
-        Ok(())
-    }
-
-    /// Record a pending decision (an escalation) on a session, awaiting a human.
-    ///
-    /// Why: the intent-conformance FRONT gate (#1360) escalates *before* the
-    /// runtime is spawned. It must surface the divergence reason + the conformant
-    /// default through the SAME channel the harness uses (`pending_decision` /
-    /// `proposed_default`), so it appears in `GET …/activity`, MCP
-    /// `session_status`, the supervisor, and the `tm` CLI with zero new UI. The
-    /// session is left NOT `Active` (the runtime never started) so it reads as
-    /// awaiting approval until a human resolves it via `POST …/answer`.
-    /// What: looks up the record, sets `pending_decision`/`proposed_default`,
-    /// leaves the lifecycle state untouched (it stays `Provisioning` — the
-    /// runtime was withheld), and persists. No tmux input is sent (unlike
-    /// `answer_decision`): the pane has no running harness to receive it yet.
-    /// Test: `front_gate_escalation_sets_pending_decision` in
-    /// tests/session_manager_mvp.rs.
-    pub async fn set_pending_decision(
-        &self,
-        id: &ManagedSessionId,
-        decision: &str,
-        proposed_default: Option<&str>,
-    ) -> Result<(), ManagedError> {
-        let mut record = self.get(id).await?;
-        record.pending_decision = Some(decision.to_string());
-        record.proposed_default = proposed_default.map(str::to_string);
-        record.last_activity_at = Some(Utc::now());
-        self.store.write().await.upsert(record).await?;
-        Ok(())
-    }
-
-    /// Record a source project identity on a session, with a bounded retry
-    /// (#2157 item 5, the #2154 remedy).
-    ///
-    /// Why: the in-project spawn path (#1706) associates a session with a
-    /// specific `owner/repo` so callers can later filter sessions by project
-    /// and reconnect instead of spawning duplicates. Setting it post-creation
-    /// (rather than via `create_with_id`) keeps the manager's SINGLE generic
-    /// create path clean of in-project concerns. Previously a single transient
-    /// `get`/`upsert` failure here was `warn!`-and-continue at the call site —
-    /// leaving `source_id: None` on the record PERMANENTLY, which makes the
-    /// session invisible to every `?source_id=` filtered listing (the guided
-    /// picker, `tm session ls --project`) forever, since nothing else ever
-    /// retries the write.
-    /// What: retries the read-modify-write up to `MAX_SET_SOURCE_ID_ATTEMPTS`
-    /// times with a short linear backoff between attempts, returning `Ok(())`
-    /// on the first success. If every attempt fails, logs a `tracing::error!`
-    /// (loud, not `warn!`) carrying `id` and `source_id` so a future
-    /// reconcile/doctor pass can self-heal a `source_id: None` record from its
-    /// `repo_url`/`workspace_path`, then returns the last error.
-    /// Test: `set_source_id_succeeds_first_try`,
-    /// `set_source_id_returns_err_after_retries_for_missing_session` in
-    /// `tests.rs`.
-    pub async fn set_source_id(
-        &self,
-        id: &ManagedSessionId,
-        source_id: &str,
-    ) -> Result<(), ManagedError> {
-        const MAX_SET_SOURCE_ID_ATTEMPTS: u8 = 3;
-        let mut last_err: Option<ManagedError> = None;
-        for attempt in 1..=MAX_SET_SOURCE_ID_ATTEMPTS {
-            let result: Result<(), ManagedError> = async {
-                let mut record = self.get(id).await?;
-                record.source_id = Some(source_id.to_string());
-                self.store.write().await.upsert(record).await?;
-                Ok(())
-            }
-            .await;
-            match result {
-                Ok(()) => return Ok(()),
-                Err(e) => {
-                    warn!(
-                        id = %id,
-                        attempt,
-                        max_attempts = MAX_SET_SOURCE_ID_ATTEMPTS,
-                        "set_source_id: attempt failed: {e}"
-                    );
-                    last_err = Some(e);
-                    if attempt < MAX_SET_SOURCE_ID_ATTEMPTS {
-                        tokio::time::sleep(std::time::Duration::from_millis(
-                            50 * u64::from(attempt),
-                        ))
-                        .await;
-                    }
-                }
-            }
-        }
-        error!(
-            id = %id,
-            source_id = %source_id,
-            attempts = MAX_SET_SOURCE_ID_ATTEMPTS,
-            "set_source_id: exhausted all attempts — session will be invisible to \
-             project-filtered listing (source_id: None) until a reconcile/doctor pass \
-             repairs it from repo_url/workspace_path"
-        );
-        Err(last_err.unwrap_or_else(|| ManagedError::SessionNotFound(id.to_string())))
-    }
-
-    /// Record which Deliverable a session is working on (DOC-35 §10.6, #2379).
-    ///
-    /// Why: `tm sessions new --deliverable <id>` binds a fresh session to a
-    /// Deliverable AFTER the session record already exists (mirroring
-    /// [`Self::set_source_id`]'s post-creation setter shape, which keeps
-    /// [`Self::create_with_id`]'s already-long parameter list from growing
-    /// further). The caller (the daemon spawn path,
-    /// `daemon::managed_routes::lifecycle`) validates the Deliverable exists
-    /// and belongs to the session's project via `DeliverableManager` BEFORE
-    /// calling this — this setter trusts that validation and does no lookup of
-    /// its own. Per §11, this is a PURE POINTER write: it never mutates the
-    /// Deliverable record itself (no auto-transition of its status).
-    /// What: a plain read-modify-write — look up the record, set
-    /// `deliverable_id`, persist. No retry loop (unlike `set_source_id`):
-    /// losing this link on a rare transient store error is a stale pointer,
-    /// not a session made invisible to a whole filtered listing, so the
-    /// simpler shape matches `set_workspace`/`set_pending_decision`.
-    /// Test: `set_deliverable_id_persists`,
-    /// `set_deliverable_id_missing_session_errors` in `set_deliverable_id_tests.rs`.
-    pub async fn set_deliverable_id(
-        &self,
-        id: &ManagedSessionId,
-        deliverable_id: crate::deliverable::DeliverableId,
-    ) -> Result<(), ManagedError> {
-        let mut record = self.get(id).await?;
-        record.deliverable_id = Some(deliverable_id);
-        self.store.write().await.upsert(record).await?;
-        Ok(())
-    }
-
-    /// Clear a pending decision WITHOUT injecting any text into the pane.
-    ///
-    /// Why: a FRONT-gate (#1360) escalation is resolved *before* a harness exists
-    /// — the session is still `Provisioning` with no runtime in the pane. Unlike
-    /// [`answer_decision`](Self::answer_decision) (which sends the answer to a
-    /// LIVE harness), the FRONT-gate answer path must clear the decision and then
-    /// LAUNCH the withheld runtime; sending the answer to a bare shell would be
-    /// meaningless. This method does the clear half only.
-    /// What: looks up the record, clears `pending_decision`/`proposed_default`,
-    /// updates `last_activity_at`, and persists. No tmux I/O.
-    /// Test: `front_gate_answer_unblocks_spawn` in tests/session_manager_mvp.rs.
-    pub async fn clear_pending_decision(&self, id: &ManagedSessionId) -> Result<(), ManagedError> {
-        let mut record = self.get(id).await?;
-        record.pending_decision = None;
-        record.proposed_default = None;
-        record.last_activity_at = Some(Utc::now());
-        self.store.write().await.upsert(record).await?;
-        Ok(())
     }
 }

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -30,6 +30,7 @@ pub mod reactivate;
 mod reconcile;
 pub mod record;
 pub mod rename;
+pub mod residency_state;
 pub mod restart_ops;
 /// #6568: the auto-resume circuit breaker's policy and its persisted counters.
 pub mod resume_breaker;

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod resume_workdir;
 pub mod retention;
 pub mod search_gc;
 pub mod session_guard;
+pub mod setters;
 pub mod slots;
 pub mod snapshot;
 // #6194: `stop` / `stop_with_cause`, split out of `manager.rs` at its SLOC cap.

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -1148,7 +1148,28 @@ async fn reconcile_tombstones_an_adopted_reserved_record_whose_tmux_is_gone() {
         store.upsert(created.clone()).await.unwrap();
     }
 
+    // #7087: the sweep drops the record out of the set `mpm.residency.active`
+    // serves, so seed a cache entry the sweep must evict and capture the
+    // generation the sweep must move. The gone arm the other two records take
+    // does not bump, so only the sweep can satisfy the assertion below.
+    let leak_root = std::path::PathBuf::from("/tmp/leak-ws");
+    mgr.residency_cache_store(leaked.id, leak_root.clone(), None, Vec::new())
+        .await;
+    let generation_before = mgr.residency_generation();
+
     let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert!(
+        mgr.residency_generation() > generation_before,
+        "the sweep leaves the active-project set, so it must bump the \
+         residency generation: before={generation_before} after={}",
+        mgr.residency_generation()
+    );
+    assert_eq!(
+        mgr.residency_cache_lookup(&leaked.id, &leak_root).await,
+        None,
+        "a swept record is terminal — its derivation cache entry must go with it"
+    );
 
     let after = mgr.get(&leaked.id).await.unwrap();
     assert_eq!(

--- a/crates/trusty-mpm/src/session_manager/reactivate.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate.rs
@@ -75,7 +75,9 @@ impl SessionManager {
     /// `mark_reactivated_flips_decommissioned_to_active`,
     /// `mark_reactivated_rejects_non_stopped`,
     /// `mark_reactivated_refuses_when_workspace_removed_by_decommission`,
-    /// `mark_reactivated_clears_stale_claude_session_id`.
+    /// `mark_reactivated_clears_stale_claude_session_id`; the #7087 residency
+    /// bump by `generation_increments_across_mark_reactivated` in
+    /// `daemon::managed_routes::residency`'s route tests.
     pub async fn mark_reactivated(
         &self,
         id: &ManagedSessionId,
@@ -133,6 +135,10 @@ impl SessionManager {
         // ever being compared against a later, unrelated report.
         record.claude_session_id = None;
         self.store.write().await.upsert(record.clone()).await?;
+        // #7087: Stopped/Decommissioned -> Active re-enters the active-project
+        // set — a revived tombstone in particular is a project that was gone
+        // from the set entirely one call ago.
+        self.bump_residency_generation();
         info!(
             id = %id,
             name = %record.tmux_name,

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -257,7 +257,13 @@ impl SessionManager {
                      a leaked test session is not a session to keep, resume or relaunch; its \
                      pane goes back to the orphan-GC"
                 );
+                let swept_id = record.id;
                 guard.upsert(record).await?;
+                // #7087: the record may have been Active a moment ago, so the
+                // tombstone leaves the active-project set; `Deleted` is
+                // terminal, so its derivation entry is dead weight.
+                self.bump_residency_generation();
+                self.residency_cache_evict(&swept_id).await;
                 continue;
             }
 

--- a/crates/trusty-mpm/src/session_manager/residency_state.rs
+++ b/crates/trusty-mpm/src/session_manager/residency_state.rs
@@ -18,11 +18,20 @@
 //! [`SessionManager::residency_cache_store`] wrap the per-session
 //! `(root, palace_id, index_ids)` cache, keyed by [`ManagedSessionId`] and
 //! invalidated by a root mismatch (the session's `workspace_path`/`cwd`
-//! changed since the cached entry was written).
+//! changed since the cached entry was written);
+//! [`SessionManager::residency_cache_evict`] drops a session's entry when the
+//! session reaches a terminal state, so the map is bounded by the live record
+//! count rather than by every session the daemon has ever seen (#7087).
 //! Test: `residency_generation_starts_at_zero_and_bumps`,
-//! `residency_cache_hits_on_matching_root_and_misses_on_change` below;
-//! generation bumps at the four call sites are covered by
-//! `residency_generation_bumps_across_create_and_stop` and
+//! `residency_cache_hits_on_matching_root_and_misses_on_change`,
+//! `residency_cache_evict_drops_the_entry` below; generation bumps at the
+//! production call sites are covered by
+//! `generation_increments_across_create_and_stop`,
+//! `generation_increments_across_resume`,
+//! `generation_increments_across_mark_reactivated`,
+//! `generation_increments_across_mark_runtime_exited_stopped`,
+//! `generation_increments_across_forced_delete` and
+//! `forced_delete_evicts_the_residency_cache_entry` in
 //! `daemon::managed_routes::residency`'s route tests.
 
 use std::path::{Path, PathBuf};
@@ -34,11 +43,21 @@ use super::record::ManagedSessionId;
 impl SessionManager {
     /// Bump the residency generation and return the NEW value.
     ///
-    /// Called at every site that changes which sessions are active: `create`,
-    /// `stop`/`stop_with_cause`, `adopt_existing`, and both decommission paths
-    /// (record-only and full teardown). Never called by `resume`/
-    /// `mark_reactivated` — neither changes the active SET, only whether an
-    /// already-active-or-not session's runtime is running.
+    /// The rule: call this wherever a persisted record enters or leaves the
+    /// set `mpm.residency.active` serves — the route keeps exactly the records
+    /// whose state is `Active` or `Provisioning`, so every transition across
+    /// that boundary in either direction is a set change a polling consumer
+    /// must be able to notice. Entering: `create`, `adopt_existing`, `resume`
+    /// (`Stopped`/`Errored -> Active`) and `mark_reactivated`
+    /// (`Stopped`/`Decommissioned -> Active`). Leaving: `stop`/
+    /// `stop_with_cause`, `mark_runtime_exited_stopped`, both decommission
+    /// paths (record-only and full teardown), `delete_record` (`--force`
+    /// reaches it straight from `Active`/`Provisioning`), and
+    /// `reconcile_on_boot`'s leaked-test-adoption sweep (#6116).
+    ///
+    /// The generation is advisory-monotonic, never a set hash: bumping when
+    /// the set happens to be unchanged only costs a consumer one redundant
+    /// diff, while a missed bump serves a stale set forever.
     pub fn bump_residency_generation(&self) -> u64 {
         self.residency_generation.fetch_add(1, Ordering::SeqCst) + 1
     }
@@ -77,6 +96,27 @@ impl SessionManager {
             .write()
             .await
             .insert(id, (root, palace_id, index_ids));
+    }
+
+    /// Drop a session's cached derivation.
+    ///
+    /// Why: the cache is keyed by [`ManagedSessionId`] and nothing else would
+    /// ever remove a key, so without this it grows with the number of sessions
+    /// the daemon has ever served — a leak measured in historical sessions,
+    /// not live ones. Same shape as [`super::slots::SlotRegistry::release`]:
+    /// an in-memory-only map whose one removal point is the moment the record
+    /// behind the key stops being something the map can be asked about.
+    /// What: removes `id`'s entry. An id the cache never held is a no-op —
+    /// most sessions never reach a residency poll, so a miss is the norm.
+    /// Called from the terminal transitions (`delete_record`, both
+    /// decommission paths); a `Stopped` session keeps its entry because a
+    /// resume re-enters the set at the same root.
+    /// Test: `residency_cache_evict_drops_the_entry` below;
+    /// `forced_delete_evicts_the_residency_cache_entry` in
+    /// `daemon::managed_routes::residency`'s route tests covers the
+    /// production call site.
+    pub async fn residency_cache_evict(&self, id: &ManagedSessionId) {
+        self.residency_cache.write().await.remove(id);
     }
 }
 
@@ -124,5 +164,23 @@ mod tests {
         // — the stale entry must not be served.
         let other_root = PathBuf::from("/repo/other-checkout");
         assert_eq!(mgr.residency_cache_lookup(&id, &other_root).await, None);
+    }
+
+    #[tokio::test]
+    async fn residency_cache_evict_drops_the_entry() {
+        let dir = crate::test_support::hermetic_temp_dir();
+        let (mgr, _fake) = make_manager(&dir).await;
+        let id = ManagedSessionId::new();
+        let root = PathBuf::from("/repo/evict-me");
+
+        mgr.residency_cache_store(id, root.clone(), Some("palace-1".to_string()), Vec::new())
+            .await;
+        assert!(mgr.residency_cache_lookup(&id, &root).await.is_some());
+
+        mgr.residency_cache_evict(&id).await;
+        assert_eq!(mgr.residency_cache_lookup(&id, &root).await, None);
+
+        // Evicting an id the cache never held is a no-op, not a panic.
+        mgr.residency_cache_evict(&ManagedSessionId::new()).await;
     }
 }

--- a/crates/trusty-mpm/src/session_manager/residency_state.rs
+++ b/crates/trusty-mpm/src/session_manager/residency_state.rs
@@ -1,0 +1,128 @@
+//! Residency-generation counter and per-session derivation cache for
+//! [`SessionManager`] (#7087 slice 1b).
+//!
+//! Why: `mpm.residency.active` publishes
+//! [`trusty_common::residency::ActiveProjectSet::generation`] so a future
+//! consumer can skip redundant pin/evict work on a set it has already applied,
+//! and must not re-run `resolve_palace_slug`/`derive_project_index_id` — both
+//! filesystem- (the second, `git`-) touching — on every poll of an
+//! otherwise-unchanged session. Both concerns are the same shape as
+//! `slots.rs`'s in-memory-only registry: state that lives for the daemon
+//! process, is never persisted, and is owned by [`SessionManager`] so every
+//! route reads the same instance instead of each deriving its own. Extracted
+//! to its own file (rather than added to `manager.rs`) to keep that file under
+//! its 500-SLOC production cap.
+//! What: [`SessionManager::bump_residency_generation`] /
+//! [`SessionManager::residency_generation`] wrap the atomic counter;
+//! [`SessionManager::residency_cache_lookup`] /
+//! [`SessionManager::residency_cache_store`] wrap the per-session
+//! `(root, palace_id, index_ids)` cache, keyed by [`ManagedSessionId`] and
+//! invalidated by a root mismatch (the session's `workspace_path`/`cwd`
+//! changed since the cached entry was written).
+//! Test: `residency_generation_starts_at_zero_and_bumps`,
+//! `residency_cache_hits_on_matching_root_and_misses_on_change` below;
+//! generation bumps at the four call sites are covered by
+//! `residency_generation_bumps_across_create_and_stop` and
+//! `daemon::managed_routes::residency`'s route tests.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
+
+use super::manager::SessionManager;
+use super::record::ManagedSessionId;
+
+impl SessionManager {
+    /// Bump the residency generation and return the NEW value.
+    ///
+    /// Called at every site that changes which sessions are active: `create`,
+    /// `stop`/`stop_with_cause`, `adopt_existing`, and both decommission paths
+    /// (record-only and full teardown). Never called by `resume`/
+    /// `mark_reactivated` — neither changes the active SET, only whether an
+    /// already-active-or-not session's runtime is running.
+    pub fn bump_residency_generation(&self) -> u64 {
+        self.residency_generation.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Read the current residency generation without bumping it.
+    pub fn residency_generation(&self) -> u64 {
+        self.residency_generation.load(Ordering::SeqCst)
+    }
+
+    /// Look up a session's cached `(palace_id, index_ids)` derivation.
+    ///
+    /// `None` on a cache miss OR when the cached entry's root no longer
+    /// matches `root` (the session's `workspace_path`/`cwd` changed since the
+    /// entry was written) — both read as "derive it fresh."
+    pub async fn residency_cache_lookup(
+        &self,
+        id: &ManagedSessionId,
+        root: &Path,
+    ) -> Option<(Option<String>, Vec<String>)> {
+        let cache = self.residency_cache.read().await;
+        cache
+            .get(id)
+            .filter(|(cached_root, _, _)| cached_root == root)
+            .map(|(_, palace_id, index_ids)| (palace_id.clone(), index_ids.clone()))
+    }
+
+    /// Store a session's derivation, keyed by its id.
+    pub async fn residency_cache_store(
+        &self,
+        id: ManagedSessionId,
+        root: PathBuf,
+        palace_id: Option<String>,
+        index_ids: Vec<String>,
+    ) {
+        self.residency_cache
+            .write()
+            .await
+            .insert(id, (root, palace_id, index_ids));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::super::tests::make_manager;
+    use super::ManagedSessionId;
+
+    #[tokio::test]
+    async fn residency_generation_starts_at_zero_and_bumps() {
+        let dir = crate::test_support::hermetic_temp_dir();
+        let (mgr, _fake) = make_manager(&dir).await;
+
+        assert_eq!(mgr.residency_generation(), 0);
+        assert_eq!(mgr.bump_residency_generation(), 1);
+        assert_eq!(mgr.bump_residency_generation(), 2);
+        assert_eq!(mgr.residency_generation(), 2);
+    }
+
+    #[tokio::test]
+    async fn residency_cache_hits_on_matching_root_and_misses_on_change() {
+        let dir = crate::test_support::hermetic_temp_dir();
+        let (mgr, _fake) = make_manager(&dir).await;
+        let id = ManagedSessionId::new();
+        let root = PathBuf::from("/repo/checkout");
+
+        assert_eq!(mgr.residency_cache_lookup(&id, &root).await, None);
+
+        mgr.residency_cache_store(
+            id,
+            root.clone(),
+            Some("palace-1".to_string()),
+            vec!["idx-1".to_string()],
+        )
+        .await;
+
+        assert_eq!(
+            mgr.residency_cache_lookup(&id, &root).await,
+            Some((Some("palace-1".to_string()), vec!["idx-1".to_string()]))
+        );
+
+        // The root changed (e.g. the session's workspace_path was reassigned)
+        // — the stale entry must not be served.
+        let other_root = PathBuf::from("/repo/other-checkout");
+        assert_eq!(mgr.residency_cache_lookup(&id, &other_root).await, None);
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/residency_state.rs
+++ b/crates/trusty-mpm/src/session_manager/residency_state.rs
@@ -30,9 +30,12 @@
 //! `generation_increments_across_resume`,
 //! `generation_increments_across_mark_reactivated`,
 //! `generation_increments_across_mark_runtime_exited_stopped`,
+//! `generation_increments_across_mark_errored`,
 //! `generation_increments_across_forced_delete` and
 //! `forced_delete_evicts_the_residency_cache_entry` in
-//! `daemon::managed_routes::residency`'s route tests.
+//! `daemon::managed_routes::residency`'s route tests, and — for the boot
+//! sweep — `reconcile_tombstones_an_adopted_reserved_record_whose_tmux_is_gone`
+//! in `naming_tests.rs`.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
@@ -50,10 +53,21 @@ impl SessionManager {
     /// must be able to notice. Entering: `create`, `adopt_existing`, `resume`
     /// (`Stopped`/`Errored -> Active`) and `mark_reactivated`
     /// (`Stopped`/`Decommissioned -> Active`). Leaving: `stop`/
-    /// `stop_with_cause`, `mark_runtime_exited_stopped`, both decommission
-    /// paths (record-only and full teardown), `delete_record` (`--force`
-    /// reaches it straight from `Active`/`Provisioning`), and
+    /// `stop_with_cause`, `mark_runtime_exited_stopped`, `mark_errored`, both
+    /// decommission paths (record-only and full teardown), `delete_record`
+    /// (`--force` reaches it straight from `Active`/`Provisioning`), and
     /// `reconcile_on_boot`'s leaked-test-adoption sweep (#6116).
+    ///
+    /// `set_workspace` is deliberately absent: every caller passes `Active`
+    /// onto a `Provisioning` record, which does not cross the boundary. See
+    /// its doc for what a future caller owes.
+    ///
+    /// `reconcile_on_boot`'s live/gone arms are deliberately absent too. They
+    /// run once, before any consumer has pulled from this process, and the
+    /// counter starts at zero on every daemon start — so there is no earlier
+    /// generation for that pass to invalidate. The sweep above bumps because
+    /// it also evicts, and the two belong together. A transition added to the
+    /// boot loop that a LATER pull could disagree with does owe a bump.
     ///
     /// The generation is advisory-monotonic, never a set hash: bumping when
     /// the set happens to be unchanged only costs a consumer one redundant

--- a/crates/trusty-mpm/src/session_manager/setters.rs
+++ b/crates/trusty-mpm/src/session_manager/setters.rs
@@ -37,7 +37,9 @@ impl SessionManager {
     /// `Provisioning`; marking it errored surfaces the failure to `tm session ls`.
     /// What: transitions the record to `ManagedSessionState::Errored` and appends
     /// the error message to the task field for observability, then persists.
-    /// Test: covered by handler_spawn_wires_provision_and_spawn error path.
+    /// Test: covered by handler_spawn_wires_provision_and_spawn error path;
+    /// the #7087 residency bump by `generation_increments_across_mark_errored`
+    /// in `daemon::managed_routes::residency`'s route tests.
     pub async fn mark_errored(
         &self,
         id: &ManagedSessionId,
@@ -47,6 +49,10 @@ impl SessionManager {
         record.state = ManagedSessionState::Errored;
         record.task = format!("{} [error: {}]", record.task, error_msg);
         self.store.write().await.upsert(record).await?;
+        // #7087: `Errored` is not `Active`/`Provisioning`, so a failed spawn,
+        // a failed resume or a parked auto-resume drops the session out of the
+        // set `mpm.residency.active` serves.
+        self.bump_residency_generation();
         Ok(())
     }
 
@@ -56,6 +62,15 @@ impl SessionManager {
     /// must be persisted so `tm session ls` shows it and `activity` can infer
     /// context.
     /// What: looks up the record, sets `workspace_path` and `state`, and persists.
+    ///
+    /// #7087: `new_state` is arbitrary, and this method does NOT bump the
+    /// residency generation. Every caller today passes `Active` onto a
+    /// `Provisioning` record, which stays inside the set
+    /// `mpm.residency.active` serves, so no bump is owed. A caller that passes
+    /// a state OUTSIDE `Active`/`Provisioning` crosses that boundary and must
+    /// call [`SessionManager::bump_residency_generation`] itself — or route
+    /// through the verb that owns that transition (`stop`, `mark_errored`,
+    /// `decommission`, `delete_record`), which is the better answer.
     /// Test: covered by handler_spawn_wires_provision_and_spawn.
     pub async fn set_workspace(
         &self,

--- a/crates/trusty-mpm/src/session_manager/setters.rs
+++ b/crates/trusty-mpm/src/session_manager/setters.rs
@@ -1,0 +1,218 @@
+//! Post-creation field setters for [`SessionManager`] records (#7087).
+//!
+//! Why: extracted from `manager.rs` when residency-generation tracking (#7087
+//! slice 1b) needed room under that file's 500-SLOC production cap. This
+//! follows the precedent `stop.rs` / `create.rs` / `reactivate.rs` /
+//! `reconcile.rs` already set for this file: a cohesive group of methods moves
+//! to its own sibling module rather than the cap being gamed or raised. The
+//! group is cohesive because every method here is the same shape — a plain
+//! read-modify-write against one existing record, called AFTER the session
+//! already exists (`create`/`stop`/`resume` cover the state-machine
+//! transitions; these cover incidental fields set alongside or after them).
+//! What: [`SessionManager::mark_errored`], [`SessionManager::set_workspace`],
+//! [`SessionManager::set_pending_decision`],
+//! [`SessionManager::set_source_id`], [`SessionManager::set_deliverable_id`],
+//! and [`SessionManager::clear_pending_decision`]. No behavior change — a pure
+//! relocation.
+//! Test: covered by handler_spawn_wires_provision_and_spawn (`mark_errored`,
+//! `set_workspace`), `front_gate_escalation_sets_pending_decision` and
+//! `front_gate_answer_unblocks_spawn` in tests/session_manager_mvp.rs
+//! (`set_pending_decision`, `clear_pending_decision`),
+//! `set_source_id_succeeds_first_try` /
+//! `set_source_id_returns_err_after_retries_for_missing_session` in
+//! `tests.rs` (`set_source_id`), `set_deliverable_id_persists` /
+//! `set_deliverable_id_missing_session_errors` in
+//! `set_deliverable_id_tests.rs` (`set_deliverable_id`).
+
+use chrono::Utc;
+use tracing::{error, warn};
+
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState};
+
+impl SessionManager {
+    /// Mark a session as errored with a message.
+    ///
+    /// Why: when provisioning or spawning fails the session must not remain in
+    /// `Provisioning`; marking it errored surfaces the failure to `tm session ls`.
+    /// What: transitions the record to `ManagedSessionState::Errored` and appends
+    /// the error message to the task field for observability, then persists.
+    /// Test: covered by handler_spawn_wires_provision_and_spawn error path.
+    pub async fn mark_errored(
+        &self,
+        id: &ManagedSessionId,
+        error_msg: &str,
+    ) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.state = ManagedSessionState::Errored;
+        record.task = format!("{} [error: {}]", record.task, error_msg);
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
+
+    /// Update a session's workspace path and transition to a new state.
+    ///
+    /// Why: after the workspace path is resolved
+    /// must be persisted so `tm session ls` shows it and `activity` can infer
+    /// context.
+    /// What: looks up the record, sets `workspace_path` and `state`, and persists.
+    /// Test: covered by handler_spawn_wires_provision_and_spawn.
+    pub async fn set_workspace(
+        &self,
+        id: &ManagedSessionId,
+        workspace_path: std::path::PathBuf,
+        new_state: ManagedSessionState,
+    ) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.workspace_path = Some(workspace_path);
+        record.state = new_state;
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
+
+    /// Record a pending decision (an escalation) on a session, awaiting a human.
+    ///
+    /// Why: the intent-conformance FRONT gate (#1360) escalates *before* the
+    /// runtime is spawned. It must surface the divergence reason + the conformant
+    /// default through the SAME channel the harness uses (`pending_decision` /
+    /// `proposed_default`), so it appears in `GET …/activity`, MCP
+    /// `session_status`, the supervisor, and the `tm` CLI with zero new UI. The
+    /// session is left NOT `Active` (the runtime never started) so it reads as
+    /// awaiting approval until a human resolves it via `POST …/answer`.
+    /// What: looks up the record, sets `pending_decision`/`proposed_default`,
+    /// leaves the lifecycle state untouched (it stays `Provisioning` — the
+    /// runtime was withheld), and persists. No tmux input is sent (unlike
+    /// `answer_decision`): the pane has no running harness to receive it yet.
+    /// Test: `front_gate_escalation_sets_pending_decision` in
+    /// tests/session_manager_mvp.rs.
+    pub async fn set_pending_decision(
+        &self,
+        id: &ManagedSessionId,
+        decision: &str,
+        proposed_default: Option<&str>,
+    ) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.pending_decision = Some(decision.to_string());
+        record.proposed_default = proposed_default.map(str::to_string);
+        record.last_activity_at = Some(Utc::now());
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
+
+    /// Record a source project identity on a session, with a bounded retry
+    /// (#2157 item 5, the #2154 remedy).
+    ///
+    /// Why: the in-project spawn path (#1706) associates a session with a
+    /// specific `owner/repo` so callers can later filter sessions by project
+    /// and reconnect instead of spawning duplicates. Setting it post-creation
+    /// (rather than via `create_with_id`) keeps the manager's SINGLE generic
+    /// create path clean of in-project concerns. Previously a single transient
+    /// `get`/`upsert` failure here was `warn!`-and-continue at the call site —
+    /// leaving `source_id: None` on the record PERMANENTLY, which makes the
+    /// session invisible to every `?source_id=` filtered listing (the guided
+    /// picker, `tm session ls --project`) forever, since nothing else ever
+    /// retries the write.
+    /// What: retries the read-modify-write up to `MAX_SET_SOURCE_ID_ATTEMPTS`
+    /// times with a short linear backoff between attempts, returning `Ok(())`
+    /// on the first success. If every attempt fails, logs a `tracing::error!`
+    /// (loud, not `warn!`) carrying `id` and `source_id` so a future
+    /// reconcile/doctor pass can self-heal a `source_id: None` record from its
+    /// `repo_url`/`workspace_path`, then returns the last error.
+    /// Test: `set_source_id_succeeds_first_try`,
+    /// `set_source_id_returns_err_after_retries_for_missing_session` in
+    /// `tests.rs`.
+    pub async fn set_source_id(
+        &self,
+        id: &ManagedSessionId,
+        source_id: &str,
+    ) -> Result<(), ManagedError> {
+        const MAX_SET_SOURCE_ID_ATTEMPTS: u8 = 3;
+        let mut last_err: Option<ManagedError> = None;
+        for attempt in 1..=MAX_SET_SOURCE_ID_ATTEMPTS {
+            let result: Result<(), ManagedError> = async {
+                let mut record = self.get(id).await?;
+                record.source_id = Some(source_id.to_string());
+                self.store.write().await.upsert(record).await?;
+                Ok(())
+            }
+            .await;
+            match result {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    warn!(
+                        id = %id,
+                        attempt,
+                        max_attempts = MAX_SET_SOURCE_ID_ATTEMPTS,
+                        "set_source_id: attempt failed: {e}"
+                    );
+                    last_err = Some(e);
+                    if attempt < MAX_SET_SOURCE_ID_ATTEMPTS {
+                        tokio::time::sleep(std::time::Duration::from_millis(
+                            50 * u64::from(attempt),
+                        ))
+                        .await;
+                    }
+                }
+            }
+        }
+        error!(
+            id = %id,
+            source_id = %source_id,
+            attempts = MAX_SET_SOURCE_ID_ATTEMPTS,
+            "set_source_id: exhausted all attempts — session will be invisible to \
+             project-filtered listing (source_id: None) until a reconcile/doctor pass \
+             repairs it from repo_url/workspace_path"
+        );
+        Err(last_err.unwrap_or_else(|| ManagedError::SessionNotFound(id.to_string())))
+    }
+
+    /// Record which Deliverable a session is working on (DOC-35 §10.6, #2379).
+    ///
+    /// Why: `tm sessions new --deliverable <id>` binds a fresh session to a
+    /// Deliverable AFTER the session record already exists (mirroring
+    /// [`Self::set_source_id`]'s post-creation setter shape, which keeps
+    /// [`Self::create_with_id`]'s already-long parameter list from growing
+    /// further). The caller (the daemon spawn path,
+    /// `daemon::managed_routes::lifecycle`) validates the Deliverable exists
+    /// and belongs to the session's project via `DeliverableManager` BEFORE
+    /// calling this — this setter trusts that validation and does no lookup of
+    /// its own. Per §11, this is a PURE POINTER write: it never mutates the
+    /// Deliverable record itself (no auto-transition of its status).
+    /// What: a plain read-modify-write — look up the record, set
+    /// `deliverable_id`, persist. No retry loop (unlike `set_source_id`):
+    /// losing this link on a rare transient store error is a stale pointer,
+    /// not a session made invisible to a whole filtered listing, so the
+    /// simpler shape matches `set_workspace`/`set_pending_decision`.
+    /// Test: `set_deliverable_id_persists`,
+    /// `set_deliverable_id_missing_session_errors` in `set_deliverable_id_tests.rs`.
+    pub async fn set_deliverable_id(
+        &self,
+        id: &ManagedSessionId,
+        deliverable_id: crate::deliverable::DeliverableId,
+    ) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.deliverable_id = Some(deliverable_id);
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
+
+    /// Clear a pending decision WITHOUT injecting any text into the pane.
+    ///
+    /// Why: a FRONT-gate (#1360) escalation is resolved *before* a harness exists
+    /// — the session is still `Provisioning` with no runtime in the pane. Unlike
+    /// [`answer_decision`](Self::answer_decision) (which sends the answer to a
+    /// LIVE harness), the FRONT-gate answer path must clear the decision and then
+    /// LAUNCH the withheld runtime; sending the answer to a bare shell would be
+    /// meaningless. This method does the clear half only.
+    /// What: looks up the record, clears `pending_decision`/`proposed_default`,
+    /// updates `last_activity_at`, and persists. No tmux I/O.
+    /// Test: `front_gate_answer_unblocks_spawn` in tests/session_manager_mvp.rs.
+    pub async fn clear_pending_decision(&self, id: &ManagedSessionId) -> Result<(), ManagedError> {
+        let mut record = self.get(id).await?;
+        record.pending_decision = None;
+        record.proposed_default = None;
+        record.last_activity_at = Some(Utc::now());
+        self.store.write().await.upsert(record).await?;
+        Ok(())
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/stop.rs
+++ b/crates/trusty-mpm/src/session_manager/stop.rs
@@ -100,6 +100,8 @@ impl SessionManager {
         // undo one of those.
         record.stop_cause = Some(cause);
         self.store.write().await.upsert(record.clone()).await?;
+        // #7087: a stopped session leaves the active-project set.
+        self.bump_residency_generation();
         info!(id = %id, name = %record.tmux_name, cause = ?cause, "managed session stopped (workspace intact)");
         Ok(record)
     }


### PR DESCRIPTION
## Summary

Slice 1b of #7087. trusty-mpm becomes the producer for the wire contract slice 1a defined (`trusty_common::residency::ActiveProjectSet`, `trusty_common::mpm_rpc::{METHOD_RESIDENCY_ACTIVE, fetch_active_projects_at}`).

- `mpm.residency.active` (socket-only, `daemon/managed_routes/residency.rs`) lists every managed session in state `Active`/`Provisioning` whose `tmux_name` a live `tmux list-sessions` still confirms, groups the survivors by project root (`workspace_path` else `cwd`), and derives each group's palace id / trusty-search index id(s) once (worktree roots get two: the worktree's own plus its base checkout's).
- Fail-closed: a `tmux list_sessions` error is logged and every persisted `Active`/`Provisioning` record is served, rather than the set collapsing to empty (#6836).
- `SessionManager` gains a monotonic `residency_generation` (`AtomicU64`), bumped at `create`, `stop`/`stop_with_cause`, `adopt_existing`, and both decommission paths — never `resume`/`reactivate`, which change readiness but not set membership — plus a per-session `(root, palace_id, index_ids)` derivation cache so an unchanged root never re-touches the filesystem/`git` on a later poll.
- `session_manager/manager.rs` was at the 500-SLOC cap; the post-creation field setters (`mark_errored`, `set_workspace`, `set_pending_decision`, `set_source_id`, `set_deliverable_id`, `clear_pending_decision`) move to a new sibling `setters.rs` (separate commit), following the `stop.rs`/`create.rs` precedent.

## Test plan (rung 6 on rung 3)

- [x] `cargo fmt --check -p trusty-mpm`
- [x] `cargo check -p trusty-mpm --all-targets`
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- [x] `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — every target ran, all passed
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] `bash scripts/check_changelog_fragment.sh --staged`
- [x] `bash scripts/check_rustdoc_links.sh` — 0 broken
- [x] `bash scripts/check_capabilities.sh` — up to date (no CLI/doctor text changed)
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling

New tests: 8 in `daemon::managed_routes::residency::residency_tests` (persisted+tmux-live filter, root grouping, worktree → two index_ids, tmux-failure fail-closed, generation bump across create/stop) and `session_manager::residency_state::tests`, plus one real-socket round trip (`daemon::rpc::managed::managed_tests::residency_active_round_trips_over_the_real_socket`) and the `mpm.residency.active` pin in `every_scoped_route_has_a_method`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0151qNBjHoPkqTebUtKjPJ8V