### PR TITLE
fix(trusty-audit): redact home path in audit gap text and manifest

### DIFF
--- a/crates/trusty-audit/changelog.d/7137-redact-home-path-in-gaps.md
+++ b/crates/trusty-audit/changelog.d/7137-redact-home-path-in-gaps.md
@@ -1,0 +1,12 @@
+Fixed
+
+- The operator's home-directory path no longer reaches a client-facing member
+  of an engagement package. `package.toml`'s per-repository `gaps`, the same
+  gaps in `reports/index.md`, and each packaged `manifest.toml`'s
+  `[[repositories]] path` now render `~` where the absolute
+  `/Users/<operator>/...` prefix used to appear, so the recipient no longer
+  learns the auditing operator's local account name once per repository. The
+  substitution lives in one new module, `redact`, whose `home_paths`,
+  `home_paths_under`, `home_paths_in` and `packaged_manifest` are the crate's
+  only home-path redaction; nothing else about a gap's text changed
+  (issue #7137).

--- a/crates/trusty-audit/src/index_report.rs
+++ b/crates/trusty-audit/src/index_report.rs
@@ -267,12 +267,13 @@ pub struct IndexEntry {
     /// same promotion applied to the whole list rather than one marker.
     /// What: a straight copy of the unit's recorded gaps, in the order they were
     /// recorded. Rendered by this module's own `gaps_section` as one bullet list
-    /// per unit that has any, and silent for a unit that has none. This crate
-    /// does not reword
-    /// or redact a gap's text here — it renders exactly the string the collector
-    /// wrote. // See #7137
+    /// per unit that has any, and silent for a unit that has none. The stored
+    /// value is a straight copy — nothing is reworded here. The one change
+    /// `gaps_section` makes on the way out is [`crate::redact::home_paths`],
+    /// which collapses the operator's home directory to `~` (#7137).
     /// Test: `index_tests::the_gaps_section_lists_only_units_that_recorded_one`,
-    /// `index_tests::a_clean_run_renders_no_gaps_section`.
+    /// `index_tests::a_clean_run_renders_no_gaps_section`,
+    /// `index_tests::a_gap_naming_the_operators_home_renders_it_redacted`.
     pub gaps: Vec<String>,
 }
 
@@ -630,11 +631,12 @@ fn reports(report: &IndexReport, dir: &Path, out: &mut String) {
 /// section is the same treatment applied to every OTHER collector's gaps.
 /// What: silent — no heading, no line — when no unit recorded a gap, so a clean
 /// run's index states nothing extra. Otherwise one `## Gaps` section, a summary
-/// line, and one bullet list per unit that recorded at least one, each gap
-/// rendered verbatim (never reworded, never redacted — see the wording note on
-/// [`IndexEntry::gaps`], // See #7137).
+/// line, and one bullet list per unit that recorded at least one, each gap in
+/// the collector's own words with only the operator's home directory collapsed
+/// to `~` by [`crate::redact::home_paths`] (#7137).
 /// Test: `index_tests::the_gaps_section_lists_only_units_that_recorded_one`,
-/// `index_tests::a_clean_run_renders_no_gaps_section`.
+/// `index_tests::a_clean_run_renders_no_gaps_section`,
+/// `index_tests::a_gap_naming_the_operators_home_renders_it_redacted`.
 fn gaps_section(report: &IndexReport, out: &mut String) {
     let with_gaps: Vec<&IndexEntry> = report
         .entries
@@ -655,7 +657,10 @@ fn gaps_section(report: &IndexReport, out: &mut String) {
     for entry in with_gaps {
         out.push_str(&format!("- **{}**\n", entry.name));
         for gap in &entry.gaps {
-            out.push_str(&format!("  - {gap}\n"));
+            // #7137: the gap's own words, with the operator's home directory
+            // collapsed to `~` — the one thing in a collector's path that names
+            // the machine rather than the finding.
+            out.push_str(&format!("  - {}\n", crate::redact::home_paths(gap)));
         }
     }
     out.push('\n');
@@ -1232,6 +1237,47 @@ mod index_tests {
         assert!(
             !text.contains("acme/web**"),
             "the clean repository picked up a Gaps bullet of its own:\n{text}"
+        );
+    }
+
+    /// Regression for #7137: the operator's home path inside a gap line reaches
+    /// the client-facing `reports/index.md` verbatim.
+    ///
+    /// Why this is worth a test: every gap a collector writes about this crate's
+    /// own working area names `<home>/.trusty-tools/trusty-audit/work/...`, and
+    /// the recipient of the package has no use for that path beyond learning the
+    /// operator's local account name.
+    /// What: a gap line built from the running home directory — read, never
+    /// written, so no other test in this binary is disturbed — and the assertion
+    /// that the rendered index states `~` and never the home prefix.
+    ///
+    /// Fails before the fix: `gaps_section` rendered each gap verbatim, so the
+    /// home prefix appeared in the output.
+    /// Test: this is the test.
+    #[test]
+    fn a_gap_naming_the_operators_home_renders_it_redacted() {
+        let Some(home) = dirs::home_dir().and_then(|h| h.to_str().map(str::to_owned)) else {
+            return;
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("01-acme");
+        std::fs::create_dir_all(&dir).expect("create dir");
+
+        let mut degraded = entry("acme/api", dir);
+        degraded.gaps = vec![format!(
+            "secrets-scan: trusty-search could not index \
+             {home}/.trusty-tools/trusty-audit/work/repos/acme-api"
+        )];
+
+        let text = render(&report(Producer::Package, vec![degraded]), tmp.path());
+
+        assert!(
+            !text.contains(&home),
+            "the index leaks the operator's home path:\n{text}"
+        );
+        assert!(
+            text.contains("~/.trusty-tools/trusty-audit/work/repos/acme-api"),
+            "the redacted path did not render:\n{text}"
         );
     }
 

--- a/crates/trusty-audit/src/lib.rs
+++ b/crates/trusty-audit/src/lib.rs
@@ -114,6 +114,9 @@ pub mod package;
 // #5823: the seam a front end renders live progress through, and the pump that
 // reads a spawned child's stages back out of its output.
 pub mod progress;
+// #7137: the one place this crate collapses the operator's home path out of
+// text a client receives.
+pub mod redact;
 pub mod registry;
 mod relay;
 // #6080: the render step of the sweep, run on its own by whoever RECEIVED the

--- a/crates/trusty-audit/src/package.rs
+++ b/crates/trusty-audit/src/package.rs
@@ -861,17 +861,7 @@ fn fill_archive(
         (EXCERPTS_ENTRY, generated.excerpts),
     ];
     for (entry, text) in members.into_iter().filter_map(|(e, t)| t.map(|t| (e, t))) {
-        // #6245: this member quotes the reason strings recorded for each failed
-        // repository, and a reason can carry text a child produced. Generated or
-        // not, it is scanned before it is written — the same bar every collected
-        // member meets.
-        credential_scan::refuse_if_credential(&text, entry, config, github_token)?;
-        start(&mut zip, entry, text.len() as u64, temporary)?;
-        zip.write_all(text.as_bytes())
-            .map_err(|source| AuditError::Package {
-                path: temporary.to_path_buf(),
-                source,
-            })?;
+        write_text_member(&mut zip, entry, &text, config, github_token, temporary)?;
         manifest.push(signing::ManifestFile {
             entry: entry.to_owned(),
             sha256: hex_digest(sha2::Sha256::digest(text.as_bytes())),
@@ -885,6 +875,23 @@ fn fill_archive(
     }
 
     for (entry, source) in collected {
+        // #7137: a manifest names the operator's own checkout path, so the
+        // recipient's copy is rewritten with `~` in place of the home
+        // directory rather than streamed through byte for byte.
+        if let Some(text) = crate::redact::packaged_manifest(&entry, &source)? {
+            write_text_member(&mut zip, &entry, &text, config, github_token, temporary)?;
+            manifest.push(signing::ManifestFile {
+                entry: entry.clone(),
+                sha256: hex_digest(sha2::Sha256::digest(text.as_bytes())),
+                bytes: text.len() as u64,
+            });
+            files.push(PackagedFile {
+                entry,
+                source: Some(source),
+                bytes: text.len() as u64,
+            });
+            continue;
+        }
         // #5481: hashed in the same pass that scans and copies, so the digest
         // is over the bytes that actually reached the archive.
         let mut digest = sha2::Sha256::new();
@@ -938,6 +945,34 @@ fn fill_archive(
         source: std::io::Error::other(e),
     })?;
     Ok(files)
+}
+
+/// Write one text member into the archive, refusing it if it carries a
+/// credential.
+///
+/// The generated members and the redacted `manifest.toml` (#7137) both arrive
+/// as text this process holds, so both go through one writer — the scan cannot
+/// then apply to one and not the other. Bytes another program wrote still take
+/// [`credential_scan::copy_member`], which streams rather than buffering.
+/// Test: `package_tests::no_packaged_member_names_the_operators_home`.
+fn write_text_member(
+    zip: &mut Archive,
+    entry: &str,
+    text: &str,
+    config: &EngagementConfig,
+    github_token: Option<&str>,
+    temporary: &Path,
+) -> Result<(), AuditError> {
+    // #6245: a generated member quotes reason strings a child produced.
+    // Generated or not, it is scanned before it is written — the same bar every
+    // collected member meets.
+    credential_scan::refuse_if_credential(text, entry, config, github_token)?;
+    start(zip, entry, text.len() as u64, temporary)?;
+    zip.write_all(text.as_bytes())
+        .map_err(|source| AuditError::Package {
+            path: temporary.to_path_buf(),
+            source,
+        })
 }
 
 /// A SHA-256 digest as lower-case hex — the form the manifest records.
@@ -1417,6 +1452,64 @@ trusty-review = "0.15.1"
         }
         assert!(package.total_bytes > 0);
         assert!(package.excluded.is_empty());
+    }
+
+    /// 🔴 #7137 closure condition 1, over the REAL assembler: no member of a
+    /// finished package names the operator's home directory.
+    ///
+    /// Why this is worth a test: the leak was reproduced across three members at
+    /// once — `package.toml`'s per-repository `gaps`, the same gaps in
+    /// `reports/index.md`, and each `manifest.toml`'s `[[repositories]] path` —
+    /// so a test that reads only one of them would pass while the package still
+    /// shipped the operator's account name 59 times.
+    /// What: a repository whose recorded gap and whose manifest path both sit
+    /// under the running home directory (read, never written), assembled by
+    /// `assemble`, then each of the three members checked for the prefix and for
+    /// the `~` that replaced it.
+    ///
+    /// Fails before the fix: all three members carry the home prefix verbatim.
+    /// Test: this is the test.
+    #[test]
+    fn no_packaged_member_names_the_operators_home() {
+        let Some(home) = dirs::home_dir().and_then(|h| h.to_str().map(str::to_owned)) else {
+            return;
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        install_record(&work);
+        let mut run = audited(&work, "00-acme-api", "acme-api");
+        let checkout = format!("{home}/.trusty-tools/trusty-audit/work/repos/acme-api");
+        std::fs::write(
+            run.output.join("manifest.toml"),
+            format!(
+                "[report]\ntitle = \"Acme\"\n\n[[repositories]]\nname = \"acme\"\n\
+                 path = \"{checkout}\"\n"
+            ),
+        )
+        .expect("write manifest");
+        run.gaps = vec![format!(
+            "secrets-scan: trusty-search could not index {checkout}"
+        )];
+        let report = RunReport::of(vec![run]);
+        let destination = default_destination(&work);
+
+        assemble(&work, &config(), &report, &[], &[], &destination, None).expect("assembles");
+
+        for entry in [
+            METADATA_ENTRY,
+            INDEX_ENTRY,
+            "reports/00-acme-api/manifest.toml",
+        ] {
+            let text = read_entry(&destination, entry);
+            assert!(
+                !text.contains(&home),
+                "{entry} leaks the operator's home path:\n{text}"
+            );
+            assert!(
+                text.contains("~/.trusty-tools/trusty-audit/work/repos/acme-api"),
+                "{entry} did not carry the redacted path:\n{text}"
+            );
+        }
     }
 
     /// The digest document, parsed out of the finished zip.

--- a/crates/trusty-audit/src/package/generated.rs
+++ b/crates/trusty-audit/src/package/generated.rs
@@ -382,7 +382,11 @@ pub(super) fn render_metadata(
                 crate::run::RepoResult::Failed { reason } => Some(reason.clone()),
                 crate::run::RepoResult::Succeeded => None,
             },
-            gaps: run.gaps.clone(),
+            // #7137: the recipient's copy of the gap list, with the operator's
+            // home directory collapsed to `~` — the same redaction
+            // `crate::index_report` applies to the copy in `reports/index.md`,
+            // so the two members still cannot disagree.
+            gaps: crate::redact::home_paths_in(&run.gaps),
         })
         .collect();
     let metadata = PackageMetadata {

--- a/crates/trusty-audit/src/redact.rs
+++ b/crates/trusty-audit/src/redact.rs
@@ -1,0 +1,191 @@
+//! Collapsing the operator's home-directory path out of client-facing text
+//! (#7137).
+//!
+//! Why: every path this crate records about its own working area starts with
+//! the operator's home directory, and three client-facing members carried it
+//! verbatim — `package.toml`'s per-repository `gaps`, the same gaps in
+//! `reports/index.md`, and each `manifest.toml`'s `[[repositories]] path`. The
+//! recipient of an engagement package therefore learned the auditing operator's
+//! local account name and machine layout, repeated once per repository. The
+//! path is also worth nothing to them: it names a directory on a machine they
+//! do not have.
+//! What: [`home_paths`] replaces the home-directory prefix with `~`, the
+//! spelling every shell and every reader already resolves. It is a textual
+//! substitution over rendered output rather than a `Path` operation, because
+//! the values it has to reach are embedded in prose a collector wrote
+//! ("trusty-search could not index /Users/…/work/repos/acme") as often as they
+//! are standalone fields.
+//!
+//! This is the crate's ONE home-path redaction (the "common entry point" rule).
+//! Credential redaction is a different job with a different shape and lives in
+//! `trusty_common::credentials::redact`; nothing here masks a secret.
+//! Test: `redact_tests`.
+
+use std::path::Path;
+
+/// What a redacted home-directory prefix is rendered as.
+pub const HOME_PLACEHOLDER: &str = "~";
+
+/// `text` with every occurrence of this machine's home directory collapsed to
+/// [`HOME_PLACEHOLDER`].
+///
+/// Why: the client-facing render sites (`crate::index_report::render`,
+/// `crate::package::generated::render_metadata`, and the packaged
+/// `manifest.toml`) each hold text assembled long after the home directory was
+/// read, so they ask for it here rather than threading it through.
+/// What: [`home_paths_under`] against `dirs::home_dir()`, and `text` unchanged
+/// on a machine that reports no home directory — there is then no prefix to
+/// match, and inventing one would rewrite unrelated text.
+/// Test: `redact_tests::the_running_home_is_collapsed`.
+pub fn home_paths(text: &str) -> String {
+    match dirs::home_dir() {
+        Some(home) => home_paths_under(text, &home),
+        None => text.to_owned(),
+    }
+}
+
+/// `text` with every occurrence of `home` collapsed to [`HOME_PLACEHOLDER`].
+///
+/// Why: the pure half of [`home_paths`], so a test states its own home value
+/// instead of reading the one the test process happens to run under — this
+/// crate's tests never write `HOME` (`crate::chain`'s note on the same point).
+/// What: a plain substring replacement of `home`'s string form with any
+/// trailing separator trimmed off first, so `/Users/ada/x` becomes `~/x`, a
+/// bare `/Users/ada` becomes `~`, and a `home` value that arrived with a
+/// trailing slash does not leave `~//x` behind. A `home` that is empty,
+/// or the filesystem root, is left alone: both match nearly every absolute path
+/// and would shred the text rather than redact it. Non-UTF-8 home paths are
+/// left alone for the same reason — there is no needle to search for.
+/// Test: `redact_tests::the_home_prefix_becomes_a_tilde`,
+/// `redact_tests::a_degenerate_home_is_left_alone`,
+/// `redact_tests::text_without_the_home_prefix_is_untouched`.
+pub fn home_paths_under(text: &str, home: &Path) -> String {
+    let Some(home) = home.to_str() else {
+        return text.to_owned();
+    };
+    if home.is_empty() || home == "/" || home == std::path::MAIN_SEPARATOR_STR {
+        return text.to_owned();
+    }
+    let trimmed = home.trim_end_matches(std::path::MAIN_SEPARATOR);
+    if trimmed.is_empty() {
+        return text.to_owned();
+    }
+    text.replace(trimmed, HOME_PLACEHOLDER)
+}
+
+/// Every string in `lines`, redacted by [`home_paths`].
+///
+/// A convenience for the two render sites that hold a `Vec<String>` of gap
+/// lines; it exists so neither of them spells the `map`/`collect` itself.
+/// Test: `redact_tests::a_gap_list_is_redacted_line_by_line`.
+pub fn home_paths_in(lines: &[String]) -> Vec<String> {
+    lines.iter().map(|line| home_paths(line)).collect()
+}
+
+/// The redacted text of a packaged `manifest.toml`, or `None` for any other
+/// member.
+///
+/// Why: `manifest.toml`'s `[[repositories]] path` is the third place the
+/// operator's home directory reached a recipient (#7137), and it is the only
+/// one that arrives as bytes another program wrote — `tga audit` records the
+/// absolute checkout it scanned. The path is meaningless on the recipient's
+/// machine either way, so the packaged copy states `~`.
+/// What: `Some(redacted)` when `entry` names a `manifest.toml` member, read
+/// whole because a manifest is a few kilobytes of TOML, never the hundreds of
+/// megabytes an extract database can run to. `None` for every other member and
+/// for a manifest that is not valid UTF-8 — both then take the streaming copy
+/// path unchanged.
+///
+/// # Errors
+///
+/// [`crate::error::AuditError::Package`] when the file cannot be read at all.
+/// Test: `crate::package::package_tests::no_packaged_member_names_the_operators_home`.
+pub fn packaged_manifest(
+    entry: &str,
+    source: &Path,
+) -> Result<Option<String>, crate::error::AuditError> {
+    if !entry.ends_with(crate::manifest::AuditManifest::FILE_NAME) {
+        return Ok(None);
+    }
+    match std::fs::read(source) {
+        Ok(bytes) => Ok(String::from_utf8(bytes).ok().map(|text| home_paths(&text))),
+        Err(source_error) => Err(crate::error::AuditError::Package {
+            path: source.to_path_buf(),
+            source: source_error,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod redact_tests {
+    use super::*;
+
+    /// The shape #7137 reported: an operator's home path inside collector prose.
+    ///
+    /// Fails before the fix: `home_paths_under` does not exist.
+    #[test]
+    fn the_home_prefix_becomes_a_tilde() {
+        let text = "trusty-search could not index \
+                    /Users/operator/.trusty-tools/trusty-audit/work/repos/acme-api";
+        let redacted = home_paths_under(text, Path::new("/Users/operator"));
+        assert_eq!(
+            redacted,
+            "trusty-search could not index ~/.trusty-tools/trusty-audit/work/repos/acme-api"
+        );
+        assert!(!redacted.contains("/Users/operator"), "{redacted}");
+    }
+
+    /// A trailing separator on the home value must not leave `~/` doubled.
+    #[test]
+    fn a_trailing_separator_on_home_is_tolerated() {
+        let redacted = home_paths_under("/Users/operator/work", Path::new("/Users/operator/"));
+        assert_eq!(redacted, "~/work");
+    }
+
+    /// A bare home path, with nothing under it, is the placeholder alone.
+    #[test]
+    fn a_bare_home_path_becomes_the_placeholder() {
+        assert_eq!(
+            home_paths_under("/Users/operator", Path::new("/Users/operator")),
+            "~"
+        );
+    }
+
+    /// Root and empty match nearly every path, so they redact nothing.
+    #[test]
+    fn a_degenerate_home_is_left_alone() {
+        let text = "/Users/operator/work/repos/acme";
+        assert_eq!(home_paths_under(text, Path::new("/")), text);
+        assert_eq!(home_paths_under(text, Path::new("")), text);
+    }
+
+    /// Text that never names the home directory comes back byte-identical.
+    #[test]
+    fn text_without_the_home_prefix_is_untouched() {
+        let text = "trusty-search could not index /srv/checkouts/acme-api";
+        assert_eq!(home_paths_under(text, Path::new("/Users/operator")), text);
+    }
+
+    /// The running-home wrapper is the same substitution, read from `dirs`.
+    #[test]
+    fn the_running_home_is_collapsed() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let Some(home) = home.to_str() else {
+            return;
+        };
+        let redacted = home_paths(&format!("indexed {home}/x/y"));
+        assert_eq!(redacted, "indexed ~/x/y", "home was {home}");
+    }
+
+    /// The list helper redacts each line rather than joining them.
+    #[test]
+    fn a_gap_list_is_redacted_line_by_line() {
+        let Some(home) = dirs::home_dir().and_then(|h| h.to_str().map(str::to_owned)) else {
+            return;
+        };
+        let lines = vec![format!("a: {home}/one"), format!("b: {home}/two")];
+        assert_eq!(home_paths_in(&lines), vec!["a: ~/one", "b: ~/two"]);
+    }
+}


### PR DESCRIPTION
Refs [#7137](https://github.com/bobmatnyc/trusty-tools/issues/7137)

Every gap string in `reports/index.md`, the `package.toml` per-repository `gaps`, and a packaged `manifest.toml` now passes through one home-path redaction (`crates/trusty-audit/src/redact.rs`), so the operator's home directory renders as `~`. The DD report's `Source document` field is written by trusty-git-analytics and is out of scope here.

Test ladder: rung 3 (localized, trusty-audit). Gate: `cargo fmt --check && cargo check -p trusty-audit && cargo clippy -p trusty-audit --all-targets -- -D warnings && cargo test -p trusty-audit --no-fail-fast` — 1078 lib + 34 integration passed, 0 failed, 5+2 ignored (ONNX). Two regression tests shown failing at origin/main before the fix: `index_tests::a_gap_naming_the_operators_home_renders_it_redacted`, `package_tests::no_packaged_member_names_the_operators_home`. Doc gates: check_line_cap.sh 0 violations, check_test_pointers.sh 0 dangling, check_changelog_fragment.sh recorded. Fragment: `crates/trusty-audit/changelog.d/7137-redact-home-path-in-gaps.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01WoNso6Y6dQxN7a8KrXbdVR
