### PR TITLE
fix(trusty-audit): kill a clone that crosses the disk budget, including its whole process group (Refs #5669)

### DIFF
--- a/crates/trusty-audit/changelog.d/5669-clone-budget-watchdog.md
+++ b/crates/trusty-audit/changelog.d/5669-clone-budget-watchdog.md
@@ -5,13 +5,21 @@ Fixed
   against a 20 GiB ceiling still admitted a 100 GB monorepo and finished at
   119 GiB — on a client's own machine, during an unattended engagement, with
   nobody watching to intervene. While a clone runs, its staged tree is now
-  measured every 500ms and the child is signalled once `spent + staged` crosses
+  measured every 500ms and the clone is signalled once `spent + staged` crosses
   the ceiling: `SIGTERM` first, so `git` and `gh` remove their own temporary
   pack files, then `SIGKILL` after a five-second grace, and the child is reaped
-  either way. The partial tree is removed by the same path a failed clone takes,
-  so nothing survives under staging or is promoted into `repos/`. The overshoot
-  is bounded by the sampling interval rather than being zero — a clone can
-  exceed the ceiling by what it writes in one sample period.
+  either way. The signal goes to the clone's whole process group, because a
+  clone is a tree of processes — `gh` forks `git`, `git` forks `ssh`,
+  `git-index-pack` and `git-unpack-objects`, and those grandchildren are what
+  hold the sockets and write the bytes. Signalling only the process this crate
+  spawned left them fetching into, and recreating, the staged directory the
+  cleanup had just removed. The partial tree is removed by the same path a
+  failed clone takes, so nothing survives under staging or is promoted into
+  `repos/` — and when that removal itself fails, the surviving bytes are
+  measured, counted against the budget, and named in a gap line of their own
+  rather than silently ignored. The overshoot is bounded by the sampling
+  interval rather than being zero: a clone can exceed the ceiling by what it
+  writes in one sample period.
 - The outcome lands on its own `CloneState::BudgetExceeded` rather than on
   `Failed` or on the existing start-gate `Skipped`, and renders as
   `OVER BUDGET — stopped mid-clone at <size> against a <size> ceiling`. A
@@ -24,6 +32,13 @@ Fixed
   previously counted as zero bytes and so could never trip the ceiling. A
   partial walk below the root stays a floor and is not a failure, because `git`
   creating and removing pack files mid-fetch makes one ordinary.
+- Every disk figure now comes from one measuring function that tells those two
+  cases apart, and all three of its call sites — the watchdog's sample, the
+  freshly promoted checkout, and a checkout reused from an earlier run — get the
+  same answer. The last two used to collapse an unopenable root to zero bytes
+  and feed that straight into the budget ledger, so a reused checkout of any
+  size could be spent invisibly. Both are now named gaps instead. A checkout
+  that was already on disk when the run started is never removed.
 - `CloneOptions::budget_bytes`, `DEFAULT_BUDGET_BYTES`, and the `--budget-gb`
   help text no longer say the budget stops clones from starting without capping
   one in flight.

--- a/crates/trusty-audit/changelog.d/5669-clone-budget-watchdog.md
+++ b/crates/trusty-audit/changelog.d/5669-clone-budget-watchdog.md
@@ -39,6 +39,20 @@ Fixed
   and feed that straight into the budget ledger, so a reused checkout of any
   size could be spent invisibly. Both are now named gaps instead. A checkout
   that was already on disk when the run started is never removed.
+- Ctrl-C during a clone now stops the clone. Putting each clone in a process
+  group of its own is what lets one signal reach the whole tree, and it is also
+  what takes that tree out of the terminal's foreground group — so a raw Ctrl-C
+  used to kill `taudit` outright, running no destructors, and leave `ssh` and
+  `git-index-pack` fetching into the client's disk with the watchdog dead. The
+  interrupt is now forwarded to every clone group the terminal can no longer
+  reach, anything still running 250ms later is killed, and `trusty-audit` then
+  dies by `SIGINT` under its default disposition, so a shell script or CI runner
+  still sees the run as interrupted rather than as finished.
+- A partial checkout that can be neither removed nor measured is now reported as
+  an unknown size naming the measurement failure, instead of as "at least 0
+  bytes are still on disk" — a figure that reads as measured for a tree that may
+  hold gigabytes. Its bytes are excluded from the budget ledger and every later
+  budget decision in the run is marked a floor.
 - `CloneOptions::budget_bytes`, `DEFAULT_BUDGET_BYTES`, and the `--budget-gb`
   help text no longer say the budget stops clones from starting without capping
   one in flight.

--- a/crates/trusty-audit/changelog.d/5669-clone-budget-watchdog.md
+++ b/crates/trusty-audit/changelog.d/5669-clone-budget-watchdog.md
@@ -1,0 +1,29 @@
+Fixed
+
+- `--budget-gb` is now a cap on what the clones occupy, not only a gate on what
+  they start. It used to be checked between repositories, so 19 GiB spent
+  against a 20 GiB ceiling still admitted a 100 GB monorepo and finished at
+  119 GiB — on a client's own machine, during an unattended engagement, with
+  nobody watching to intervene. While a clone runs, its staged tree is now
+  measured every 500ms and the child is signalled once `spent + staged` crosses
+  the ceiling: `SIGTERM` first, so `git` and `gh` remove their own temporary
+  pack files, then `SIGKILL` after a five-second grace, and the child is reaped
+  either way. The partial tree is removed by the same path a failed clone takes,
+  so nothing survives under staging or is promoted into `repos/`. The overshoot
+  is bounded by the sampling interval rather than being zero — a clone can
+  exceed the ceiling by what it writes in one sample period.
+- The outcome lands on its own `CloneState::BudgetExceeded` rather than on
+  `Failed` or on the existing start-gate `Skipped`, and renders as
+  `OVER BUDGET — stopped mid-clone at <size> against a <size> ceiling`. A
+  recipient reading `FAILED` would go looking for a wrong repository name or a
+  revoked credential; there is no fault here, and the gap line says to raise
+  `--budget-gb` or drop the repository instead.
+- A sample the watchdog cannot take now fails the clone CLOSED — the child is
+  killed and the attempt reported — rather than letting the clone run on
+  unmeasured. That includes a staged tree whose own root cannot be opened, which
+  previously counted as zero bytes and so could never trip the ceiling. A
+  partial walk below the root stays a floor and is not a failure, because `git`
+  creating and removing pack files mid-fetch makes one ordinary.
+- `CloneOptions::budget_bytes`, `DEFAULT_BUDGET_BYTES`, and the `--budget-gb`
+  help text no longer say the budget stops clones from starting without capping
+  one in flight.

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -128,10 +128,11 @@ pub enum Verb {
         /// Repositories to clone, as owner/name.
         #[arg(value_name = "OWNER/NAME", required = true)]
         repos: Vec<String>,
-        /// Stop STARTING clones once this many gigabytes are on disk (0: never).
+        /// Cap what the clones may occupy, in gigabytes (0: no cap).
         ///
-        /// Not a cap on one repository: a clone already running is never
-        /// interrupted, so a single large repository can exceed this.
+        /// #5669: a cap on the run, not only on what it starts. A clone whose
+        /// checkout crosses the ceiling while it is fetching is stopped and its
+        /// partial tree removed, and the repository is reported as excluded.
         #[arg(long, value_name = "GB")]
         budget_gb: Option<u64>,
     },
@@ -1098,6 +1099,17 @@ mod cli_tests {
                     bytes: 0,
                     bytes_complete: true,
                 },
+                // #5669: a budget kill must not read as a failure.
+                ClonedRepo {
+                    name_with_owner: "acme/monorepo".to_owned(),
+                    path: PathBuf::from("/w/repos/acme/monorepo"),
+                    state: CloneState::BudgetExceeded {
+                        staged_bytes: 4096,
+                        budget_bytes: 3072,
+                    },
+                    bytes: 0,
+                    bytes_complete: true,
+                },
             ],
             total_bytes: 2048,
             total_bytes_complete: true,
@@ -1108,6 +1120,27 @@ mod cli_tests {
         assert!(text.contains("2.0 KiB"), "{text}");
         assert!(text.contains("FAILED"), "{text}");
         assert!(text.contains("Gap: acme/web"), "{text}");
+        // #5669: the budget kill gets its own rendered line, and that ONE line
+        // has to carry the repository and both sizes — a reader who cannot see
+        // which repository was dropped, or against what ceiling, is back to the
+        // silent overrun this issue is about.
+        let over = text
+            .lines()
+            .find(|line| line.contains("OVER BUDGET"))
+            .unwrap_or_else(|| panic!("the budget kill must be rendered: {text}"));
+        assert!(
+            over.contains("acme/monorepo"),
+            "the line names the repository: {over}"
+        );
+        assert!(
+            over.contains("4.0 KiB") && over.contains("3.0 KiB"),
+            "the line names what it reached and the ceiling it crossed: {over}"
+        );
+        assert!(
+            over.contains("stopped mid-clone"),
+            "the line says it was interrupted, not refused: {over}"
+        );
+        assert!(!over.contains("FAILED"), "a ceiling is not a fault: {over}");
     }
 
     /// A budget so large it overflows must clamp, never panic or wrap to zero.

--- a/crates/trusty-audit/src/cli.rs
+++ b/crates/trusty-audit/src/cli.rs
@@ -1091,6 +1091,7 @@ mod cli_tests {
                     state: CloneState::Cloned,
                     bytes: 2048,
                     bytes_complete: true,
+                    staging_residue: None,
                 },
                 ClonedRepo {
                     name_with_owner: "acme/web".to_owned(),
@@ -1098,6 +1099,7 @@ mod cli_tests {
                     state: CloneState::Failed("no such repository".to_owned()),
                     bytes: 0,
                     bytes_complete: true,
+                    staging_residue: None,
                 },
                 // #5669: a budget kill must not read as a failure.
                 ClonedRepo {
@@ -1109,6 +1111,7 @@ mod cli_tests {
                     },
                     bytes: 0,
                     bytes_complete: true,
+                    staging_residue: None,
                 },
             ],
             total_bytes: 2048,
@@ -1168,6 +1171,7 @@ mod cli_tests {
                     state: CloneState::Cloned,
                     bytes: 1024,
                     bytes_complete: false,
+                    staging_residue: None,
                 },
                 ClonedRepo {
                     name_with_owner: "acme/blank".to_owned(),
@@ -1175,6 +1179,7 @@ mod cli_tests {
                     state: CloneState::Empty("the repository has no commits".to_owned()),
                     bytes: 0,
                     bytes_complete: true,
+                    staging_residue: None,
                 },
             ],
             total_bytes: 1024,
@@ -1474,6 +1479,7 @@ mod cli_tests {
                     state: CloneState::Failed("no such repository".to_owned()),
                     bytes: 0,
                     bytes_complete: true,
+                    staging_residue: None,
                 }],
                 total_bytes: 0,
                 total_bytes_complete: true,

--- a/crates/trusty-audit/src/cli/render.rs
+++ b/crates/trusty-audit/src/cli/render.rs
@@ -12,7 +12,6 @@
 //! Test: `super::cli_tests`.
 
 use crate::chain::ChainReport;
-use crate::clone::CloneState;
 use crate::distribute::InstallPackage;
 use crate::registry::{COVERAGE_COACHING, TargetKind};
 use crate::run::{RepoResult, RunStatus};
@@ -206,7 +205,7 @@ pub fn render(outcome: &Outcome) -> String {
             out
         }
         Outcome::Run(report) => render_run(report),
-        Outcome::Cloned(report) => render_cloned(report),
+        Outcome::Cloned(report) => cloned::render(report),
         // #5822: an idempotent re-add and a fresh registration are different
         // facts, and an operator re-running `add` over a list needs to see
         // which one happened rather than the same line twice.
@@ -273,6 +272,9 @@ pub fn render(outcome: &Outcome) -> String {
 
 // #5563: the verify arm's own file, because this one is at the 500-SLOC cap.
 mod verify;
+
+// #5669: same reason — the clone report's own file.
+mod cloned;
 
 /// The regenerated reports, where they landed, and what did not come back.
 ///
@@ -454,7 +456,7 @@ fn render_chain(report: &ChainReport) -> String {
         ));
     }
     if let Some(acquired) = &report.acquired {
-        out.push_str(&render_cloned(acquired));
+        out.push_str(&cloned::render(acquired));
         out.push('\n');
     }
     out.push_str(&render_run(&report.run));
@@ -596,46 +598,6 @@ fn render_run(report: &crate::run::RunReport) -> String {
             report.repos.len()
         ),
     });
-    out
-}
-
-/// What acquisition put on disk, and what it could not.
-///
-/// Test: `super::cli_tests::rendering_a_clone_report_names_every_exclusion`.
-fn render_cloned(report: &crate::clone::CloneReport) -> String {
-    let mut out = String::new();
-    for repo in &report.repos {
-        // #5215: a repository that is NOT in the audit has to read as
-        // excluded, never as a blank line the recipient scrolls past.
-        let state = match &repo.state {
-            CloneState::Cloned => "cloned".to_string(),
-            CloneState::Reused => "already present".to_string(),
-            CloneState::Failed(why) => format!("FAILED — {why}"),
-            CloneState::Empty(why) => format!("NOTHING CLONED — {why}"),
-            CloneState::Skipped(why) => format!("SKIPPED — {why}"),
-        };
-        out.push_str(&format!("  {:<40} {state}\n", repo.name_with_owner));
-    }
-    out.push_str(&format!(
-        "{} on disk, using {}{}.\n",
-        count_of(
-            report.repos.iter().filter(|r| r.state.is_usable()).count(),
-            "repository",
-            "repositories"
-        ),
-        // #5215 review: a walk that hit something unreadable produces a
-        // floor, and saying "using X" of a floor is a confident number
-        // nothing measured.
-        if report.total_bytes_complete {
-            ""
-        } else {
-            "at least "
-        },
-        human_bytes(report.total_bytes)
-    ));
-    for gap in &report.gaps {
-        out.push_str(&format!("Gap: {gap}\n"));
-    }
     out
 }
 

--- a/crates/trusty-audit/src/cli/render/cloned.rs
+++ b/crates/trusty-audit/src/cli/render/cloned.rs
@@ -1,0 +1,66 @@
+//! The lines a clone report prints (#5669).
+//!
+//! Why: its own file for the reason `super::verify` has one — `super` sits at
+//! the 500-SLOC production cap, and #5669's `OVER BUDGET` arm is what pushed it
+//! over. The clone report is the cohesive piece to lift out: every arm here
+//! answers one question, which repositories are in the audit and which are not,
+//! and none of the other renderers name a [`CloneState`].
+//!
+//! What: [`render`], an exhaustive match over [`CloneState`] per repository,
+//! then the disk total and the gap lines. Exhaustive so a state added without a
+//! way to display it is a compile error rather than a repository that silently
+//! prints nothing.
+//! Test: `crate::cli::cli_tests::rendering_a_clone_report_names_every_exclusion`.
+
+use super::{count_of, human_bytes};
+use crate::clone::CloneState;
+
+/// What acquisition put on disk, and what it could not.
+///
+/// Test: `crate::cli::cli_tests::rendering_a_clone_report_names_every_exclusion`.
+pub(super) fn render(report: &crate::clone::CloneReport) -> String {
+    let mut out = String::new();
+    for repo in &report.repos {
+        // #5215: a repository that is NOT in the audit has to read as
+        // excluded, never as a blank line the recipient scrolls past.
+        let state = match &repo.state {
+            CloneState::Cloned => "cloned".to_string(),
+            CloneState::Reused => "already present".to_string(),
+            CloneState::Failed(why) => format!("FAILED — {why}"),
+            CloneState::Empty(why) => format!("NOTHING CLONED — {why}"),
+            CloneState::Skipped(why) => format!("SKIPPED — {why}"),
+            // #5669: distinct from FAILED, because nothing is wrong with the
+            // repository — the run hit the ceiling the operator set.
+            CloneState::BudgetExceeded {
+                staged_bytes,
+                budget_bytes,
+            } => format!(
+                "OVER BUDGET — stopped mid-clone at {} against a {} ceiling",
+                human_bytes(*staged_bytes),
+                human_bytes(*budget_bytes)
+            ),
+        };
+        out.push_str(&format!("  {:<40} {state}\n", repo.name_with_owner));
+    }
+    out.push_str(&format!(
+        "{} on disk, using {}{}.\n",
+        count_of(
+            report.repos.iter().filter(|r| r.state.is_usable()).count(),
+            "repository",
+            "repositories"
+        ),
+        // #5215 review: a walk that hit something unreadable produces a
+        // floor, and saying "using X" of a floor is a confident number
+        // nothing measured.
+        if report.total_bytes_complete {
+            ""
+        } else {
+            "at least "
+        },
+        human_bytes(report.total_bytes)
+    ));
+    for gap in &report.gaps {
+        out.push_str(&format!("Gap: {gap}\n"));
+    }
+    out
+}

--- a/crates/trusty-audit/src/clone.rs
+++ b/crates/trusty-audit/src/clone.rs
@@ -26,7 +26,7 @@
 //! **What a caller may assume, and may not.** A directory under
 //! [`Area::Repos`] is a COMPLETED, VERIFIED checkout, always. Work happens
 //! under [`Area::State`] (see [`STAGING_DIR`]) and is renamed into place only
-//! after `gh` exits zero AND [`verify_checkout`] confirms a resolvable `HEAD`,
+//! after `gh` exits zero AND [`disk::verify_checkout`] confirms a resolvable `HEAD`,
 //! so neither an interrupted run nor a commitless repository leaves something a
 //! later stage would silently analyze as whole (#5215).
 //!
@@ -63,7 +63,10 @@ use crate::progress::{Operation, Progress, UnitOutcome};
 use crate::run::{self, SelectedRepo};
 use crate::workdir::{Area, WorkDir};
 
+mod disk;
 mod watchdog;
+
+use disk::{finish_one, measure_tree};
 
 /// Directory under [`Area::State`] where in-progress clones are built.
 ///
@@ -126,7 +129,12 @@ pub enum CloneState {
     Cloned,
     /// A completed clone was already there; nothing was fetched.
     Reused,
-    /// The clone failed. Nothing was left under [`Area::Repos`] for it.
+    /// The clone failed, or what was on disk for it could not be measured.
+    ///
+    /// Nothing this run staged is left under [`Area::Repos`] or [`STAGING_DIR`],
+    /// unless the removal itself failed — which is reported separately, in
+    /// [`ClonedRepo::staging_residue`], rather than silently (#5669). A checkout
+    /// that was ALREADY there when the run started is never removed.
     Failed(String),
     /// `gh` exited zero but produced no checkout worth analyzing.
     ///
@@ -150,9 +158,12 @@ pub enum CloneState {
     /// that ran, was interrupted, and had its partial tree removed. This one
     /// says: raise `--budget-gb`, or drop the repository from the request.
     ///
-    /// Nothing survives under [`Area::Repos`] or [`STAGING_DIR`] for it.
+    /// Nothing survives under [`Area::Repos`] or [`STAGING_DIR`] for it — and on
+    /// the one path where the removal itself fails, that failure is reported in
+    /// [`ClonedRepo::staging_residue`] and its bytes counted, never swallowed.
     /// Test: `super::clone_tests::a_budget_kill_removes_the_staged_tree`,
-    /// `super::clone_tests::a_budget_kill_is_named_as_its_own_gap`.
+    /// `super::clone_tests::a_budget_kill_is_named_as_its_own_gap`,
+    /// `super::clone_tests::a_staged_tree_that_cannot_be_removed_is_its_own_gap`.
     BudgetExceeded {
         /// What the staged tree measured when it was stopped.
         staged_bytes: u64,
@@ -178,7 +189,12 @@ pub struct ClonedRepo {
     pub path: PathBuf,
     /// What happened.
     pub state: CloneState,
-    /// Bytes on disk. Zero unless the state is usable.
+    /// Bytes this repository occupies on disk.
+    ///
+    /// Zero for a state that is not usable, with one exception: a partial tree
+    /// this run tried and failed to remove is still on disk, so its bytes are
+    /// counted here and against the budget rather than reported as nothing
+    /// (#5669). [`ClonedRepo::staging_residue`] says when that happened.
     pub bytes: u64,
     /// Whether [`ClonedRepo::bytes`] counted the whole tree.
     ///
@@ -188,6 +204,15 @@ pub struct ClonedRepo {
     /// about a number a failed walk produced (#5215 review).
     /// Test: `super::clone_tests::an_unreadable_subtree_marks_the_size_incomplete`.
     pub bytes_complete: bool,
+    /// Why a partial tree this run had to remove is still on disk (#5669).
+    ///
+    /// `None` is the ordinary case, and the one every "nothing survives"
+    /// guarantee is written for. `Some` says [`std::fs::remove_dir_all`] failed
+    /// — the bytes are still there, [`ClonedRepo::bytes`] counts them, and this
+    /// sentence becomes a gap line of its own so the recipient learns about
+    /// disk the audit could not reclaim.
+    /// Test: `super::clone_tests::a_staged_tree_that_cannot_be_removed_is_its_own_gap`.
+    pub staging_residue: Option<String>,
 }
 
 /// The whole acquisition step's result.
@@ -479,136 +504,6 @@ fn clone_command(name_with_owner: &str, into: &Path) -> GhCommand {
     GhCommand::new(args).env_remove("GH_REPO")
 }
 
-/// Bytes occupied by a directory tree, and whether the walk saw all of it.
-///
-/// Why: an unreadable subdirectory used to contribute 0 silently, so a failed
-/// walk produced a confident-looking total that understated disk use and made
-/// the budget stop later than asked. The flag is what stops the caller
-/// presenting a floor as a figure (#5215 review).
-/// What: recursive, never following symlinks. `false` means some entry could
-/// not be read, so the count is a lower bound.
-/// Test: `super::clone_tests::an_unreadable_subtree_marks_the_size_incomplete`.
-fn dir_size(path: &Path) -> (u64, bool) {
-    let Ok(entries) = std::fs::read_dir(path) else {
-        return (0, false);
-    };
-    let mut total = 0u64;
-    let mut complete = true;
-    for entry in entries {
-        let Ok(entry) = entry else {
-            complete = false;
-            continue;
-        };
-        let child = entry.path();
-        if child.is_symlink() {
-            continue;
-        }
-        if child.is_dir() {
-            let (bytes, ok) = dir_size(&child);
-            total = total.saturating_add(bytes);
-            complete &= ok;
-        } else {
-            match std::fs::symlink_metadata(&child) {
-                Ok(meta) => total = total.saturating_add(meta.len()),
-                Err(_) => complete = false,
-            }
-        }
-    }
-    (total, complete)
-}
-
-/// Is this staged tree a checkout the sweep can actually read?
-///
-/// Why: `gh` exiting zero is not proof of a usable repository. Cloning a
-/// COMMITLESS repository exits zero and leaves a directory
-/// holding only `.git`, and `gh repo clone` forwards that status — reported as
-/// `Cloned`, the audit claims coverage of a repository nothing ever read
-/// (#5215 review). This is the check the `#[ignore]`d live test was making and
-/// the production path was not.
-/// What: `.git` must be a real directory, and `HEAD` must resolve — either to a
-/// detached SHA, or to a ref that exists loose or in `packed-refs`. An
-/// unresolvable `HEAD` is exactly the commitless case.
-/// Test: `super::clone_tests::a_commitless_clone_is_not_a_usable_checkout`,
-/// `super::clone_tests::a_checkout_with_a_packed_head_ref_is_usable`.
-fn verify_checkout(tree: &Path) -> Result<(), String> {
-    let git = tree.join(".git");
-    if !git.is_dir() {
-        return Err("the clone left no .git directory".to_string());
-    }
-    let head = match std::fs::read_to_string(git.join("HEAD")) {
-        Ok(text) => text.trim().to_string(),
-        Err(source) => return Err(format!("the clone left no readable .git/HEAD: {source}")),
-    };
-    let Some(reference) = head.strip_prefix("ref:").map(str::trim) else {
-        // A detached HEAD is a raw SHA, which means there is a commit.
-        return Ok(());
-    };
-    if git.join(reference).exists() {
-        return Ok(());
-    }
-    let packed = std::fs::read_to_string(git.join("packed-refs")).unwrap_or_default();
-    if packed.lines().any(|line| line.ends_with(reference)) {
-        return Ok(());
-    }
-    Err(format!(
-        "the repository has no commits — HEAD points at {reference}, which does not exist"
-    ))
-}
-
-/// Turn one `gh` result into a state, moving the partial into place or removing it.
-///
-/// Why: this is the fail-open site. `gh repo clone` failing part-way leaves a
-/// directory that LOOKS like a checkout, and a caller that reported success on
-/// it would hand a half-fetched repository to the sweep, which would analyze it
-/// and report on it as if it were whole. The rename is what makes "a directory
-/// under `repos/` is a completed clone" true by construction rather than by
-/// convention.
-/// What: on a failure or a budget kill, removes the staged tree and returns
-/// why. On completion, VERIFIES the tree before promoting it — a zero exit that
-/// produced no usable checkout becomes [`CloneState::Empty`], and nothing is
-/// promoted. Only a verified tree is renamed onto `dest`. Never leaves the
-/// staged tree behind.
-/// Test: `super::clone_tests::a_failed_clone_leaves_nothing_behind`,
-/// `super::clone_tests::a_successful_clone_is_renamed_into_place`,
-/// `super::clone_tests::a_commitless_clone_is_not_a_usable_checkout`,
-/// `super::clone_tests::a_budget_kill_removes_the_staged_tree`.
-fn finish_one(dest: &Path, staged: &Path, outcome: watchdog::Outcome) -> (CloneState, u64, bool) {
-    let discard = |state: CloneState| {
-        let _ = std::fs::remove_dir_all(staged);
-        (state, 0, true)
-    };
-    match outcome {
-        // #6001: the reason arrives as a string rather than a `GhError`, because
-        // acquisition now has two mechanisms and only one of them is `gh`.
-        watchdog::Outcome::Failed(reason) => return discard(CloneState::Failed(reason)),
-        // #5669: the same removal a failure gets — a tree the budget stopped is
-        // as unusable as one the remote refused, and leaving it would defeat
-        // the ceiling it just crossed.
-        watchdog::Outcome::OverBudget {
-            staged_bytes,
-            budget_bytes,
-        } => {
-            return discard(CloneState::BudgetExceeded {
-                staged_bytes,
-                budget_bytes,
-            });
-        }
-        watchdog::Outcome::Completed => {}
-    }
-    // #5215: verify BEFORE the rename, so an unusable tree never occupies the
-    // destination even briefly.
-    if let Err(why) = verify_checkout(staged) {
-        return discard(CloneState::Empty(why));
-    }
-    if let Err(source) = std::fs::rename(staged, dest) {
-        return discard(CloneState::Failed(format!(
-            "clone completed but could not be moved into place: {source}"
-        )));
-    }
-    let (bytes, complete) = dir_size(dest);
-    (CloneState::Cloned, bytes, complete)
-}
-
 /// Assemble the report, deciding whether the sequence may continue.
 ///
 /// Why: DOC-68 §14 Q2's decision, encoded rather than cited — one failure is a
@@ -629,6 +524,14 @@ fn summarize(repos: Vec<ClonedRepo>) -> Result<CloneReport, AuditError> {
     let usable_repos = || repos.iter().filter(|r| r.state.is_usable());
     let total_bytes = usable_repos().map(|r| r.bytes).sum();
     let total_bytes_complete = usable_repos().all(|r| r.bytes_complete);
+    // #5669: a tree that could not be removed is its own line, whatever state
+    // the repository itself ended in — the recipient has disk to reclaim by
+    // hand, and a failed `remove_dir_all` is the only way to learn of it.
+    let residues = repos.iter().filter_map(|r| {
+        r.staging_residue
+            .as_ref()
+            .map(|why| format!("{} left disk behind — {why}", r.name_with_owner))
+    });
     let gaps = repos
         .iter()
         .filter_map(|r| match &r.state {
@@ -655,6 +558,7 @@ fn summarize(repos: Vec<ClonedRepo>) -> Result<CloneReport, AuditError> {
             )),
             CloneState::Cloned | CloneState::Reused => None,
         })
+        .chain(residues)
         .collect();
     Ok(CloneReport {
         repos,
@@ -787,6 +691,10 @@ pub async fn clone_all(
     progress.operation_started(Operation::CloneRepos, total);
     let mut out = Vec::with_capacity(total);
     let mut spent: u64 = 0;
+    // #5669: whether `spent` is a total or a floor. The gate below can only
+    // compare the number it has, so when that number is a lower bound the
+    // reason it prints says so instead of reading as a measured figure.
+    let mut spent_complete = true;
     for (index, (name_with_owner, source, dest, staged)) in planned.into_iter().enumerate() {
         progress.unit_started(
             Operation::CloneRepos,
@@ -801,8 +709,31 @@ pub async fn clone_all(
         ensure_real_dir(dest.clone())?;
 
         if dest.is_dir() {
-            let (bytes, complete) = dir_size(&dest);
+            // #5669: a reused checkout feeds the same ledger a fresh one does,
+            // so an unreadable root here is the identical fail-open — it would
+            // contribute 0 for a tree of any size and let the run spend the
+            // whole budget invisibly. It is a gap instead. The checkout itself
+            // is left exactly as it was found.
+            let (bytes, complete) = match measure_tree(&dest) {
+                Ok(measured) => measured,
+                Err(why) => {
+                    let state = CloneState::Failed(format!(
+                        "{why} — a checkout of unknown size cannot be held to the disk budget"
+                    ));
+                    announce(progress, &name_with_owner, &state);
+                    out.push(ClonedRepo {
+                        name_with_owner,
+                        path: dest,
+                        state,
+                        bytes: 0,
+                        bytes_complete: false,
+                        staging_residue: None,
+                    });
+                    continue;
+                }
+            };
             spent = spent.saturating_add(bytes);
+            spent_complete &= complete;
             announce(progress, &name_with_owner, &CloneState::Reused);
             out.push(ClonedRepo {
                 name_with_owner,
@@ -810,12 +741,18 @@ pub async fn clone_all(
                 state: CloneState::Reused,
                 bytes,
                 bytes_complete: complete,
+                staging_residue: None,
             });
             continue;
         }
         if options.budget_bytes.is_some_and(|b| spent >= b) {
+            let floor = if spent_complete {
+                ""
+            } else {
+                " (a floor — part of an earlier checkout could not be read)"
+            };
             let state = CloneState::Skipped(format!(
-                "the {spent}-byte disk budget for clones was already spent"
+                "the {spent}-byte disk budget for clones was already spent{floor}"
             ));
             announce(progress, &name_with_owner, &state);
             out.push(ClonedRepo {
@@ -824,6 +761,7 @@ pub async fn clone_all(
                 state,
                 bytes: 0,
                 bytes_complete: true,
+                staging_residue: None,
             });
             continue;
         }
@@ -845,15 +783,19 @@ pub async fn clone_all(
             .budget_bytes
             .map(|budget| watchdog::Watch::new(spent, budget));
         let ran = acquire(&name_with_owner, &source, &staged, watch).await;
-        let (state, bytes, complete) = finish_one(&dest, &staged, ran);
-        spent = spent.saturating_add(bytes);
-        announce(progress, &name_with_owner, &state);
+        let finished = finish_one(&dest, &staged, ran);
+        // #5669: bytes a failed removal left behind are still on disk, so they
+        // count against the ceiling exactly as a promoted checkout's do.
+        spent = spent.saturating_add(finished.bytes);
+        spent_complete &= finished.bytes_complete;
+        announce(progress, &name_with_owner, &finished.state);
         out.push(ClonedRepo {
             name_with_owner,
             path: dest,
-            state,
-            bytes,
-            bytes_complete: complete,
+            state: finished.state,
+            bytes: finished.bytes,
+            bytes_complete: finished.bytes_complete,
+            staging_residue: finished.residue,
         });
     }
     let usable = out.iter().filter(|r| r.state.is_usable()).count();
@@ -949,6 +891,8 @@ fn announce(progress: &Progress, name_with_owner: &str, state: &CloneState) {
 #[cfg(test)]
 mod clone_tests {
     use super::*;
+    // Exercised only from here; `super` reaches them through `finish_one`.
+    use super::disk::{discard_at, verify_checkout};
     use crate::local_repo::local_repo_tests::{run_git, source_repo};
     use trusty_common::gh::GhError;
 
@@ -973,6 +917,7 @@ mod clone_tests {
             state,
             bytes,
             bytes_complete: true,
+            staging_residue: None,
         }
     }
 
@@ -1033,13 +978,17 @@ mod clone_tests {
         std::fs::create_dir_all(staged.join(".git/refs/heads")).expect("mkdir");
         std::fs::write(staged.join(".git/HEAD"), b"ref: refs/heads/main\n").expect("HEAD");
 
-        let (state, bytes, _) = finish_one(&dest, &staged, watchdog::Outcome::Completed);
-        let CloneState::Empty(why) = &state else {
-            panic!("a zero exit with no commits must not be Cloned: {state:?}");
+        let finished = finish_one(&dest, &staged, watchdog::Outcome::Completed);
+        let CloneState::Empty(why) = &finished.state else {
+            panic!(
+                "a zero exit with no commits must not be Cloned: {:?}",
+                finished.state
+            );
         };
         assert!(why.contains("no commits"), "{why}");
-        assert!(!state.is_usable());
-        assert_eq!(bytes, 0);
+        assert!(!finished.state.is_usable());
+        assert_eq!(finished.bytes, 0);
+        assert_eq!(finished.residue, None, "the tree was removed");
         assert!(!dest.exists(), "nothing may be promoted");
         assert!(!staged.exists());
     }
@@ -1228,12 +1177,80 @@ mod clone_tests {
         std::fs::write(blocked.join("hidden"), b"0123456789").expect("write");
         std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).expect("chmod");
 
-        let (bytes, complete) = dir_size(&tree);
+        let measured = measure_tree(&tree);
         // Restore first, so a failed assertion cannot leave an undeletable tree.
         std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o755))
             .expect("restore");
+        let (bytes, complete) = measured.expect("the ROOT opened, so this is a floor not an error");
         assert!(!complete, "an unreadable subtree must not read as a total");
         assert_eq!(bytes, 5, "the readable part is still counted: {bytes}");
+    }
+
+    /// The fail-open every disk figure shared (#5669).
+    ///
+    /// A tree whose own root cannot be opened measured `(0, false)`, and a
+    /// confident zero for a checkout of any size means the ceiling is never
+    /// reached and so never enforced. Two of the three call sites — the promoted
+    /// checkout and the reused one — dropped the flag entirely, so the zero
+    /// arrived at the budget ledger with nothing marking it as a non-answer.
+    #[test]
+    fn an_unreadable_root_is_a_measurement_failure_not_a_zero() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // root ignores the mode bits, so the case cannot be staged there.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let tree = tmp.path().join("tree");
+        std::fs::create_dir_all(&tree).expect("mkdir");
+        std::fs::write(tree.join("big"), vec![b'x'; 8192]).expect("write");
+        std::fs::set_permissions(&tree, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+        let measured = measure_tree(&tree);
+
+        std::fs::set_permissions(&tree, std::fs::Permissions::from_mode(0o755)).expect("restore");
+        let why = measured.expect_err("an unopenable root is not an empty tree");
+        assert!(why.contains("could not be measured"), "{why}");
+    }
+
+    /// The reused-checkout path is the third call site, and it fed `spent`
+    /// directly: a checkout of any size that could not be opened contributed
+    /// zero and let the run go on spending a budget it had already used (#5669).
+    #[tokio::test]
+    async fn a_reused_checkout_that_cannot_be_measured_is_a_gap() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+        let present = destination(&work, "acme/api").expect("valid");
+        std::fs::create_dir_all(&present).expect("mkdir");
+        std::fs::write(present.join("f"), vec![b'x'; 8192]).expect("write");
+        std::fs::set_permissions(&present, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+        let outcome = clone_all(
+            &work,
+            &["acme/api".to_string()],
+            &CloneOptions::default(),
+            &Progress::none(),
+        )
+        .await;
+
+        std::fs::set_permissions(&present, std::fs::Permissions::from_mode(0o755))
+            .expect("restore");
+        // The only entry is unusable, so the run has nothing to audit at all.
+        let err = outcome.expect_err("an unmeasurable checkout is not a usable one");
+        assert!(
+            matches!(err, AuditError::AllClonesFailed { attempted: 1 }),
+            "{err:?}"
+        );
+        assert!(
+            present.join("f").is_file(),
+            "a checkout that was already there is never removed"
+        );
     }
 
     #[test]
@@ -1284,13 +1301,18 @@ mod clone_tests {
         plant_checkout(&staged);
         std::fs::write(staged.join("README.md"), b"partial").expect("write");
 
-        let (state, bytes, _) = finish_one(
+        let finished = finish_one(
             &dest,
             &staged,
             watchdog::Outcome::Failed(gh_failure().to_string()),
         );
-        assert!(matches!(state, CloneState::Failed(_)), "{state:?}");
-        assert_eq!(bytes, 0);
+        assert!(
+            matches!(finished.state, CloneState::Failed(_)),
+            "{:?}",
+            finished.state
+        );
+        assert_eq!(finished.bytes, 0);
+        assert_eq!(finished.residue, None, "the removal succeeded");
         assert!(
             !dest.exists(),
             "a failed clone must not appear as a checkout"
@@ -1306,13 +1328,14 @@ mod clone_tests {
         plant_checkout(&staged);
         std::fs::write(staged.join("f"), b"0123456789").expect("write");
 
-        let (state, bytes, complete) = finish_one(&dest, &staged, watchdog::Outcome::Completed);
-        assert_eq!(state, CloneState::Cloned);
+        let finished = finish_one(&dest, &staged, watchdog::Outcome::Completed);
+        assert_eq!(finished.state, CloneState::Cloned);
         assert!(
-            bytes >= 10,
-            "the measured tree includes the payload: {bytes}"
+            finished.bytes >= 10,
+            "the measured tree includes the payload: {}",
+            finished.bytes
         );
-        assert!(complete);
+        assert!(finished.bytes_complete);
         assert!(dest.join(".git").is_dir());
         assert!(!staged.exists());
     }
@@ -1806,7 +1829,7 @@ mod clone_tests {
         plant_checkout(&staged);
         std::fs::write(staged.join("huge"), vec![b'x'; 8192]).expect("write");
 
-        let (state, bytes, _) = finish_one(
+        let finished = finish_one(
             &dest,
             &staged,
             watchdog::Outcome::OverBudget {
@@ -1816,16 +1839,86 @@ mod clone_tests {
         );
 
         assert_eq!(
-            state,
+            finished.state,
             CloneState::BudgetExceeded {
                 staged_bytes: 8192,
                 budget_bytes: 4096
             }
         );
-        assert!(!state.is_usable());
-        assert_eq!(bytes, 0);
+        assert!(!finished.state.is_usable());
+        assert_eq!(finished.bytes, 0);
+        assert_eq!(
+            finished.residue, None,
+            "the removal worked, so there is nothing to report"
+        );
         assert!(!dest.exists(), "a killed clone must not be promoted");
         assert!(!staged.exists(), "the partial tree must be removed");
+    }
+
+    /// The removal FAILING is not nothing (#5669).
+    ///
+    /// `discard` used to be `let _ = std::fs::remove_dir_all(staged)`, so a
+    /// staging directory that could not be emptied left the whole partial tree
+    /// on disk while the report said the state was `BudgetExceeded` and the
+    /// bytes were zero — the ceiling that just stopped the clone then went on
+    /// being measured against a figure missing everything the clone wrote.
+    #[test]
+    fn a_staged_tree_that_cannot_be_removed_is_its_own_gap() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // root ignores the mode bits, so the case cannot be staged there.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        std::fs::create_dir_all(&staged).expect("mkdir");
+        std::fs::write(staged.join("huge"), vec![b'x'; 8192]).expect("write");
+        // Unlinking an entry needs write permission on the directory HOLDING
+        // it, so a read-only `staged` is a removal that fails with the payload
+        // intact. A read-only PARENT would not do: `remove_dir_all` empties the
+        // tree first and only then fails to unlink the directory itself.
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o555)).expect("chmod");
+
+        let finished = discard_at(
+            &staged,
+            CloneState::BudgetExceeded {
+                staged_bytes: 8192,
+                budget_bytes: 4096,
+            },
+        );
+
+        // Restore before the assertions so the tempdir can always be removed.
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let residue = finished
+            .residue
+            .as_deref()
+            .expect("a removal that failed must say so");
+        assert!(residue.contains("could not be removed"), "{residue}");
+        assert!(
+            finished.bytes >= 8192,
+            "the surviving bytes are counted, not reported as zero: {}",
+            finished.bytes
+        );
+        assert!(staged.exists(), "the fixture's premise: the tree survived");
+
+        let report = summarize(vec![
+            cloned("acme/api", CloneState::Cloned, 100),
+            ClonedRepo {
+                staging_residue: finished.residue,
+                bytes: finished.bytes,
+                ..cloned("acme/monorepo", finished.state, finished.bytes)
+            },
+        ])
+        .expect("one usable checkout keeps the run going");
+        assert!(
+            report
+                .gaps
+                .iter()
+                .any(|g| g.contains("acme/monorepo") && g.contains("could not be removed")),
+            "the removal failure is named to the recipient: {:?}",
+            report.gaps
+        );
     }
 
     /// The gap line says what to change, and does not read as a failure.

--- a/crates/trusty-audit/src/clone.rs
+++ b/crates/trusty-audit/src/clone.rs
@@ -63,6 +63,8 @@ use crate::progress::{Operation, Progress, UnitOutcome};
 use crate::run::{self, SelectedRepo};
 use crate::workdir::{Area, WorkDir};
 
+mod watchdog;
+
 /// Directory under [`Area::State`] where in-progress clones are built.
 ///
 /// Why: the staging path must be one no repository name can address. Building
@@ -77,8 +79,7 @@ pub const STAGING_DIR: &str = "clone-staging";
 
 /// Default ceiling on what the clones may occupy, in bytes (20 GiB).
 ///
-/// Read [`CloneOptions::budget_bytes`] for what this does and does not bound —
-/// it stops new clones from STARTING, and does not cap one already running.
+/// A cap, not a start gate: see [`CloneOptions::budget_bytes`].
 pub const DEFAULT_BUDGET_BYTES: u64 = 20 * 1024 * 1024 * 1024;
 
 /// How to clone.
@@ -89,16 +90,22 @@ pub const DEFAULT_BUDGET_BYTES: u64 = 20 * 1024 * 1024 * 1024;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct CloneOptions {
-    /// Stop STARTING new clones once this much is already on disk. `None` never
-    /// stops.
+    /// Ceiling on what the clones may occupy on disk. `None` never stops.
     ///
-    /// This is a start gate, not a cap. It is checked between repositories and
-    /// nothing interrupts a clone in flight, so a single repository larger than
-    /// the remaining budget still lands in full — 19 GiB spent against a 20 GiB
-    /// budget admits a 100 GB monorepo and finishes at 119 GiB. Capping one
-    /// clone needs a watchdog that kills the child mid-fetch, which is not
-    /// implemented (#5215 review). Say "stops starting", never "bounded".
-    /// Test: `super::clone_tests::a_spent_budget_skips_rather_than_clones`.
+    /// Enforced at two points, and it is a cap because of the second (#5669).
+    /// Between repositories, a run whose total already meets the ceiling starts
+    /// no further clone — [`CloneState::Skipped`]. And WHILE a clone runs, its
+    /// staged tree is measured at a bounded interval, so a repository larger
+    /// than the remaining budget is killed mid-fetch and its partial tree
+    /// removed — [`CloneState::BudgetExceeded`]. The start gate alone let 19 GiB
+    /// spent against a 20 GiB budget admit a 100 GB monorepo and finish at
+    /// 119 GiB.
+    ///
+    /// The overshoot is bounded by the sampling interval, not zero: a clone can
+    /// exceed the ceiling by what it writes in one sample period before it is
+    /// stopped. See [`watchdog`].
+    /// Test: `super::clone_tests::a_spent_budget_skips_rather_than_clones`,
+    /// `super::watchdog::watchdog_tests::a_running_child_that_crosses_the_ceiling_is_stopped`.
     pub budget_bytes: Option<u64>,
 }
 
@@ -133,6 +140,25 @@ pub enum CloneState {
     Empty(String),
     /// Not attempted — the disk budget was already spent.
     Skipped(String),
+    /// Started, then stopped: the staged tree crossed the disk budget (#5669).
+    ///
+    /// Why: its own state rather than `Failed` or `Skipped`, because a report
+    /// reader has to tell three different things apart and act differently on
+    /// each. `Failed` sends them looking for a fault — a wrong name, a revoked
+    /// credential, an unreachable remote — and there is none here. `Skipped`
+    /// says the run never touched this repository, which understates a clone
+    /// that ran, was interrupted, and had its partial tree removed. This one
+    /// says: raise `--budget-gb`, or drop the repository from the request.
+    ///
+    /// Nothing survives under [`Area::Repos`] or [`STAGING_DIR`] for it.
+    /// Test: `super::clone_tests::a_budget_kill_removes_the_staged_tree`,
+    /// `super::clone_tests::a_budget_kill_is_named_as_its_own_gap`.
+    BudgetExceeded {
+        /// What the staged tree measured when it was stopped.
+        staged_bytes: u64,
+        /// The ceiling it crossed.
+        budget_bytes: u64,
+    },
 }
 
 impl CloneState {
@@ -436,9 +462,9 @@ fn ensure_real_dir(path: PathBuf) -> Result<(), AuditError> {
 /// and every line in the tree attributed to whoever last touched it — measured
 /// on `BurntSushi/xsv`, whose real history is 407 commits by 30 authors from
 /// 2014 to 2025. Every CSV in the deliverable was a header and one row. What
-/// bounds the disk that saved is [`CloneOptions::budget_bytes`], which stops
-/// STARTING clones and does not need history thrown away to work: the same
-/// repository is 628 KiB shallow and 1.2 MiB full, against a 20 GiB default.
+/// bounds the disk that saved is [`CloneOptions::budget_bytes`], which caps the
+/// run and does not need history thrown away to work: the same repository is
+/// 628 KiB shallow and 1.2 MiB full, against a 20 GiB default.
 /// What: `gh repo clone <owner/name> <dest>`, with no flags forwarded to `git`
 /// at all — so there is no `--` separator either.
 /// Test: `super::clone_tests::a_clone_asks_git_for_the_whole_history`.
@@ -537,22 +563,37 @@ fn verify_checkout(tree: &Path) -> Result<(), String> {
 /// and report on it as if it were whole. The rename is what makes "a directory
 /// under `repos/` is a completed clone" true by construction rather than by
 /// convention.
-/// What: on `Err`, removes the staged tree and returns the reason. On `Ok`,
-/// VERIFIES the tree before promoting it — a zero exit that produced no usable
-/// checkout becomes [`CloneState::Empty`], and nothing is promoted. Only a
-/// verified tree is renamed onto `dest`. Never leaves the staged tree behind.
+/// What: on a failure or a budget kill, removes the staged tree and returns
+/// why. On completion, VERIFIES the tree before promoting it — a zero exit that
+/// produced no usable checkout becomes [`CloneState::Empty`], and nothing is
+/// promoted. Only a verified tree is renamed onto `dest`. Never leaves the
+/// staged tree behind.
 /// Test: `super::clone_tests::a_failed_clone_leaves_nothing_behind`,
 /// `super::clone_tests::a_successful_clone_is_renamed_into_place`,
-/// `super::clone_tests::a_commitless_clone_is_not_a_usable_checkout`.
-fn finish_one(dest: &Path, staged: &Path, outcome: Result<(), String>) -> (CloneState, u64, bool) {
+/// `super::clone_tests::a_commitless_clone_is_not_a_usable_checkout`,
+/// `super::clone_tests::a_budget_kill_removes_the_staged_tree`.
+fn finish_one(dest: &Path, staged: &Path, outcome: watchdog::Outcome) -> (CloneState, u64, bool) {
     let discard = |state: CloneState| {
         let _ = std::fs::remove_dir_all(staged);
         (state, 0, true)
     };
-    // #6001: the reason arrives as a string rather than a `GhError`, because
-    // acquisition now has two mechanisms and only one of them is `gh`.
-    if let Err(reason) = outcome {
-        return discard(CloneState::Failed(reason));
+    match outcome {
+        // #6001: the reason arrives as a string rather than a `GhError`, because
+        // acquisition now has two mechanisms and only one of them is `gh`.
+        watchdog::Outcome::Failed(reason) => return discard(CloneState::Failed(reason)),
+        // #5669: the same removal a failure gets — a tree the budget stopped is
+        // as unusable as one the remote refused, and leaving it would defeat
+        // the ceiling it just crossed.
+        watchdog::Outcome::OverBudget {
+            staged_bytes,
+            budget_bytes,
+        } => {
+            return discard(CloneState::BudgetExceeded {
+                staged_bytes,
+                budget_bytes,
+            });
+        }
+        watchdog::Outcome::Completed => {}
     }
     // #5215: verify BEFORE the rename, so an unusable tree never occupies the
     // destination even briefly.
@@ -602,7 +643,17 @@ fn summarize(repos: Vec<ClonedRepo>) -> Result<CloneReport, AuditError> {
             CloneState::Skipped(why) => {
                 Some(format!("{} was not audited — {why}", r.name_with_owner))
             }
-            _ => None,
+            // #5669: says what was stopped and what to change, not "failed".
+            CloneState::BudgetExceeded {
+                staged_bytes,
+                budget_bytes,
+            } => Some(format!(
+                "{} was not audited — the clone was stopped once it reached {staged_bytes} bytes \
+                 against the {budget_bytes}-byte disk budget, and its partial checkout was \
+                 removed; raise --budget-gb to include it",
+                r.name_with_owner
+            )),
+            CloneState::Cloned | CloneState::Reused => None,
         })
         .collect();
     Ok(CloneReport {
@@ -674,8 +725,9 @@ fn record_selection(
 /// produce a local checkout with no prior manual `git clone`.
 /// What: guards `repos/` BEFORE creating anything, validates every name, then
 /// per repository: reuses a completed checkout, discards any leftover staged
-/// tree, clones into staging, verifies it, and renames it into place. Stops
-/// STARTING clones once the budget is spent; failures become gaps. Finally
+/// tree, clones into staging, verifies it, and renames it into place. Starts no
+/// clone once the budget is spent and stops one that crosses the ceiling while
+/// running (#5669); failures and both budget outcomes become gaps. Finally
 /// records the usable checkouts as the sweep's selection — see
 /// [`record_selection`].
 /// Test: `super::clone_tests`, `tests/cli_end_to_end.rs`, and
@@ -787,7 +839,12 @@ pub async fn clone_all(
             })?;
         }
 
-        let ran = acquire(&name_with_owner, &source, &staged).await;
+        // #5669: the ceiling travels into the clone, so a repository larger
+        // than what is left is stopped mid-fetch rather than landing in full.
+        let watch = options
+            .budget_bytes
+            .map(|budget| watchdog::Watch::new(spent, budget));
+        let ran = acquire(&name_with_owner, &source, &staged, watch).await;
         let (state, bytes, complete) = finish_one(&dest, &staged, ran);
         spent = spent.saturating_add(bytes);
         announce(progress, &name_with_owner, &state);
@@ -817,23 +874,47 @@ pub async fn clone_all(
 /// What: `gh repo clone` for a remote, `git clone <path>` for a local one.
 /// Either failure comes back as the reason `finish_one` records, so a bad
 /// source is one repository's gap and not the sweep's abort.
+///
+/// #5669: both children are now SPAWNED here rather than run to completion by
+/// their own module, because a budget that cannot interrupt is not a budget —
+/// [`watchdog`] owns the running of either. The `gh` child is still built by
+/// [`clone_command`] and configured by `trusty_common`'s own
+/// [`GhCommand::to_std_command`], so there is no second decision about which
+/// binary, which argv, or which environment scrub; the `git` child is still
+/// built from [`local_repo::clone_argv`] and hardened by [`crate::git::spawn`].
 /// Test: `super::clone_tests::a_local_path_is_acquired_under_the_local_owner`,
 /// `super::clone_tests::a_source_that_went_bad_after_registration_is_a_gap`.
-async fn acquire(name_with_owner: &str, source: &Source, staged: &Path) -> Result<(), String> {
-    match source {
-        Source::Remote => clone_command(name_with_owner, staged)
-            .output()
-            .await
-            .and_then(|o| o.ok())
-            .map(|_| ())
-            .map_err(|e| e.to_string()),
+async fn acquire(
+    name_with_owner: &str,
+    source: &Source,
+    staged: &Path,
+    watch: Option<watchdog::Watch>,
+) -> watchdog::Outcome {
+    let (spec, command) = match source {
+        Source::Remote => (
+            watchdog::Spawn {
+                label: "gh repo clone",
+                missing_hint: trusty_common::gh::GH_MISSING_HINT,
+            },
+            tokio::process::Command::from(clone_command(name_with_owner, staged).to_std_command()),
+        ),
         Source::Local(path) => {
-            local_repo::inspect(path)
-                .await
-                .map_err(|reason| format!("{} is no longer usable: {reason}", path.display()))?;
-            local_repo::clone_into(path, staged).await
+            if let Err(reason) = local_repo::inspect(path).await {
+                return watchdog::Outcome::Failed(format!(
+                    "{} is no longer usable: {reason}",
+                    path.display()
+                ));
+            }
+            (
+                watchdog::Spawn {
+                    label: "git clone",
+                    missing_hint: "`git` must be installed and on PATH for this to work.",
+                },
+                crate::git::spawn(local_repo::clone_argv(path, staged)),
+            )
         }
-    }
+    };
+    watchdog::run(&spec, command, staged, watch).await
 }
 
 /// Tell a watching front end how one repository ended.
@@ -844,7 +925,9 @@ async fn acquire(name_with_owner: &str, source: &Source, staged: &Path) -> Resul
 /// from acquisition state to display verdict is written once.
 /// What: [`CloneState::Reused`] and [`CloneState::Cloned`] are successes;
 /// `Empty` is a failure (it is not a checkout anything can read); `Failed` and
-/// `Skipped` carry their own reasons.
+/// `Skipped` carry their own reasons. `BudgetExceeded` is SKIPPED rather than
+/// failed (#5669) — the repository is out of the audit by the operator's own
+/// ceiling, which is the same thing the start gate reports.
 /// Test: `super::clone_tests::every_acquisition_outcome_is_reported_once`.
 fn announce(progress: &Progress, name_with_owner: &str, state: &CloneState) {
     let outcome = match state {
@@ -853,6 +936,12 @@ fn announce(progress: &Progress, name_with_owner: &str, state: &CloneState) {
             UnitOutcome::Failed(reason.clone())
         }
         CloneState::Skipped(reason) => UnitOutcome::Skipped(reason.clone()),
+        CloneState::BudgetExceeded {
+            staged_bytes,
+            budget_bytes,
+        } => UnitOutcome::Skipped(format!(
+            "stopped at {staged_bytes} bytes against the {budget_bytes}-byte disk budget"
+        )),
     };
     progress.unit_finished(Operation::CloneRepos, name_with_owner, outcome);
 }
@@ -944,7 +1033,7 @@ mod clone_tests {
         std::fs::create_dir_all(staged.join(".git/refs/heads")).expect("mkdir");
         std::fs::write(staged.join(".git/HEAD"), b"ref: refs/heads/main\n").expect("HEAD");
 
-        let (state, bytes, _) = finish_one(&dest, &staged, Ok(()));
+        let (state, bytes, _) = finish_one(&dest, &staged, watchdog::Outcome::Completed);
         let CloneState::Empty(why) = &state else {
             panic!("a zero exit with no commits must not be Cloned: {state:?}");
         };
@@ -1195,7 +1284,11 @@ mod clone_tests {
         plant_checkout(&staged);
         std::fs::write(staged.join("README.md"), b"partial").expect("write");
 
-        let (state, bytes, _) = finish_one(&dest, &staged, Err(gh_failure().to_string()));
+        let (state, bytes, _) = finish_one(
+            &dest,
+            &staged,
+            watchdog::Outcome::Failed(gh_failure().to_string()),
+        );
         assert!(matches!(state, CloneState::Failed(_)), "{state:?}");
         assert_eq!(bytes, 0);
         assert!(
@@ -1213,7 +1306,7 @@ mod clone_tests {
         plant_checkout(&staged);
         std::fs::write(staged.join("f"), b"0123456789").expect("write");
 
-        let (state, bytes, complete) = finish_one(&dest, &staged, Ok(()));
+        let (state, bytes, complete) = finish_one(&dest, &staged, watchdog::Outcome::Completed);
         assert_eq!(state, CloneState::Cloned);
         assert!(
             bytes >= 10,
@@ -1669,6 +1762,10 @@ mod clone_tests {
             CloneState::Failed("remote refused".into()),
             CloneState::Empty("no commits".into()),
             CloneState::Skipped("budget spent".into()),
+            CloneState::BudgetExceeded {
+                staged_bytes: 4097,
+                budget_bytes: 4096,
+            },
         ] {
             announce(&progress, "acme/api", &state);
         }
@@ -1691,7 +1788,121 @@ mod clone_tests {
                 // it is a failure here even though `gh` exited zero.
                 UnitOutcome::Failed("no commits".into()),
                 UnitOutcome::Skipped("budget spent".into()),
+                // #5669: the operator's own ceiling excluded it, so it reads
+                // as skipped rather than as a fault to go looking for.
+                UnitOutcome::Skipped(
+                    "stopped at 4097 bytes against the 4096-byte disk budget".into()
+                ),
             ]
+        );
+    }
+
+    /// #5669: a budget kill leaves nothing — not under `repos/`, not in staging.
+    #[test]
+    fn a_budget_kill_removes_the_staged_tree() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest = tmp.path().join("api");
+        let staged = tmp.path().join("staged");
+        plant_checkout(&staged);
+        std::fs::write(staged.join("huge"), vec![b'x'; 8192]).expect("write");
+
+        let (state, bytes, _) = finish_one(
+            &dest,
+            &staged,
+            watchdog::Outcome::OverBudget {
+                staged_bytes: 8192,
+                budget_bytes: 4096,
+            },
+        );
+
+        assert_eq!(
+            state,
+            CloneState::BudgetExceeded {
+                staged_bytes: 8192,
+                budget_bytes: 4096
+            }
+        );
+        assert!(!state.is_usable());
+        assert_eq!(bytes, 0);
+        assert!(!dest.exists(), "a killed clone must not be promoted");
+        assert!(!staged.exists(), "the partial tree must be removed");
+    }
+
+    /// The gap line says what to change, and does not read as a failure.
+    #[test]
+    fn a_budget_kill_is_named_as_its_own_gap() {
+        let report = summarize(vec![
+            cloned("acme/api", CloneState::Cloned, 100),
+            cloned(
+                "acme/monorepo",
+                CloneState::BudgetExceeded {
+                    staged_bytes: 8192,
+                    budget_bytes: 4096,
+                },
+                0,
+            ),
+        ])
+        .expect("one usable checkout keeps the run going");
+
+        assert_eq!(
+            report.total_bytes, 100,
+            "a killed clone contributes nothing"
+        );
+        assert_eq!(report.gaps.len(), 1);
+        let gap = &report.gaps[0];
+        assert!(gap.contains("acme/monorepo"), "{gap}");
+        assert!(gap.contains("8192"), "{gap}");
+        assert!(gap.contains("4096"), "{gap}");
+        assert!(gap.contains("--budget-gb"), "it says what to change: {gap}");
+        assert!(
+            !gap.contains("the clone failed"),
+            "a ceiling is not a fault: {gap}"
+        );
+    }
+
+    /// The whole path against a real remote, with a ceiling no clone can meet.
+    ///
+    /// #5669: the unit tests prove the watchdog stops a child that writes into
+    /// the staged tree; this proves the child it stops in production is a real
+    /// `gh repo clone`, and that nothing survives it.
+    ///
+    /// `#[ignore]` because it needs an authenticated `gh` and network —
+    /// `cargo test -p trusty-audit -- --include-ignored` runs it.
+    #[tokio::test]
+    #[ignore = "needs an authenticated gh and network access"]
+    async fn a_real_clone_over_the_budget_is_killed_mid_fetch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let work = work_in(tmp.path());
+
+        let report = clone_all(
+            &work,
+            &["BurntSushi/xsv".to_string()],
+            // One byte: the first sample after `gh` writes anything is over it.
+            &CloneOptions {
+                budget_bytes: Some(1),
+            },
+            &Progress::none(),
+        )
+        .await;
+
+        let Err(AuditError::AllClonesFailed { attempted }) = report else {
+            panic!("the only repository was stopped, so there is nothing to audit: {report:?}");
+        };
+        assert_eq!(attempted, 1);
+        assert!(
+            !destination(&work, "BurntSushi/xsv")
+                .expect("valid")
+                .exists(),
+            "nothing may be promoted"
+        );
+        assert!(
+            !work
+                .path(Area::State)
+                .join(STAGING_DIR)
+                .join("BurntSushi")
+                .join("xsv")
+                .exists(),
+            "the partial staged tree must be removed"
         );
     }
 }

--- a/crates/trusty-audit/src/clone.rs
+++ b/crates/trusty-audit/src/clone.rs
@@ -68,6 +68,9 @@ mod watchdog;
 
 use disk::{finish_one, measure_tree};
 
+/// The Ctrl-C path a binary running this module's clones must install (#5669).
+pub use watchdog::stop_clones_on_interrupt;
+
 /// Directory under [`Area::State`] where in-progress clones are built.
 ///
 /// Why: the staging path must be one no repository name can address. Building
@@ -1918,6 +1921,63 @@ mod clone_tests {
                 .any(|g| g.contains("acme/monorepo") && g.contains("could not be removed")),
             "the removal failure is named to the recipient: {:?}",
             report.gaps
+        );
+    }
+
+    /// A residue that cannot be MEASURED is unknown, not "at least 0" (#5669).
+    ///
+    /// `measure_tree(path).unwrap_or((0, false))` folded a root that could not
+    /// be opened into the same shape as a partial walk, so the gap line said
+    /// "at least 0 bytes are still on disk" for a tree that may hold gigabytes —
+    /// a figure a recipient reads as measured. The 0o555 fixture above cannot
+    /// reach this arm: a read-only directory still OPENS, so the measurement
+    /// there succeeds and only the removal fails.
+    #[test]
+    fn an_unmeasurable_residue_is_reported_unknown_not_zero() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // root ignores the mode bits, so the case cannot be staged there.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        std::fs::create_dir_all(&staged).expect("mkdir");
+        std::fs::write(staged.join("huge"), vec![b'x'; 8192]).expect("write");
+        // 0o000 denies the read the REMOVAL walks with and the read the
+        // MEASUREMENT walks with, which is the pair 0o555 cannot produce.
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+        let finished = discard_at(
+            &staged,
+            CloneState::BudgetExceeded {
+                staged_bytes: 8192,
+                budget_bytes: 4096,
+            },
+        );
+
+        // Restore before the assertions so the tempdir can always be removed.
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let residue = finished
+            .residue
+            .as_deref()
+            .expect("a removal that failed must say so");
+        assert!(residue.contains("could not be removed"), "{residue}");
+        assert!(
+            residue.contains("size is unknown"),
+            "an unmeasured tree is named as unknown: {residue}"
+        );
+        assert!(
+            residue.contains("could not be measured"),
+            "the measurement failure itself is named: {residue}"
+        );
+        assert!(
+            !residue.contains("at least 0 bytes"),
+            "an unmeasured tree must not read as a measured floor: {residue}"
+        );
+        assert!(
+            !finished.bytes_complete,
+            "an unknown size makes every later budget decision in the run a floor"
         );
     }
 

--- a/crates/trusty-audit/src/clone/disk.rs
+++ b/crates/trusty-audit/src/clone/disk.rs
@@ -152,7 +152,15 @@ pub(super) struct Finished {
 /// it MEASURES what survived, so the bytes count against the budget instead of
 /// being reported as zero, and returns the sentence the report prints as its own
 /// gap line.
-/// Test: `super::clone_tests::a_staged_tree_that_cannot_be_removed_is_its_own_gap`.
+///
+/// A tree that cannot be REMOVED and cannot be MEASURED either is a third case,
+/// and it is reported as unknown rather than as a floor of zero: "at least 0
+/// bytes" reads as a measured figure to a recipient, and the number it hides can
+/// be gigabytes. The gap line names the measurement failure, and
+/// [`Finished::bytes_complete`] is cleared, which is what turns every later
+/// budget decision in the run into the floor it has become (#5669).
+/// Test: `super::clone_tests::a_staged_tree_that_cannot_be_removed_is_its_own_gap`,
+/// `super::clone_tests::an_unmeasurable_residue_is_reported_unknown_not_zero`.
 pub(super) fn discard_at(path: &Path, state: CloneState) -> Finished {
     let source = match std::fs::remove_dir_all(path) {
         Ok(()) => {
@@ -173,22 +181,36 @@ pub(super) fn discard_at(path: &Path, state: CloneState) -> Finished {
         }
         Err(source) => source,
     };
-    // The removal failed, so whatever is there is still occupying disk. An
-    // unreadable root gives no figure at all, which is reported as a floor of
-    // zero rather than as a confident zero.
-    let (bytes, bytes_complete) = measure_tree(path).unwrap_or((0, false));
-    let size = if bytes_complete {
-        format!("{bytes} bytes")
-    } else {
-        format!("at least {bytes} bytes")
+    // #5669: the removal failed, so whatever is there is still occupying disk.
+    // Whether that is a FIGURE at all is what this match keeps: an unopenable
+    // root used to collapse into `(0, false)`, which the sentence below then
+    // printed as "at least 0 bytes" — a measurement, of a tree nothing measured.
+    let (bytes, bytes_complete, size) = match measure_tree(path) {
+        Ok((bytes, true)) => (
+            bytes,
+            true,
+            format!("{bytes} bytes are still on disk and count against the disk budget"),
+        ),
+        Ok((bytes, false)) => (
+            bytes,
+            false,
+            format!("at least {bytes} bytes are still on disk and count against the disk budget"),
+        ),
+        Err(why) => (
+            0,
+            false,
+            format!(
+                "its size is unknown ({why}), so what it holds is not counted against the disk \
+                 budget and every later budget decision in this run is a floor"
+            ),
+        ),
     };
     Finished {
         state,
         bytes,
         bytes_complete,
         residue: Some(format!(
-            "the partial checkout at {} could not be removed: {source}; {size} are still on \
-             disk and count against the disk budget",
+            "the partial checkout at {} could not be removed: {source}; {size}",
             path.display()
         )),
     }

--- a/crates/trusty-audit/src/clone/disk.rs
+++ b/crates/trusty-audit/src/clone/disk.rs
@@ -1,0 +1,271 @@
+//! The trees a clone leaves on disk, and what is done with them (#5669).
+//!
+//! Why: its own file for the reason `super::super::cli::render::cloned` has
+//! one — `super` sits at the 500-SLOC production cap, and #5669's shared
+//! measuring function is what pushed it over. This is the cohesive piece to
+//! lift out: every item here answers one question, what is on disk for one
+//! repository and whether it stays there. `super` keeps the loop, the report,
+//! and the names.
+//!
+//! What: [`measure_tree`], the one measurement every disk figure and every
+//! budget decision comes from; [`verify_checkout`], which decides whether a
+//! staged tree is a checkout at all; and [`finish_one`], which promotes it or
+//! removes it through [`discard_at`].
+//! Test: `super::clone_tests`.
+
+use std::path::Path;
+
+use super::{CloneState, watchdog};
+
+/// The one measurement every disk figure and every budget decision comes from.
+///
+/// Why: a tree whose own ROOT cannot be opened used to measure 0 bytes, and a
+/// confident 0 for a checkout of any size is the fail-open the budget cannot
+/// survive — the ceiling is never reached, so it is never enforced. That is a
+/// different fact from an entry BELOW the root being unreadable, which is
+/// ordinary: `git` creates and removes temporary pack files throughout a fetch,
+/// so a walk racing one sees an entry vanish. The two used to collapse into the
+/// same `(0, false)` (#5669).
+/// What: `Err` when the root cannot be opened, so the caller must decide rather
+/// than silently count nothing. `Ok((bytes, false))` when the root opened but
+/// something below it did not, which makes `bytes` a floor — and a floor over a
+/// ceiling still crosses it. The root is opened exactly ONCE and the walk reads
+/// that handle, so there is no window between a guard and the walk it guards.
+/// Never follows symlinks.
+/// Test: `super::clone_tests::an_unreadable_subtree_marks_the_size_incomplete`,
+/// `super::clone_tests::an_unreadable_root_is_a_measurement_failure_not_a_zero`.
+///
+/// # Errors
+///
+/// One line naming the path and the OS error, ready to become a gap.
+pub(super) fn measure_tree(path: &Path) -> Result<(u64, bool), String> {
+    match std::fs::read_dir(path) {
+        Ok(entries) => Ok(walk(entries)),
+        Err(source) => Err(format!(
+            "{} could not be measured: {source}",
+            path.display()
+        )),
+    }
+}
+
+/// Bytes occupied by a directory tree BELOW the root, and whether the walk saw
+/// all of it.
+///
+/// The floor semantics [`measure_tree`] documents, applied to a subdirectory:
+/// an unreadable one contributes 0 and clears the flag rather than failing the
+/// whole measurement (#5215 review).
+pub(super) fn dir_size(path: &Path) -> (u64, bool) {
+    match std::fs::read_dir(path) {
+        Ok(entries) => walk(entries),
+        Err(_) => (0, false),
+    }
+}
+
+/// Sum one already-opened directory handle, recursing into its subdirectories.
+pub(super) fn walk(entries: std::fs::ReadDir) -> (u64, bool) {
+    let mut total = 0u64;
+    let mut complete = true;
+    for entry in entries {
+        let Ok(entry) = entry else {
+            complete = false;
+            continue;
+        };
+        let child = entry.path();
+        if child.is_symlink() {
+            continue;
+        }
+        if child.is_dir() {
+            let (bytes, ok) = dir_size(&child);
+            total = total.saturating_add(bytes);
+            complete &= ok;
+        } else {
+            match std::fs::symlink_metadata(&child) {
+                Ok(meta) => total = total.saturating_add(meta.len()),
+                Err(_) => complete = false,
+            }
+        }
+    }
+    (total, complete)
+}
+
+/// Is this staged tree a checkout the sweep can actually read?
+///
+/// Why: `gh` exiting zero is not proof of a usable repository. Cloning a
+/// COMMITLESS repository exits zero and leaves a directory
+/// holding only `.git`, and `gh repo clone` forwards that status — reported as
+/// `Cloned`, the audit claims coverage of a repository nothing ever read
+/// (#5215 review). This is the check the `#[ignore]`d live test was making and
+/// the production path was not.
+/// What: `.git` must be a real directory, and `HEAD` must resolve — either to a
+/// detached SHA, or to a ref that exists loose or in `packed-refs`. An
+/// unresolvable `HEAD` is exactly the commitless case.
+/// Test: `super::clone_tests::a_commitless_clone_is_not_a_usable_checkout`,
+/// `super::clone_tests::a_checkout_with_a_packed_head_ref_is_usable`.
+pub(super) fn verify_checkout(tree: &Path) -> Result<(), String> {
+    let git = tree.join(".git");
+    if !git.is_dir() {
+        return Err("the clone left no .git directory".to_string());
+    }
+    let head = match std::fs::read_to_string(git.join("HEAD")) {
+        Ok(text) => text.trim().to_string(),
+        Err(source) => return Err(format!("the clone left no readable .git/HEAD: {source}")),
+    };
+    let Some(reference) = head.strip_prefix("ref:").map(str::trim) else {
+        // A detached HEAD is a raw SHA, which means there is a commit.
+        return Ok(());
+    };
+    if git.join(reference).exists() {
+        return Ok(());
+    }
+    let packed = std::fs::read_to_string(git.join("packed-refs")).unwrap_or_default();
+    if packed.lines().any(|line| line.ends_with(reference)) {
+        return Ok(());
+    }
+    Err(format!(
+        "the repository has no commits — HEAD points at {reference}, which does not exist"
+    ))
+}
+
+/// What one acquisition settled to, before it becomes a [`ClonedRepo`].
+#[derive(Debug)]
+pub(super) struct Finished {
+    /// What happened to the repository.
+    pub(super) state: CloneState,
+    /// Bytes this repository leaves on disk — the checkout when it was
+    /// promoted, and what a failed removal left behind when it was not.
+    pub(super) bytes: u64,
+    /// Whether [`Finished::bytes`] is a total or a floor.
+    pub(super) bytes_complete: bool,
+    /// Why a tree that should have been removed still exists — see
+    /// [`ClonedRepo::staging_residue`].
+    pub(super) residue: Option<String>,
+}
+
+/// Remove a tree this run must not leave behind, saying so when it cannot.
+///
+/// Why: the removal used to be `let _ = std::fs::remove_dir_all(staged)`, which
+/// makes "nothing survives under staging" a claim the code does not enforce —
+/// a read-only parent directory or a file held open leaves the whole partial
+/// tree on disk, unreported, uncounted against the ceiling that just stopped it,
+/// and ready to be resumed as a corrupt checkout by the next run (#5669).
+/// What: removes the tree; an already-absent tree is success. On a real failure
+/// it MEASURES what survived, so the bytes count against the budget instead of
+/// being reported as zero, and returns the sentence the report prints as its own
+/// gap line.
+/// Test: `super::clone_tests::a_staged_tree_that_cannot_be_removed_is_its_own_gap`.
+pub(super) fn discard_at(path: &Path, state: CloneState) -> Finished {
+    let source = match std::fs::remove_dir_all(path) {
+        Ok(()) => {
+            return Finished {
+                state,
+                bytes: 0,
+                bytes_complete: true,
+                residue: None,
+            };
+        }
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            return Finished {
+                state,
+                bytes: 0,
+                bytes_complete: true,
+                residue: None,
+            };
+        }
+        Err(source) => source,
+    };
+    // The removal failed, so whatever is there is still occupying disk. An
+    // unreadable root gives no figure at all, which is reported as a floor of
+    // zero rather than as a confident zero.
+    let (bytes, bytes_complete) = measure_tree(path).unwrap_or((0, false));
+    let size = if bytes_complete {
+        format!("{bytes} bytes")
+    } else {
+        format!("at least {bytes} bytes")
+    };
+    Finished {
+        state,
+        bytes,
+        bytes_complete,
+        residue: Some(format!(
+            "the partial checkout at {} could not be removed: {source}; {size} are still on \
+             disk and count against the disk budget",
+            path.display()
+        )),
+    }
+}
+
+/// Turn one `gh` result into a state, moving the partial into place or removing it.
+///
+/// Why: this is the fail-open site. `gh repo clone` failing part-way leaves a
+/// directory that LOOKS like a checkout, and a caller that reported success on
+/// it would hand a half-fetched repository to the sweep, which would analyze it
+/// and report on it as if it were whole. The rename is what makes "a directory
+/// under `repos/` is a completed clone" true by construction rather than by
+/// convention.
+/// What: on a failure or a budget kill, removes the staged tree and returns
+/// why — and when the removal itself fails, says so rather than swallowing it,
+/// see [`discard_at`]. On completion, VERIFIES the tree before promoting it — a
+/// zero exit that produced no usable checkout becomes [`CloneState::Empty`], and
+/// nothing is promoted. Only a verified tree is renamed onto `dest`, and a
+/// promoted tree that cannot then be MEASURED is removed again: an unmeasurable
+/// checkout is one the ceiling can never be enforced against, which is the same
+/// answer [`watchdog`] gives for the same reading (#5669).
+/// Test: `super::clone_tests::a_failed_clone_leaves_nothing_behind`,
+/// `super::clone_tests::a_successful_clone_is_renamed_into_place`,
+/// `super::clone_tests::a_commitless_clone_is_not_a_usable_checkout`,
+/// `super::clone_tests::a_budget_kill_removes_the_staged_tree`,
+/// `super::clone_tests::a_staged_tree_that_cannot_be_removed_is_its_own_gap`.
+pub(super) fn finish_one(dest: &Path, staged: &Path, outcome: watchdog::Outcome) -> Finished {
+    match outcome {
+        // #6001: the reason arrives as a string rather than a `GhError`, because
+        // acquisition now has two mechanisms and only one of them is `gh`.
+        watchdog::Outcome::Failed(reason) => {
+            return discard_at(staged, CloneState::Failed(reason));
+        }
+        // #5669: the same removal a failure gets — a tree the budget stopped is
+        // as unusable as one the remote refused, and leaving it would defeat
+        // the ceiling it just crossed.
+        watchdog::Outcome::OverBudget {
+            staged_bytes,
+            budget_bytes,
+        } => {
+            return discard_at(
+                staged,
+                CloneState::BudgetExceeded {
+                    staged_bytes,
+                    budget_bytes,
+                },
+            );
+        }
+        watchdog::Outcome::Completed => {}
+    }
+    // #5215: verify BEFORE the rename, so an unusable tree never occupies the
+    // destination even briefly.
+    if let Err(why) = verify_checkout(staged) {
+        return discard_at(staged, CloneState::Empty(why));
+    }
+    if let Err(source) = std::fs::rename(staged, dest) {
+        return discard_at(
+            staged,
+            CloneState::Failed(format!(
+                "clone completed but could not be moved into place: {source}"
+            )),
+        );
+    }
+    match measure_tree(dest) {
+        Ok((bytes, bytes_complete)) => Finished {
+            state: CloneState::Cloned,
+            bytes,
+            bytes_complete,
+            residue: None,
+        },
+        // #5669: a promoted tree that measures 0 for any size would spend the
+        // whole budget invisibly, so it is discarded rather than counted.
+        Err(why) => discard_at(
+            dest,
+            CloneState::Failed(format!(
+                "{why} — a checkout of unknown size cannot be held to the disk budget"
+            )),
+        ),
+    }
+}

--- a/crates/trusty-audit/src/clone/watchdog.rs
+++ b/crates/trusty-audit/src/clone/watchdog.rs
@@ -1,0 +1,695 @@
+//! Bounding a clone that is ALREADY RUNNING (#5669).
+//!
+//! Why: [`CloneOptions::budget_bytes`](super::CloneOptions::budget_bytes) used
+//! to be checked only between repositories, so 19 GiB spent against a 20 GiB
+//! ceiling still admitted a 100 GB monorepo and finished at 119 GiB. This runs
+//! unattended on a client's own machine during an audit engagement, and the
+//! recipient has no view of the run while it happens. A start gate that cannot
+//! interrupt is not a budget.
+//!
+//! What: while the acquisition child runs, its staged tree is measured at a
+//! bounded interval. Once `spent + staged` crosses the ceiling the child is
+//! signalled — `SIGTERM`, then `SIGKILL` if it does not exit within the grace —
+//! and the caller gets [`Outcome::OverBudget`], which
+//! [`finish_one`](super::finish_one) turns into
+//! [`CloneState::BudgetExceeded`](super::CloneState::BudgetExceeded) and a
+//! removed staged tree. The start gate stays: it is what stops a clone nobody
+//! needs to start, and this is what stops one already fetching.
+//!
+//! **A finished child does not exempt its tree.** The exit is measured one last
+//! time before it is reported as complete, so a clone that outran the sampling
+//! interval is bounded too — and so the answer at the boundary, a child exiting
+//! in the same instant the budget trips, is the same whichever arm observes it.
+//! Exactly one verdict is produced per child either way.
+//!
+//! **A sample that fails does not disable the watchdog.** It fails the clone
+//! CLOSED — the child is killed and the attempt reported — because a watchdog
+//! that silently stops measuring is the fail-open this module exists to remove.
+//! A PARTIAL walk is different and is not a failure: `git` creates and removes
+//! temporary pack files throughout a fetch, so a walk racing one is ordinary.
+//! That count is a floor, which still trips the ceiling when it crosses it and
+//! is re-measured on the next interval when it does not. The tree's own ROOT is
+//! the exception — an unopenable root would count 0 bytes forever, so it is
+//! opened explicitly and fails closed like any other unmeasurable sample.
+//!
+//! Test: `super::watchdog::watchdog_tests`.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::AsyncReadExt;
+use tokio::process::{Child, Command};
+
+/// How often a running clone's staged tree is measured.
+///
+/// The interval bounds the overshoot: a clone can exceed the ceiling by at most
+/// what it writes in one sample period. Half a second keeps that overshoot
+/// small against a multi-gigabyte fetch while a recursive walk of a partial
+/// checkout stays cheap.
+pub(super) const SAMPLE_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How long a signalled child has to exit before it is killed outright.
+pub(super) const TERM_GRACE: Duration = Duration::from_secs(5);
+
+/// The ceiling one clone is watched against.
+///
+/// `spent` is what earlier repositories in the same run already committed, so
+/// the comparison is against the run's total rather than this repository alone
+/// — the same arithmetic the start gate performs.
+/// Test: `super::watchdog::watchdog_tests::the_ceiling_counts_what_earlier_repositories_spent`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Watch {
+    /// Bytes earlier repositories in this run already put on disk.
+    pub spent: u64,
+    /// The ceiling `spent + staged` must not cross.
+    pub budget_bytes: u64,
+    /// How often the staged tree is measured.
+    pub interval: Duration,
+    /// How long the child gets after `SIGTERM` before `SIGKILL`.
+    pub grace: Duration,
+}
+
+impl Watch {
+    /// A watch at the production interval and grace.
+    pub(super) fn new(spent: u64, budget_bytes: u64) -> Self {
+        Self {
+            spent,
+            budget_bytes,
+            interval: SAMPLE_INTERVAL,
+            grace: TERM_GRACE,
+        }
+    }
+
+    /// Would this staged size put the run over its ceiling?
+    fn over(&self, staged_bytes: u64) -> bool {
+        self.spent.saturating_add(staged_bytes) > self.budget_bytes
+    }
+}
+
+/// How the child is named when its failure becomes a gap line.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct Spawn<'a> {
+    /// The command, as an operator would recognise it.
+    pub label: &'a str,
+    /// Appended when the binary itself is not on `PATH`.
+    pub missing_hint: &'a str,
+}
+
+/// What one watched acquisition produced.
+///
+/// [`Outcome::OverBudget`] is deliberately not a flavour of [`Outcome::Failed`]:
+/// nothing went wrong with the repository or the remote, and a recipient
+/// reading "FAILED" would go looking for a fault that does not exist (#5669).
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum Outcome {
+    /// The child exited zero and its tree is within the ceiling.
+    Completed,
+    /// Acquisition failed, for this reason.
+    Failed(String),
+    /// The clone was stopped because its staged tree crossed the ceiling.
+    OverBudget {
+        /// What the tree measured when it was stopped.
+        staged_bytes: u64,
+        /// The ceiling it crossed.
+        budget_bytes: u64,
+    },
+}
+
+/// Spawn the acquisition child and watch it against the budget.
+///
+/// stdout is discarded — no caller has ever read it — and stderr is drained by
+/// a task of its own so a chatty `git` cannot fill the pipe buffer and wedge a
+/// child this function is otherwise prepared to wait on indefinitely.
+/// Test: `super::watchdog::watchdog_tests::a_missing_binary_names_itself`.
+pub(super) async fn run(
+    spec: &Spawn<'_>,
+    mut command: Command,
+    staged: &Path,
+    watch: Option<Watch>,
+) -> Outcome {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(source) => {
+            let hint = if source.kind() == std::io::ErrorKind::NotFound {
+                format!(" {}", spec.missing_hint)
+            } else {
+                String::new()
+            };
+            return Outcome::Failed(format!("`{}` could not be run: {source}{hint}", spec.label));
+        }
+    };
+    watch_child(spec, child, staged, watch).await
+}
+
+/// Watch an already-spawned child, so a test can hold its pid.
+///
+/// Test: `super::watchdog::watchdog_tests::a_killed_child_leaves_no_process_behind`.
+pub(super) async fn watch_child(
+    spec: &Spawn<'_>,
+    mut child: Child,
+    staged: &Path,
+    watch: Option<Watch>,
+) -> Outcome {
+    let drain = child.stderr.take().map(|mut pipe| {
+        tokio::spawn(async move {
+            let mut buf = Vec::new();
+            let _ = pipe.read_to_end(&mut buf).await;
+            buf
+        })
+    });
+    let verdict = supervise(&mut child, staged, watch).await;
+    let stderr = match drain {
+        Some(handle) => handle.await.unwrap_or_default(),
+        None => Vec::new(),
+    };
+    report(spec, verdict, &stderr, watch)
+}
+
+/// What the supervision loop observed, before it is worded for a report.
+#[derive(Debug)]
+enum Verdict {
+    /// The child exited, within budget.
+    Exited(std::process::ExitStatus),
+    /// The child could not be waited on at all.
+    WaitFailed(std::io::Error),
+    /// The staged tree crossed the ceiling; the child is no longer running.
+    OverBudget(u64),
+    /// The staged tree could not be measured; the child is no longer running.
+    Unmeasurable(String),
+}
+
+/// Run the child to its end, measuring the staged tree as it goes.
+///
+/// Returns exactly once, so a child is never classified twice — the completion
+/// arm and the sampling arm are alternatives, not both.
+/// Test: `super::watchdog::watchdog_tests::a_child_that_exits_as_the_budget_trips_is_over_budget`.
+async fn supervise(child: &mut Child, staged: &Path, watch: Option<Watch>) -> Verdict {
+    // #5669: with no ceiling there is nothing to enforce, so the child is not
+    // sampled at all — an unbudgeted run pays no walk.
+    let Some(watch) = watch else {
+        return match child.wait().await {
+            Ok(status) => Verdict::Exited(status),
+            Err(source) => Verdict::WaitFailed(source),
+        };
+    };
+    let mut seen = false;
+    loop {
+        tokio::select! {
+            status = child.wait() => {
+                let status = match status {
+                    Ok(status) => status,
+                    Err(source) => return Verdict::WaitFailed(source),
+                };
+                // #5669: the child finishing does not exempt its tree. One last
+                // measurement is what bounds a clone that outran the interval,
+                // and what makes the boundary — an exit in the same instant the
+                // budget trips — answer the same whichever arm saw it first.
+                return match sample(staged, &mut seen) {
+                    Sample::Bytes(bytes) if watch.over(bytes) => Verdict::OverBudget(bytes),
+                    Sample::Bytes(_) => Verdict::Exited(status),
+                    Sample::Unmeasurable(why) => Verdict::Unmeasurable(why),
+                };
+            }
+            () = tokio::time::sleep(watch.interval) => {
+                match sample(staged, &mut seen) {
+                    Sample::Bytes(bytes) if watch.over(bytes) => {
+                        terminate(child, watch.grace).await;
+                        return Verdict::OverBudget(bytes);
+                    }
+                    Sample::Bytes(_) => {}
+                    Sample::Unmeasurable(why) => {
+                        // #5669: fails CLOSED. A watchdog that cannot measure
+                        // and keeps going is not watching anything.
+                        terminate(child, watch.grace).await;
+                        return Verdict::Unmeasurable(why);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// End the child, politely and then not.
+///
+/// `SIGTERM` first because both `git` and `gh` remove their temporary pack
+/// files on it, which leaves less for the caller's `remove_dir_all` to walk.
+/// `SIGKILL` follows on the grace expiring, and the child is reaped either way
+/// — an unreaped child is the orphan this whole path exists to avoid.
+/// Test: `super::watchdog::watchdog_tests::a_killed_child_leaves_no_process_behind`.
+async fn terminate(child: &mut Child, grace: Duration) {
+    if let Some(pid) = child.id() {
+        // `libc::kill` is the only way to send a signal other than `SIGKILL`;
+        // `Child::kill` sends `SIGKILL` unconditionally. The pid is this
+        // process's own child and has not been reaped, so it cannot have been
+        // reused.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+        if tokio::time::timeout(grace, child.wait()).await.is_ok() {
+            return;
+        }
+    }
+    let _ = child.kill().await;
+}
+
+/// One measurement of the staged tree.
+#[derive(Debug, PartialEq, Eq)]
+enum Sample {
+    /// Bytes on disk, a floor when part of the walk was unreadable.
+    Bytes(u64),
+    /// The tree could not be measured at all, for this reason.
+    Unmeasurable(String),
+}
+
+/// Measure the staged tree, distinguishing "not there yet" from "gone".
+///
+/// Why: the staged directory is created by the CHILD, not by the caller, so an
+/// absent tree before the first successful measurement is ordinary and an
+/// absent tree after one is the failure the watchdog must not run blind past.
+/// `seen` is the only state that separates them.
+/// Test: `super::watchdog::watchdog_tests::an_absent_tree_reads_as_empty_until_it_has_been_seen`,
+/// `super::watchdog::watchdog_tests::a_tree_that_vanishes_after_being_seen_is_unmeasurable`,
+/// `super::watchdog::watchdog_tests::an_unopenable_tree_root_is_unmeasurable_not_empty`.
+fn sample(staged: &Path, seen: &mut bool) -> Sample {
+    match std::fs::symlink_metadata(staged) {
+        Ok(meta) if meta.is_dir() => {
+            // #5669: `dir_size` answers `(0, false)` when the tree's own root
+            // cannot be opened, which reads as an empty tree and never trips
+            // the ceiling. Open the root here so that case fails CLOSED like
+            // every other unmeasurable one. Entries BELOW the root stay a
+            // floor, because `git` creating and removing pack files mid-fetch
+            // makes a partial walk ordinary rather than a failure.
+            if let Err(source) = std::fs::read_dir(staged) {
+                return Sample::Unmeasurable(format!(
+                    "the staged tree at {} could not be measured: {source}",
+                    staged.display()
+                ));
+            }
+            *seen = true;
+            // The completeness flag is deliberately dropped: a partial walk is
+            // a floor, and a floor over the ceiling still trips it.
+            let (bytes, _floor) = super::dir_size(staged);
+            Sample::Bytes(bytes)
+        }
+        Ok(_) => Sample::Unmeasurable(format!(
+            "the staged tree at {} is not a directory",
+            staged.display()
+        )),
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound && !*seen => Sample::Bytes(0),
+        Err(source) => Sample::Unmeasurable(format!(
+            "the staged tree at {} could not be measured: {source}",
+            staged.display()
+        )),
+    }
+}
+
+/// Word one verdict as the outcome a gap line is built from.
+fn report(spec: &Spawn<'_>, verdict: Verdict, stderr: &[u8], watch: Option<Watch>) -> Outcome {
+    let budget_bytes = watch.map_or(0, |w| w.budget_bytes);
+    match verdict {
+        Verdict::Exited(status) if status.success() => Outcome::Completed,
+        Verdict::Exited(status) => Outcome::Failed(format!(
+            "`{}` exited {status}: {}",
+            spec.label,
+            String::from_utf8_lossy(stderr).trim()
+        )),
+        Verdict::WaitFailed(source) => Outcome::Failed(format!(
+            "`{}` could not be waited for: {source}",
+            spec.label
+        )),
+        Verdict::OverBudget(staged_bytes) => Outcome::OverBudget {
+            staged_bytes,
+            budget_bytes,
+        },
+        Verdict::Unmeasurable(why) => Outcome::Failed(format!(
+            "`{}` was stopped because the disk budget could not be enforced: {why}",
+            spec.label
+        )),
+    }
+}
+
+#[cfg(test)]
+mod watchdog_tests {
+    use super::*;
+
+    const SPEC: Spawn<'static> = Spawn {
+        label: "fake clone",
+        missing_hint: "install it",
+    };
+
+    /// The budget-plus-tolerance a stop is asserted against.
+    ///
+    /// [`tiny_watch`] samples every 5ms and allows a 200ms grace, so a working
+    /// watchdog finishes in tens of milliseconds. Ten seconds is loose enough
+    /// that a loaded CI box never trips it and tight enough that a watchdog
+    /// which never fires fails the test instead of hanging it.
+    const STOP_DEADLINE: Duration = Duration::from_secs(10);
+
+    /// A child that appends `chunk` bytes to `<dir>/blob`, `iterations` times.
+    ///
+    /// Every write is a shell builtin, so the child forks nothing — a kill of
+    /// this pid is a kill of the whole job, and the no-orphan assertion is
+    /// about the process the watchdog actually signalled.
+    fn writer(dir: &Path, chunk: usize, iterations: u64) -> Command {
+        let script = r#"mkdir -p "$1" || exit 1
+i=0
+while [ "$i" -lt "$3" ]; do
+  printf '%s' "$2" >> "$1/blob"
+  i=$((i + 1))
+done
+"#;
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg(script)
+            .arg("watchdog-fixture")
+            .arg(dir)
+            .arg("x".repeat(chunk))
+            .arg(iterations.to_string())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            // A fixture that outlives a FAILING test is an orphan writing to
+            // the disk this module is about. Dropping the child ends it.
+            .kill_on_drop(true);
+        command
+    }
+
+    /// [`watch_child`] under a deadline.
+    ///
+    /// Every runaway fixture here writes until it is stopped, so a regression
+    /// that never fires the watchdog would WEDGE the suite rather than report
+    /// itself. The deadline turns that hang into an ordinary failure (#5669).
+    async fn stopped(child: Child, staged: &Path, watch: Watch) -> Outcome {
+        tokio::time::timeout(
+            STOP_DEADLINE,
+            watch_child(&SPEC, child, staged, Some(watch)),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("the watchdog left the child running past {STOP_DEADLINE:?}"))
+    }
+
+    /// Is this pid still a process on this machine?
+    fn alive(pid: u32) -> bool {
+        // Signal 0 performs the permission and existence check without
+        // delivering anything.
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+
+    fn tiny_watch(spent: u64, budget_bytes: u64) -> Watch {
+        Watch {
+            spent,
+            budget_bytes,
+            interval: Duration::from_millis(5),
+            grace: Duration::from_millis(200),
+        }
+    }
+
+    /// #5669's whole point: a clone in flight is stopped, not merely refused.
+    ///
+    /// The child would run for hours, so the assertion is about BOTH halves —
+    /// the verdict is over-budget, and it arrives promptly. A watchdog that
+    /// eventually notices is the same fail-open as one that never does, so the
+    /// deadline is asserted rather than left to the harness to time out on.
+    #[tokio::test]
+    async fn a_running_child_that_crosses_the_ceiling_is_stopped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        let child = writer(&staged, 1024, u64::from(u32::MAX))
+            .spawn()
+            .expect("/bin/sh");
+
+        let started = std::time::Instant::now();
+        let outcome = stopped(child, &staged, tiny_watch(0, 4096)).await;
+        let elapsed = started.elapsed();
+
+        let Outcome::OverBudget {
+            staged_bytes,
+            budget_bytes,
+        } = outcome
+        else {
+            panic!("a runaway clone must be stopped, not {outcome:?}");
+        };
+        assert!(
+            staged_bytes > 4096,
+            "it crossed the ceiling: {staged_bytes}"
+        );
+        assert_eq!(budget_bytes, 4096);
+        assert!(
+            elapsed < STOP_DEADLINE,
+            "stopped after {elapsed:?}, past the {STOP_DEADLINE:?} deadline"
+        );
+    }
+
+    /// The reaping #5669 owes, asserted on the child itself rather than on a
+    /// live-pid probe: `try_wait` answers `Some` only once the status has been
+    /// collected, so a zombie left behind fails this.
+    #[tokio::test]
+    async fn a_terminated_child_is_reaped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut child = writer(&tmp.path().join("staged"), 1024, u64::from(u32::MAX))
+            .spawn()
+            .expect("/bin/sh");
+
+        terminate(&mut child, Duration::from_millis(200)).await;
+
+        assert!(
+            matches!(child.try_wait(), Ok(Some(_))),
+            "the signalled child must be reaped, not left unwaited-for"
+        );
+    }
+
+    /// Several clones watched at once: each verdict is its own, each child dies.
+    ///
+    /// `clone_all` watches one repository at a time today, but the watchdog is
+    /// what a concurrent caller would reuse, and a shared timer or a signal
+    /// aimed at the wrong pid would only show up with more than one in flight.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_watches_each_stop_their_own_child() {
+        const WATCHED: u32 = 4;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut pids = Vec::new();
+        let mut running = Vec::new();
+        for i in 0..WATCHED {
+            let staged = tmp.path().join(format!("staged-{i}"));
+            let child = writer(&staged, 1024, u64::from(u32::MAX))
+                .spawn()
+                .expect("/bin/sh");
+            pids.push(child.id().expect("a freshly spawned child has a pid"));
+            running.push(tokio::spawn(async move {
+                stopped(child, &staged, tiny_watch(0, 4096)).await
+            }));
+        }
+
+        for (i, handle) in running.into_iter().enumerate() {
+            let outcome = handle.await.expect("the watch task must not panic");
+            assert!(
+                matches!(outcome, Outcome::OverBudget { .. }),
+                "watch {i} produced {outcome:?}"
+            );
+        }
+        for pid in pids {
+            assert!(!alive(pid), "pid {pid} survived its own watch");
+        }
+    }
+
+    /// A root that cannot be opened must not read as an empty tree (#5669).
+    ///
+    /// `dir_size` answers `(0, false)` for it, which would hold the sample at
+    /// zero for the whole clone and never trip the ceiling — the fail-open the
+    /// watchdog exists to remove.
+    #[test]
+    fn an_unopenable_tree_root_is_unmeasurable_not_empty() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // root ignores the mode bits, so the case cannot be staged there.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        std::fs::create_dir_all(&staged).expect("mkdir");
+        std::fs::write(staged.join("blob"), vec![b'x'; 8192]).expect("write");
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o000)).expect("chmod");
+
+        let mut seen = true;
+        let sampled = sample(&staged, &mut seen);
+
+        // Restore before the assertion so the tempdir can always be removed.
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+        let Sample::Unmeasurable(why) = sampled else {
+            panic!("an unreadable tree root must not read as empty: {sampled:?}");
+        };
+        assert!(why.contains("could not be measured"), "{why}");
+    }
+
+    /// The kill reaps: nothing is left running or unwaited-for.
+    #[tokio::test]
+    async fn a_killed_child_leaves_no_process_behind() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        let child = writer(&staged, 1024, u64::from(u32::MAX))
+            .spawn()
+            .expect("/bin/sh");
+        let pid = child.id().expect("a freshly spawned child has a pid");
+
+        let outcome = stopped(child, &staged, tiny_watch(0, 4096)).await;
+
+        assert!(matches!(outcome, Outcome::OverBudget { .. }), "{outcome:?}");
+        assert!(!alive(pid), "pid {pid} survived the kill path");
+    }
+
+    /// A clone that stays under the ceiling is untouched.
+    #[tokio::test]
+    async fn a_child_under_the_ceiling_completes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        let child = writer(&staged, 64, 4).spawn().expect("/bin/sh");
+
+        let outcome = watch_child(&SPEC, child, &staged, Some(tiny_watch(0, 1_000_000))).await;
+
+        assert_eq!(outcome, Outcome::Completed);
+        assert!(staged.join("blob").is_file(), "the tree is left in place");
+    }
+
+    /// The boundary #5669 has to answer once: the child exits in the same
+    /// instant the tree crosses the ceiling.
+    ///
+    /// The interval is set beyond the child's whole lifetime, so the completion
+    /// arm is the only one that can fire — and it still reports over-budget,
+    /// which is what makes the two arms agree instead of racing.
+    #[tokio::test]
+    async fn a_child_that_exits_as_the_budget_trips_is_over_budget() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        let child = writer(&staged, 1024, 1).spawn().expect("/bin/sh");
+        let watch = Watch {
+            interval: Duration::from_secs(600),
+            ..tiny_watch(0, 100)
+        };
+
+        let outcome = watch_child(&SPEC, child, &staged, Some(watch)).await;
+
+        let Outcome::OverBudget { staged_bytes, .. } = outcome else {
+            panic!("a completed clone over the ceiling is still over it, not {outcome:?}");
+        };
+        assert!(staged_bytes >= 1024, "{staged_bytes}");
+    }
+
+    /// A sample that cannot be taken fails the clone CLOSED, killing the child.
+    #[tokio::test]
+    async fn an_unmeasurable_tree_fails_the_clone_closed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // The staged path is a FILE, so every sample of it fails from the first
+        // one — the same shape as a permission error, without needing one.
+        let staged = tmp.path().join("staged");
+        std::fs::write(&staged, b"not a directory").expect("write");
+        let child = writer(&tmp.path().join("elsewhere"), 1024, u64::from(u32::MAX))
+            .spawn()
+            .expect("/bin/sh");
+        let pid = child.id().expect("a freshly spawned child has a pid");
+
+        let outcome = stopped(child, &staged, tiny_watch(0, 4096)).await;
+
+        let Outcome::Failed(why) = outcome else {
+            panic!("an unmeasurable tree must fail the clone, not {outcome:?}");
+        };
+        assert!(
+            why.contains("disk budget could not be enforced"),
+            "the reason names the watchdog, not the remote: {why}"
+        );
+        assert!(!alive(pid), "pid {pid} survived the fail-closed kill");
+    }
+
+    /// The child creates the staged directory, so absence before it does is not
+    /// a measurement failure.
+    #[test]
+    fn an_absent_tree_reads_as_empty_until_it_has_been_seen() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut seen = false;
+        assert_eq!(
+            sample(&tmp.path().join("nope"), &mut seen),
+            Sample::Bytes(0)
+        );
+        assert!(!seen, "nothing was measured, so nothing was seen");
+    }
+
+    /// Absence AFTER a successful measurement is the fail-closed case.
+    #[test]
+    fn a_tree_that_vanishes_after_being_seen_is_unmeasurable() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        std::fs::create_dir_all(&staged).expect("mkdir");
+        std::fs::write(staged.join("f"), b"0123456789").expect("write");
+
+        let mut seen = false;
+        assert_eq!(sample(&staged, &mut seen), Sample::Bytes(10));
+        assert!(seen);
+
+        std::fs::remove_dir_all(&staged).expect("rm");
+        let Sample::Unmeasurable(why) = sample(&staged, &mut seen) else {
+            panic!("a tree that vanished mid-clone must not read as empty");
+        };
+        assert!(why.contains("could not be measured"), "{why}");
+    }
+
+    /// The ceiling is the RUN's, not this repository's.
+    #[test]
+    fn the_ceiling_counts_what_earlier_repositories_spent() {
+        let watch = Watch::new(19, 20);
+        assert!(!watch.over(1), "19 + 1 is the ceiling, not past it");
+        assert!(watch.over(2), "19 + 2 is past it");
+        assert_eq!(watch.interval, SAMPLE_INTERVAL);
+        assert_eq!(watch.grace, TERM_GRACE);
+    }
+
+    /// No ceiling means no sampling and no interruption.
+    #[tokio::test]
+    async fn an_unbudgeted_child_runs_to_completion() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        let child = writer(&staged, 1024, 8).spawn().expect("/bin/sh");
+
+        assert_eq!(
+            watch_child(&SPEC, child, &staged, None).await,
+            Outcome::Completed
+        );
+    }
+
+    /// A non-zero exit carries the child's own stderr into the gap line.
+    #[tokio::test]
+    async fn a_failing_child_reports_its_stderr() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        let mut command = Command::new("/bin/sh");
+        command.arg("-c").arg("echo 'remote refused' >&2; exit 3");
+
+        let outcome = run(&SPEC, command, &staged, Some(tiny_watch(0, 4096))).await;
+
+        let Outcome::Failed(why) = outcome else {
+            panic!("a non-zero exit is a failure, not {outcome:?}");
+        };
+        assert!(why.contains("remote refused"), "{why}");
+        assert!(why.contains("fake clone"), "{why}");
+    }
+
+    /// A binary that is not there says so, with the caller's own hint.
+    #[tokio::test]
+    async fn a_missing_binary_names_itself() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let command = Command::new(tmp.path().join("no-such-binary"));
+
+        let outcome = run(&SPEC, command, &tmp.path().join("staged"), None).await;
+
+        let Outcome::Failed(why) = outcome else {
+            panic!("a missing binary is a failure, not {outcome:?}");
+        };
+        assert!(why.contains("could not be run"), "{why}");
+        assert!(why.contains("install it"), "the hint is carried: {why}");
+    }
+}

--- a/crates/trusty-audit/src/clone/watchdog.rs
+++ b/crates/trusty-audit/src/clone/watchdog.rs
@@ -41,6 +41,7 @@
 
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::{Mutex, PoisonError};
 use std::time::Duration;
 
 use tokio::io::AsyncReadExt;
@@ -56,6 +57,144 @@ pub(super) const SAMPLE_INTERVAL: Duration = Duration::from_millis(500);
 
 /// How long a signalled child has to exit before it is killed outright.
 pub(super) const TERM_GRACE: Duration = Duration::from_secs(5);
+
+/// How long a clone group gets to wind down after a Ctrl-C.
+///
+/// Deliberately far shorter than [`TERM_GRACE`]: this one runs while an operator
+/// is holding a terminal that has stopped answering them, and five seconds there
+/// reads as a hang. `git` and `ssh` unlink their temporary files on the `SIGINT`
+/// that arrives first, so the `SIGKILL` this precedes is only for whatever
+/// ignored it.
+const INTERRUPT_GRACE: Duration = Duration::from_millis(250);
+
+/// The clone process groups this process has taken out of the terminal's reach.
+///
+/// Why: `process_group(0)` in [`run`] is what lets one signal reach a whole
+/// clone tree, and the very same call is what removes that tree from the
+/// terminal's FOREGROUND group — so a raw Ctrl-C arrives at `taudit` alone. This
+/// list is the only record of what the terminal can no longer signal, and
+/// [`stop_clones_on_interrupt`] is what walks it (#5669).
+/// What: pids of process-group LEADERS, added when a child is spawned and
+/// removed once it has been waited on. The sweep clones one repository at a
+/// time, so there is at most one entry in practice — a list rather than a slot
+/// because a second caller must not be able to displace the first's group.
+/// Test: `super::watchdog::watchdog_tests::an_interrupt_kills_a_detached_clone_group`,
+/// `super::watchdog::watchdog_tests::a_detached_group_is_deregistered_when_its_guard_drops`.
+static DETACHED: Mutex<Vec<u32>> = Mutex::new(Vec::new());
+
+/// One entry in [`DETACHED`], removed however [`run`] returns.
+///
+/// A panic between the spawn and the wait would otherwise leave a pid behind
+/// that a later interrupt would signal, and pids are reused.
+/// Test: `super::watchdog::watchdog_tests::a_detached_group_is_deregistered_when_its_guard_drops`.
+struct Detached(u32);
+
+impl Detached {
+    /// Record a child that now leads a process group of its own.
+    fn register(pid: u32) -> Self {
+        // A poisoned lock must not disarm the one record of what is still
+        // running: this guards against orphaned clones, so it recovers the
+        // inner value rather than skipping the write.
+        DETACHED
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(pid);
+        Self(pid)
+    }
+}
+
+impl Drop for Detached {
+    fn drop(&mut self) {
+        DETACHED
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .retain(|pid| *pid != self.0);
+    }
+}
+
+/// Give Ctrl-C back its meaning, then die the way an uncaught one would have.
+///
+/// Why: [`run`] puts every clone in a process group of its own so that one
+/// signal reaches the whole tree, and the price is that the tree is no longer in
+/// the terminal's foreground group. This crate installed no signal handling at
+/// all, so a raw Ctrl-C killed `taudit` by `SIGINT`'s default disposition — no
+/// destructors, `kill_on_drop` never reached — and left `ssh` and
+/// `git-index-pack` fetching into a client's disk with nothing watching the
+/// ceiling any more (#5669).
+/// What: awaits `SIGINT`, passes it on to every group the terminal can no longer
+/// reach, kills whatever outlives [`INTERRUPT_GRACE`], and then re-raises
+/// `SIGINT` under the default disposition. Awaiting this registers a handler, so
+/// `SIGINT` stops killing the process on its own from the first poll onwards;
+/// the re-raise is what puts that back. Never returns.
+///
+/// This belongs to the BINARY, not to [`super::clone_all`]: it ends the process,
+/// and a front end embedding this crate owns that decision itself.
+/// Test: `super::watchdog::watchdog_tests::an_interrupt_kills_a_detached_clone_group`.
+pub async fn stop_clones_on_interrupt() {
+    if tokio::signal::ctrl_c().await.is_err() {
+        // The handler could not be installed, so `SIGINT` keeps its default
+        // disposition and this task has nothing left to contribute. Returning
+        // would instead re-raise on a signal that never arrived.
+        std::future::pending::<()>().await;
+    }
+    interrupt_detached_groups(INTERRUPT_GRACE).await;
+    die_by_sigint()
+}
+
+/// Deliver the interrupt on to every detached clone group.
+///
+/// Split from [`stop_clones_on_interrupt`] so it can be reasoned about without a
+/// real `SIGINT`; the groups it reads and the signalling it delegates are tested
+/// separately, because a test that called this would signal every OTHER test's
+/// clone in the same process.
+/// Test: `super::watchdog::watchdog_tests::an_interrupt_kills_a_detached_clone_group`.
+async fn interrupt_detached_groups(grace: Duration) {
+    let groups = DETACHED
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clone();
+    stop_groups(&groups, grace).await;
+}
+
+/// Signal these process groups, killing whatever outlives the grace.
+///
+/// Test: `super::watchdog::watchdog_tests::an_interrupt_kills_a_detached_clone_group`.
+async fn stop_groups(groups: &[u32], grace: Duration) {
+    if groups.is_empty() {
+        return;
+    }
+    // #5669: `SIGINT`, because that is exactly what the terminal would have
+    // delivered had `process_group(0)` not moved the tree out of its reach.
+    for pgid in groups {
+        signal_group(*pgid, libc::SIGINT);
+    }
+    tokio::time::sleep(grace).await;
+    // A process may IGNORE `SIGINT` — a shell gives its background jobs
+    // `SIG_IGN` for it, and that disposition survives `exec`. The kill is what
+    // makes "nothing keeps writing" true rather than merely requested.
+    for pgid in groups {
+        signal_group(*pgid, libc::SIGKILL);
+    }
+}
+
+/// Die the way an uncaught Ctrl-C would have.
+///
+/// Exiting 0 — or on any invented code — tells a shell's `set -e`, a `for` loop
+/// over engagements, and a CI runner that the run finished. Restoring the
+/// default disposition and re-raising is what makes the parent observe
+/// `WIFSIGNALED(SIGINT)` instead, which is where the conventional 130 comes
+/// from.
+fn die_by_sigint() -> ! {
+    // SAFETY: both calls act on this process alone and take no pointer.
+    // `SIG_DFL` for `SIGINT` is termination, so the `raise` does not return.
+    unsafe {
+        libc::signal(libc::SIGINT, libc::SIG_DFL);
+        libc::raise(libc::SIGINT);
+    }
+    // Reachable only if `SIGINT` is blocked for this thread, which nothing here
+    // does. 130 is the shell's own encoding of the same death.
+    std::process::exit(130)
+}
 
 /// The ceiling one clone is watched against.
 ///
@@ -137,11 +276,13 @@ pub(super) enum Outcome {
 /// them; [`terminate`] sends it (#5669).
 ///
 /// The cost is that the child no longer shares this process's group, so a
-/// terminal `SIGINT` reaches the audit and not the clone. The watchdog is the
-/// interruption path either way, and `kill_on_drop` covers the future being
-/// dropped, but a `taudit` killed outright leaves the clone running.
+/// terminal `SIGINT` reaches the audit and not the clone. That is why the group
+/// is recorded in [`DETACHED`] the moment it is spawned:
+/// [`stop_clones_on_interrupt`] is what forwards a Ctrl-C to it, and a binary
+/// that does not run that task gets a clone which outlives its own audit.
 /// Test: `super::watchdog::watchdog_tests::a_missing_binary_names_itself`,
-/// `super::watchdog::watchdog_tests::a_budget_kill_reaches_a_grandchild`.
+/// `super::watchdog::watchdog_tests::a_budget_kill_reaches_a_grandchild`,
+/// `super::watchdog::watchdog_tests::an_interrupt_kills_a_detached_clone_group`.
 pub(super) async fn run(
     spec: &Spawn<'_>,
     mut command: Command,
@@ -166,6 +307,9 @@ pub(super) async fn run(
             return Outcome::Failed(format!("`{}` could not be run: {source}{hint}", spec.label));
         }
     };
+    // #5669: the `process_group(0)` above put this tree beyond the terminal's
+    // reach, so record it while it runs — see `stop_clones_on_interrupt`.
+    let _detached = child.id().map(Detached::register);
     watch_child(spec, child, staged, watch).await
 }
 
@@ -299,15 +443,38 @@ async fn terminate(child: &mut Child, grace: Duration) {
 /// Test: `super::watchdog::watchdog_tests::a_budget_kill_reaches_a_grandchild`,
 /// `super::watchdog::watchdog_tests::a_child_in_our_own_process_group_is_signalled_alone`.
 fn signal_tree(pid: u32, signal: libc::c_int) {
-    let pid = pid as libc::pid_t;
+    let raw = pid as libc::pid_t;
     // SAFETY: the pid is this process's own child and has not been reaped, so
-    // it cannot have been reused; `getpgid` only reads. A negative pid names
-    // the process GROUP with that id, which is why it is sent only when the
-    // child is that group's leader.
-    unsafe {
-        let target = if libc::getpgid(pid) == pid { -pid } else { pid };
-        libc::kill(target, signal);
+    // it cannot have been reused; `getpgid` only reads.
+    let leads_a_group = unsafe { libc::getpgid(raw) == raw };
+    if leads_a_group {
+        signal_group(pid, signal);
+    } else {
+        // SAFETY: a positive pid names that process alone, which is the only
+        // safe target for a child sharing THIS process's group.
+        unsafe { libc::kill(raw, signal) };
     }
+}
+
+/// Signal a process group named by its leader's pid.
+///
+/// Why: a group OUTLIVES its leader, and [`interrupt_detached_groups`] needs
+/// that. Its first signal kills the leading `gh` or `git`, which this process
+/// then reaps — after which `getpgid` on that pid answers `ESRCH` and
+/// [`signal_tree`] can no longer recognise the group, so the follow-up `SIGKILL`
+/// would land on nothing and the grandchildren would keep fetching (#5669).
+/// Every pid in [`DETACHED`] is a leader by construction — [`run`] is the only
+/// registrar and it always sets `process_group(0)` — so the group can be named
+/// directly there rather than probed for.
+/// What: `kill(-pgid)`. A group id is not reused while any member survives,
+/// which is exactly the case this is called in; an already-empty group answers
+/// `ESRCH` and nothing happens.
+/// Test: `super::watchdog::watchdog_tests::an_interrupt_kills_a_detached_clone_group`.
+fn signal_group(pgid: u32, signal: libc::c_int) {
+    // SAFETY: a negative pid names the process GROUP with that id and takes no
+    // pointer. `pgid` leads a group in both call paths — checked by `getpgid` in
+    // `signal_tree`, guaranteed by `process_group(0)` in the other.
+    unsafe { libc::kill(-(pgid as libc::pid_t), signal) };
 }
 
 /// One measurement of the staged tree.
@@ -478,6 +645,28 @@ done
         !alive(pid)
     }
 
+    /// The pid [`forking_writer`] recorded, once it has finished recording it.
+    ///
+    /// The fixture writes the pid while the test polls for it, so a single read
+    /// could catch a half-written number and name an unrelated process. Two
+    /// identical reads of a pid that is actually alive is what settles it.
+    async fn grandchild_pid(pidfile: &Path) -> u32 {
+        let started = std::time::Instant::now();
+        let mut last = None;
+        while started.elapsed() < STOP_DEADLINE {
+            if let Ok(text) = std::fs::read_to_string(pidfile)
+                && let Ok(pid) = text.trim().parse::<u32>()
+            {
+                if last == Some(pid) && alive(pid) {
+                    return pid;
+                }
+                last = Some(pid);
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("the fixture recorded no live grandchild within {STOP_DEADLINE:?}");
+    }
+
     /// [`watch_child`] under a deadline.
     ///
     /// Every runaway fixture here writes until it is stopped, so a regression
@@ -490,6 +679,20 @@ done
         )
         .await
         .unwrap_or_else(|_| panic!("the watchdog left the child running past {STOP_DEADLINE:?}"))
+    }
+
+    /// A snapshot of [`DETACHED`], so an assertion never holds its lock.
+    fn registered() -> Vec<u32> {
+        DETACHED.lock().expect("an unpoisoned lock").clone()
+    }
+
+    /// The process group this pid belongs to.
+    fn group_of(pid: u32) -> u32 {
+        // SAFETY: `getpgid` only reads, and the pid names a live process the
+        // caller has just observed.
+        let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
+        assert!(pgid > 0, "pid {pid} has no process group");
+        pgid as u32
     }
 
     /// Is this pid still a process on this machine?
@@ -873,5 +1076,86 @@ done
         };
         assert!(why.contains("could not be run"), "{why}");
         assert!(why.contains("install it"), "the hint is carried: {why}");
+    }
+
+    /// A Ctrl-C must reach the clone the terminal can no longer see (#5669).
+    ///
+    /// `process_group(0)` is what took the tree out of the foreground group, so
+    /// a raw `SIGINT` killed `taudit` on the default disposition and left `ssh`
+    /// and `git-index-pack` writing into a client's disk with the watchdog dead.
+    /// The budget here is `u64::MAX`, which takes the watchdog itself out of the
+    /// picture: the only thing that can stop this fixture is the interrupt path.
+    #[tokio::test]
+    async fn an_interrupt_kills_a_detached_clone_group() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        let pidfile = tmp.path().join("grandchild.pid");
+
+        let clone = tokio::spawn({
+            let (staged, pidfile) = (staged.clone(), pidfile.clone());
+            async move {
+                // No ceiling this fixture can reach, so nothing but the
+                // interrupt can end it.
+                let unreachable_ceiling = Watch {
+                    budget_bytes: u64::MAX,
+                    ..tiny_watch(0, u64::MAX)
+                };
+                run(
+                    &SPEC,
+                    forking_writer(&staged, &pidfile, 1024),
+                    &staged,
+                    Some(unreachable_ceiling),
+                )
+                .await
+            }
+        });
+
+        let pid = grandchild_pid(&pidfile).await;
+        let group = group_of(pid);
+
+        // Half the finding: `run` must have RECORDED this group, or an interrupt
+        // has nothing to walk. `interrupt_detached_groups` is not called here —
+        // it signals every registered group, and the other tests in this binary
+        // clone too.
+        assert!(
+            registered().contains(&group),
+            "run must register the group it detached; {group} is not in {:?}",
+            registered()
+        );
+        // The other half: signalling that group ends the whole tree.
+        stop_groups(&[group], Duration::from_millis(50)).await;
+
+        assert!(
+            died_within(pid, Duration::from_secs(5)).await,
+            "grandchild {pid} outlived the interrupt and would keep fetching into a tree \
+             nothing is watching any more"
+        );
+        // Reap the fixture's own shell, which the same signal stopped.
+        let _ = tokio::time::timeout(STOP_DEADLINE, clone).await;
+    }
+
+    /// A guard's entry does not outlive the guard (#5669).
+    ///
+    /// A pid left in [`DETACHED`] is a pid a later interrupt signals, and the
+    /// kernel reuses pids. Asserted on a sentinel rather than on a real clone
+    /// because [`DETACHED`] is process-global: a sibling test registering its
+    /// own clone must not be able to decide this one.
+    #[test]
+    fn a_detached_group_is_deregistered_when_its_guard_drops() {
+        // Above every pid this kernel hands out, so it names nothing.
+        const SENTINEL: u32 = 0x7fff_fffe;
+
+        {
+            let _guard = Detached::register(SENTINEL);
+            assert!(
+                registered().contains(&SENTINEL),
+                "registered while the guard is held"
+            );
+        }
+
+        assert!(
+            !registered().contains(&SENTINEL),
+            "the entry is gone once the guard drops"
+        );
     }
 }

--- a/crates/trusty-audit/src/clone/watchdog.rs
+++ b/crates/trusty-audit/src/clone/watchdog.rs
@@ -8,9 +8,13 @@
 //! interrupt is not a budget.
 //!
 //! What: while the acquisition child runs, its staged tree is measured at a
-//! bounded interval. Once `spent + staged` crosses the ceiling the child is
-//! signalled — `SIGTERM`, then `SIGKILL` if it does not exit within the grace —
-//! and the caller gets [`Outcome::OverBudget`], which
+//! bounded interval. Once `spent + staged` crosses the ceiling the child's whole
+//! PROCESS GROUP is signalled — `SIGTERM`, then `SIGKILL` if it does not exit
+//! within the grace. The group, not the child: a clone forks `ssh`,
+//! `git-index-pack` and `git-unpack-objects`, and those grandchildren are what
+//! hold the sockets and write the bytes, so a signal aimed at the direct child
+//! leaves the fetch running against a staged directory the caller has already
+//! removed. The caller gets [`Outcome::OverBudget`], which
 //! [`finish_one`](super::finish_one) turns into
 //! [`CloneState::BudgetExceeded`](super::CloneState::BudgetExceeded) and a
 //! removed staged tree. The start gate stays: it is what stops a clone nobody
@@ -29,8 +33,9 @@
 //! temporary pack files throughout a fetch, so a walk racing one is ordinary.
 //! That count is a floor, which still trips the ceiling when it crosses it and
 //! is re-measured on the next interval when it does not. The tree's own ROOT is
-//! the exception — an unopenable root would count 0 bytes forever, so it is
-//! opened explicitly and fails closed like any other unmeasurable sample.
+//! the exception — an unopenable root would count 0 bytes forever — and
+//! [`super::disk::measure_tree`] is where the two are told apart, for this module and
+//! for every other disk figure the crate reports.
 //!
 //! Test: `super::watchdog::watchdog_tests`.
 
@@ -121,7 +126,22 @@ pub(super) enum Outcome {
 /// stdout is discarded — no caller has ever read it — and stderr is drained by
 /// a task of its own so a chatty `git` cannot fill the pipe buffer and wedge a
 /// child this function is otherwise prepared to wait on indefinitely.
-/// Test: `super::watchdog::watchdog_tests::a_missing_binary_names_itself`.
+///
+/// **The child leads its own process group.** A real clone is a TREE, not one
+/// process: `gh` forks `git`, and `git` forks `ssh`, `git-index-pack` and
+/// `git-unpack-objects`, every one of which writes into the staged tree.
+/// Signalling the direct child alone leaves those grandchildren fetching, and an
+/// orphan that keeps writing — into a directory [`super::finish_one`] has by
+/// then already removed, and which the orphan recreates — defeats the ceiling
+/// that stopped it. `process_group(0)` is what makes one signal reach all of
+/// them; [`terminate`] sends it (#5669).
+///
+/// The cost is that the child no longer shares this process's group, so a
+/// terminal `SIGINT` reaches the audit and not the clone. The watchdog is the
+/// interruption path either way, and `kill_on_drop` covers the future being
+/// dropped, but a `taudit` killed outright leaves the clone running.
+/// Test: `super::watchdog::watchdog_tests::a_missing_binary_names_itself`,
+/// `super::watchdog::watchdog_tests::a_budget_kill_reaches_a_grandchild`.
 pub(super) async fn run(
     spec: &Spawn<'_>,
     mut command: Command,
@@ -131,7 +151,10 @@ pub(super) async fn run(
     command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::piped());
+        .stderr(Stdio::piped())
+        // See #5669.
+        .process_group(0)
+        .kill_on_drop(true);
     let child = match command.spawn() {
         Ok(child) => child,
         Err(source) => {
@@ -234,27 +257,57 @@ async fn supervise(child: &mut Child, staged: &Path, watch: Option<Watch>) -> Ve
     }
 }
 
-/// End the child, politely and then not.
+/// End the child AND everything it forked, politely and then not.
 ///
-/// `SIGTERM` first because both `git` and `gh` remove their temporary pack
-/// files on it, which leaves less for the caller's `remove_dir_all` to walk.
-/// `SIGKILL` follows on the grace expiring, and the child is reaped either way
-/// — an unreaped child is the orphan this whole path exists to avoid.
-/// Test: `super::watchdog::watchdog_tests::a_killed_child_leaves_no_process_behind`.
+/// `SIGTERM` first because both `git` and `gh` remove their temporary pack files
+/// on it, which leaves less for the caller's `remove_dir_all` to walk. `SIGKILL`
+/// follows on the grace expiring, and the child is reaped either way — an
+/// unreaped child is the orphan this whole path exists to avoid.
+///
+/// Both signals go to the whole process group, because the direct child is not
+/// where the bytes come from: see [`run`] and [`signal_tree`].
+/// Test: `super::watchdog::watchdog_tests::a_killed_child_leaves_no_process_behind`,
+/// `super::watchdog::watchdog_tests::a_budget_kill_reaches_a_grandchild`.
 async fn terminate(child: &mut Child, grace: Duration) {
     if let Some(pid) = child.id() {
-        // `libc::kill` is the only way to send a signal other than `SIGKILL`;
-        // `Child::kill` sends `SIGKILL` unconditionally. The pid is this
-        // process's own child and has not been reaped, so it cannot have been
-        // reused.
-        unsafe {
-            libc::kill(pid as libc::pid_t, libc::SIGTERM);
-        }
-        if tokio::time::timeout(grace, child.wait()).await.is_ok() {
+        signal_tree(pid, libc::SIGTERM);
+        // #5669: `Ok(Err(_))` is a wait that FAILED, not a child that exited.
+        // `is_ok()` on the timeout treated the two the same and returned
+        // without ever sending the `SIGKILL` this grace exists to precede.
+        if let Ok(Ok(_)) = tokio::time::timeout(grace, child.wait()).await {
             return;
         }
+        signal_tree(pid, libc::SIGKILL);
     }
+    // Reaps, and covers the child whose pid is already gone.
     let _ = child.kill().await;
+}
+
+/// Signal the child and every process it forked.
+///
+/// Why: killing the direct child alone is what let a clone keep running (#5669)
+/// — `git-index-pack` and `ssh` are grandchildren, they hold the sockets and do
+/// the writing, and nothing reparents them into the grave when their parent
+/// dies. [`run`] puts the child in a process group of its own precisely so one
+/// signal can reach the lot.
+/// What: `kill(-pid)` — the whole group — when the child LEADS its own group,
+/// which is what `process_group(0)` arranged. A child that does not lead one is
+/// in THIS process's group, where a group signal would kill the audit itself, so
+/// it is signalled alone. The check is `getpgid`, asked rather than assumed,
+/// because [`watch_child`] is also reached with children this module did not
+/// spawn.
+/// Test: `super::watchdog::watchdog_tests::a_budget_kill_reaches_a_grandchild`,
+/// `super::watchdog::watchdog_tests::a_child_in_our_own_process_group_is_signalled_alone`.
+fn signal_tree(pid: u32, signal: libc::c_int) {
+    let pid = pid as libc::pid_t;
+    // SAFETY: the pid is this process's own child and has not been reaped, so
+    // it cannot have been reused; `getpgid` only reads. A negative pid names
+    // the process GROUP with that id, which is why it is sent only when the
+    // child is that group's leader.
+    unsafe {
+        let target = if libc::getpgid(pid) == pid { -pid } else { pid };
+        libc::kill(target, signal);
+    }
 }
 
 /// One measurement of the staged tree.
@@ -277,25 +330,22 @@ enum Sample {
 /// `super::watchdog::watchdog_tests::an_unopenable_tree_root_is_unmeasurable_not_empty`.
 fn sample(staged: &Path, seen: &mut bool) -> Sample {
     match std::fs::symlink_metadata(staged) {
-        Ok(meta) if meta.is_dir() => {
-            // #5669: `dir_size` answers `(0, false)` when the tree's own root
-            // cannot be opened, which reads as an empty tree and never trips
-            // the ceiling. Open the root here so that case fails CLOSED like
-            // every other unmeasurable one. Entries BELOW the root stay a
-            // floor, because `git` creating and removing pack files mid-fetch
-            // makes a partial walk ordinary rather than a failure.
-            if let Err(source) = std::fs::read_dir(staged) {
-                return Sample::Unmeasurable(format!(
-                    "the staged tree at {} could not be measured: {source}",
-                    staged.display()
-                ));
+        // #5669: one measurement, so there is no window between a guard and the
+        // walk it guards — an explicit `read_dir` check followed by `dir_size`'s
+        // own `read_dir` were two separate opens, and a root that became
+        // unreadable between them still read as an empty tree.
+        // `super::disk::measure_tree` fails on an unreadable ROOT, which would
+        // otherwise count 0 forever and never trip the ceiling, and returns a
+        // floor for anything below it: `git` creates and removes pack files
+        // throughout a fetch, so a partial walk is ordinary, and a floor over
+        // the ceiling still trips it.
+        Ok(meta) if meta.is_dir() => match super::disk::measure_tree(staged) {
+            Ok((bytes, _floor)) => {
+                *seen = true;
+                Sample::Bytes(bytes)
             }
-            *seen = true;
-            // The completeness flag is deliberately dropped: a partial walk is
-            // a floor, and a floor over the ceiling still trips it.
-            let (bytes, _floor) = super::dir_size(staged);
-            Sample::Bytes(bytes)
-        }
+            Err(why) => Sample::Unmeasurable(why),
+        },
         Ok(_) => Sample::Unmeasurable(format!(
             "the staged tree at {} is not a directory",
             staged.display()
@@ -380,6 +430,54 @@ done
         command
     }
 
+    /// A child that FORKS, the way every real clone does.
+    ///
+    /// `gh` forks `git`, `git` forks `ssh` and `git-index-pack`; [`writer`]
+    /// forks nothing, so no test built on it can see a grandchild survive the
+    /// kill. The grandchild here only sleeps — the claim under test is that the
+    /// budget kill REACHES it, and a grandchild that also wrote would be a
+    /// runaway of its own on the day the kill regresses. The parent does the
+    /// writing that trips the ceiling.
+    ///
+    /// `sh -c` runs without job control, so the background job stays in the
+    /// parent's process group: reaching it is exactly the group-kill property.
+    fn forking_writer(dir: &Path, pidfile: &Path, chunk: usize) -> Command {
+        let script = r#"mkdir -p "$1" || exit 1
+sleep 300 &
+printf '%s' "$!" > "$2"
+while :; do
+  printf '%s' "$3" >> "$1/blob"
+done
+"#;
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg(script)
+            .arg("watchdog-forking-fixture")
+            .arg(dir)
+            .arg(pidfile)
+            .arg("x".repeat(chunk))
+            .kill_on_drop(true);
+        command
+    }
+
+    /// Wait out the window between a signal and the reaping that follows it.
+    ///
+    /// A grandchild's parent dies first, so the grandchild is reparented and
+    /// reaped by `init` rather than by anything here — `kill(pid, 0)` answers
+    /// "alive" for the moment it spends as a zombie. Polling a bounded deadline
+    /// keeps that from reading as a survival.
+    async fn died_within(pid: u32, deadline: Duration) -> bool {
+        let started = std::time::Instant::now();
+        while started.elapsed() < deadline {
+            if !alive(pid) {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        !alive(pid)
+    }
+
     /// [`watch_child`] under a deadline.
     ///
     /// Every runaway fixture here writes until it is stopped, so a regression
@@ -443,6 +541,90 @@ done
         assert!(
             elapsed < STOP_DEADLINE,
             "stopped after {elapsed:?}, past the {STOP_DEADLINE:?} deadline"
+        );
+    }
+
+    /// The kill reaches the whole clone, not just the process this module
+    /// spawned (#5669).
+    ///
+    /// A real clone's bytes come from grandchildren — `ssh`, `git-index-pack`,
+    /// `git-unpack-objects` — and one that outlives the budget kill keeps
+    /// fetching into, and RECREATES, the staged directory `finish_one` has by
+    /// then removed. Every other kill test here uses a fixture that forks
+    /// nothing, so this is the only one that can see it.
+    ///
+    /// Goes through [`run`], not [`watch_child`], because `process_group(0)` is
+    /// applied there: this asserts the production spawn path, not a property a
+    /// test fixture arranged for itself.
+    ///
+    /// A surviving grandchild fails this test in either of two ways, and both
+    /// are the same defect. It inherits the stderr pipe, so it holds that pipe
+    /// open after its parent dies and `watch_child`'s drain never finishes —
+    /// that is the deadline arm. When it does not hold the pipe, the pid check
+    /// at the end is what catches it.
+    #[tokio::test]
+    async fn a_budget_kill_reaches_a_grandchild() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let staged = tmp.path().join("staged");
+        let pidfile = tmp.path().join("grandchild.pid");
+
+        let outcome = tokio::time::timeout(
+            STOP_DEADLINE,
+            run(
+                &SPEC,
+                forking_writer(&staged, &pidfile, 1024),
+                &staged,
+                Some(tiny_watch(0, 4096)),
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "no verdict within {STOP_DEADLINE:?} — a grandchild that survived the kill is \
+                 still holding the inherited stderr pipe open"
+            )
+        });
+
+        assert!(matches!(outcome, Outcome::OverBudget { .. }), "{outcome:?}");
+        let pid: u32 = std::fs::read_to_string(&pidfile)
+            .expect("the fixture recorded its grandchild's pid")
+            .trim()
+            .parse()
+            .expect("a pid");
+        assert!(
+            died_within(pid, Duration::from_secs(5)).await,
+            "grandchild {pid} outlived the budget kill and would keep writing into the tree \
+             the caller is about to remove"
+        );
+    }
+
+    /// A child this module did not put in its own group is signalled ALONE.
+    ///
+    /// The group signal is `kill(-pid)`, and `-pid` for a child sharing our
+    /// group would name some other group entirely — or, if this process led it,
+    /// the audit itself. [`signal_tree`] asks `getpgid` rather than assuming,
+    /// and this is the arm that answers no: the child is spawned without
+    /// `process_group`, so it inherits ours.
+    #[tokio::test]
+    async fn a_child_in_our_own_process_group_is_signalled_alone() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut child = writer(&tmp.path().join("staged"), 1024, u64::from(u32::MAX))
+            .spawn()
+            .expect("/bin/sh");
+        let pid = child.id().expect("a freshly spawned child has a pid");
+        assert_ne!(
+            unsafe { libc::getpgid(pid as libc::pid_t) },
+            pid as libc::pid_t,
+            "the fixture must NOT lead its own group for this to be the case under test"
+        );
+
+        terminate(&mut child, Duration::from_millis(200)).await;
+
+        // Reaching this line at all is half the assertion: a group signal aimed
+        // at our own group would have killed the test process.
+        assert!(
+            matches!(child.try_wait(), Ok(Some(_))),
+            "a child sharing our group is still ended and reaped"
         );
     }
 

--- a/crates/trusty-audit/src/main.rs
+++ b/crates/trusty-audit/src/main.rs
@@ -28,6 +28,14 @@ use trusty_audit::workdir::{WORKDIR_ENV, WorkDir};
 // shim owns the runtime. Nothing else moved here.
 #[tokio::main]
 async fn main() -> Result<()> {
+    // #5669: the clone watchdog puts each clone in a process group of its own,
+    // which is also what takes it out of this terminal's reach — so Ctrl-C is
+    // forwarded to the clone here, and the process then dies by `SIGINT` as it
+    // always did. It lives in the binary because it ends the process, which a
+    // library embedded by a front end must not decide. Spawned before anything
+    // can start a clone.
+    tokio::spawn(trusty_audit::clone::stop_clones_on_interrupt());
+
     let cli = Cli::parse();
 
     let cwd = std::env::current_dir().context("cannot determine the current directory")?;


### PR DESCRIPTION
## Outcome

Refs #5669

## Changes

A watchdog samples the staged tree every 500ms and terminates the clone's whole process group (the clone runs in its own group) when the disk ceiling is crossed, reusing the failure-removal path; overshoot is bounded by one sample period and documented; a Ctrl-C forwards to the detached group with a SIGKILL backstop before taudit re-raises; a staged tree that cannot be removed or measured is reported as a floor or unknown, never zero, and feeds later budget decisions as a floor. `clone.rs` split into `clone/disk.rs` and `render.rs` into `render/cloned.rs` for the SLOC cap.

## Risk

Normal — cross-crate change to process termination (trusty-audit) with new signal handling and disk measurement. Test ladder rung 5. Direct dependents: none beyond internal tests.

## Tests

`cargo fmt --check` 0, `cargo clippy -p trusty-audit --all-targets -- -D warnings` 0, `cargo test -p trusty-audit --no-fail-fast` 8 targets 0 failed (lib 1102 passed), `--include-ignored clone::` 59 passed ten consecutive runs (real `gh repo clone` killed mid-fetch), mutation proof on every new test.

## Baseline

No pre-existing failures.

## Docs

Changelog fragment: `crates/trusty-audit/changelog.d/5669-clone-watchdog.md` added. Doc follow-up: library embedders must spawn `clone::stop_clones_on_interrupt` themselves; noted for a follow-up doc PR (critic round 3 MEDIUM finding).

## Review

Critic: round 3 APPROVE with one MEDIUM doc follow-up noted above.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
