### PR TITLE
fix(trusty-mpm): decide the commit stats footer by git's commit source

### DIFF
--- a/crates/trusty-mpm/changelog.d/7249-commit-source-aware-trailers.md
+++ b/crates/trusty-mpm/changelog.d/7249-commit-source-aware-trailers.md
@@ -1,0 +1,7 @@
+Fixed
+- The bundled `prepare-commit-msg` hook now reads git's commit-source argument
+  (#7249). A `merge` or `squash` commit is no longer stamped with the committing
+  session's token trailers, and a `commit` source — cherry-pick, revert,
+  `--amend`, `-c`/`-C` — has the original commit's stale figures stripped and
+  replaced with the current session's, or stripped and left empty when there is
+  no current session.

--- a/crates/trusty-mpm/src/assets/hooks/prepare-commit-msg
+++ b/crates/trusty-mpm/src/assets/hooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/bin/sh
-# trusty-mpm-commit-stats: v2
+# trusty-mpm-commit-stats: v3
 #
 # Stamp the commit message with the session's token counts, savings percentage
 # and model id, as git trailers (#7074). Installed by trusty-mpm into the
@@ -20,13 +20,45 @@
 #
 # Set TM_SKIP_COMMIT_STATS=1 to turn it off for one commit, or
 # TM_COMMIT_STATS_TIMEOUT to a whole number of seconds to change the budget.
+#
+# Git's SECOND argument says where the message came from, and the footer means
+# something different for each source (#7249). Tokens are a property of one
+# session's work on one message:
+#
+#   merge     git built the message from the merge's parents. The tokens of
+#             whoever ran `git merge` describe none of it. No stamping.
+#   squash    the message is assembled by git or GitHub from a branch's
+#             commits, each with its own figures. No stamping.
+#   commit    the message comes from an existing commit — a cherry-pick, a
+#             revert, `--amend`, `-c`/`-C`. Any block in it belongs to the
+#             session that made the ORIGINAL commit, so it is STRIPPED and this
+#             session's figures are stamped in its place. With no current
+#             session the strip still happens and nothing is added: no block is
+#             correct where another session's block is not. This is the one
+#             source that runs the stamper outside a Claude Code session.
+#   message   `-m` / `-F`, and `template` — the message is this commit's own.
+#             Stamped, as is the empty source git passes for an editor commit.
+#
+# `tm commit-trailers` is handed the source and applies the same rules, so the
+# `merge` and `squash` arms below are the cheap short-circuit rather than the
+# decision. Stamping stays idempotent WITHIN a source: a re-run over a message
+# this session already stamped adds nothing.
 
 set -u
 
 [ -n "${TM_SKIP_COMMIT_STATS:-}" ] && exit 0
 
-# Only a commit made inside a Claude Code session has stats to report.
-[ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || exit 0
+commit_source="${2:-}"
+
+case "$commit_source" in
+  merge | squash) exit 0 ;;
+esac
+
+# Only a commit made inside a Claude Code session has stats to report — except
+# a reused message, which may carry another session's stats to remove.
+if [ "$commit_source" != commit ] && [ -z "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+  exit 0
+fi
 
 command -v tm >/dev/null 2>&1 || exit 0
 
@@ -35,7 +67,7 @@ case "$budget" in
   '' | *[!0-9]*) budget=2 ;;
 esac
 
-tm commit-trailers --message-file "$1" >/dev/null 2>&1 &
+tm commit-trailers --message-file "$1" --commit-source "$commit_source" >/dev/null 2>&1 &
 stamper=$!
 
 # Poll in tenths of a second so a stamper that finishes in milliseconds — the

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -1663,6 +1663,13 @@ pub(crate) struct CommitTrailersArgs {
     /// `prepare-commit-msg` hook. Omitted, the trailers go to stdout.
     #[arg(long, value_name = "PATH")]
     pub(crate) message_file: Option<std::path::PathBuf>,
+    /// Git's commit source — its second `prepare-commit-msg` argument (#7249).
+    ///
+    /// `merge` and `squash` write nothing; `commit` (cherry-pick, revert,
+    /// amend, `-c`/`-C`) strips any inherited block before stamping; anything
+    /// else, the empty string included, stamps as usual.
+    #[arg(long, value_name = "SOURCE")]
+    pub(crate) commit_source: Option<String>,
 }
 
 #[derive(Debug, Clone, clap::Args)]

--- a/crates/trusty-mpm/src/bin/tm/commands/commit_trailers.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/commit_trailers.rs
@@ -22,13 +22,21 @@
 //! command exits 0 on every path, including one where it stamps nothing: a
 //! commit must never fail over its own statistics.
 //!
+//! Which of those happens at all depends on git's commit SOURCE, passed through
+//! as `--commit-source` (#7249): a merge or squash message belongs to no single
+//! session and gets nothing, and a reused message — cherry-pick, revert, amend
+//! — has the previous session's block stripped before this one's is written.
+//!
 //! Test: `stats_are_empty_without_a_session`, `stamps_a_message_file`,
-//! `an_unstampable_message_is_left_alone`.
+//! `an_unstampable_message_is_left_alone`, `a_merge_source_writes_nothing`,
+//! `a_reused_message_is_stripped_in_place`.
 
 use std::path::Path;
 
 use anyhow::Context as _;
-use trusty_mpm::core::commit_trailers::{CommitStats, append_trailers, render_trailers};
+use trusty_mpm::core::commit_trailers::{
+    CommitStats, StampPolicy, append_trailers, render_trailers, stamp_policy, strip_trailers,
+};
 use trusty_mpm::core::savings::{claude_code_session_id, fold_session, savings_log_in};
 use trusty_mpm::core::session_model::read_session_model;
 use trusty_mpm::core::session_record::{KIND_TRANSCRIPT, read_session_record};
@@ -70,11 +78,26 @@ pub(crate) fn gather_stats(
 
 /// Print the trailers, or splice them into a commit-message file.
 ///
-/// Why/What: see the module doc. Exits 0 whether or not anything was stamped —
-/// the caller is a `prepare-commit-msg` hook, and a non-zero exit there aborts
-/// the operator's commit.
-/// Test: `stamps_a_message_file`, `an_unstampable_message_is_left_alone`.
+/// Why/What: see the module doc. `--commit-source` decides what happens before
+/// anything is gathered (#7249): a merge or squash returns having written
+/// nothing, and a reused message — cherry-pick, revert, amend — has its
+/// inherited block stripped first, so a session with nothing of its own to say
+/// still leaves no other session's figures behind. Exits 0 whether or not
+/// anything was stamped — the caller is a `prepare-commit-msg` hook, and a
+/// non-zero exit there aborts the operator's commit.
+/// Test: `stamps_a_message_file`, `an_unstampable_message_is_left_alone`,
+/// `a_merge_source_writes_nothing`.
 pub(crate) fn run(args: &CommitTrailersArgs) -> anyhow::Result<()> {
+    let policy = stamp_policy(args.commit_source.as_deref().unwrap_or_default());
+    if policy == StampPolicy::Skip {
+        return Ok(());
+    }
+    if policy == StampPolicy::Restamp
+        && let Some(path) = args.message_file.as_deref()
+    {
+        rewrite_message_file(path, strip_trailers)?;
+    }
+
     let Some(session_id) = claude_code_session_id() else {
         return Ok(());
     };
@@ -98,20 +121,28 @@ pub(crate) fn run(args: &CommitTrailersArgs) -> anyhow::Result<()> {
 /// Splice `trailers` into the commit message at `path`.
 ///
 /// Why: the hook hands over git's own `COMMIT_EDITMSG`-shaped file, comments
-/// and scissors included, so the placement rules live in
-/// [`append_trailers`] rather than here. The write is atomic because the hook
-/// now enforces a wall-clock budget and can kill this process mid-run: a
-/// half-written `COMMIT_EDITMSG` would cost the operator their commit message,
-/// where a temp-file rename leaves either the original or the stamped text.
-/// What: reads, appends, and writes back only when the text actually changed,
-/// so an amend over an already-stamped message does no write at all.
+/// and scissors included, so the placement rules live in [`append_trailers`]
+/// rather than here.
 /// Test: `stamps_a_message_file`, `an_unstampable_message_is_left_alone`.
 fn stamp_message_file(path: &Path, trailers: &str) -> anyhow::Result<()> {
+    rewrite_message_file(path, |message| append_trailers(message, trailers))
+}
+
+/// Apply `transform` to the commit message at `path`.
+///
+/// Why: the write is atomic because the hook enforces a wall-clock budget and
+/// can kill this process mid-run — a half-written `COMMIT_EDITMSG` would cost
+/// the operator their commit message, where a temp-file rename leaves either
+/// the original or the new text.
+/// What: reads, transforms, and writes back only when the text actually
+/// changed, so an amend over an already-stamped message does no write at all.
+/// Test: `stamps_a_message_file`, `a_reused_message_is_stripped_in_place`.
+fn rewrite_message_file(path: &Path, transform: impl FnOnce(&str) -> String) -> anyhow::Result<()> {
     use std::io::Write as _;
 
     let original = std::fs::read_to_string(path)
         .with_context(|| format!("cannot read the commit message file {}", path.display()))?;
-    let stamped = append_trailers(&original, trailers);
+    let stamped = transform(&original);
     if stamped == original {
         return Ok(());
     }
@@ -252,6 +283,48 @@ mod tests {
             stamped.contains("Model: claude-opus-4-1-20250805"),
             "{stamped}"
         );
+    }
+
+    /// Why (#7249): a merge commit's message is assembled from its parents, so
+    /// the tokens of whoever ran `git merge` describe none of it. The command
+    /// must return before it gathers or writes anything.
+    /// Test: itself.
+    #[test]
+    fn a_merge_source_writes_nothing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let msg = dir.path().join("MERGE_MSG");
+        std::fs::write(&msg, "Merge branch 'topic'\n").expect("write");
+
+        run(&CommitTrailersArgs {
+            message_file: Some(msg.clone()),
+            commit_source: Some("merge".to_string()),
+        })
+        .expect("run");
+
+        assert_eq!(
+            std::fs::read_to_string(&msg).expect("read"),
+            "Merge branch 'topic'\n"
+        );
+    }
+
+    /// Why (#7249): the `commit` source hands over a message from an EARLIER
+    /// commit, whose block describes another session. The strip is what removes
+    /// it, and it must survive the comment block git appends to the file.
+    /// Test: itself.
+    #[test]
+    fn a_reused_message_is_stripped_in_place() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let msg = dir.path().join("COMMIT_EDITMSG");
+        std::fs::write(
+            &msg,
+            "feat: x\n\nTokens-In: 999\nTokens-Out: 888\nModel: stale\n\n# a git comment\n",
+        )
+        .expect("write");
+
+        rewrite_message_file(&msg, strip_trailers).expect("strip");
+
+        let stripped = std::fs::read_to_string(&msg).expect("read");
+        assert_eq!(stripped, "feat: x\n\n# a git comment\n", "{stripped}");
     }
 
     /// Why: an amend re-runs the hook over a message that already carries the

--- a/crates/trusty-mpm/src/core/commit_trailers.rs
+++ b/crates/trusty-mpm/src/core/commit_trailers.rs
@@ -32,6 +32,11 @@
 //! - **`git commit --verbose` appends a diff after a scissors line.** Anything
 //!   below that line is discarded, so the scissors bound the insert.
 //!
+//! Whether a message gets a block at all depends on git's commit SOURCE, not
+//! only on its text: [`stamp_policy`] maps the source to skip, restamp, or
+//! stamp, and [`strip_trailers`] removes a block a reused message carried in
+//! from another session (#7249).
+//!
 //! Test: the inline suite in `commit_trailers_tests.rs` —
 //! `render_omits_absent_fields`, `render_is_none_when_nothing_is_known`,
 //! `git_interpret_trailers_parses_the_appended_block`,
@@ -78,6 +83,142 @@ pub const TRAILER_MODEL: &str = "Model";
 /// trailer inserted below it never reaches the commit object.
 /// Test: `append_stays_above_the_scissors_line`.
 const SCISSORS: &str = "# ------------------------ >8 ------------------------";
+
+/// The five keys this footer owns, in render order.
+///
+/// Why: [`strip_trailers`] has to recognise a block it wrote in an earlier
+/// session, and recognising it by key is the only thing available — the values
+/// are exactly what changed.
+/// Test: `strip_removes_an_inherited_block`.
+const STATS_KEYS: [&str; 5] = [
+    TRAILER_TOKENS_IN,
+    TRAILER_TOKENS_OUT,
+    TRAILER_TOKENS_WINDOW,
+    TRAILER_SAVINGS,
+    TRAILER_MODEL,
+];
+
+/// What to do with a commit message, given how git says the commit was made.
+///
+/// Why: git tells a `prepare-commit-msg` hook its second argument — the commit
+/// SOURCE — and the footer means something different for each (#7249). Tokens
+/// are a property of one session's work on one message; a source that assembles
+/// a message from other commits, or carries one in from another session, has no
+/// such figure to state.
+/// What: three answers, one per source class. See [`stamp_policy`].
+/// Test: `stamp_policy_skips_merge_and_squash`,
+/// `stamp_policy_restamps_a_reused_message`, `stamp_policy_stamps_a_new_message`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StampPolicy {
+    /// Write nothing: the message belongs to no single session.
+    Skip,
+    /// Remove any inherited block first, then stamp this session's figures.
+    Restamp,
+    /// Stamp, leaving anything already there alone.
+    Stamp,
+}
+
+/// Which policy git's commit-source argument earns.
+///
+/// Why (#7249): the hook used to ignore the argument, so a merge or squash got
+/// the committing session's token counts stamped onto a message assembled from
+/// other people's commits, and a cherry-pick kept the ORIGINAL commit's counts —
+/// [`already_stamped`] read the inherited block as this session's own work and
+/// left it in place. The four rules below are what the sources actually mean:
+///
+/// - `merge` — git built the message from the merge's parents. The tokens of
+///   whoever ran `git merge` describe none of it. **Skip.**
+/// - `squash` — the message is assembled by git or GitHub from a branch's
+///   commits, each with its own figures. **Skip.**
+/// - `commit` — the message comes from an existing commit: a cherry-pick, a
+///   revert, `--amend`, `-c`/`-C`. The new commit is this session's work, so any
+///   inherited block is stale and misattributed. **Restamp** — strip what came
+///   in, then stamp this session's figures. With no current session there is
+///   nothing to stamp, and the strip still happens: no block at all is correct,
+///   another session's block is not.
+/// - `message` (`-m`/`-F`), `template`, and the empty source git passes for an
+///   ordinary editor commit — the message is this commit's own. **Stamp.**
+///
+/// What: an unrecognised source stamps, matching the empty-source case, because
+/// a source git adds later is far likelier to be message-shaped than
+/// merge-shaped, and a wrong stamp is recoverable where a silently skipped one
+/// is invisible.
+/// Test: `stamp_policy_skips_merge_and_squash`,
+/// `stamp_policy_restamps_a_reused_message`, `stamp_policy_stamps_a_new_message`.
+pub fn stamp_policy(source: &str) -> StampPolicy {
+    match source.trim() {
+        "merge" | "squash" => StampPolicy::Skip,
+        "commit" => StampPolicy::Restamp,
+        _ => StampPolicy::Stamp,
+    }
+}
+
+/// Remove a stats footer this code wrote, wherever the message came from.
+///
+/// Why (#7249): a cherry-picked or amended message arrives carrying the ORIGINAL
+/// commit's figures. Those numbers are not wrong about anything the new commit
+/// did — they describe a different session's work — so they are removed rather
+/// than left beside a second block.
+/// What: only the message's LAST content paragraph is considered, and only when
+/// every one of its lines is one of [`STATS_KEYS`] — that is the exact shape
+/// [`append_trailers`] writes, and confining the match to it keeps a `Model:`
+/// line in someone's prose out of scope. The blank line that separated the block
+/// from the paragraph above goes with it. A trailing comment block and anything
+/// below a `--verbose` scissors line are left where they are. A message with no
+/// such block is returned unchanged.
+/// Test: `strip_removes_an_inherited_block`,
+/// `strip_leaves_a_message_that_has_none`,
+/// `strip_keeps_a_trailing_comment_block`,
+/// `strip_leaves_a_paragraph_that_is_not_only_trailers`.
+pub fn strip_trailers(message: &str) -> String {
+    let lines: Vec<&str> = message.lines().collect();
+    let scissors_at = lines.iter().position(|line| line.trim_end() == SCISSORS);
+    let search_end = scissors_at.unwrap_or(lines.len());
+    let Some(last) = lines[..search_end]
+        .iter()
+        .rposition(|line| is_content(line))
+    else {
+        return message.to_string();
+    };
+
+    let mut first = last;
+    while first > 0 && is_content(lines[first - 1]) {
+        first -= 1;
+    }
+    if !lines[first..=last]
+        .iter()
+        .all(|line| is_stats_trailer(line))
+    {
+        return message.to_string();
+    }
+
+    let mut cut_from = first;
+    if cut_from > 0 && lines[cut_from - 1].trim().is_empty() {
+        cut_from -= 1;
+    }
+
+    let mut kept: Vec<&str> = Vec::with_capacity(lines.len());
+    kept.extend_from_slice(&lines[..cut_from]);
+    kept.extend_from_slice(&lines[last + 1..]);
+
+    let mut out = kept.join("\n");
+    if message.ends_with('\n') && !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+/// Is `line` one of this footer's own trailer lines?
+///
+/// Test: `strip_removes_an_inherited_block`.
+fn is_stats_trailer(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    STATS_KEYS.iter().any(|key| {
+        trimmed
+            .strip_prefix(key)
+            .is_some_and(|rest| rest.starts_with(':'))
+    })
+}
 
 /// What one commit's stats footer states, each field independently optional.
 ///
@@ -223,6 +364,12 @@ pub fn append_trailers(message: &str, trailers: &str) -> String {
 
 /// Does `message` already carry a stats footer?
 ///
+/// Why: this is the idempotency guard WITHIN one commit source — `git commit
+/// --amend` and a retried hook both re-run over a message this session already
+/// stamped, and a second block would be the one git parses. It cannot tell that
+/// block apart from one a cherry-pick carried in from another session, which is
+/// why the `commit` source strips before it stamps rather than asking here
+/// (#7249, [`stamp_policy`]).
 /// Test: `append_is_idempotent`.
 fn already_stamped(message: &str) -> bool {
     message.lines().any(|line| {

--- a/crates/trusty-mpm/src/core/commit_trailers_tests.rs
+++ b/crates/trusty-mpm/src/core/commit_trailers_tests.rs
@@ -234,3 +234,82 @@ fn append_preserves_the_attribution_footer() {
         "session link lost:\n{out}"
     );
 }
+
+/// Why (#7249): a merge message is built from its parents and a squash message
+/// from a branch's commits, so the committing session's figures describe
+/// neither. Both sources write nothing.
+/// Test: itself.
+#[test]
+fn stamp_policy_skips_merge_and_squash() {
+    assert_eq!(stamp_policy("merge"), StampPolicy::Skip);
+    assert_eq!(stamp_policy("squash"), StampPolicy::Skip);
+}
+
+/// Why (#7249): `commit` is git's source for a cherry-pick, a revert, an amend
+/// and `-c`/`-C` — every case where the message arrives from an earlier commit
+/// carrying that session's figures.
+/// Test: itself.
+#[test]
+fn stamp_policy_restamps_a_reused_message() {
+    assert_eq!(stamp_policy("commit"), StampPolicy::Restamp);
+}
+
+/// Why: the message sources — `-m`/`-F`, a template, and the empty source git
+/// passes for an ordinary editor commit — describe this commit's own work, and
+/// an unrecognised source is treated as one of them rather than silently
+/// skipped.
+/// Test: itself.
+#[test]
+fn stamp_policy_stamps_a_new_message() {
+    assert_eq!(stamp_policy(""), StampPolicy::Stamp);
+    assert_eq!(stamp_policy("message"), StampPolicy::Stamp);
+    assert_eq!(stamp_policy("template"), StampPolicy::Stamp);
+    assert_eq!(stamp_policy("something-git-adds-later"), StampPolicy::Stamp);
+}
+
+/// Why (#7249): this is the cherry-pick case — the message arrives stamped by
+/// the session that made the original commit. The whole block goes, blank
+/// separator included, and the attribution paragraph above it stays.
+/// Test: itself.
+#[test]
+fn strip_removes_an_inherited_block() {
+    let stamped = append_trailers(
+        &message_with_footer(),
+        &render_trailers(&full_stats()).expect("trailers"),
+    );
+    let stripped = strip_trailers(&stamped);
+    assert_eq!(stripped, message_with_footer(), "{stripped}");
+}
+
+/// Why: an ordinary message must come back byte-identical — the strip runs on
+/// every cherry-pick and amend, and a message with no block is the common case.
+/// Test: itself.
+#[test]
+fn strip_leaves_a_message_that_has_none() {
+    assert_eq!(
+        strip_trailers(&message_with_footer()),
+        message_with_footer()
+    );
+}
+
+/// Why: git hands the hook a file whose tail is `#`-prefixed help text, so the
+/// block is not the file's last lines. The strip has to find it above that run
+/// and leave the comments where they are.
+/// Test: itself.
+#[test]
+fn strip_keeps_a_trailing_comment_block() {
+    let message = "feat: x\n\nTokens-In: 5\nSavings: 3%\n\n# Please enter the commit message.\n#\n";
+    assert_eq!(
+        strip_trailers(message),
+        "feat: x\n\n# Please enter the commit message.\n#\n"
+    );
+}
+
+/// Why: the strip matches only a paragraph that is ENTIRELY this footer's keys,
+/// so a body ending in a line that merely looks like one is left alone.
+/// Test: itself.
+#[test]
+fn strip_leaves_a_paragraph_that_is_not_only_trailers() {
+    let message = "feat: x\n\nModel: the T-800 is not a trailer.\nIt sits in prose.\n";
+    assert_eq!(strip_trailers(message), message);
+}

--- a/crates/trusty-mpm/tests/commit_stats_hook_budget.rs
+++ b/crates/trusty-mpm/tests/commit_stats_hook_budget.rs
@@ -7,9 +7,13 @@
 //! wall-clock budget rather than holding the commit open. Asserting on the
 //! hook's TEXT would prove neither; these tests run the real script under
 //! `/bin/sh` with a stamper on `PATH` that stalls, fails, or succeeds.
-//! What: five runs of the script — a stalled `tm`, a failing `tm`, a prompt
-//! `tm`, no session id, and the real `tm` binary folding a transcript larger
-//! than the fold's byte cap.
+//! It must also honour git's SECOND argument, the commit source (#7249) — a
+//! decision about WHOSE tokens the message describes, which likewise cannot be
+//! proved by reading the script.
+//! What: runs of the script under `/bin/sh` — a stalled `tm`, a failing `tm`, a
+//! prompt `tm`, no session id, the real `tm` binary folding a transcript larger
+//! than the fold's byte cap, and one run per commit source that changes the
+//! answer: `merge`, `squash`, and `commit` with and without a session.
 //! Test: this file IS the test module.
 
 use std::io::Write as _;
@@ -70,8 +74,33 @@ impl Fixture {
         write_executable(&self.bin.join("tm"), body);
     }
 
-    /// Run the hook, returning its exit status and how long it took.
+    /// Put the real `tm` binary on the hook's `PATH`, as a shim rather than a
+    /// copy: it keeps the test off any code-signing question and costs nothing.
+    fn real_tm(&self) {
+        write_executable(
+            &self.bin.join("tm"),
+            &format!("#!/bin/sh\nexec {:?} \"$@\"\n", env!("CARGO_BIN_EXE_tm")),
+        );
+    }
+
+    /// Run the hook with git's one-argument form, as an ordinary editor commit.
     fn run(&self, session_id: Option<&str>, budget: &str) -> (std::process::ExitStatus, Duration) {
+        self.run_sourced(session_id, budget, None, None)
+    }
+
+    /// Run the hook, returning its exit status and how long it took.
+    ///
+    /// `source` is git's second `prepare-commit-msg` argument, passed only when
+    /// given so the one-argument call git makes for an editor commit is
+    /// exercised too. `root` sets `TRUSTY_MPM_ROOT` for a run against the real
+    /// binary.
+    fn run_sourced(
+        &self,
+        session_id: Option<&str>,
+        budget: &str,
+        source: Option<&str>,
+        root: Option<&Path>,
+    ) -> (std::process::ExitStatus, Duration) {
         let path = format!(
             "{}:{}",
             self.bin.display(),
@@ -84,13 +113,44 @@ impl Fixture {
             .env("TM_COMMIT_STATS_TIMEOUT", budget)
             .env_remove("TM_SKIP_COMMIT_STATS")
             .env_remove("CLAUDE_CODE_SESSION_ID");
+        if let Some(source) = source {
+            cmd.arg(source);
+        }
         if let Some(id) = session_id {
             cmd.env("CLAUDE_CODE_SESSION_ID", id);
+        }
+        if let Some(root) = root {
+            cmd.env("TRUSTY_MPM_ROOT", root);
         }
 
         let started = Instant::now();
         let status = cmd.status().expect("the hook must be runnable");
         (status, started.elapsed())
+    }
+
+    /// Overwrite the commit message the hook will be handed.
+    fn set_message(&self, text: &str) {
+        std::fs::write(&self.message, text).expect("write message");
+    }
+
+    /// A managed root whose only session, `session_id`, has a transcript worth
+    /// 10 input and 7 output tokens.
+    fn seed_root(&self, session_id: &str) -> PathBuf {
+        let root = self.root.path().join("mpm-root");
+        std::fs::create_dir_all(&root).expect("create root");
+        let transcript = self.root.path().join(format!("{session_id}.jsonl"));
+        std::fs::write(
+            &transcript,
+            b"{\"type\":\"assistant\",\"message\":{\"id\":\"m1\",\"usage\":{\"input_tokens\":10,\"output_tokens\":7}}}\n",
+        )
+        .expect("write transcript");
+        record_session_value(
+            &root,
+            KIND_TRANSCRIPT,
+            session_id,
+            &transcript.display().to_string(),
+        );
+        root
     }
 
     fn message_text(&self) -> String {
@@ -189,13 +249,7 @@ fn no_session_id_means_no_stamper_at_all() {
 #[test]
 fn the_real_stamper_folds_an_oversized_transcript_inside_the_budget() {
     let fixture = Fixture::new();
-
-    // The hook resolves `tm` off PATH. A shim rather than a copy of the binary:
-    // it keeps the test off any code-signing question and costs nothing.
-    write_executable(
-        &fixture.bin.join("tm"),
-        &format!("#!/bin/sh\nexec {:?} \"$@\"\n", env!("CARGO_BIN_EXE_tm")),
-    );
+    fixture.real_tm();
 
     let root = fixture.root.path().join("mpm-root");
     std::fs::create_dir_all(&root).expect("create root");
@@ -208,23 +262,7 @@ fn the_real_stamper_folds_an_oversized_transcript_inside_the_budget() {
         &transcript.display().to_string(),
     );
 
-    let path = format!(
-        "{}:{}",
-        fixture.bin.display(),
-        std::env::var("PATH").unwrap_or_default()
-    );
-    let started = Instant::now();
-    let status = Command::new("/bin/sh")
-        .arg(&fixture.hook)
-        .arg(&fixture.message)
-        .env("PATH", path)
-        .env("TRUSTY_MPM_ROOT", &root)
-        .env("CLAUDE_CODE_SESSION_ID", "sess-big")
-        .env("TM_COMMIT_STATS_TIMEOUT", "20")
-        .env_remove("TM_SKIP_COMMIT_STATS")
-        .status()
-        .expect("the hook must be runnable");
-    let elapsed = started.elapsed();
+    let (status, elapsed) = fixture.run_sourced(Some("sess-big"), "20", None, Some(&root));
 
     assert!(status.success(), "the hook must exit 0: {status:?}");
     let stamped = fixture.message_text();
@@ -237,6 +275,95 @@ fn the_real_stamper_folds_an_oversized_transcript_inside_the_budget() {
     assert!(
         elapsed < Duration::from_secs(20),
         "the capped fold must finish well inside the budget: {elapsed:?}"
+    );
+}
+
+/// Why (#7249): git passes the commit SOURCE as its second argument, and a
+/// merge message is assembled from the merge's parents — the tokens of whoever
+/// ran `git merge` describe none of it. The hook must not spawn the stamper at
+/// all. A hook that ignored the argument stamps here, which is the bug.
+/// Test: itself.
+#[test]
+fn a_merge_source_leaves_the_message_untouched() {
+    let fixture = Fixture::new();
+    // The hook invokes `tm commit-trailers --message-file <path>`, so the
+    // message file is the third argument.
+    fixture.fake_tm("#!/bin/sh\nprintf '\\nTokens-In: 42\\n' >> \"$3\"\n");
+
+    let (status, _) = fixture.run_sourced(Some("sess-merge"), "60", Some("merge"), None);
+
+    assert!(status.success(), "the hook must exit 0: {status:?}");
+    assert_eq!(
+        fixture.message_text(),
+        "feat: a thing (Refs #7074)\n",
+        "a merge commit's message belongs to no single session"
+    );
+}
+
+/// Why (#7249): the same rule for `squash` — the message is assembled by git or
+/// GitHub from a branch's commits, each with its own figures.
+/// Test: itself.
+#[test]
+fn a_squash_source_leaves_the_message_untouched() {
+    let fixture = Fixture::new();
+    fixture.fake_tm("#!/bin/sh\nprintf '\\nTokens-In: 42\\n' >> \"$3\"\n");
+
+    let (status, _) = fixture.run_sourced(Some("sess-squash"), "60", Some("squash"), None);
+
+    assert!(status.success(), "the hook must exit 0: {status:?}");
+    assert_eq!(fixture.message_text(), "feat: a thing (Refs #7074)\n");
+}
+
+/// Why (#7249): a cherry-pick hands the hook the ORIGINAL commit's message,
+/// block included. Before this fix `already_stamped()` read that inherited
+/// block as this session's own work and left the stale figures in place. The
+/// whole path — hook, source argument, real `tm` — has to replace them.
+/// Test: itself.
+#[test]
+fn a_commit_source_replaces_inherited_trailers() {
+    let fixture = Fixture::new();
+    fixture.real_tm();
+    let root = fixture.seed_root("sess-pick");
+    fixture.set_message(
+        "feat: a thing (Refs #7249)\n\nTokens-In: 999999\nTokens-Out: 888888\nModel: some-other-model\n",
+    );
+
+    let (status, _) = fixture.run_sourced(Some("sess-pick"), "20", Some("commit"), Some(&root));
+
+    assert!(status.success(), "the hook must exit 0: {status:?}");
+    let stamped = fixture.message_text();
+    assert!(
+        !stamped.contains("999999") && !stamped.contains("some-other-model"),
+        "the original commit's figures must be gone: {stamped}"
+    );
+    assert!(stamped.contains("Tokens-In: 10"), "{stamped}");
+    assert!(stamped.contains("Tokens-Out: 7"), "{stamped}");
+    assert_eq!(
+        stamped.matches("Tokens-In:").count(),
+        1,
+        "exactly one stats block: {stamped}"
+    );
+}
+
+/// Why (#7249): the strip is not conditional on having something to write in
+/// its place. Cherry-picking outside a Claude Code session must still remove
+/// the original session's figures — no block at all is correct, another
+/// session's block is not.
+/// Test: itself.
+#[test]
+fn a_commit_source_strips_even_with_no_session() {
+    let fixture = Fixture::new();
+    fixture.real_tm();
+    let root = fixture.seed_root("sess-pick");
+    fixture.set_message("feat: a thing (Refs #7249)\n\nTokens-In: 999999\nSavings: 91%\n");
+
+    let (status, _) = fixture.run_sourced(None, "20", Some("commit"), Some(&root));
+
+    assert!(status.success(), "the hook must exit 0: {status:?}");
+    assert_eq!(
+        fixture.message_text(),
+        "feat: a thing (Refs #7249)\n",
+        "the inherited block goes and nothing replaces it"
     );
 }
 

--- a/docs/trusty-mpm/statusline-savings.md
+++ b/docs/trusty-mpm/statusline-savings.md
@@ -213,6 +213,29 @@ A value with no source is left out rather than written as a zero, exactly as
 the segment omits itself. A commit made outside a tm session gets no block at
 all.
 
+### Which commits get a block
+
+Tokens are a property of one session's work on one message, so the footer
+follows git's **commit source** — the second argument git hands a
+`prepare-commit-msg` hook — rather than being written onto every commit
+(#7249).
+
+| Commit source | What happens | Why |
+|---|---|---|
+| `merge` | nothing written | git built the message from the merge's parents; the tokens of whoever ran `git merge` describe none of it |
+| `squash` | nothing written | the message is assembled by git or GitHub from a branch's commits, each with its own figures |
+| `commit` — cherry-pick, revert, `--amend`, `-c`/`-C` | the inherited block is **removed**, then this session's figures are written in its place | the message arrives carrying the block the ORIGINAL commit's session wrote; those numbers describe different work |
+| `message` (`-m`/`-F`), `template`, and the empty source of an ordinary editor commit | written | the message is this commit's own |
+
+Cherry-picking outside a tm session removes the inherited block and adds
+nothing: no block at all is correct where another session's block is not. That
+one case is why the hook runs `tm commit-trailers` even with no
+`CLAUDE_CODE_SESSION_ID` set. With no `tm` on `PATH` nothing runs at all, and an
+inherited block stays as it is.
+
+Within a single source the stamp is idempotent — a re-run over a message this
+session already stamped adds nothing, so the block never doubles.
+
 ### Why it is a separate paragraph
 
 Git recognises a trailer block only as the message's **last paragraph, whose
@@ -226,8 +249,9 @@ repository's effective hooks directory by the same installer as the `pre-push`
 guard, and refused the same way when a symlink, a foreign hook, or a
 `core.hooksPath` redirect says the slot belongs to somebody else. It places the
 block above any trailing comment block and above a `git commit --verbose`
-scissors line, and it never stamps twice — an amend re-runs the hook over a
-message that already carries the block and leaves it alone.
+scissors line, and it never stamps twice — a re-run over a message this session
+already stamped leaves it alone, and an amend, which git reports as the `commit`
+source, replaces the block rather than adding a second one.
 
 `TM_SKIP_COMMIT_STATS=1 git commit …` skips it for one commit. The hook exits 0
 on every path: a missing `tm`, a session with nothing recorded, or a failure


### PR DESCRIPTION
## Outcome

Fixes the bundled `prepare-commit-msg` hook to decide the commit-stats trailer
treatment by git's own commit-source argument, instead of applying the same
treatment to every commit regardless of source.

Refs [#7249](https://github.com/bobmatnyc/trusty-tools/issues/7249)

## Changes

The hook ignored git's second argument (the commit source), so every commit got
the same trailer treatment. A merge or squash commit was stamped with the
committing session's token counts, and a cherry-pick kept the *original*
commit's trailer block — `already_stamped()` read the inherited trailers as this
session's own work and left the stale figures in place.

The hook now reads the source and passes it to `tm commit-trailers
--commit-source`, which applies four rules:

- `merge`, `squash`: write nothing — the message is assembled from other commits.
- `commit` (cherry-pick, revert, `--amend`, `-c`/`-C`): strip the inherited
  block, then stamp this session's figures. With no current session the strip
  still runs and nothing replaces it — no block is correct where another
  session's block is not. This is the one source that runs the stamper outside
  a Claude Code session.
- `message` (`-m`/`-F`), `template`, and the empty source of an editor commit:
  stamp as before.

`strip_trailers()` removes a block only when the message's last content
paragraph is entirely this footer's five keys — the exact shape
`append_trailers()` writes — so a `Model:` line inside someone's prose is out of
scope. `already_stamped()` stays the idempotency guard within one source, so the
block never doubles.

Out of scope: the trailer content or format itself — only when it is applied,
and stale-trailer handling on non-`message` sources, changed.

## Risk / blast radius

Confined to `trusty-mpm`'s bundled hook and its `commit-trailers` command path
— `crates/trusty-mpm/src/assets/hooks/prepare-commit-msg`,
`crates/trusty-mpm/src/bin/tm/commands/commit_trailers.rs`,
`crates/trusty-mpm/src/core/commit_trailers.rs`. No cross-crate surface.

## Test evidence

Test ladder rung 3 (localized behavior inside one crate). The engineer ran:

```
cargo test -p trusty-mpm --no-fail-fast
```

Every target passed, including four new hook-level regression tests that fail
on the pre-fix code: merge and squash leave the message untouched, and a
`commit` source replaces inherited trailers both with and without a current
session.

## Baseline

None observed on this branch.

## Docs

- `docs/trusty-mpm/statusline-savings.md` updated to describe the per-source
  behavior.
- Changelog fragment: `crates/trusty-mpm/changelog.d/7249-commit-source-aware-trailers.md`.

## Review

No prior review round on this PR; not applicable.

Refs #7249

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
