### PR TITLE
docs(trusty-mpm): qualify the pm_guard intra-doc link in pm_guard_response

### DIFF
--- a/crates/trusty-mpm/changelog.d/7172-rustdoc-link.md
+++ b/crates/trusty-mpm/changelog.d/7172-rustdoc-link.md
@@ -1,0 +1,3 @@
+Documentation
+
+- Qualified the `pm_guard` intra-doc link in `pm_guard_response.rs`'s deny-response doc comment to `crate::commands::pm_guard::pm_guard`, fixing the broken-link regression `rustdoc-links` caught after #7213 (#7172).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_response.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_response.rs
@@ -22,7 +22,7 @@
 /// `{"hookSpecificOutput":{"hookEventName":"PreToolUse",
 /// "permissionDecision":"deny","permissionDecisionReason":"…"}}`, and the
 /// documented ALLOW form is simply exit 0 with no JSON — which is why
-/// [`pm_guard`] prints nothing on ALLOW rather than emitting a
+/// [`crate::commands::pm_guard::pm_guard`] prints nothing on ALLOW rather than emitting a
 /// `permissionDecision:"allow"` object. Mirrors
 /// `hook_rewrite::build_pretooluse_rewrite_response` (same `hookSpecificOutput`
 /// envelope, different decision payload).


### PR DESCRIPTION
Refs #7172

#7213 merged with the Rustdoc intra-doc links check red: `pm_guard_response.rs:25` linked [`pm_guard`] unqualified. Now `[`crate::commands::pm_guard::pm_guard`]`. Main is red on that gate until this lands.

Test ladder: rung 1 (doc comment only; fragment added because the path is under src/). Gate: `bash scripts/check_rustdoc_links.sh` → `SUMMARY 26 crate(s) examined by rustdoc, 0 broken link(s), baseline 0`; `cargo fmt --check`, `cargo check -p trusty-mpm --all-targets`, line-cap, test-pointers, changelog fragment all green.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01WoNso6Y6dQxN7a8KrXbdVR
