### PR TITLE
chore(trusty-audit): bump to 0.14.5 for reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11488,7 +11488,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-audit"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/trusty-audit/Cargo.toml
+++ b/crates/trusty-audit/Cargo.toml
@@ -26,7 +26,7 @@ name = "trusty-audit"
 # changes `src/**`. The change is confined to the body of the private
 # `grounding::osv::absorb`, which now honours the producer's `resolved` flag;
 # no public item is added, removed, or reshaped.
-version = "0.14.4"
+version = "0.14.5"
 description = "Auditor client — installs its pinned audit tooling and drives an audit engagement on the recipient's own codebases."
 readme = "README.md"
 homepage = "https://github.com/bobmatnyc/trusty-tools"


### PR DESCRIPTION
Rung 1 (version-only). Bumps `crates/trusty-audit` from 0.14.4 to 0.14.5 for a local reinstall so `--version` identifies the build.

Refs #7133
Refs #7134
Refs #7135
Refs #6144

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01FyUbvauNb9njeUPToo12mJ