### PR TITLE
chore(trusty-mpm): bump to 1.5.20 for reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11917,7 +11917,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.19"
+version = "1.5.20"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -25,7 +25,10 @@ name = "trusty-mpm"
 # changes in the test suite under an already-published version.
 # 1.5.18 (refs #6892): patch — 1.5.17 is published and this PR edits `src/**`.
 # The edits are doc comments only, so no public item changed signature.
-version = "1.5.19"
+# 1.5.20 (owner-authorized reinstall, refs #7209 #7198 #7180 #7185 #7196
+# #7172): patch, version-only — 1.5.19 is already published and this bump
+# exists solely so `tm --version` identifies the reinstalled build.
+version = "1.5.20"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Owner-authorized reinstall bump, per the standing rule that every reinstall carries a patch bump so `tm --version` identifies the build.
- Version-only change: `crates/trusty-mpm/Cargo.toml` 1.5.19 → 1.5.20, plus the matching `Cargo.lock` entry. No source edits.

Rung 1 (docs/version-only) — no crate `src/**` touched, so no changelog fragment is owed and no Cargo test gate applies. Gates run:
- `bash scripts/check_changelog_fragment.sh --staged` — OK, 0 crate-source paths
- `bash scripts/check-pr-version-bump.sh` — OK, 2 changed paths, none under `crates/<crate>/src/**`
- `bash scripts/check_workspace_dep_versions.sh` — OK, all 12 internal rows accept their member version (a 1.x patch needs no row widening)
- `bash scripts/check_line_cap.sh` — OK, 0 violations

Refs #7209 #7198 #7180 #7185 #7196 #7172

## Test plan
- [x] Changelog fragment gate (version-only exemption confirmed)
- [x] PR version-bump gate
- [x] Workspace dependency version gate
- [x] SLOC line-cap gate

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01WoNso6Y6dQxN7a8KrXbdVR