### PR TITLE
docs(trusty-mpm): document the write-then-execute residual in destructive_delete (Refs #7190)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7190-destructive-delete-write-then-execute-residual.md
+++ b/crates/trusty-mpm/changelog.d/7190-destructive-delete-write-then-execute-residual.md
@@ -1,0 +1,3 @@
+Documentation
+
+- **`destructive_delete`'s residual-bypasses list now names the write-then-execute shape.** One segment writing a script that contains a delete verb (`python3 -c "open('/tmp/x.sh','w').write('rm -rf /')"`, or the same payload as a heredoc body) and a later segment merely executing that file (`bash /tmp/x.sh`) carries no delete-verb token in either segment, so the guard's per-segment token scan finds nothing to deny. Owner ruling: accepted as a pre-existing gap rather than closed — closing it needs cross-segment tracking this module does not attempt ([#7190](https://github.com/bobmatnyc/trusty-tools/issues/7190))

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/destructive_delete.rs
@@ -69,6 +69,18 @@
 //! - The Guard 2/3 operator escape hatches
 //!   (`TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED`) lift this rule
 //!   along with every other in the file — tracked separately as issue #3981.
+//! - A delete verb hidden inside a file this module never opens is not
+//!   detected: one segment WRITES a script containing `rm -rf /` (e.g.
+//!   `python3 -c "open('/tmp/x.sh','w').write('rm -rf /')"`, or the same
+//!   payload as a heredoc body) and a later segment merely EXECUTES that file
+//!   (`bash /tmp/x.sh`) — neither segment's own tokens carry a delete verb, so
+//!   per-segment scanning ([`split_shell_segments`]) finds nothing to deny.
+//!   Pre-existing today via the one-line form above; accepted rather than
+//!   closed (owner ruling, #7190) — closing it needs cross-segment tracking
+//!   of "this path was just written, and a later segment executes it", which
+//!   this module does not attempt. A heredoc-body allowlist redesign
+//!   considered for #7190 does not add this class, only removes an
+//!   incidental catch a masked multi-line body happened to trigger.
 //!
 //! Test: `denies_filesystem_root_deletion`, `denies_repo_root_deletion`,
 //! `denies_dot_git_deletion`, `denies_worktree_root_deletion`,


### PR DESCRIPTION
Owner's Option A ruling of 2026-09-09 accepts the write-then-execute bypass flagged in the round-4 code-critic review as a pre-existing, documented gap (reachable on main today with no heredoc), so this PR adds it to the module's residual-bypasses doc list plus a changelog fragment, and asks the reviewer to re-review the earlier WARN under that ruling.

**Test ladder rung 1 (docs-only plus comment-only .rs edit):**

- `check_sld.sh`: 0 errors
- `check_doc_paths.sh`: all resolve
- `check_line_cap.sh`: pass
- `check_test_pointers.sh`: pass
- `check_changelog_fragment.sh --staged`: pass

Refs [#7190](https://github.com/bobmatnyc/trusty-tools/issues/7190)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01QQiX3t6xPjP3mCE4TrteUa
