### PR TITLE
feat(trusty-mpm): bare tm opens the session TUI too (Refs #7263)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7224-bare-tm-session-tui.md
+++ b/crates/trusty-mpm/changelog.d/7224-bare-tm-session-tui.md
@@ -1,0 +1,3 @@
+Changed
+
+- Bare `tm` now opens the same full-screen session TUI `tm ls` opens, through the same gate rather than a second copy of it: two real TTYs, a `TERM` that can address the cursor, and at least one live session. `guided::try_show_picker` calls the new `session_ls_connector::run_bare_tm_surface` where it called `run_tty_picker` directly, so a gate added to `should_show_picker` reaches both surfaces at once. The numbered picker stays the fallback for the two cases the TUI cannot serve — an empty fleet, where launching a new session is the point, and a terminal that cannot enter raw mode — and inside a tm-managed pane (`TM_MANAGED_SESSION_ID` set), where bare `tm` remains that pane's relaunch verb and must not take the pane over (#7224).

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -369,7 +369,9 @@ pub(crate) async fn run_guided_default(
 /// What: fetches the project's live sessions via the shared
 /// [`super::session_picker::fetch_live_sessions`] (decommissioned tombstones
 /// already filtered, #1809), runs the tty-gate, renders the two-panel daily
-/// banner (#1808), then hands off to [`super::session_picker::run_tty_picker`].
+/// banner (#1808), then hands off to
+/// [`super::session_ls_connector::run_bare_tm_surface`] (#7224 — the session
+/// TUI, or the numbered picker when the shared gate refuses raw mode).
 /// Returns `None` when the daemon is unreachable so the caller can try
 /// auto-start; returns `Some(result)` once the daemon responded.
 /// Test: indirectly covered by guided-default e2e tests; the pure sub-functions
@@ -407,7 +409,12 @@ async fn try_show_picker(
     // #3552: mutable — the picker's `[s]` / `/<text>` keys rewrite the scope's
     // sort, filter, and pinned default in place.
     let mut scope = super::session_picker::PickerScope::project(source_id, repo_url);
-    Some(super::session_picker::run_tty_picker(client, url, &mut scope, sessions).await)
+    // #7224: bare `tm` opens the same session TUI `tm ls` does, decided by the
+    // one gate both surfaces share — see
+    // [`super::session_ls_connector::bare_tm_opens_session_tui`]. The numbered
+    // picker is still what an empty fleet, a managed pane, or a `TERM` with no
+    // cursor addressing gets.
+    Some(super::session_ls_connector::run_bare_tm_surface(client, url, &mut scope, sessions).await)
 }
 
 // ── Project derivation ───────────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/bin/tm/commands/session_ls_connector.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_ls_connector.rs
@@ -13,10 +13,16 @@
 //! from here, so there is one implementation of each.
 //!
 //! #7224: the interactive branch now opens the full-screen
-//! [`super::session_tui`] rather than the line-based numbered picker. The
-//! picker itself is unchanged and still serves bare `tm`
-//! (`guided::try_show_picker`); what moved is only which surface `tm ls`
-//! reaches. `--plain` is the new opt-out back to the static table.
+//! [`super::session_tui`] rather than the line-based numbered picker.
+//! `--plain` is the opt-out back to the static table.
+//!
+//! #7224: bare `tm` reaches that same TUI, through this module rather than a
+//! second copy of the gate. [`bare_tm_opens_session_tui`] is the decision and
+//! [`run_bare_tm_surface`] the dispatch; `guided::try_show_picker` calls the
+//! latter where it used to call `run_tty_picker` directly. The numbered picker
+//! is still bare `tm`'s fallback — it is the surface that can launch a NEW
+//! session, which the TUI cannot, so an empty fleet or a dumb terminal keeps
+//! it.
 //!
 //! Test: the gate is unit-tested by `ls_connector_should_show_picker_*` in
 //! `tests_behavior_d_tests.rs`; the orchestrator's argument parsing is covered
@@ -266,4 +272,106 @@ pub(crate) async fn run_ls_connector(
         self_tmux_name,
     )
     .await
+}
+
+/// Does bare `tm` open the session TUI on this invocation?
+///
+/// Why (#7224): the owner ruling is that bare `tm` reaches the same surface
+/// `tm ls` reaches. Re-spelling the gate here is the defect #7224 round 2 just
+/// removed — the `TERM` check lived in `tm f` and not in `tm ls`, so one
+/// surface entered raw mode where the other refused. The body is therefore one
+/// delegation to [`should_show_picker`], and a gate added there reaches bare
+/// `tm` without a second edit.
+/// What: `json`, `all`, `attached`, and `plain` are pinned `false` because bare
+/// `tm` has no grammar that could set them — it takes no flags and no
+/// positionals (a leading token parses as `cli::Command::External`), so
+/// `tm recent` and `tm alpha <filter>` are not forms that exist. The one
+/// operand bare `tm` alone carries is `managed_pane`: inside a tm-managed pane,
+/// bare `tm` is that pane's relaunch verb, so a full-screen surface must never
+/// take the pane over there. `tm ls` in the same pane still opens the TUI and
+/// reads the same variable for its self-delete guard — two different questions
+/// about one fact, not a divergent gate. The operand is a `bool` for the same
+/// reason [`super::guided_outside_git::route_bare_tm`]'s is: what counts as a
+/// managed pane is
+/// [`guided_inplace::resolve_env_managed_session_id`](super::guided_inplace::resolve_env_managed_session_id),
+/// the one implementation of that lookup, and re-deciding it here would be a
+/// second one.
+/// Test: `bare_tm_opens_the_session_tui_on_two_ttys_with_a_capable_term`,
+/// `bare_tm_never_opens_the_tui_inside_a_managed_pane`,
+/// `bare_tm_and_ls_refuse_the_tui_on_the_same_inputs`.
+pub(crate) fn bare_tm_opens_session_tui(
+    stdin_tty: bool,
+    stdout_tty: bool,
+    term: Option<&str>,
+    managed_pane: bool,
+    session_count: usize,
+) -> bool {
+    if managed_pane {
+        return false;
+    }
+    should_show_picker(
+        stdin_tty,
+        stdout_tty,
+        false,
+        false,
+        false,
+        false,
+        term,
+        session_count,
+    )
+}
+
+/// Open bare `tm`'s managed-session surface: the TUI, or the numbered picker.
+///
+/// Why (#7224): `guided::try_show_picker` used to call
+/// [`super::session_picker::run_tty_picker`] unconditionally, so the surface
+/// the owner asked for was reachable from `tm ls` and from nothing else.
+/// Putting the choice HERE rather than in `guided.rs` is what keeps the gate
+/// single: this module already owns "which surface does a managed-session
+/// listing open", and `guided.rs` sits one line under the 500-SLOC cap.
+/// What: reads `TERM` and the managed-session id at this I/O boundary and
+/// injects them into [`bare_tm_opens_session_tui`], mirroring
+/// [`run_ls_connector`] — the gate stays pure and `src/bin/tm/**` keeps its
+/// no-process-global-env posture (#5544), which these reads never violate. The
+/// id comes from
+/// [`guided_inplace::resolve_env_managed_session_id`](super::guided_inplace::resolve_env_managed_session_id),
+/// the process-env-then-tmux-env chain `try_inplace_relaunch` and
+/// `try_outside_git` already ask, rather than a third reading of the variable.
+/// The picker is the fallback, not a lesser one: it is the only surface with a
+/// launch-new action, which is exactly what an empty fleet needs, and it reads
+/// whole lines instead of raw-mode keys, which is exactly what a `TERM` with no
+/// cursor addressing needs.
+/// Test: the choice is `bare_tm_opens_the_session_tui_*` and
+/// `bare_tm_never_opens_the_tui_inside_a_managed_pane`; the two surfaces it
+/// dispatches to carry their own.
+pub(crate) async fn run_bare_tm_surface(
+    client: &reqwest::Client,
+    url: &str,
+    scope: &mut PickerScope,
+    sessions: Vec<trusty_mpm::client::ManagedSessionSummary>,
+) -> anyhow::Result<()> {
+    let self_session_id = super::guided_inplace::resolve_env_managed_session_id();
+    let term_var = std::env::var("TERM").ok();
+    if bare_tm_opens_session_tui(
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+        term_var.as_deref(),
+        self_session_id.is_some(),
+        sessions.len(),
+    ) {
+        // `self_session_id` is `None` on this branch by construction — the gate
+        // above refuses a managed pane — and is still threaded through so the
+        // TUI's self-delete guard reads the same operand `tm ls` hands it.
+        let self_tmux_name = super::tmux_attach::current_tmux_session_name();
+        return super::session_tui::run_session_tui(
+            client,
+            url,
+            scope,
+            sessions,
+            self_session_id,
+            self_tmux_name,
+        )
+        .await;
+    }
+    super::session_picker::run_tty_picker(client, url, scope, sessions).await
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
@@ -24,7 +24,13 @@
 //! suspend/resume around the tmux hand-off come from
 //! [`trusty_mpm::tui::terminal`], shared with the coordinator and `project_ctl`
 //! screens. What is NOT shared is the input loop: a full-screen surface needs
-//! raw-mode keys, and the numbered picker keeps its line reader for bare `tm`.
+//! raw-mode keys, and the numbered picker keeps its line reader for the cases
+//! this surface cannot serve — an empty fleet (only the picker can launch a
+//! NEW session) and a terminal that cannot enter raw mode.
+//!
+//! #7224: bare `tm` opens this surface too, through
+//! [`super::session_ls_connector::run_bare_tm_surface`] — the same gate, not a
+//! second copy of it.
 //!
 //! `tm ls --plain`, `--json`, `--all`, `--attached`, and any non-TTY stream
 //! still print the static table, unchanged — see

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_ls_connector_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_ls_connector_tests.rs
@@ -376,3 +376,90 @@ fn ls_connector_dumb_term_reaches_the_static_renderer() {
         "a real TERM on the same invocation still opens the TUI"
     );
 }
+
+// ── bare `tm` reaches the same surface (#7224) ───────────────────────────────
+
+use crate::commands::session_ls_connector::bare_tm_opens_session_tui;
+
+/// Bare `tm` on a real terminal opens the session TUI, exactly as `tm ls` does.
+///
+/// Why (#7224): this is the owner ruling — "bare tm should also open the TUI" —
+/// and it FAILS on the parent commit, where `guided::try_show_picker` called
+/// `run_tty_picker` unconditionally and no gate existed to assert against. It
+/// is the positive mirror of
+/// `ls_connector_dumb_term_reaches_the_static_renderer`: same operands, same
+/// shape, opposite claim.
+/// What: two TTYs, a cursor-addressable `TERM`, no managed pane, and a
+/// non-empty fleet must open the TUI — for every `TERM` a real terminal
+/// reports.
+#[test]
+fn bare_tm_opens_the_session_tui_on_two_ttys_with_a_capable_term() {
+    for term in [
+        Some("xterm-256color"),
+        Some("screen"),
+        Some("tmux-256color"),
+    ] {
+        assert!(
+            bare_tm_opens_session_tui(true, true, term, false, 1),
+            "TERM={term:?}: bare `tm` on two TTYs with a live fleet must open the TUI"
+        );
+    }
+    assert!(
+        bare_tm_opens_session_tui(true, true, REAL_TERM, false, 12),
+        "fleet size is not a reason to refuse"
+    );
+}
+
+/// Inside a tm-managed pane bare `tm` never opens the TUI.
+///
+/// Why (#7224): a managed pane is the pane whose agent bare `tm` relaunches in
+/// place. A full-screen alternate-screen surface would take that pane over
+/// instead, so the relaunch/"this pane" behavior has to survive the new
+/// surface. `tm ls` in that same pane still opens the TUI — it reads the same
+/// id as its self-delete guard, not as a refusal — which is why the operand
+/// lives on this wrapper and not in `should_show_picker`.
+/// What: a managed pane refuses on an otherwise fully interactive invocation
+/// with a live fleet, and refuses for every `TERM` — the pane, not the
+/// terminal, is what settles it.
+#[test]
+fn bare_tm_never_opens_the_tui_inside_a_managed_pane() {
+    for term in [Some("xterm-256color"), Some("screen"), Some("dumb"), None] {
+        assert!(
+            !bare_tm_opens_session_tui(true, true, term, true, 3),
+            "TERM={term:?}: a managed pane keeps the line picker, never a full-screen TUI"
+        );
+    }
+    assert!(
+        bare_tm_opens_session_tui(true, true, REAL_TERM, false, 3),
+        "the same invocation outside a managed pane opens the TUI"
+    );
+}
+
+/// Bare `tm` and `tm ls` refuse the TUI on exactly the same inputs.
+///
+/// Why (#7224): "a gate present on one surface and missing from the other" is
+/// the defect round 2 removed when `tm f`'s `TERM` check turned out to be
+/// absent from `tm ls`. Pinning the delegation as an IDENTITY — not a list of
+/// cases — is what makes a future gate added to `should_show_picker` reach bare
+/// `tm` for free, because a wrapper that stopped delegating would fail here.
+/// What: over every TTY / `TERM` / fleet-size combination, with no managed
+/// pane, the two decisions agree.
+#[test]
+fn bare_tm_and_ls_refuse_the_tui_on_the_same_inputs() {
+    for stdin_tty in [true, false] {
+        for stdout_tty in [true, false] {
+            for term in [Some("xterm-256color"), Some("dumb"), Some(""), None] {
+                for count in [0usize, 1, 7] {
+                    assert_eq!(
+                        bare_tm_opens_session_tui(stdin_tty, stdout_tty, term, false, count),
+                        should_show_picker(
+                            stdin_tty, stdout_tty, false, false, false, false, term, count
+                        ),
+                        "bare `tm` and `tm ls` disagree at \
+                         stdin={stdin_tty} stdout={stdout_tty} TERM={term:?} count={count}"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Outcome

Refs #7263, Refs #7224

Owner ruling: the session TUI is the default for bare `tm` as well as `tm ls`. Bare `tm` on a terminal now reaches the same TUI through the same gate object.

## Changes

`bare_tm_opens_session_tui` delegates to `should_show_picker` with the `ls`-only flags pinned false, so a gate added to one surface reaches the other with no second edit; `run_bare_tm_surface` reads `TERM` and the managed-session id at the I/O boundary. Inside a tm-managed pane bare `tm` never opens the TUI; the relaunch path still wins. A pipe keeps the existing non-TTY hint; `TERM=dumb` reaches the numbered picker rather than the static table, because the picker is the only surface that can launch a new session and it reads whole lines, never raw mode. Bare `tm` has no sort/filter grammar, so the TUI starts on the project scope's defaults, and `s` / `/` change them live.

## Risk

Low. The change gates via existing decision logic; no new TUI path is created, only reused.

## Tests

Test ladder rung 6 (UI surface). `cargo fmt --check` OK; `cargo clippy -p trusty-mpm --all-targets -- -D warnings` OK; `cargo test -p trusty-mpm --no-fail-fast`: 55 targets, both tm bins 2385 passed, lib 6364 passed, one pre-existing failure `resume_managed_heals_stale_bare_status_line_command` (#7244, under `target-<N>` dir, not in this diff). New tests: `bare_tm_opens_the_session_tui_on_two_ttys_with_a_capable_term`, `bare_tm_never_opens_the_tui_inside_a_managed_pane`, `bare_tm_and_ls_refuse_the_tui_on_the_same_inputs` (asserts decision equality across every TTY, TERM and fleet-size combination); on 97eec066a the test file does not compile because the decision did not exist. `tm ls` pty smoke with `TERM=dumb` prints the static table with zero alternate-screen sequences.

## Baseline

One pre-existing failure: `resume_managed_heals_stale_bare_status_line_command` (#7244). File is under `target-<N>/` and not included in this diff.

## Docs

Doc gates: `check_line_cap` OK, `check_test_pointers` 0 dangling, `check_changelog_fragment` OK. Known gap: nothing pins the `guided.rs` call site itself.

## Review

None.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
