### PR TITLE
feat(trusty-common): hoist the UDS→SSE bridge helpers out of trusty-console

### DIFF
--- a/crates/trusty-common/changelog.d/6637-uds-sse-hoist.md
+++ b/crates/trusty-common/changelog.d/6637-uds-sse-hoist.md
@@ -1,0 +1,8 @@
+Added
+- `uds::sse`, behind the `axum-server` feature: renders one framed JSON-RPC
+  stream as the Server-Sent Events a browser reads — `sse_response`, `sse_tail`,
+  `sse_data`, the 20-second `SSE_HEARTBEAT_INTERVAL` and the 64-item
+  `SSE_BUFFER`. Hoisted verbatim out of `trusty-console`'s crate-private
+  `uds_sse` so a second UI crate bridging a webview onto a daemon socket shares
+  it rather than carrying a third copy
+  ([#6637](https://github.com/bobmatnyc/trusty-tools/issues/6637)).

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -73,6 +73,12 @@ pub mod singleton;
 // #6896: one place that sizes SO_SNDBUF/SO_RCVBUF, so both ends of every socket
 // this module owns are sized identically and no consumer sets them itself.
 pub mod sockbuf;
+// #6637: the SSE rendering of an opened stream, hoisted out of trusty-console
+// so a second UI crate bridging a webview onto a socket shares it rather than
+// carrying a third copy. Behind `axum-server` because it is axum types all the
+// way down; a crate that only dials a socket must not pull axum in.
+#[cfg(feature = "axum-server")]
+pub mod sse;
 // #6286: the reading half of a multi-frame response, so a token stream has one
 // definition of what terminates it rather than one per consumer.
 pub mod stream_client;

--- a/crates/trusty-common/src/uds/sse.rs
+++ b/crates/trusty-common/src/uds/sse.rs
@@ -6,7 +6,9 @@
 //! keep-alive comment, the cancel-safe reader task, and the response head are
 //! identical for both, because none of them is about which daemon is on the
 //! other end. A second copy is how one bridge starts closing a failed stream
-//! silently while the other reports it.
+//! silently while the other reports it. #6637 hoisted it out of trusty-console
+//! for the same reason one step out: trusty-code-gui's webview bridge is a
+//! third consumer of the identical shape, and it lives in a different crate.
 //!
 //! What is NOT here: anything a service owns. Which method is streaming, which
 //! JSON-RPC code becomes which HTTP status, and what the peek before the
@@ -31,9 +33,9 @@
 //!   consumer reads a closed stream as a COMPLETED operation and a silent close
 //!   would report a broken one as finished.
 //!
-//! Test: `sse_data_is_one_line_per_event` below, plus
-//! `tests/search_uds_bridge.rs` and `tests/memory_uds_bridge.rs`, which drive
-//! whole streams through the real router.
+//! Test: `sse_data_is_one_line_per_event` below. Whole streams run through a
+//! real router in trusty-console's `tests/search_uds_bridge.rs` and
+//! `tests/memory_uds_bridge.rs`.
 
 use axum::body::{Body, Bytes};
 use axum::http::{StatusCode, header};
@@ -42,20 +44,21 @@ use futures_util::StreamExt as _;
 use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use tracing::warn;
-use trusty_common::uds::UdsRpcError;
-use trusty_common::uds::stream_client::FramedStream;
+
+use super::UdsRpcError;
+use super::stream_client::FramedStream;
 
 /// How often an open stream emits an SSE keep-alive comment.
 ///
 /// The same 20 s the daemons' own SSE routes used, so an idle browser
 /// connection sees the byte sequence it saw before the migration.
-const SSE_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+pub const SSE_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// How many stream items may buffer between the socket reader and the browser.
 ///
 /// Matches the daemon-side producer buffer, so neither side is the first to
 /// accumulate behind a slow reader.
-const SSE_BUFFER: usize = 64;
+pub const SSE_BUFFER: usize = 64;
 
 /// Build the `200 text/event-stream` response for an already-opened stream.
 ///
@@ -67,8 +70,11 @@ const SSE_BUFFER: usize = 64;
 /// well-formed empty answer, and an immediately-closed event stream.
 /// What: the peeked item, then [`sse_tail`], under the three headers a browser
 /// and any reverse proxy in front of the console need.
-/// Test: `tests/memory_uds_bridge.rs`'s `a_stream_reaches_the_browser_frame_for_frame`.
-pub(crate) fn sse_response(
+/// Test: covered end to end by trusty-console's
+/// `tests/memory_uds_bridge.rs`, in `a_stream_reaches_the_browser_frame_for_frame`.
+///
+/// [`sse_tail`]: crate::uds::sse::sse_tail
+pub fn sse_response(
     first: Option<Value>,
     stream: FramedStream<Value>,
     method: &'static str,
@@ -93,7 +99,7 @@ pub(crate) fn sse_response(
 /// The rest of an open stream, as SSE frames plus keep-alive comments.
 ///
 /// Why the reader runs in its own task rather than inside the `select!`:
-/// `FramedStream::next_frame` reads a line off a `BufReader`, and cancelling
+/// [`FramedStream::next_frame`] reads a line off a `BufReader`, and cancelling
 /// that mid-line — which a heartbeat tick would do — discards the bytes already
 /// read. Moving the read behind an `mpsc` makes both arms of the select
 /// cancel-safe, since `Receiver::recv` and `Interval::tick` both are.
@@ -104,11 +110,15 @@ pub(crate) fn sse_response(
 /// frame — a status stream can be silent for minutes, and waiting for a frame
 /// that will never come would hold the socket, and the daemon's producer behind
 /// it, open for exactly that long. Either way the task returns, dropping the
-/// `FramedStream` and closing the socket, which is what ends the producer.
+/// [`FramedStream`] and closing the socket, which is what ends the producer.
 ///
-/// Test: `tests/search_uds_bridge.rs`'s `a_mid_stream_failure_becomes_an_error_event`
+/// Test: covered end to end by trusty-console's
+/// `tests/search_uds_bridge.rs`, in `a_mid_stream_failure_becomes_an_error_event`
 /// and `a_browser_disconnect_releases_the_daemon_socket`.
-fn sse_tail(
+///
+/// [`FramedStream`]: crate::uds::stream_client::FramedStream
+/// [`FramedStream::next_frame`]: crate::uds::stream_client::FramedStream::next_frame
+pub fn sse_tail(
     mut stream: FramedStream<Value>,
     method: &'static str,
 ) -> impl futures_util::Stream<Item = Result<Bytes, std::convert::Infallible>> {
@@ -164,7 +174,7 @@ fn sse_tail(
 /// stream carries parsed JSON, and re-serialising is what puts it back on one
 /// line — an embedded newline would split one event into two.
 /// Test: `sse_data_is_one_line_per_event`.
-fn sse_data(value: &Value) -> Bytes {
+pub fn sse_data(value: &Value) -> Bytes {
     Bytes::from(format!("data: {value}\n\n"))
 }
 

--- a/crates/trusty-console/changelog.d/6637-uds-sse-hoist.md
+++ b/crates/trusty-console/changelog.d/6637-uds-sse-hoist.md
@@ -1,0 +1,6 @@
+Changed
+- The crate-private `uds_sse` module moved to `trusty_common::uds::sse`; the
+  search and memory bridges import it from there. No behaviour change — the
+  `data:` encoding, the 20-second keep-alive, the cancel-safe reader task and
+  the terminal error event are the same bytes on the wire
+  ([#6637](https://github.com/bobmatnyc/trusty-tools/issues/6637)).

--- a/crates/trusty-console/src/analyze_uds/routes.rs
+++ b/crates/trusty-console/src/analyze_uds/routes.rs
@@ -8,9 +8,10 @@
 //! What: one handler. It maps the request through [`super::map::map_request`],
 //! dials the socket, and answers the daemon's JSON body.
 //!
-//! What is NOT here: an SSE arm. `crate::uds_sse` exists for exactly that and
-//! both other bridges use it, but trusty-analyze registers no streaming method
-//! (`map`'s module docs record why), so there is nothing to hand it.
+//! What is NOT here: an SSE arm. `trusty_common::uds::sse` exists for exactly
+//! that and both other bridges use it, but trusty-analyze registers no
+//! streaming method (`map`'s module docs record why), so there is nothing to
+//! hand it.
 //!
 //! Test: `tests/analyze_uds_bridge.rs` drives the whole router against a stub
 //! daemon socket.

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -79,8 +79,6 @@ pub mod service_metrics;
 // #6155: the trusty-search, trusty-memory and trusty-analyze SPAs, mounted
 // under /tools/<tool>/.
 pub mod tools_ui;
-// #6155: the SSE plumbing both UDS bridges hand an opened stream to.
-pub(crate) mod uds_sse;
 pub mod webhook;
 
 /// How often the background sweep re-attempts pending webhook deliveries.

--- a/crates/trusty-console/src/memory_uds/mod.rs
+++ b/crates/trusty-console/src/memory_uds/mod.rs
@@ -154,8 +154,9 @@ pub(crate) const STREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(60);
 /// `200` with no leading item rather than failing. A refusal is produced by the
 /// handler before any event and arrives at once, so this window separates the
 /// two cases that actually occur. A refusal slower than this window is not lost:
-/// it arrives on the open stream as the `{"type":"error"}` event `uds_sse`
-/// writes for a terminal frame, which the feed renders rather than swallowing.
+/// it arrives on the open stream as the `{"type":"error"}` event
+/// `trusty_common::uds::sse` writes for a terminal frame, which the feed renders
+/// rather than swallowing.
 /// Test: `an_idle_stream_still_gets_its_response_head`.
 pub(crate) const STREAM_FIRST_FRAME_PEEK: Duration = Duration::from_secs(2);
 

--- a/crates/trusty-console/src/memory_uds/routes.rs
+++ b/crates/trusty-console/src/memory_uds/routes.rs
@@ -10,9 +10,9 @@
 //! dials the socket, and answers either a JSON body or an open
 //! `text/event-stream`.
 //!
-//! The SSE plumbing itself is [`crate::uds_sse`]'s, shared with the trusty-search
-//! bridge. What stays here is what trusty-memory owns: which JSON-RPC code
-//! becomes which HTTP status, and the peek below.
+//! The SSE plumbing itself is [`trusty_common::uds::sse`]'s, shared with the
+//! trusty-search bridge. What stays here is what trusty-memory owns: which
+//! JSON-RPC code becomes which HTTP status, and the peek below.
 //!
 //! A refusal that arrives BEFORE the first item becomes an HTTP status, not a
 //! `200` carrying an error event — which is why the first frame is read before
@@ -38,7 +38,7 @@ use super::{
     call, json_response, open_stream,
 };
 use crate::server::AppState;
-use crate::uds_sse::sse_response;
+use trusty_common::uds::sse::sse_response;
 
 /// `ANY /api/memory/{*path}` — reach trusty-memory over its socket.
 ///

--- a/crates/trusty-console/src/search_uds/routes.rs
+++ b/crates/trusty-console/src/search_uds/routes.rs
@@ -13,9 +13,9 @@
 //! ## The SSE bridge, frame for frame
 //!
 //! `trusty_search::service::rpc::streams` states the contract this side has to
-//! honour, and [`crate::uds_sse`] is where honouring it lives — the `data:`
-//! encoding, the 20-second keep-alive comment, and the terminal error event that
-//! keeps a broken reindex from reading as a finished one
+//! honour, and [`trusty_common::uds::sse`] is where honouring it lives — the
+//! `data:` encoding, the 20-second keep-alive comment, and the terminal error
+//! event that keeps a broken reindex from reading as a finished one
 //! (`crates/trusty-console/ui-search/src/lib/views/Indexes.svelte` treats a closed
 //! stream as a completed reindex). #6155 moved that plumbing there so the
 //! trusty-memory bridge shares it rather than carrying a second copy.
@@ -48,7 +48,7 @@ use super::{
     open_stream,
 };
 use crate::server::AppState;
-use crate::uds_sse::sse_response;
+use trusty_common::uds::sse::sse_response;
 
 /// `ANY /api/search/{*path}` — reach trusty-search over its socket.
 ///

--- a/crates/trusty-console/tests/memory_uds_bridge.rs
+++ b/crates/trusty-console/tests/memory_uds_bridge.rs
@@ -502,11 +502,12 @@ fn silent_stub_daemon(dir: &Path, quiet: std::time::Duration) -> PathBuf {
 /// Why: the peek's expiry commits to `200` before the daemon has said anything,
 /// so a refusal that arrives AFTER it can no longer become an HTTP status. The
 /// `STREAM_FIRST_FRAME_PEEK` doc claims that refusal still reaches the operator,
-/// as the `{"type":"error"}` event `uds_sse` writes for a terminal frame — and
-/// nothing asserted it. Every other stream case here answers immediately, leads
-/// with an item, or answers nothing at all; this is the one that crosses the
-/// window with a refusal behind it. Without the commit-on-expiry arm the request
-/// fails outright and the browser sees no stream and no event.
+/// as the `{"type":"error"}` event `trusty_common::uds::sse` writes for a
+/// terminal frame — and nothing asserted it. Every other stream case here
+/// answers immediately, leads with an item, or answers nothing at all; this is
+/// the one that crosses the window with a refusal behind it. Without the
+/// commit-on-expiry arm the request fails outright and the browser sees no
+/// stream and no event.
 /// What: a daemon that accepts the subscription, stays silent past the peek
 /// window, then sends one terminal error frame and closes. The head must be a
 /// `200` event stream and the body must carry the daemon's refusal.


### PR DESCRIPTION
Refs #6637 (PR 2a of the PR 2 chain; epic #6284)

`crates/trusty-console/src/uds_sse.rs` (`sse_response`, `sse_tail`, `sse_data`, heartbeat 20s, buffer 64, terminal-error framing) moves to `trusty_common::uds::sse`, `pub`, gated on the existing `axum-server` feature (with `uds`). Pure move: bodies byte-identical, git rename 85%; trusty-console imports the hoisted module and its copy is deleted. Needed by PR 2b, where trusty-code-gui's bridge renders `session.events`/`workstream.events` as `text/event-stream`; a second copy would violate the common-entry-point rule. No version bump here; trusty-common's next bump is MINOR under the 0.y rule and needs the workspace row widened at release time.

Test ladder: rung 4 (shared library). Gate: `cargo fmt --check`; `cargo check --workspace --all-targets`; `cargo clippy -p trusty-common --all-targets --features uds,axum-server -- -D warnings`; `cargo clippy -p trusty-console --all-targets -- -D warnings`; `cargo test -p trusty-common --features uds,axum-server --no-fail-fast` — 686 passed 0 failed 6 ignored; `cargo test -p trusty-console --no-fail-fast` — lib 471 passed, `tests/search_uds_bridge.rs` 18, `tests/memory_uds_bridge.rs` 16, `tests/analyze_uds_bridge.rs` 13, 0 failed. `./scripts/check_rustdoc_links.sh` 26 crates 0 broken; line-cap, test-pointers, changelog (2 crates), workspace-dep-versions green. Fragments: `crates/trusty-common/changelog.d/6637-uds-sse-hoist.md`, `crates/trusty-console/changelog.d/6637-uds-sse-hoist.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01WoNso6Y6dQxN7a8KrXbdVR
