### PR TITLE
feat(trusty-mpm): no-component-label exemption in tm issue audit

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7198-ticketing-agent-no-component-label.md
+++ b/crates/trusty-agents-common/changelog.d/7198-ticketing-agent-no-component-label.md
@@ -1,0 +1,3 @@
+Changed
+
+- The bundled `ticketing` agent now instructs posting a `no-component-label: <reason>` comment whenever no crate label fits the finding's file path, alongside the existing `no-milestone: <reason>` rule (#7198). Without that comment `tm issue audit` reports the absent component label as a FAIL; with it the row renders SKIP with the reason quoted.

--- a/crates/trusty-agents-common/src/assets/agents/ticketing.md
+++ b/crates/trusty-agents-common/src/assets/agents/ticketing.md
@@ -107,7 +107,12 @@ Resolve an abbreviation against the project's own table rather than
 guessing — in trusty-tools that is the root `CLAUDE.md` section
 "Abbreviations & Aliases". **When no crate label fits the file path, apply
 none** — an unlabeled component field is correct more often than a guessed
-one.
+one. Then post `no-component-label: <reason>` as a comment on the issue in the
+same dispatch, exactly as an unset milestone takes a `no-milestone: <reason>`
+one. Without that comment an absent component label is a defect; with it,
+`tm issue audit` prints `component label  SKIP  <reason>` instead of FAIL
+(#7198). A `website/` or CI-only path — no Cargo crate owns it — is the shape
+this is for.
 
 🔴 **There is no second, unnamed label axis for "which session found this."
 `trusty-mpm` never fills one, because none exists.** `trusty-mpm` is a crate

--- a/crates/trusty-mpm/changelog.d/7198-no-component-label-exemption.md
+++ b/crates/trusty-mpm/changelog.d/7198-no-component-label-exemption.md
@@ -1,0 +1,3 @@
+Added
+
+- `tm issue audit` reads a `no-component-label: <reason>` comment as the component row's escape hatch and prints `component label  SKIP  <reason>` instead of FAIL (#7198). It mirrors the existing `no-milestone: <reason>` hatch — same case-insensitive line match, same SKIP-never-PASS rendering — and covers the shape where no Cargo crate owns the changed path (a `website/` or CI-only issue), which `tm-ticketing` policy already treats as correct. A present component label still wins over a waiver comment, and the FAIL line now names the hatch so the fix is discoverable from the failing row.

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -200,6 +200,13 @@ because the session that filed the issue happened to run under tm. When no
 component label fits, apply none — that decision is final, not a trigger to
 reach for `trusty-mpm`.
 
+Then post a `no-component-label: <reason>` comment on the issue in the same
+dispatch, exactly as an unset milestone takes a `no-milestone: <reason>` one.
+That comment is the only thing that makes an absent component label legitimate:
+`tm issue audit` reads it and prints `component label  SKIP  <reason>` instead
+of FAIL (#7198). The `website/` and CI-only shape — no Cargo crate owns the
+changed path — is what it is for.
+
 🔴 **Seed the harness's own labels on first use in a repository.** `tm issue
 seed-labels` creates the four `status:*` lifecycle labels, `trusty-mpm`, and
 `ws/<session>`. It is idempotent and never rewrites a label that already

--- a/crates/trusty-mpm/src/core/issue_audit.rs
+++ b/crates/trusty-mpm/src/core/issue_audit.rs
@@ -25,7 +25,10 @@
 //! `no-milestone: <reason>` comment is the standard's own escape hatch and
 //! renders as SKIP with the reason quoted, never as a pass — a reader must be
 //! able to tell "no milestone was needed, here is why" from "a milestone is
-//! present". Relationships are always INFO: a standalone issue legitimately has
+//! present". `no-component-label: <reason>` is the same hatch for the component
+//! row (#7198): when no Cargo crate owns the changed path — a `website/` or
+//! CI-only issue — applying no component label is policy-correct.
+//! Relationships are always INFO: a standalone issue legitimately has
 //! no parent, no blocker, and no sub-issues, so their absence is a fact to
 //! report and never a violation.
 //!
@@ -51,6 +54,15 @@ pub const AUDIT_JSON_FIELDS: &str =
 
 /// The comment prefix that excuses an unset milestone (#7067's escape hatch).
 pub const NO_MILESTONE_PREFIX: &str = "no-milestone:";
+
+/// The comment prefix that excuses an absent component label (#7198).
+///
+/// Why: when no Cargo crate owns the changed path — a `website/` or CI-only
+/// issue — `tm-ticketing` policy is that applying no component label is
+/// correct, so the audit needs the same recorded-waiver escape hatch the
+/// milestone row already has.
+/// Test: `a_missing_component_label_with_a_reason_comment_is_a_skip`.
+pub const NO_COMPONENT_LABEL_PREFIX: &str = "no-component-label:";
 
 /// A `{"title": …}` node — a milestone or a project item.
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -340,23 +352,42 @@ fn milestone_row(facts: &IssueFacts, ticketing: &ResolvedTicketing) -> AuditRow 
 
 /// The reason from the first `no-milestone: <reason>` comment, if any.
 ///
-/// Why: the standard's escape hatch is a comment, so the audit has to read
-/// comment bodies rather than infer intent from an absent field.
-/// What: matches the prefix case-insensitively at the start of any LINE of any
-/// comment (an agent posting the note inside a longer comment still counts),
-/// and returns the trimmed remainder. An empty remainder still counts as
-/// recorded — the standard asks for a reason, and reporting an empty one is
-/// more useful than silently treating the comment as absent.
 /// Test: `an_unset_milestone_with_a_reason_comment_is_a_skip`,
 /// `the_no_milestone_comment_is_matched_case_insensitively`,
 /// `a_no_milestone_note_inside_a_longer_comment_counts`.
 fn no_milestone_reason(comments: &[CommentRef]) -> Option<String> {
+    waiver_reason(comments, NO_MILESTONE_PREFIX)
+}
+
+/// The reason from the first `no-component-label: <reason>` comment, if any.
+///
+/// Test: `a_missing_component_label_with_a_reason_comment_is_a_skip`,
+/// `the_no_component_label_comment_is_matched_case_insensitively`.
+// #7198: mirrors `no_milestone_reason` over the component-label prefix.
+fn no_component_label_reason(comments: &[CommentRef]) -> Option<String> {
+    waiver_reason(comments, NO_COMPONENT_LABEL_PREFIX)
+}
+
+/// The reason from the first `<prefix> <reason>` comment line, if any.
+///
+/// Why: the standard's escape hatches are comments, so the audit has to read
+/// comment bodies rather than infer intent from an absent field. #7198 added a
+/// second prefix, and one matcher is what keeps the two hatches behaving
+/// identically.
+/// What: matches `prefix` case-insensitively at the start of any LINE of any
+/// comment (an agent posting the note inside a longer comment still counts),
+/// and returns the trimmed remainder. An empty remainder still counts as
+/// recorded — the standard asks for a reason, and reporting an empty one is
+/// more useful than silently treating the comment as absent.
+/// Test: `a_no_milestone_note_inside_a_longer_comment_counts`,
+/// `the_no_component_label_comment_is_matched_case_insensitively`.
+fn waiver_reason(comments: &[CommentRef], prefix: &str) -> Option<String> {
     comments.iter().find_map(|c| {
         c.body.lines().find_map(|line| {
             let line = line.trim();
-            let head = line.get(..NO_MILESTONE_PREFIX.len())?;
-            head.eq_ignore_ascii_case(NO_MILESTONE_PREFIX)
-                .then(|| line[NO_MILESTONE_PREFIX.len()..].trim().to_string())
+            let head = line.get(..prefix.len())?;
+            head.eq_ignore_ascii_case(prefix)
+                .then(|| line[prefix.len()..].trim().to_string())
         })
     })
 }
@@ -368,9 +399,15 @@ fn no_milestone_reason(comments: &[CommentRef]) -> Option<String> {
 /// correctly labelled with the crate that owns it failed. The accepted set is
 /// now [`ComponentLabels`]'s, and the FAIL line names every label in it so the
 /// fix is a label the reader can copy rather than a guess.
+/// A `no-component-label: <reason>` comment renders SKIP with the reason
+/// quoted, never PASS — the website/CI shape where no crate owns the changed
+/// path is policy-correct, and a reader must still be able to tell a waived
+/// row from a labelled one (#7198).
 /// Test: `a_missing_component_label_fails`,
 /// `a_non_mpm_crate_component_label_passes`,
-/// `trusty_audit_alone_passes_the_component_label_check`.
+/// `trusty_audit_alone_passes_the_component_label_check`,
+/// `a_missing_component_label_with_a_reason_comment_is_a_skip`,
+/// `a_present_component_label_wins_over_a_waiver_comment`.
 fn component_row(facts: &IssueFacts, components: &ComponentLabels) -> AuditRow {
     let present: Vec<&str> = facts
         .labels
@@ -379,10 +416,20 @@ fn component_row(facts: &IssueFacts, components: &ComponentLabels) -> AuditRow {
         .filter(|name| components.accepts(name))
         .collect();
     let (verdict, detail) = if present.is_empty() {
+        // #7198: a recorded waiver downgrades the miss to SKIP, mirroring
+        // `milestone`'s `no-milestone:` hatch.
+        if let Some(reason) = no_component_label_reason(&facts.comments) {
+            return AuditRow {
+                requirement: REQ_COMPONENT,
+                verdict: Verdict::Skip,
+                detail: format!("({reason})"),
+            };
+        }
         (
             Verdict::Fail,
             format!(
-                "none of [{}] present (labels: {})",
+                "none of [{}] present and no `no-component-label: <reason>` \
+                 comment (labels: {})",
                 components.names().join(", "),
                 if facts.labels.is_empty() {
                     "none".to_string()

--- a/crates/trusty-mpm/src/core/issue_audit_tests.rs
+++ b/crates/trusty-mpm/src/core/issue_audit_tests.rs
@@ -261,6 +261,70 @@ fn a_missing_component_label_fails() {
     );
 }
 
+#[test]
+fn a_missing_component_label_with_a_reason_comment_is_a_skip() {
+    // #7198: the website/CI shape — no Cargo crate owns the changed path, so
+    // applying no component label is policy-correct, not a violation.
+    let json = COMPLIANT
+        .replace(
+            r#"[{"name": "enhancement"}, {"name": "trusty-mpm"}]"#,
+            r#"[{"name": "bug"}, {"name": "ci"}]"#,
+        )
+        .replace(
+            r#""comments": []"#,
+            r#""comments": [{"body": "no-component-label: website/ tests, no crate owns the path"}]"#,
+        );
+    let audit = audit_issue(&parse(&json), &standard(), &components());
+    let component = row(&audit, "component label");
+    assert_eq!(component.verdict, Verdict::Skip);
+    assert!(
+        component
+            .detail
+            .contains("website/ tests, no crate owns the path"),
+        "the reason is quoted: {}",
+        component.detail
+    );
+    assert!(!audit.failed(), "a recorded waiver must not exit 1");
+}
+
+#[test]
+fn the_no_component_label_comment_is_matched_case_insensitively() {
+    // #7198: mirrors `the_no_milestone_comment_is_matched_case_insensitively` —
+    // an agent writing `No-Component-Label:` still records a waiver.
+    let json = COMPLIANT
+        .replace(
+            r#"[{"name": "enhancement"}, {"name": "trusty-mpm"}]"#,
+            r#"[{"name": "bug"}]"#,
+        )
+        .replace(
+            r#""comments": []"#,
+            r#""comments": [{"body": "context\nNo-Component-Label: CI workflow only"}]"#,
+        );
+    let audit = audit_issue(&parse(&json), &standard(), &components());
+    let component = row(&audit, "component label");
+    assert_eq!(component.verdict, Verdict::Skip);
+    assert!(
+        component.detail.contains("CI workflow only"),
+        "the reason is quoted: {}",
+        component.detail
+    );
+}
+
+#[test]
+fn a_present_component_label_wins_over_a_waiver_comment() {
+    // #7198: a waiver never downgrades a label that IS present — the row still
+    // names the crate, so a reader cannot mistake a labelled issue for a waived
+    // one.
+    let json = COMPLIANT.replace(
+        r#""comments": []"#,
+        r#""comments": [{"body": "no-component-label: stale waiver"}]"#,
+    );
+    let audit = audit_issue(&parse(&json), &standard(), &components());
+    let component = row(&audit, "component label");
+    assert_eq!(component.verdict, Verdict::Pass);
+    assert_eq!(component.detail, "trusty-mpm");
+}
+
 /// A throwaway workspace whose crate labels are the ones #7139 carries.
 ///
 /// Why: the two #7123 regressions below have to run the real derivation — a


### PR DESCRIPTION
## Outcome

Refs #7198

`tm issue audit` now treats a `no-component-label: <reason>` comment line the way it already treats `no-milestone: <reason>`: the component-label row reports Skip with the reason instead of Fail. Both hatches share one `waiver_reason` matcher. A present accepted label still wins over a waiver comment.

## Changes

- Modified `trusty-mpm` to add `no-component-label:` waiver support in issue audit
- Updated `trusty-agents-common` ticketing agent asset to document the new convention alongside `no-milestone:`
- Added regression tests for comment matching and waiver behavior

## Risk

Localized to trusty-mpm's issue audit module and the ticketing agent asset. No breaking changes to public APIs. Waiver logic is additive — existing audit behavior unchanged.

## Tests

Test ladder: rung 3 (localized; trusty-mpm and trusty-agents-common doc asset). Gate: `cargo fmt --check && cargo check -p trusty-mpm && cargo clippy -p trusty-mpm --all-targets -- -D warnings && cargo test -p trusty-mpm --no-fail-fast` — 50 targets, lib 6315 passed 0 failed 8 ignored; `cargo test -p trusty-agents-common --no-fail-fast` 556 passed 0 failed. Regression tests shown failing at origin/main before the fix: `core::issue_audit::tests::a_missing_component_label_with_a_reason_comment_is_a_skip`, `the_no_component_label_comment_is_matched_case_insensitively`.

## Baseline

No pre-existing failures in required checks.

## Docs

Doc gates: check_line_cap.sh 0 violations, check_test_pointers.sh 0 dangling, check_changelog_fragment.sh 2 crates recorded. Fragments: `crates/trusty-mpm/changelog.d/7198-no-component-label-exemption.md`, `crates/trusty-agents-common/changelog.d/7198-ticketing-agent-no-component-label.md`. Convention documented in tm-ticketing skill and the ticketing agent asset alongside `no-milestone:`.

## Review

No review findings. Implementation verified against the test ladder requirements.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
