### PR TITLE
fix(trusty-mpm): pm-guard denies a pinned subagent's EnterWorktree switch

### DIFF
--- a/crates/trusty-mpm/changelog.d/7172-guard-follows-enter-worktree.md
+++ b/crates/trusty-mpm/changelog.d/7172-guard-follows-enter-worktree.md
@@ -1,0 +1,16 @@
+Fixed
+
+- `tm hook --pm-guard` now refuses an `EnterWorktree` call from a subagent
+  already standing in a worktree, naming both the pinned tree and the target
+  and pointing at the recovery. Previously the call was allowed, the harness
+  reported success and moved the working directory, and its own isolation
+  guard stayed pinned to the dispatch-time path — after which every command,
+  a bare `pwd` included, was refused and `ExitWorktree` was refused too. That
+  pin lives in the Claude Code binary and cannot be re-pointed from a hook, so
+  the guard refuses the switch instead of letting a success wedge the agent.
+  Re-entering the pinned tree stays allowed (it is the only recovery), the PM
+  is untouched, and a target outside `.claude/worktrees/`/`.worktrees/` is
+  refused rather than compared (#7172).
+- New `core::project_aliases::worktree_root` resolves any path inside a
+  worktree to the tree's own root, so "is this the same tree?" has one
+  definition beside `is_worktree_path` and `main_checkout_root` (#7172).

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -97,7 +97,12 @@ pub(crate) mod pm_guard_builder_cap;
 pub(crate) mod pm_guard_cost;
 pub(crate) mod pm_guard_deny_by_default;
 pub(crate) mod pm_guard_dispatch;
+// #7172: a worktree-pinned agent's `EnterWorktree` switch, refused rather than
+// left to succeed and wedge the agent — see its module doc for why the pin it
+// names belongs to the harness and cannot be moved from here.
+pub(crate) mod pm_guard_enter_worktree;
 pub(crate) mod pm_guard_fanout;
+pub(crate) mod pm_guard_response;
 pub(crate) mod pm_guard_routing;
 pub(crate) mod pm_guard_worktree_grant;
 pub(crate) mod pm_guard_write_boundary;

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -220,7 +220,13 @@ use crate::commands::pm_guard_builder_cap;
 use crate::commands::pm_guard_cost;
 use crate::commands::pm_guard_deny_by_default::{self, PERSONA_DENY_REASON};
 use crate::commands::pm_guard_dispatch;
+use crate::commands::pm_guard_enter_worktree;
 use crate::commands::pm_guard_fanout;
+// #7172: split out of this file to keep it under the 500-SLOC cap; re-exported
+// so every existing `pm_guard::build_pretooluse_*` path still resolves.
+pub(crate) use crate::commands::pm_guard_response::{
+    build_pretooluse_context_response, build_pretooluse_deny_response,
+};
 use crate::commands::pm_guard_routing::{GENERIC_ENGINEER_HINT, delegation_hint_for_path};
 use crate::commands::pm_guard_worktree_grant;
 use crate::commands::pm_guard_write_boundary;
@@ -561,6 +567,23 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
     if let Some(reason) = pm_guard_fanout::evaluate_subagent_fanout(tool_name, caller_is_subagent) {
         audit_denied_tool(url, session_id, tool_name, reason).await;
         println!("{}", build_pretooluse_deny_response(reason));
+        return Ok(());
+    }
+
+    // #7172: a worktree-pinned agent that switches trees is left wedged — the
+    // harness reports the switch as a success and its own isolation guard stays
+    // pinned to the dispatch-time path. Placed here for the same structural
+    // reason as the fan-out deny directly above: it fires only when the caller
+    // IS a subagent, the exact case Guards 1 and 4 early-return ALLOW for, and
+    // `caller_is_subagent` is not resolved until this point.
+    if let Some(reason) = pm_guard_enter_worktree::evaluate_enter_worktree(
+        tool_name,
+        tool_input,
+        caller_is_subagent,
+        &hook_cwd,
+    ) {
+        audit_denied_tool(url, session_id, tool_name, &reason).await;
+        println!("{}", build_pretooluse_deny_response(&reason));
         return Ok(());
     }
 
@@ -1089,62 +1112,6 @@ pub(crate) fn is_source_code_path(path: &str) -> bool {
         .is_some_and(|e| SOURCE_CODE_EXTENSIONS.contains(&e.as_str()))
 }
 
-/// Build the `hookSpecificOutput.permissionDecision = "deny"` JSON body.
-///
-/// Why: this is the exact shape Claude Code parses on a `PreToolUse` hook's
-/// `exit 0` stdout to block a tool call. Confirmed against the live Claude Code
-/// hooks reference (<https://code.claude.com/docs/en/hooks>, confirmed
-/// 2026-07-03): a deny is
-/// `{"hookSpecificOutput":{"hookEventName":"PreToolUse",
-/// "permissionDecision":"deny","permissionDecisionReason":"…"}}`, and the
-/// documented ALLOW form is simply exit 0 with no JSON — which is why
-/// [`pm_guard`] prints nothing on ALLOW rather than emitting a
-/// `permissionDecision:"allow"` object. Mirrors
-/// `hook_rewrite::build_pretooluse_rewrite_response` (same `hookSpecificOutput`
-/// envelope, different decision payload).
-/// What: returns the deny `serde_json::Value`; its `Display` impl is compact
-/// single-line JSON, so `println!("{}", …)` satisfies the protocol's "stdout
-/// must contain only the JSON object" rule.
-/// Test: `build_pretooluse_deny_response_has_expected_shape`.
-pub(crate) fn build_pretooluse_deny_response(reason: &str) -> serde_json::Value {
-    serde_json::json!({
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": reason
-        }
-    })
-}
-
-/// Build a `hookSpecificOutput.additionalContext` body — a message TO the agent
-/// that changes no decision.
-///
-/// Why (#4837 review, HIGH): the agent-cost warning is addressed to the agent
-/// ("wrap up and report back"), but the only channel it had was an audit POST
-/// to the daemon, so no agent ever read it — the graduated warn-then-stop
-/// response did not exist from the agent's side. `additionalContext` is the
-/// channel that fixes it: Claude Code injects the string next to the tool
-/// result, and the object carries **no** `permissionDecision`, so the call
-/// still goes through the normal permission flow. Per the hooks reference
-/// (<https://code.claude.com/docs/en/hooks>, confirmed 2026-08-04): "Exit code
-/// 0 with no output means the hook has no decision to report, so the tool call
-/// continues through the normal permission flow… staying silent doesn't approve
-/// it", and `additionalContext` is listed for `PreToolUse` as appearing "next
-/// to the tool result". That is precisely the property the author needed and
-/// could not find: context reaches the agent, and an explicit `allow` — which
-/// WOULD bypass the permission flow — is never emitted.
-/// What: returns the `serde_json::Value` whose compact `Display` is the single
-/// stdout object; mirrors [`build_pretooluse_deny_response`]'s envelope.
-/// Test: `build_pretooluse_context_response_carries_no_decision`.
-pub(crate) fn build_pretooluse_context_response(context: &str) -> serde_json::Value {
-    serde_json::json!({
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "additionalContext": context
-        }
-    })
-}
-
 /// Emit a pending agent-cost notice at a subagent's ALLOW exit.
 ///
 /// Why (#4837 review, HIGH): a `PreToolUse` hook's stdout may carry exactly one
@@ -1484,31 +1451,5 @@ mod tests {
         // Missing/empty command fails open to ALLOW.
         assert_eq!(evaluate_tool("Bash", Some(&serde_json::json!({}))), None);
         assert_eq!(evaluate_tool("Bash", None), None);
-    }
-
-    #[test]
-    fn build_pretooluse_deny_response_has_expected_shape() {
-        let v = build_pretooluse_deny_response("nope");
-        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PreToolUse");
-        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "deny");
-        assert_eq!(v["hookSpecificOutput"]["permissionDecisionReason"], "nope");
-        // Display is compact single-line JSON (protocol: stdout is only the object).
-        assert!(!v.to_string().contains('\n'));
-    }
-
-    #[test]
-    fn build_pretooluse_context_response_carries_no_decision() {
-        // #4837 review HIGH: this is the channel that reaches the AGENT. The
-        // absence of `permissionDecision` is the whole safety property — with
-        // one, the object would approve the call and bypass the permission
-        // flow, which is exactly what the author declined to do.
-        let v = build_pretooluse_context_response("wrap up");
-        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PreToolUse");
-        assert_eq!(v["hookSpecificOutput"]["additionalContext"], "wrap up");
-        assert!(
-            v["hookSpecificOutput"].get("permissionDecision").is_none(),
-            "an explicit decision here would bypass the permission flow"
-        );
-        assert!(!v.to_string().contains('\n'));
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -77,10 +77,13 @@ pub(crate) use worktree_remove_rechecks::evaluate_removal_rechecks;
 use std::path::Path;
 
 use crate::commands::hook_rewrite::{effective_tool_name, first_command_token};
-// Re-exported for the sibling rule modules, which reach these through
-// `super::…` — one definition of "which directory does this token name", and
-// one answer to "what did not expand" (#7098, #7100).
-use path_tokens::{PathEnv, resolve_target_path, unexpanded_shell_variable};
+// Reached by the sibling rule modules through `super::…` — one answer to "what
+// did not expand" (#7098, #7100).
+use path_tokens::unexpanded_shell_variable;
+// One definition of "which directory does this token name", crate-visible since
+// #7172: the `EnterWorktree` rule is no Bash rule but asks the same question, so
+// it reaches this resolver instead of growing a second normalizer.
+pub(crate) use path_tokens::{PathEnv, resolve_target_path};
 use shell_lex::QuoteScan;
 
 /// Deny reason for editing files through a shell tool (sed/awk/patch/git apply/redirection).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/path_tokens.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/path_tokens.rs
@@ -44,15 +44,15 @@ use std::path::{Path, PathBuf};
 /// inherits the guard process's environment, and the guard expands against it.
 /// Test: `evaluate_worktree_add_command_expands_tmpdir_and_home` builds one
 /// directly; every other caller goes through [`PathEnv::from_process`].
-pub(super) struct PathEnv {
-    pub(super) tmpdir: Option<String>,
-    pub(super) tmp: Option<String>,
-    pub(super) home: Option<String>,
+pub(crate) struct PathEnv {
+    pub(crate) tmpdir: Option<String>,
+    pub(crate) tmp: Option<String>,
+    pub(crate) home: Option<String>,
 }
 
 impl PathEnv {
     /// Read `$TMPDIR`, `$TMP`, and `$HOME` from the guard process.
-    pub(super) fn from_process() -> Self {
+    pub(crate) fn from_process() -> Self {
         Self {
             tmpdir: std::env::var("TMPDIR").ok(),
             tmp: std::env::var("TMP").ok(),
@@ -90,7 +90,7 @@ impl PathEnv {
 /// the guard process's own environment, which a `Bash` tool call inherits
 /// unchanged. Anything it could NOT expand survives as a literal path
 /// component; [`unexpanded_shell_variable`] is how a caller finds out.
-pub(super) fn resolve_target_path(token: &str, base: &Path, env: &PathEnv) -> PathBuf {
+pub(crate) fn resolve_target_path(token: &str, base: &Path, env: &PathEnv) -> PathBuf {
     let mut expanded = token.to_string();
     if let Some(tmpdir) = env.tmpdir.as_deref() {
         expanded = expanded

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_enter_worktree.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_enter_worktree.rs
@@ -1,0 +1,300 @@
+//! `tm hook --pm-guard` — `EnterWorktree` from a worktree-pinned agent, denied
+//! with a message that names both paths (issue #7172).
+//!
+//! Why: a subagent dispatched with `isolation: "worktree"` was told to switch
+//! into a different, already-existing worktree. `EnterWorktree` reported
+//! success and moved the agent's working directory, and the harness's own
+//! isolation guard stayed pinned to the dispatch-time path. Every command
+//! after that was refused — a bare `pwd` included — with "a worktree-isolated
+//! agent's commands must run inside its worktree", and `ExitWorktree` was
+//! refused too, so there was no way back except guessing at a re-entry into
+//! the original tree. A success that wedges the agent is worse than a refusal.
+//!
+//! **The pin this guard cannot move belongs to the harness, not to `tm`.** The
+//! refusal strings above are emitted by the Claude Code binary
+//! (`This agent is isolated in the worktree …` is present in the harness and
+//! absent from every `trusty-*` binary), and nothing in a `PreToolUse` hook can
+//! re-point that state. So the re-pin half of #7172 is not implementable here
+//! and this module takes the issue's other option: refuse the switch, and say
+//! why, instead of letting the harness report a success that strands the agent.
+//! `tm`'s OWN worktree model already follows the move — the delegation tracker
+//! rewrites `last_agent_cwd` from each hook event's `cwd` (#6556) — so no
+//! `tm`-side state is pinned and none needs re-pinning.
+//!
+//! What: [`evaluate_enter_worktree`] denies an `EnterWorktree` call when the
+//! caller is a subagent AND it is standing in a worktree AND the call would
+//! move it out of that worktree. Three arms allow:
+//!
+//! * the PM, and anything else whose caller context is indeterminate — the
+//!   fail-open direction inherited from
+//!   [`super::pm_guard_fanout::caller_is_subagent`], for its reasons;
+//! * a subagent that is NOT standing in a worktree, whose case is #5799 and is
+//!   deliberately untouched here;
+//! * re-entering the tree the agent is already in — the ONE recovery an agent
+//!   wedged by this bug has, so it must never be blocked.
+//!
+//! Everything else denies, and the indeterminate directions deny with it: a
+//! target that resolves outside `.claude/worktrees/`/`.worktrees/` is refused
+//! rather than compared, and so is a create-a-new-tree call (`name` with no
+//! `path`), which #5649 forbids an agent regardless of this issue. That is the
+//! opposite bias from the fan-out guard next door, and it is affordable for the
+//! same reason the ADR-0057 re-checks can afford it: this rule fires only when
+//! the caller is already proven to be a subagent standing in a worktree, so a
+//! false deny costs one tool call by an agent that has a working tree, while a
+//! false allow costs that agent every subsequent command.
+//!
+//! Test: `denies_a_switch_to_another_worktree`,
+//! `denies_a_target_outside_the_worktree_family`,
+//! `denies_creating_a_new_worktree_while_pinned`,
+//! `resolves_a_relative_target_before_comparing`,
+//! `allows_re_entering_the_pinned_worktree`,
+//! `allows_the_pm`, `allows_an_agent_outside_a_worktree`,
+//! `allows_every_other_tool` below;
+//! `pm_guard_denies_enter_worktree_switch_from_a_pinned_subagent` and siblings
+//! in `tests/tm_hook_pm_guard.rs` run the stdin→decision→stdout path through
+//! the real binary.
+
+use std::path::{Path, PathBuf};
+
+use trusty_mpm::core::project_aliases::worktree_root;
+
+use crate::commands::pm_guard_bash::{PathEnv, resolve_target_path};
+
+/// The harness tool that moves a session or agent into a worktree.
+///
+/// Why: named once so the guard and its tests cannot drift apart on spelling,
+/// and matched case-sensitively — an unrelated tool named `enterworktree` is
+/// not this one.
+/// What: the `tool_name` Claude Code stamps on the call.
+/// Test: `allows_every_other_tool`.
+const ENTER_WORKTREE_TOOL: &str = "EnterWorktree";
+
+/// The advice every `EnterWorktree` deny carries, after the two paths.
+///
+/// Why (#7172): a bare refusal makes the model retry the same call, and the
+/// retry is what wedges it. The text states the failure mode the agent would
+/// otherwise walk into, names the workaround that actually worked in the
+/// incident — branch from the target's tip inside the tree it already has —
+/// and names the one recovery for an agent that has ALREADY switched, since
+/// that agent has no other move left.
+/// What: the tail appended to both deny shapes.
+/// Test: `denies_a_switch_to_another_worktree` asserts the workaround and the
+/// recovery are both present.
+const ENTER_WORKTREE_DENY_TAIL: &str = "A pinned agent that switches trees is left wedged: the harness reports the switch as a \
+     success and moves the working directory, but its isolation guard can stay pinned to the \
+     dispatch-time path, after which every command — a bare `pwd` included — is refused with \
+     \"a worktree-isolated agent's commands must run inside its worktree\", and `ExitWorktree` \
+     is refused too. Stay in the worktree you were given: ask the PM for the other tree's base \
+     SHA and branch from that SHA here, which is the workaround that worked in the incident. \
+     If you have already switched and every command is being refused, call `EnterWorktree` \
+     again with `path` set to your own worktree — re-entry into the pinned tree is never \
+     blocked. SendMessage is never blocked either — use it to report back.";
+
+/// Classify a `PreToolUse` call for the #7172 worktree-switch rule:
+/// `Some(reason)` denies, `None` allows.
+///
+/// Why: kept pure — caller context arrives as a `bool` and the directory as a
+/// `&Path`, so every arm is unit-testable without a process, a daemon, or an
+/// env mutation. The resolution of both inputs stays at the single call site in
+/// [`super::pm_guard::pm_guard`], where the fan-out guard resolves them too, so
+/// the two rules can never disagree about who is calling or from where.
+/// What: `None` for any tool that is not [`ENTER_WORKTREE_TOOL`], for a caller
+/// that is not a subagent, for a `hook_cwd` that names no worktree, and for a
+/// target that resolves into the SAME worktree the caller stands in.
+/// `Some(reason)` otherwise — a switch to another tree, a target outside the
+/// worktree family, or a `name`-shaped create.
+/// Test: the `tests` module below.
+pub(crate) fn evaluate_enter_worktree(
+    tool_name: &str,
+    tool_input: Option<&serde_json::Value>,
+    caller_is_subagent: bool,
+    hook_cwd: &Path,
+) -> Option<String> {
+    if tool_name != ENTER_WORKTREE_TOOL || !caller_is_subagent {
+        return None;
+    }
+    // Not standing in a worktree → not pinned to one, so this rule has nothing
+    // to protect. That case is #5799 and stays out of scope here.
+    let pinned = worktree_root(hook_cwd)?;
+    let Some(target) = target_path(tool_input) else {
+        // `EnterWorktree { name }` creates a tree, which #5649 reserves to the
+        // PM's `isolation: "worktree"` declaration.
+        return Some(deny_reason(&pinned, None));
+    };
+    // #7172: resolve before comparing — `../agent-other` names another tree
+    // while still carrying the pinned tree's own prefix as text.
+    let resolved = resolve_target_path(&target, hook_cwd, &PathEnv::from_process());
+    match worktree_root(&resolved) {
+        Some(root) if root == pinned => None,
+        Some(root) => Some(deny_reason(&pinned, Some(&root))),
+        // Outside `.claude/worktrees/`/`.worktrees/` entirely — refused rather
+        // than compared, per this module's fail-closed note.
+        None => Some(deny_reason(&pinned, Some(&resolved))),
+    }
+}
+
+/// The `path` argument of an `EnterWorktree` call, when it has one.
+///
+/// Why: `path` (switch into an existing tree) and `name` (create a new one) are
+/// mutually exclusive in the tool's schema, and only the first can be compared
+/// against the pinned tree — so the absent-`path` case must be distinguishable
+/// from an empty one rather than collapsing into it.
+/// What: `Some(trimmed)` for a non-empty string `path`; `None` for a missing,
+/// non-string, or blank one.
+/// Test: `denies_creating_a_new_worktree_while_pinned`.
+fn target_path(tool_input: Option<&serde_json::Value>) -> Option<String> {
+    let raw = tool_input?.get("path")?.as_str()?.trim();
+    (!raw.is_empty()).then(|| raw.to_string())
+}
+
+/// The `permissionDecisionReason` for a denied `EnterWorktree`.
+///
+/// Why: the incident's cost was that the agent could not tell what had happened
+/// or where it now stood, so both paths are named in the refusal itself rather
+/// than left for the agent to reconstruct.
+/// What: `target` of `None` is the create-a-tree shape; `Some` names where the
+/// switch would have gone. Both end in [`ENTER_WORKTREE_DENY_TAIL`].
+/// Test: `denies_a_switch_to_another_worktree`,
+/// `denies_creating_a_new_worktree_while_pinned`.
+fn deny_reason(pinned: &Path, target: Option<&PathBuf>) -> String {
+    let head = match target {
+        Some(target) => format!(
+            "EnterWorktree denied while worktree-pinned (#7172): this agent is pinned to the \
+             worktree {} and this call would move it to {}.",
+            pinned.display(),
+            target.display()
+        ),
+        None => format!(
+            "EnterWorktree denied while worktree-pinned (#7172, #5649): this agent is pinned to \
+             the worktree {} and this call would create a worktree of its own, which is the PM's \
+             to declare with `isolation: \"worktree\"`.",
+            pinned.display()
+        ),
+    };
+    format!("{head} {ENTER_WORKTREE_DENY_TAIL}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The tree the tests pin the caller to, and a directory inside it.
+    const PINNED: &str = "/repo/.claude/worktrees/agent-a";
+    const PINNED_SUBDIR: &str = "/repo/.claude/worktrees/agent-a/crates/trusty-mpm";
+
+    fn evaluate(input: serde_json::Value, cwd: &str) -> Option<String> {
+        evaluate_enter_worktree(ENTER_WORKTREE_TOOL, Some(&input), true, Path::new(cwd))
+    }
+
+    #[test]
+    fn denies_a_switch_to_another_worktree() {
+        // The #7172 incident itself: pinned to A, pointed at B by the PM.
+        let reason = evaluate(
+            json!({"path": "/repo/.claude/worktrees/agent-b"}),
+            PINNED_SUBDIR,
+        )
+        .expect("a switch to another worktree must deny");
+        assert!(
+            reason.contains(PINNED),
+            "the deny must name the pin: {reason}"
+        );
+        assert!(
+            reason.contains("/repo/.claude/worktrees/agent-b"),
+            "the deny must name the target: {reason}"
+        );
+        assert!(
+            reason.contains("base SHA") && reason.contains("call `EnterWorktree` again"),
+            "the deny must carry both the workaround and the recovery: {reason}"
+        );
+    }
+
+    #[test]
+    fn denies_a_target_outside_the_worktree_family() {
+        // The fail-closed arm: a main checkout is never an acceptable cwd for a
+        // pinned agent, so it is refused rather than compared.
+        let reason = evaluate(json!({"path": "/repo"}), PINNED)
+            .expect("a target outside .claude/worktrees must deny");
+        assert!(reason.contains("/repo"), "{reason}");
+    }
+
+    #[test]
+    fn denies_creating_a_new_worktree_while_pinned() {
+        // `name` with no `path` creates a tree — #5649 reserves that to the PM.
+        let reason = evaluate(json!({"name": "scratch"}), PINNED)
+            .expect("creating a worktree while pinned must deny");
+        assert!(reason.contains("#5649"), "{reason}");
+        // A blank `path` is the same shape, not an empty comparison.
+        assert!(evaluate(json!({"path": "   "}), PINNED).is_some());
+        // And so is a call with no input at all.
+        assert!(
+            evaluate_enter_worktree(ENTER_WORKTREE_TOOL, None, true, Path::new(PINNED)).is_some()
+        );
+    }
+
+    #[test]
+    fn resolves_a_relative_target_before_comparing() {
+        // `../agent-b` still carries `agent-a` as text; only normalization
+        // shows it names another tree.
+        assert!(
+            evaluate(json!({"path": "../agent-b"}), PINNED).is_some(),
+            "a relative escape into a sibling tree must deny"
+        );
+        // The mirror: a relative path back to the pinned tree's own root.
+        assert_eq!(evaluate(json!({"path": "../.."}), PINNED_SUBDIR), None);
+    }
+
+    #[test]
+    fn allows_re_entering_the_pinned_worktree() {
+        // The one recovery a wedged agent has. Asserted from the tree root and
+        // from a subdirectory of it, since both are "the same tree".
+        assert_eq!(evaluate(json!({"path": PINNED}), PINNED), None);
+        assert_eq!(evaluate(json!({"path": PINNED}), PINNED_SUBDIR), None);
+        assert_eq!(
+            evaluate(json!({"path": PINNED_SUBDIR}), PINNED),
+            None,
+            "a subdirectory of the pinned tree is still the pinned tree"
+        );
+    }
+
+    #[test]
+    fn allows_the_pm() {
+        // The PM is not pinned and must keep every worktree move it has.
+        assert_eq!(
+            evaluate_enter_worktree(
+                ENTER_WORKTREE_TOOL,
+                Some(&json!({"path": "/repo/.claude/worktrees/agent-b"})),
+                false,
+                Path::new(PINNED),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn allows_an_agent_outside_a_worktree() {
+        // A subagent standing in a main checkout is #5799's case, not this
+        // one — this rule fires only on a pin it can actually name.
+        assert_eq!(
+            evaluate(json!({"path": "/repo/.claude/worktrees/agent-b"}), "/repo"),
+            None
+        );
+    }
+
+    #[test]
+    fn allows_every_other_tool() {
+        // The rule is keyed to one tool name, case-sensitively.
+        for tool in ["Bash", "Read", "Edit", "ExitWorktree", "enterworktree"] {
+            assert_eq!(
+                evaluate_enter_worktree(
+                    tool,
+                    Some(&json!({"path": "/repo/.claude/worktrees/agent-b"})),
+                    true,
+                    Path::new(PINNED),
+                ),
+                None,
+                "{tool} must not be touched by this rule"
+            );
+        }
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_response.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_response.rs
@@ -1,0 +1,101 @@
+//! The `PreToolUse` stdout envelope every `tm hook` decision is printed in.
+//!
+//! Why: two shapes share one JSON envelope and one protocol rule — stdout may
+//! carry exactly one object — and they are printed from four modules
+//! (`pm_guard`, `divert_check`, and the rules they call). Keeping both builders
+//! in one place is what stops a second, subtly different envelope appearing at
+//! a new print site; splitting them out of `pm_guard.rs` is also what kept that
+//! file under the 500-SLOC cap when #7172 added a rule to it.
+//!
+//! What: [`build_pretooluse_deny_response`] blocks a tool call;
+//! [`build_pretooluse_context_response`] speaks to the agent and decides
+//! nothing. Neither ever emits an explicit `allow` — see each doc for why.
+//!
+//! Test: the `#[cfg(test)]` suite below.
+
+/// Build the `hookSpecificOutput.permissionDecision = "deny"` JSON body.
+///
+/// Why: this is the exact shape Claude Code parses on a `PreToolUse` hook's
+/// `exit 0` stdout to block a tool call. Confirmed against the live Claude Code
+/// hooks reference (<https://code.claude.com/docs/en/hooks>, confirmed
+/// 2026-07-03): a deny is
+/// `{"hookSpecificOutput":{"hookEventName":"PreToolUse",
+/// "permissionDecision":"deny","permissionDecisionReason":"…"}}`, and the
+/// documented ALLOW form is simply exit 0 with no JSON — which is why
+/// [`pm_guard`] prints nothing on ALLOW rather than emitting a
+/// `permissionDecision:"allow"` object. Mirrors
+/// `hook_rewrite::build_pretooluse_rewrite_response` (same `hookSpecificOutput`
+/// envelope, different decision payload).
+/// What: returns the deny `serde_json::Value`; its `Display` impl is compact
+/// single-line JSON, so `println!("{}", …)` satisfies the protocol's "stdout
+/// must contain only the JSON object" rule.
+/// Test: `build_pretooluse_deny_response_has_expected_shape`.
+pub(crate) fn build_pretooluse_deny_response(reason: &str) -> serde_json::Value {
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    })
+}
+
+/// Build a `hookSpecificOutput.additionalContext` body — a message TO the agent
+/// that changes no decision.
+///
+/// Why (#4837 review, HIGH): the agent-cost warning is addressed to the agent
+/// ("wrap up and report back"), but the only channel it had was an audit POST
+/// to the daemon, so no agent ever read it — the graduated warn-then-stop
+/// response did not exist from the agent's side. `additionalContext` is the
+/// channel that fixes it: Claude Code injects the string next to the tool
+/// result, and the object carries **no** `permissionDecision`, so the call
+/// still goes through the normal permission flow. Per the hooks reference
+/// (<https://code.claude.com/docs/en/hooks>, confirmed 2026-08-04): "Exit code
+/// 0 with no output means the hook has no decision to report, so the tool call
+/// continues through the normal permission flow… staying silent doesn't approve
+/// it", and `additionalContext` is listed for `PreToolUse` as appearing "next
+/// to the tool result". That is precisely the property the author needed and
+/// could not find: context reaches the agent, and an explicit `allow` — which
+/// WOULD bypass the permission flow — is never emitted.
+/// What: returns the `serde_json::Value` whose compact `Display` is the single
+/// stdout object; mirrors [`build_pretooluse_deny_response`]'s envelope.
+/// Test: `build_pretooluse_context_response_carries_no_decision`.
+pub(crate) fn build_pretooluse_context_response(context: &str) -> serde_json::Value {
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": context
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_pretooluse_deny_response_has_expected_shape() {
+        let v = build_pretooluse_deny_response("nope");
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert_eq!(v["hookSpecificOutput"]["permissionDecisionReason"], "nope");
+        // Display is compact single-line JSON (protocol: stdout is only the object).
+        assert!(!v.to_string().contains('\n'));
+    }
+
+    #[test]
+    fn build_pretooluse_context_response_carries_no_decision() {
+        // #4837 review HIGH: this is the channel that reaches the AGENT. The
+        // absence of `permissionDecision` is the whole safety property — with
+        // one, the object would approve the call and bypass the permission
+        // flow, which is exactly what the author declined to do.
+        let v = build_pretooluse_context_response("wrap up");
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+        assert_eq!(v["hookSpecificOutput"]["additionalContext"], "wrap up");
+        assert!(
+            v["hookSpecificOutput"].get("permissionDecision").is_none(),
+            "an explicit decision here would bypass the permission flow"
+        );
+        assert!(!v.to_string().contains('\n'));
+    }
+}

--- a/crates/trusty-mpm/src/core/project_aliases.rs
+++ b/crates/trusty-mpm/src/core/project_aliases.rs
@@ -263,6 +263,51 @@ pub fn is_worktree_path(path: &Path) -> bool {
     s.contains("/.claude/worktrees/") || s.contains("/.worktrees/")
 }
 
+/// The worktree ROOT `path` sits in — the tree itself, not a directory inside it.
+///
+/// Why (#7172): [`is_worktree_path`] answers "is this a worktree?", and the
+/// `EnterWorktree` guard has to answer a second question — "is this the SAME
+/// worktree the agent is already pinned to?". A subdirectory of a tree and the
+/// tree's root are the same tree, so comparing the raw paths would refuse an
+/// agent re-entering its own worktree from `crates/foo`, which is the one
+/// recovery path a wedged agent has. It lives here beside [`is_worktree_path`]
+/// and [`main_checkout_root`] so the worktree-vs-checkout question keeps a
+/// single definition, exactly as [`is_main_checkout`]'s doc records.
+/// What: the prefix of `path` up to and including the segment that FOLLOWS the
+/// last `.claude/worktrees` or `.worktrees` component — `<repo>/.claude/worktrees/agent-x`
+/// for `<repo>/.claude/worktrees/agent-x/crates/foo`. `None` when `path` names
+/// no worktree at all, and also when it stops AT the container directory
+/// (`…/.claude/worktrees`), which names no single tree. Purely lexical: no
+/// `stat`, no `git`, no canonicalization, matching the callers' `PreToolUse`
+/// budget and carrying the same symlink limit as [`is_worktree_path`].
+/// Test: `worktree_root_of_a_tree_root`, `worktree_root_of_a_subdirectory`,
+/// `worktree_root_of_a_non_worktree`, `worktree_root_of_the_container_itself`,
+/// `worktree_root_takes_the_innermost_container`.
+pub fn worktree_root(path: &Path) -> Option<PathBuf> {
+    let components: Vec<_> = path.components().collect();
+    // Scan from the right so a nested layout resolves to the INNERMOST tree.
+    let container_end = components.iter().enumerate().rev().find_map(|(i, c)| {
+        let name = c.as_os_str();
+        if name == "worktrees" {
+            // `.claude/worktrees` needs its `.claude` parent; `.worktrees` is
+            // one component and must not be the filesystem's first component.
+            if i > 0 && components[i - 1].as_os_str() == ".claude" {
+                return Some(i);
+            }
+            return None;
+        }
+        // A `.worktrees` directly under the filesystem root is somebody's home
+        // for repositories, not a repository's worktree container — the same
+        // second-path-level rule [`is_worktree_path`]'s doc states.
+        (name == ".worktrees"
+            && i > 0
+            && matches!(components[i - 1], std::path::Component::Normal(_)))
+        .then_some(i)
+    })?;
+    let root_end = container_end + 1;
+    (root_end < components.len()).then(|| components[..=root_end].iter().collect())
+}
+
 /// Whether `path` sits inside a repository's MAIN CHECKOUT — the operator's
 /// live working copy — rather than a linked git worktree (ADR-0037).
 ///
@@ -509,6 +554,59 @@ mod tests {
         assert!(
             !is_worktree_path(p),
             "expected is_worktree_path=false for normal project path, got true"
+        );
+    }
+
+    #[test]
+    fn worktree_root_of_a_tree_root() {
+        // The tree's own root answers itself, with no trailing-slash surprise.
+        assert_eq!(
+            worktree_root(Path::new("/repo/.claude/worktrees/agent-a")),
+            Some(PathBuf::from("/repo/.claude/worktrees/agent-a"))
+        );
+        assert_eq!(
+            worktree_root(Path::new("/repo/.worktrees/feature-x/")),
+            Some(PathBuf::from("/repo/.worktrees/feature-x"))
+        );
+    }
+
+    #[test]
+    fn worktree_root_of_a_subdirectory() {
+        // #7172: an agent standing in `crates/foo` is still in its own tree —
+        // the recovery re-entry must compare equal from anywhere inside it.
+        assert_eq!(
+            worktree_root(Path::new("/repo/.claude/worktrees/agent-a/crates/foo")),
+            Some(PathBuf::from("/repo/.claude/worktrees/agent-a"))
+        );
+    }
+
+    #[test]
+    fn worktree_root_of_a_non_worktree() {
+        // A main checkout, and a `.worktrees` sitting at the filesystem root,
+        // both name no tree.
+        assert_eq!(worktree_root(Path::new("/repo/crates/foo")), None);
+        assert_eq!(worktree_root(Path::new("/.worktrees/thing")), None);
+        assert_eq!(worktree_root(Path::new("/repo/worktrees/agent-a")), None);
+    }
+
+    #[test]
+    fn worktree_root_of_the_container_itself() {
+        // The container directory holds every tree and is not one of them.
+        assert_eq!(worktree_root(Path::new("/repo/.claude/worktrees")), None);
+        assert_eq!(worktree_root(Path::new("/repo/.worktrees")), None);
+    }
+
+    #[test]
+    fn worktree_root_takes_the_innermost_container() {
+        // A worktree that itself contains worktrees resolves to the inner one,
+        // so a guard comparing roots never mistakes an inner tree for its host.
+        assert_eq!(
+            worktree_root(Path::new(
+                "/repo/.claude/worktrees/agent-a/.claude/worktrees/agent-b/src"
+            )),
+            Some(PathBuf::from(
+                "/repo/.claude/worktrees/agent-a/.claude/worktrees/agent-b"
+            ))
         );
     }
 

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -3749,3 +3749,76 @@ fn pm_guard_denies_a_builder_when_the_machine_is_full() {
     assert!(verdict.contains("capped at 2"), "{verdict}");
     assert!(verdict.contains("builders.max_concurrent"), "{verdict}");
 }
+
+// ---------------------------------------------------------------------------
+// `EnterWorktree` from a worktree-pinned agent (issue #7172) —
+// `commands::pm_guard_enter_worktree`.
+//
+// The pure policy is unit-tested in that module; these cases prove the payload
+// resolves through the real binary — caller context from `agent_id`, the pinned
+// tree from the payload's own `cwd` — and that the refusal reaches the agent
+// instead of a success that wedges it.
+// ---------------------------------------------------------------------------
+
+/// A pinned subagent's `EnterWorktree` payload, switching to `target`.
+///
+/// Why: the cases below differ only in the target path, and hand-copying the
+/// payload is how one of them drifts into omitting `cwd` and asserting nothing.
+/// What: a `PreToolUse` payload with a non-empty `agent_id` (the subagent
+/// marker) standing inside `.claude/worktrees/agent-a`.
+fn enter_worktree_payload(target: &str) -> String {
+    format!(
+        r#"{{"hook_event_name":"PreToolUse","agent_id":"agent-a","agent_type":"rust-engineer","cwd":"/repo/.claude/worktrees/agent-a/crates/trusty-mpm","tool_name":"EnterWorktree","tool_input":{{"path":"{target}"}}}}"#
+    )
+}
+
+#[test]
+fn pm_guard_denies_enter_worktree_switch_from_a_pinned_subagent() {
+    // The #7172 incident: pinned to A, pointed at B. Before this rule the call
+    // was allowed, the harness reported success, and every command after it —
+    // `pwd` included — was refused with no way back.
+    let stdout = run_pm_guard(
+        &enter_worktree_payload("/repo/.claude/worktrees/agent-b"),
+        &[],
+    );
+    assert_denied(&stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("deny stdout must be valid JSON");
+    let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .expect("reason is a string");
+    assert!(
+        reason.contains("#7172")
+            && reason.contains("/repo/.claude/worktrees/agent-a")
+            && reason.contains("/repo/.claude/worktrees/agent-b"),
+        "the deny must name the issue, the pinned tree, and the target, got: {reason}"
+    );
+}
+
+#[test]
+fn pm_guard_denies_enter_worktree_to_a_path_outside_the_worktree_family() {
+    // The fail-closed arm: a pinned agent never accepts a cwd outside
+    // `.claude/worktrees/`, the main checkout included.
+    assert_denied(&run_pm_guard(&enter_worktree_payload("/repo"), &[]));
+}
+
+#[test]
+fn pm_guard_allows_enter_worktree_back_into_the_pinned_worktree() {
+    // The one recovery a wedged agent has — blocking it would strand exactly
+    // the agent this rule protects. Silence is the allow.
+    assert_eq!(
+        run_pm_guard(
+            &enter_worktree_payload("/repo/.claude/worktrees/agent-a"),
+            &[]
+        )
+        .trim(),
+        ""
+    );
+}
+
+#[test]
+fn pm_guard_allows_enter_worktree_from_the_pm() {
+    // No `agent_id` — the PM's own worktree moves are untouched.
+    let payload = r#"{"hook_event_name":"PreToolUse","cwd":"/repo/.claude/worktrees/agent-a","tool_name":"EnterWorktree","tool_input":{"path":"/repo/.claude/worktrees/agent-b"}}"#;
+    assert_eq!(run_pm_guard(payload, &[]).trim(), "");
+}


### PR DESCRIPTION
Refs [#7172](https://github.com/bobmatnyc/trusty-tools/issues/7172)

The "isolated in the worktree … refusing" strings come from the Claude Code harness, which pins a subagent's cwd at launch; tm holds no pin of its own (the delegation tracker rewrites `last_agent_cwd` from every hook cwd), so re-pinning from a `PreToolUse` hook is not implementable. Instead `tm hook --pm-guard` now denies the `EnterWorktree` call itself when the caller is a subagent standing in a worktree and the target would leave it, naming both paths. Allowed: the PM, an indeterminate caller, a subagent outside any worktree, and re-entry into its own tree. Denied fail-closed: a target outside `.claude/worktrees/` / `.worktrees/`, and a `name`-shaped create. New `worktree_root` in core/project_aliases.rs gives "same tree?" one definition; `pm_guard_response.rs` split out of `pm_guard.rs` to stay under the 500-SLOC cap (byte-identical envelope). #6982 untouched.

Test ladder: rung 3 (guard is a safety path; error arms included). Gate: `cargo fmt --check && cargo check -p trusty-mpm --all-targets && cargo clippy -p trusty-mpm --all-targets -- -D warnings && cargo test -p trusty-mpm --no-fail-fast` — 55 targets, 11378 passed 0 failed 18 ignored. Four binary-level tests in `tests/tm_hook_pm_guard.rs` shown failing before (the guard silently allowed the switch): `pm_guard_denies_enter_worktree_switch_from_a_pinned_subagent`, `pm_guard_denies_enter_worktree_to_a_path_outside_the_worktree_family`, plus the two allow arms. Doc gates green. code-critic: APPROVE (one LOW wording note on the malformed-`path` deny reason, carried). Fragment: `crates/trusty-mpm/changelog.d/7172-guard-follows-enter-worktree.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01WoNso6Y6dQxN7a8KrXbdVR
