### PR TITLE
fix(trusty-mpm,trusty-agents-common): prompts stop naming trusty-tools-only doc-gate scripts as universal (Refs #7247)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7247-doc-gates-per-project.md
+++ b/crates/trusty-agents-common/changelog.d/7247-doc-gates-per-project.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `BASE-AGENT.md` no longer asserts "This project: CLAUDE.md sets 500/3000 SLOC via `scripts/check_line_cap.sh`" as a fact about whatever project the agent was dispatched into, and `rust-engineer.md` no longer instructs every run to execute `check_line_cap.sh`, `check_changelog_fragment.sh` and `check_test_pointers.sh` (#7247). Those scripts exist in `trusty-tools` and nowhere else; both assets now direct the agent to read the project's own `CLAUDE.md` and `scripts/` and state the fallbacks (a grep-based SLOC count, a `CHANGELOG.md` bullet under `## [Unreleased]`) for a project that defines no gates. `engineer_assets_name_no_repo_specific_doc_gate_script` pins it.

--- a/crates/trusty-agents-common/src/agent_assets.rs
+++ b/crates/trusty-agents-common/src/agent_assets.rs
@@ -429,6 +429,48 @@ mod tests {
         }
     }
 
+    /// An engineer's shipped prompt must not name a doc-gate script that only
+    /// `trusty-tools` contains.
+    ///
+    /// Why (#7247): `BASE-AGENT.md` asserted "This project: CLAUDE.md sets
+    /// 500/3000 SLOC via `scripts/check_line_cap.sh`" as a fact about whatever
+    /// project the agent had been dispatched into, and `rust-engineer.md` told
+    /// every run to execute all three gates. In `bobmatnyc/trusty-things` none
+    /// of the three exists, and two `rust-engineer` runs on 2026-09-09 each
+    /// spent a round trip discovering that. These assets deploy unchanged into
+    /// every project, so a filename written here is a claim about a checkout
+    /// this crate has never seen.
+    /// What: rejects the three literals in the assets an engineer composes
+    /// from. `version-control.md` is deliberately out of scope — its two
+    /// mentions describe what `tm pr open` does internally, and that command
+    /// already degrades to a skip when the script is absent.
+    /// Test: this IS the assertion.
+    #[test]
+    fn engineer_assets_name_no_repo_specific_doc_gate_script() {
+        /// Gates that exist in `trusty-tools` and cannot be assumed elsewhere.
+        const REPO_SPECIFIC_GATES: [&str; 3] = [
+            "check_test_pointers.sh",
+            "check_line_cap.sh",
+            "check_changelog_fragment.sh",
+        ];
+
+        for (name, body) in [
+            ("BASE-AGENT.md", BASE_AGENT),
+            ("BASE-ENGINEER.md", BASE_ENGINEER),
+            ("rust-engineer.md", RUST_ENGINEER),
+        ] {
+            for gate in REPO_SPECIFIC_GATES {
+                assert!(
+                    !body.contains(gate),
+                    "`{name}` names `{gate}`, a script that exists in \
+                     trusty-tools and not in every project (#7247) — tell the \
+                     agent to read the project's own CLAUDE.md and `scripts/` \
+                     instead of naming a filename"
+                );
+            }
+        }
+    }
+
     /// The `BASE-*` templates are what every other asset's `extends:` chain
     /// roots at. Shipping the roster without them would make composition
     /// impossible for every consumer, which is precisely why all 42 moved

--- a/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
@@ -195,10 +195,12 @@ polish — the full gate is in `tm-workflow`.
 - Either way, match the existing bullet style. Docs-only / CI-only PRs may skip.
 
 **Doc-comment gates.** In a crate that documents entry points with a Why/What/
-Test pattern, run that project's doc-comment pointer lint (e.g.
-`check_test_pointers.sh`) alongside the line-cap and changelog-fragment gates
-before returning — a stale `Test:` pointer is a review-gate failure, not a
-warning.
+Test pattern, run that project's own doc-comment pointer lint before returning,
+alongside whatever line-cap and changelog gates it defines — a stale `Test:`
+pointer is a review-gate failure, not a warning. Find those gates the same way
+you find any project command: read the project's CLAUDE.md and list its
+`scripts/`. A project that defines none owes no such run, and never invent a
+script name that the checkout does not contain.
 
 ## Memory & Context Routing
 
@@ -259,8 +261,9 @@ Framework default: 500 lines production / 3000 lines test, non-comment
 non-blank lines only. A project's CLAUDE.md overrides the numbers and the
 measuring command; use its named tool, or fall back to
 `grep -cvE '^\s*(//|#|$)' <file>`. CLAUDE.md is the only override surface —
-never invent a config key. This project: CLAUDE.md sets 500/3000 SLOC via
-`scripts/check_line_cap.sh <file.rs>`.
+never invent a config key, and never invent a script name — read the CLAUDE.md
+in front of you for the cap tool this project actually ships. When it names
+none, the fallback count above IS the measurement.
 
 ## Minimalism Principle
 

--- a/crates/trusty-agents-common/src/assets/agents/rust-engineer.md
+++ b/crates/trusty-agents-common/src/assets/agents/rust-engineer.md
@@ -63,11 +63,13 @@ false failures.
 instead of the four-command bar above — it runs every feature lane the crate
 actually needs covered.
 
-🔴 **Touched a doc comment? Run the doc gates too:** `bash
-scripts/check_line_cap.sh`, `bash scripts/check_changelog_fragment.sh`, and
-`bash scripts/check_test_pointers.sh`. The last checks every `Test:` pointer in
-a doc comment names a test that actually exists; its ratchet also fails on a
-stale allowlist row, which gets removed, never re-added.
+🔴 **Touched a doc comment? Run this project's doc gates too, if it defines
+any.** Its CLAUDE.md names them and `scripts/` holds them — read both rather
+than assuming a filename; a project that ships none owes no such run, and the
+BASE-AGENT fallbacks (a grep-based SLOC count, a `CHANGELOG.md` bullet under
+`## [Unreleased]`) apply instead. Where a project does ship a `Test:`-pointer
+lint, it fails on a pointer naming a test that does not exist, and its ratchet
+also fails on a stale allowlist row, which gets removed, never re-added.
 
 ### Scope is for speed — never for hiding a failure
 

--- a/crates/trusty-mpm/changelog.d/7247-doc-gates-per-project.md
+++ b/crates/trusty-mpm/changelog.d/7247-doc-gates-per-project.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The composed PM prompt no longer requires every engineer brief to end with `check_test_pointers.sh`, `check_line_cap.sh` and `check_changelog_fragment.sh` (#7247). Those three scripts ship in `trusty-tools` and in no other project — in `bobmatnyc/trusty-things` none of them exists, and two `rust-engineer` runs each spent a round trip discovering that. "Delegating Well" now tells the PM to ask for the project's own doc gates, naming its `CLAUDE.md` and `scripts/` as where to find them, and says a project that defines none owes no such run. `the_delivered_prompt_names_no_repo_specific_doc_gate_script` composes through both composers with no project `CLAUDE.md` and rejects all three literals.

--- a/crates/trusty-mpm/src/assets/instructions/sections/core.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/core.md
@@ -73,8 +73,9 @@ agents that listing does not carry (#4513).
 - Every engineer delegation MUST end with: "Before returning: run
   linters/formatters, fix any issues, run tests, verify all pass. Verify ALL
   deliverables from the prompt are present (README, config, etc.). Show raw test
-  output. Including this repo's doc gates: `check_test_pointers.sh`,
-  `check_line_cap.sh`, `check_changelog_fragment.sh`."
+  output. Plus this project's own doc gates, if it defines any — its CLAUDE.md
+  names them and `scripts/` holds them; name the ones you ran. A project that
+  defines none owes no such run."
 - A running agent's scope is fixed. New work is a new agent, or it waits.
 - A brief carries findings, evidence and constraints, never the implementation
   mechanism: state what must be TRUE.

--- a/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
@@ -874,3 +874,50 @@ fn the_delivered_prompt_teaches_sprint_then_harden() {
         );
     }
 }
+
+/// Doc-gate script names in this repository's `scripts/` do not exist in every
+/// project, so the delivered prompt must never name one.
+///
+/// Why (#7247): "Delegating Well" required every engineer brief to end with
+/// "Including this repo's doc gates: `check_test_pointers.sh`,
+/// `check_line_cap.sh`, `check_changelog_fragment.sh`". Those three ship in
+/// `trusty-tools` and nowhere else — in `bobmatnyc/trusty-things` none exists,
+/// and two `rust-engineer` runs on 2026-09-09 each spent a round trip
+/// discovering that before substituting hand-run equivalents. The prompt every
+/// PM session receives is composed from bundled sections, so a repo-specific
+/// filename written into one is delivered verbatim to every project.
+/// What: composes through BOTH composers with no project `CLAUDE.md` present,
+/// so any hit is necessarily framework text rather than a project-scoped
+/// override block, and rejects the three literals. The rule generalises past
+/// these three names — the replacement text tells an agent to read the
+/// project's own CLAUDE.md and `scripts/` — but a literal list is what a
+/// reword can regress to, so a literal list is what this pins.
+/// Test: this IS the assertion.
+#[test]
+fn the_delivered_prompt_names_no_repo_specific_doc_gate_script() {
+    /// Gates that exist in `trusty-tools` and cannot be assumed anywhere else.
+    const REPO_SPECIFIC_GATES: [&str; 3] = [
+        "check_test_pointers.sh",
+        "check_line_cap.sh",
+        "check_changelog_fragment.sh",
+    ];
+
+    let packaged =
+        compose_bundled_fallback(FIXED_STACK, FIXED_ROSTER, None).expect("package composes");
+
+    // No `CLAUDE.md` written: the string assembly receives only framework text.
+    let tmp = TempDir::new().expect("tempdir");
+    let assembled = resolve_pm_prompt_with_roster(tmp.path(), || None).0;
+
+    for (composer, prompt) in [("packaged", &packaged), ("assembly", &assembled)] {
+        for gate in REPO_SPECIFIC_GATES {
+            assert!(
+                !prompt.contains(gate),
+                "the {composer} PM prompt names `{gate}`, a script that exists \
+                 in trusty-tools and not in every project (#7247) — state the \
+                 project-relative rule (read the project's CLAUDE.md and \
+                 `scripts/`) instead of a filename"
+            );
+        }
+    }
+}

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -73,8 +73,9 @@ agents that listing does not carry (#4513).
 - Every engineer delegation MUST end with: "Before returning: run
   linters/formatters, fix any issues, run tests, verify all pass. Verify ALL
   deliverables from the prompt are present (README, config, etc.). Show raw test
-  output. Including this repo's doc gates: `check_test_pointers.sh`,
-  `check_line_cap.sh`, `check_changelog_fragment.sh`."
+  output. Plus this project's own doc gates, if it defines any — its CLAUDE.md
+  names them and `scripts/` holds them; name the ones you ran. A project that
+  defines none owes no such run."
 - A running agent's scope is fixed. New work is a new agent, or it waits.
 - A brief carries findings, evidence and constraints, never the implementation
   mechanism: state what must be TRUE.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -73,8 +73,9 @@ agents that listing does not carry (#4513).
 - Every engineer delegation MUST end with: "Before returning: run
   linters/formatters, fix any issues, run tests, verify all pass. Verify ALL
   deliverables from the prompt are present (README, config, etc.). Show raw test
-  output. Including this repo's doc gates: `check_test_pointers.sh`,
-  `check_line_cap.sh`, `check_changelog_fragment.sh`."
+  output. Plus this project's own doc gates, if it defines any — its CLAUDE.md
+  names them and `scripts/` holds them; name the ones you ran. A project that
+  defines none owes no such run."
 - A running agent's scope is fixed. New work is a new agent, or it waits.
 - A brief carries findings, evidence and constraints, never the implementation
   mechanism: state what must be TRUE.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -73,8 +73,9 @@ agents that listing does not carry (#4513).
 - Every engineer delegation MUST end with: "Before returning: run
   linters/formatters, fix any issues, run tests, verify all pass. Verify ALL
   deliverables from the prompt are present (README, config, etc.). Show raw test
-  output. Including this repo's doc gates: `check_test_pointers.sh`,
-  `check_line_cap.sh`, `check_changelog_fragment.sh`."
+  output. Plus this project's own doc gates, if it defines any — its CLAUDE.md
+  names them and `scripts/` holds them; name the ones you ran. A project that
+  defines none owes no such run."
 - A running agent's scope is fixed. New work is a new agent, or it waits.
 - A brief carries findings, evidence and constraints, never the implementation
   mechanism: state what must be TRUE.


### PR DESCRIPTION
Refs #7247

The PM prompt's "Delegating Well" section and the bundled `BASE-AGENT.md` and `rust-engineer.md` assets named `check_test_pointers.sh`, `check_line_cap.sh` and `check_changelog_fragment.sh` as requirements in every project; two engineer runs in another repo looked for scripts that do not exist. Each site now says to run the project's own doc gates as its `CLAUDE.md` names them and its `scripts/` holds them, never to invent a script name the checkout does not contain, with the grep-based SLOC count and `CHANGELOG.md` fallbacks stated for a project that ships none. Two tests pin it: `engineer_assets_name_no_repo_specific_doc_gate_script` in trusty-agents-common and `the_delivered_prompt_names_no_repo_specific_doc_gate_script` in trusty-mpm, the latter composing through both composers with no project `CLAUDE.md`. The three `pm-prompt-*.md` goldens carry only the one hunk. `version-control.md` keeps its `check_changelog_fragment.sh` mentions because they describe `tm pr open`, which already skips when the script is absent.

Test ladder rung 3. `cargo fmt --check` OK; clippy `-D warnings` on both crates OK; `cargo test -p trusty-agents-common --no-fail-fast` 557 passed; `cargo test -p trusty-mpm --no-fail-fast` lib 6365 passed, bin tm 2382 passed, one failure `resume_managed_heals_stale_bare_status_line_command` (pre-existing #7244 under a `target-<N>` dir, file not in this diff). Both new tests shown failing on origin/main. Doc gates: check_line_cap OK, check_test_pointers 0 dangling, check_changelog_fragment OK (two fragments), check_sld OK.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
