### PR TITLE
chore(sessions): backfill live session snapshots (owner ruling 2026-09-09)

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-131700.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-131700.md
@@ -1,0 +1,39 @@
+# Session Pause - 2026-09-08T13:17:00.123786+00:00
+
+## Summary
+Owner-invoked pause 2026-09-08 ~13:5xZ (session trusty-tools-ec, harness job e7c8e7ea after a mid-leg process restart, tmux tm-dogfood:0:@1, session_id tmux-window-1). Supersedes the 10:54Z pause. Owner directives: "keep going, merge them when green"; bugs before console enhancements. origin/main = 9f535694e (PR #7138). TWO AGENTS IN FLIGHT at pause (verify with ListAgents / gh on resume before re-dispatching): web-qa abf549a744f75386d live-verifying #7116 "load everything" in a visible tab on the reinstalled console (pid 96930); rust-engineer afb8d939c8cb16481 on #7123 (branch fix-7123-audit-component-labels, worktree agent-afb8d939c8cb16481). CLOSED THIS LEG: #7125 (live-verified, PRs #7130 c70ddacf7 + #7131 086362af9), #7127 (accepted, not planned), #6882 (superseded), #6812 (owner: close on test evidence). MERGED: #7129 (6bc3faf67), #7130, #7131, #7138 (9f535694e), #7141, #7142 (1981c0134). PARKED by owner: saver gallery tile — #6839 + #7128 at status:merged, PRs merged, NO reinstall/tile check scheduled. INSTALLED: trusty-memory 0.26.0 (pid 66891), tm 1.5.18 (pid 89957) from 086362af9; trusty-console 0.11.0 from 9f535694e (pid 96930); saver bundle from 6bc3faf67. MATT PACKAGE (FLYR, 59 repos, LINEAR shop): two research passes done; filed #7132 #7133 #7134 #7135 #7136 #7137 #7139 #7140, reopened #212, commented #6783; milestone "trusty-audit — client re-run package". Owner decisions this leg: saver static image = Settings thumbnail; #7127 accept; park saver tile; close #6812 on tests; close #6882 superseded; drop earlier-leg worktrees. WORKTREES: 45 → 10 (20 merged-PR + 13 earlier-leg unmerged removed by PM with git worktree remove; local branches for the 13 kept; dirty diffs saved under the job scratch dir). tm prune-worktrees reclaims nothing here (session record 51786c9c claims the workspace). Agent error recorded: version-control launched prune --force unasked (third instance) — add "no prune/worktree remove" line to every version-control brief. Main checkout: same three pre-existing untracked/modified files; local main = origin/main + 2 unpushed snapshot commits (a1dde61b1, d82eb1c4a) — not pushed, owner not asked.
+
+## Completed
+- #7125 recall-all releases palaces — PRs #7130 + #7131 merged, reinstalled, live-verified (94 palaces, cached 2→3, footprint 212→273 MB), closed status:tested
+- #7127 residual dream footprint — owner accepted, closed not planned
+- #7128 saver display name — PR #7129 (6bc3faf67) + PR #7141 (install script restarts WallpaperAgent) merged; plist name confirmed working after cache kill; parked at status:merged
+- #6839 saver gallery tile — reopened; PR #7142 ships thumbnail.png/@2x (90×58, 180×116) merged; parked at status:merged, no reinstall
+- #7116 graph load-everything — PR #7138 merged 9f535694e (worker layout, one commit per frame, merged edge path, mergeSubgraph dedup + 7 regression tests); console reinstalled pid 96930; status:merged
+- #6882 shunt PoC — closed as superseded by #6887/#6958/#6959 (owner ruling)
+- #6812 tga JIRA 410 — closed on contract-test evidence (owner ruling); no JIRA target on this machine
+- Matt audit return package reviewed (2 passes): #7132 #7133 #7134 #7135 #7136 #7137 #7139 #7140 filed, #212 reopened, #6783 commented; universality: 0 PRs 59/59, deploys 24/59 vs DORA 0.0 59/59; new: stale data-retention attestation note (#7140), Linear bulk-sync/lead-time gap (#7139)
+- Worktrees 45 → 10 (owner: drop earlier-leg unmerged); local branches kept; dirty diffs saved to ~/.trusty-tools/trusty-mpm/claude-config/jobs/e7c8e7ea/tmp/dropped-worktrees/
+- Shunt status answered: #6887/#6958/#6959 shipped+tested 2026-09-07; #7074 (per-commit stats) is the only open piece
+
+## In Progress
+- web-qa abf549a744f75386d: #7116 live check of 'load everything' on http://127.0.0.1:7788 (visible tab; timing, progress/cancel, node/edge counts, no each_key_duplicate). On PASS → ticketing status:tested → closed with evidence; on FAIL → status:coded + engineer
+- rust-engineer afb8d939c8cb16481: #7123 tm issue audit component-label check (accept any crate label; regression test; live `tm issue audit 7139` PASS). On PR: security scan → arm (rung 3, no critic) → ticketing status:coded → on merge tm reinstall → status:merged → live audit check → tested
+
+## Next Steps
+- On resume: ListAgents FIRST; check gh for a #7123 PR and the web-qa result before re-dispatching either
+- Finish #7116 and #7123 chains above
+- Then console enhancements per owner ordering: #6930 #7086 #7084 #7087; #7074 shunt per-commit stats sits behind them
+- Worktree agent-ae04f1dea8e90e2a5 (PR #6862 merged) holds a staged 79-line deletion in crates/trusty-common/src/control_bus/tests.rs with no PR — owner decision; 3 locked trees a3403d9ae36c5cdf5 / a6525956bb446d5df / add1aa4a40be262a2 have unknown owners; 3 codex/* trees untouched; keep reinstall-tm-console-20260908
+- Every version-control brief: add 'Do not run tm session prune-worktrees or git worktree remove; reclaim is PM-executed'
+- Owner decisions still parked: #7097 item (c) deny gh issue create for PM; #6982 close-or-keep; Touch ID immediacy on #6900
+- Saver tile parked — do not re-dispatch unless the owner picks it up (revisit recipe in the parked-tile palace drawer)
+- Local main carries 2 unpushed snapshot commits; ask owner before pushing
+- Release note for local-ops: next trusty-common bump is MINOR; widen the root [workspace.dependencies] row
+
+## Git Context
+Branch: main
+Last commit: a1dde61b1 chore(sessions): pause snapshot for trusty-tools-ec, 2026-09-08 10:54Z
+Uncommitted changes: 3 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-150858.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-150858.md
@@ -1,0 +1,41 @@
+# Session Pause - 2026-09-08T15:08:58.420269+00:00
+
+## Summary
+Owner-invoked pause 2026-09-08 ~15:1xZ (session trusty-tools-ec, harness job e7c8e7ea, no tmux in this shell; resumed from the 13:17Z snapshot via session_id). Supersedes the 13:17Z pause. Owner directives this leg, verbatim: "let's also drive closing of bugs, P1s, and P2s"; "reclaim the stale tm-trusty-tools-02 claims and keep going"; merge-on-green unchanged. Bug/P1/P2 census at 13:3xZ: 226 open, 36 in the union, 0 open PRs at that time. CLOSED (live-verified): #7116, #7123, #7036. FILED: #7144 (P3, load-everything confirm() blocks automation in a background tab). MERGED on origin/main (tip a2937d531 at last check): #7145 (#7136), #7146 (#7140), #7147 (#7132), #7148 (#7121), #7150 (#6847 part 1). ARMED, landing on green: #7149 (#7122, head 55f1d90d9), #7153 (#6847 part 2, head b6800c5c1). FIVE AGENTS LIVE at pause (verify with ListAgents / gh before re-dispatching): local-ops a4737c0acc7ed43f9 reinstalling tga + trusty-review + tm from a2937d531 and running live checks for #7140 #7132 #7136 #7121 (all four at status:merged); rust-engineer a3185705258da431a fix round on PR #7151 (#3764: path-alias fail-open + dedup liveness re-probe); rust-engineer ac476cfb90e593a95 fix round on PR #7154 (#6536: debounce keyed by destination identity, batch cap, delete-failure test); rust-engineer aeaed5f2a8d9e7aaa fix round on PR #7155 (#6537: tests wrote into real $HOME, log dir 0700/0600, consolidate resolver+scheduler into trusty-common); rust-engineer a3d18e81274efa772 fix round 2 on PR #7152 (#6848: shutdown vs saturated semaphore) which ARMS ITSELF on completion. Reclaimed from tm-trusty-tools-02 with comments: #3764 #6533 #6611. Saver #6838 #7112 #6900 stay status:merged: owner hand-check with `log stream --predicate 'subsystem == "com.trusty.console.saver"'`. Incident reported: qa took one full-screen screenshot with private desktop content, deleted it at once. Local main is stale (70fe125f7 + 3 unpushed snapshot commits) and origin/main is ~12 ahead; this caused a false "does not compile" security finding; rebase+push awaits owner. Board also in palace drawer ws:trusty-tools-ec/board.
+
+## Completed
+- #7116 closed status:tested (PR #7138 live-verified on trusty-console 0.11.0)
+- #7123 closed status:tested (PR #7143, tm reinstalled from 201d34b9b, daemon pid 53294, tm issue audit accepts any crate label)
+- #7036 closed status:tested (PR #7105, trusty-review reinstalled, TestCoverage-only review returns APPROVE)
+- #7144 filed (P3, native confirm() on load-everything blocks automation in a background tab)
+- PRs merged: #7145 #7146 #7147 #7148 #7150; issues #7136 #7140 #7132 #7121 at status:merged awaiting live checks; #6847 stays status:coded for part 2
+- PR #7149 (#7122) armed on 55f1d90d9 after critic WARN fix round + security re-scan PASS
+- PR #7153 (#6847 part 2) armed on b6800c5c1 after critic WARN fix round
+- Stale claims #3764 #6533 #6611 reclaimed from tm-trusty-tools-02 with comments
+- Evidence comments posted on #6838 and #7112 (saver, partial verification)
+
+## In Progress
+- local-ops a4737c0acc7ed43f9: reinstall tga/trusty-review/tm from a2937d531, live checks for #7140 (attestation note), #7132 (PR-leg gap line), #7136 (CAST template rows), #7121 (BASE-ENGINEER section) — on PASS each → status:tested → closed
+- PR #7151 (#3764, status:coded): fix round in flight (a3185705258da431a) for critic WARN HIGH canon_or_raw fail-open + MEDIUM dedup branch liveness re-probe; security PASS; on report → arm
+- PR #7154 (#6536, status:coded): fix round in flight (ac476cfb90e593a95) for critic WARN: PruneCandidate keyed by cache_namespace not index, per-tick batch cap, delete-failure test; security PASS; on report → arm
+- PR #7155 (#6537, status:coded): fix round in flight (aeaed5f2a8d9e7aaa): state_dir parameterised (tests wrote real $HOME), logs dir via ensure_private_state_dir + 0600 files, consolidate resolver/scheduler into trusty-common single-source helper; on report → arm (rung 4 now spans trusty-common)
+- PR #7152 (#6848, status:coded): fix round 2 in flight (a3d18e81274efa772) for shutdown-vs-saturated-semaphore HIGH + threat-model wording; the agent arms auto-merge itself on green
+- PR #7149 and #7153 armed — verify merged with gh, then status:merged → reinstall tm / trusty-common consumers → live check → close
+
+## Next Steps
+- On resume: ListAgents FIRST, then gh pr view 7149 7151 7152 7153 7154 7155 — do not re-dispatch a fix round whose agent is still live
+- After #7149 merges: #7122 status:merged → tm reinstall → live check (cp secret.tfvars into a worktree is denied) → close; remind owner the terraform credentials from the #7122 incident have no recorded rotation
+- After #7150+#7153 merge: #6847 status:merged → close on a live PushClient→console ingest round-trip once #7152 lands
+- After #7152 merges: #6848 status:merged; then dispatch slice 3b (durable NDJSON log, seq, replay, persisted:false) on the same issue
+- Then event-stream slices #6850–#6855, #6854 in order; #6849 blocked on #6288 (held by another session)
+- After #7155 merges: follow-up under epic #6533 to migrate trusty-mpm's resolver onto the new trusty-common single-source helper
+- Release note for local-ops: next trusty-common bump is MINOR (HarnessEvent fields, LogDestination::delete, uuid mandatory); widen the root [workspace.dependencies] row
+- Every version-control brief: 'Do not run tm session prune-worktrees or git worktree remove; reclaim is PM-executed'; every security/critic brief: use gh pr diff + git show origin/main, local main is stale; every engineer: set CARGO_TARGET_DIR inside the worktree
+- Owner decisions parked: rebase+push the 3 local snapshot commits; #6982 close-or-keep; #212 go/no-go; #7074 stat shape; #7097 (c); staged deletion in worktree agent-ae04f1dea8e90e2a5; saver hand-check for #6838 #7112 #6900
+- Worktrees: many agent-* isolation trees from this leg plus reinstall-tm-console-20260908 (keep); reclaim only merged-PR trees, PM-executed
+
+## Git Context
+Branch: main
+Last commit: b131ae701 chore(sessions): pause snapshot for trusty-tools-ec, 2026-09-08 13:17Z
+Uncommitted changes: 3 file(s) changed
+

--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-182026.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-182026.md
@@ -1,0 +1,34 @@
+# Session Pause - 2026-09-08T18:20:26.045905+00:00
+
+## Summary
+Owner-invoked pause 2026-09-08 ~18:4xZ (session trusty-tools-ec, harness job e7c8e7ea, no tmux in this shell; resumed from the 15:08Z snapshot via session_id). Supersedes the 15:08Z pause. OWNER DIRECTIVES THIS LEG, verbatim: priorities "bugs; p1; audit fixes/improvements based on FLYR report; shunt reporting; console/dash consolidation/improvements; p2"; "make the account selection P1 and dispatch it now"; "Service dashboards should link back to the main console, and use the same iconography"; "For the console, let's pin the header to the top of the page. List items scroll under it"; "the shunt statusline indicator should be a percentage value, not a dollar figure"; "use the session share denominator for the savings percentage"; "reinstall tm and console once those land" (DISCHARGED round 1); "do B" on #7166 (per-account GH_CONFIG_DIR, never gh auth switch). INCIDENT resolved: load 141 from 41 detached git auto-maintenance repacks of the shared .git — killed, tmp packs removed, maintenance.auto=false/gc.auto=0 repo+global, launchd schedule registered; tm-side fix #7171 merged (PR #7182). REINSTALL ROUND 1 DONE at cbab75da6: tm 1.5.18 rebuilt+signed (daemon pid 2936), trusty-console 0.11.0 (pid 31786), tga 8.0.0. CLOSED status:tested this leg: #3764 #6536 #7123 #7167 #6439 #6848 #7177 #212. MERGED on origin/main (tip cdb195a31): #7159 #7161 #7162 #7163 #7165 #7170 #7173 #7174 #7175 #7176 #7178 #7182 #7183 #7184. THREE AGENTS LIVE at pause (verify with ListAgents / gh before re-dispatching): rust-engineer a342a54a4494ffb6f on PR #7181 (#7166, head b0fb57bc3 UNSTABLE, rebased; now adding option B per-account GH_CONFIG_DIR); rust-engineer aadfd8a069dc0ed9f extending PR #7186 (#7157, head fd5dd19b4) with the 5 git.rs doc links; rust-engineer a57ac093ed29ab339 on #7164 (fix/7164-rustdoc-code-agents, no PR yet). Open decisions parked: rebase+push local main (4 unpushed snapshot commits, origin ~30 ahead); #6982 keep open (guard refuses any bash <script>); #7097 (c); staged deletion in worktree agent-ae04f1dea8e90e2a5; saver hand-check #6838 #7112 #6900; log-drain 30-day prune default posture; #7074 per-commit average (statusline half decided).
+
+## Completed
+- #3764, #6536 closed (local-ops live checks on tm at 26a658337)
+- Reinstall round 1 at cbab75da6: tm/console/tga; closed #7123 #7167 #6439 #6848 #7177 #212 with evidence
+- Merged: #7159 (#7158) #7161 (#6848 3b) #7162 (#7157) #7163 (#212) #7165 (#7139) #7170 (#7134) #7173 (#7167) #7174 (#7160) #7175 (#6439) #7176 (#7123 r2) #7178 (#7177) #7182 (#7171) #7183+#7184 (#7179)
+- Git maintenance storm incident resolved; #7171 filed P1 and fixed; memory drawer git-auto-maintenance-pileup
+- Filed: #7160 (mouse capture), #7164 (rustdoc code/agents), #7166 (gh account selector P1), #7167, #7168 (push_client flake), #7169 (tm issue audit project FAIL), #7171, #7177, #7179
+- #7171 reopened after PR #7182 used Fixes (auto-close); #7179 reopened pending session-share live check
+- Memory: priority-order-20260908, tm-github-account-selection, statusline-savings-percentage (session-share), reinstall-tm-console-20260908, git-auto-maintenance-pileup
+
+## In Progress
+- PR #7181 (#7166, status:coded): rebased at b0fb57bc3 (UNSTABLE = checks settling); agent a342a54a4494ffb6f adding option B per-account GH_CONFIG_DIR (dir per login under tm state, hosts.yml pinned, config_dir passed to resolve_gh_account_env_with, gh api user verification under the same dir, no gh auth switch); then credentials critic + arm
+- PR #7186 (#7157 status:merged): head fd5dd19b4 fixes private_dir link; agent aadfd8a069dc0ed9f folding the 5 git.rs links so trusty-common reports 0; then arm
+- #7164 (status:in-progress): agent a57ac093ed29ab339 fixing 8 links in trusty-code/trusty-agents lib.rs; PR then arm
+- status:merged awaiting live check: #7160 (owner relaunches tm-dogfood on tm cbab75da6 → mouse_any_flag=0), #7179 (session-share 💸N% after next tm reinstall), #7171 (doctor rows maintenance_config/maintenance_processes after next tm reinstall), #7157 (after #7186), #7139 (needs a real Linear board), #7134 (needs trusty-audit reinstall), #6847 (PushClient→console round-trip), #6537 (trusty-code/agents reinstall)
+
+## Next Steps
+- On resume: ListAgents FIRST, then gh pr view 7181 7186 and gh pr list for a #7164 PR — do not re-dispatch a round whose agent is live
+- When #7186 + #7181 land: SECOND tm reinstall (owner pre-authorized 'reinstall tm and console once those land' covers tm; console unchanged since round 1) → live checks #7179 (💸 session-share), #7171 (doctor rows + burst), #7157 (rustdoc 0), #7166 (owner runs tm --account bob-duetto duettoresearch/poc-hotel-supply after gh auth login as bob-duetto) → close
+- trusty-code/trusty-agents reinstall for #6537 and #7158 live checks; trusty-audit reinstall (next audit train) for #7134
+- Then priority order: remaining bugs (#7168 flake, #7169 audit project FAIL, #6982 guard), P1 #7087 pull-path, audit tier #7133 #7135 #7137 #7156 #6144 #5669 #5470+#5478 #5499, shunt reporting #7074 (per-commit average question open), console epics #6922/#6516 slices #6850-#6855, then P2
+- Follow-ups to file/do: remaining ~50 git spawn sites sweep (domain-consolidation-audit.md); trusty-code/agents migrate onto trusty_common::private_dir; tm doctor mouse_any_flag probe; #6848 rotation-fsync test rigor (sync counter); #7135 index renders collector_gaps
+- Every version-control brief: never prune-worktrees; every critic/security brief: use gh pr diff + git show origin/main, local main is stale; every engineer: CARGO_TARGET_DIR=<worktree>/target-worktree (now gitignored via #7177), stage by name, Refs #N never Fixes/Closes
+- Worktrees to keep: reinstall-20260908b, reinstall-tm-console-20260908, verify-3764; agent-* trees for the three live agents; reclaim merged-PR trees PM-executed only
+
+## Git Context
+Branch: main
+Last commit: 997e1be36 chore(sessions): pause snapshot for trusty-tools-ec, 2026-09-08 15:08Z
+Uncommitted changes: 6 file(s) changed
+

--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-210516.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-210516.md
@@ -1,0 +1,39 @@
+# Session Pause - 2026-09-08T21:05:16.395055+00:00
+
+## Summary
+Owner-requested pause 2026-09-08 ~21:0xZ ("I can't restart until all agents are stopped"), session trusty-tools-ec, harness job e7c8e7ea, no tmux in this shell; resumed from the 18:20Z snapshot via session_id. Supersedes the 18:20Z pause. ALL AGENTS STOPPED (four killed: #7205 critic, #7137 engineer, trusty-audit 0.14.3 bump/reinstall chain, trusty-code/agents bump/reinstall chain) and all monitors stopped. OWNER DIRECTIVES THIS LEG, verbatim: "keep going, merge them when green" (standing); "every tm reinstall should be a patch bump no?" → RULE: every reinstall carries a patch bump first (memory reinstall-requires-patch-bump); "you're not linking the issues" → every #N in a reply is a GitHub link (memory link-issues-and-prs); "1. yes for both" = trusty-audit 0.14.3 bump+reinstall AND trusty-code/trusty-agents bump+reinstall AUTHORIZED, not yet executed. INSTALLED: tm 1.5.19 from de1d275f6 (PR #7195 bump incl. #7193), daemon pid 91296, supervisor 91298, signed 4JH68XUHC5; console unchanged 0.11.0. CLOSED status:tested this leg: #7157 #7164 #7188 #7179 #7171 #7168 #7169 #7197. MERGED on origin/main this leg: #7186 #7187 #7189 #7191 #7181 #7192 #7193 #7195 #7194 #7199 #7200 #7202 #7201 #7203 #7204 (tip ≥ 93c40a174 = #7204 code/agents patch bumps). PM ERROR recorded: armed #7194 while its non-required rustdoc check was red → merged red, main red on that gate until #7202 (memory arm-only-when-repo-gates-green). Required contexts read live 2026-09-08: 16, and neither "Rustdoc intra-doc links" nor "Per-PR changelog fragment" is required. Owner questions on #7087 (comment 5590672444, section 5) still unanswered: Q1 cap vs active set, Q2 project-less palaces, Q3 boot with mpm unreachable, Q4 Provisioning counts, Q5 grace 120/300 — slices 2/3 wait on them; 1b proceeds under defaults (a).
+
+## Completed
+- #7157 #7164 #7188 closed — rustdoc gate 0 broken on main (CI run 34267016112 at 81cbcc1c2)
+- #7179 #7171 closed — live checks on tm 1.5.18 round-2 install (💸33% percent; doctor rows maintenance_config/maintenance_processes)
+- #7168 closed — main shards green at 198134199
+- #7169 closed — tm issue audit/standard live on installed 1.5.19
+- #7197 closed — website Vitest green on main at 207e2a841
+- tm 1.5.19 installed and live (PR #7195 de1d275f6), first install under the patch-bump rule
+- #7087 plan posted (comment 5590672444); slice 0 merged 5896206f9 (PR #7192); slice 1a merged 23a6cb197 (PR #7194) + doc-link fix c3cdaa8a7 (PR #7202)
+- #7198 filed (tm issue audit no-component-label exemption gap), unclaimed
+- Memories written: reinstall-requires-patch-bump, arm-only-when-repo-gates-green, link-issues-and-prs; reinstall-tm-console-20260908 updated to three rounds
+
+## In Progress
+- PR #7205 (#7087 slice 1b, head 7746ca43e, feat/7087-slice1b-residency-producer-impl, NOT armed): critic round was killed mid-review — re-dispatch code-critic (brief: setters.rs pure move; active predicate + fail-closed tmux; grouping/derivation cache; generation bumps at create/stop/adopt/decommission; unbounded cache; socket round-trip test) then arm on APPROVE + all repo gates green
+- #7137 (status:in-progress, redact home path in audit gap text/manifest): engineer killed mid-implementation; worktree .claude/worktrees/agent-ab137882d139358a7 has 5 dirty uncommitted files (was wiring `crate::redact` into grounding.rs) — a fresh engineer cannot enter that worktree; re-dispatch from origin/main (render site gaps_section() in crates/trusty-audit/src/index_report.rs; reuse trusty-audit's existing redact module), or salvage by committing there manually first
+- trusty-audit 0.14.3 bump + reinstall (AUTHORIZED, not started): #7203 (#7133) merged d25377b96 so main carries #7133 #7134 #7135 #6144; local-ops: version-only bump PR → merge on green → cargo install --locked from detached worktree → trusty-audit --version 0.14.3 → live checks #7133 #7134 #7135 #6144 → tested → closed
+- trusty-code/trusty-agents reinstall (AUTHORIZED, half done): bump PR #7204 MERGED 93c40a174; remaining: cargo install --locked both from a detached worktree at ≥93c40a174, sign/restart per release-workflow.md if applicable, tcode/tagent --version show the new numbers, live checks #6537 (log drain) and #7158 (manifest cache dir 0700) → tested → closed
+- status:merged awaiting live check: #7133 #7134 #7135 #6144 (audit reinstall), #6537 #7158 (code/agents reinstall), #7160 (OWNER relaunches tm-dogfood → mouse_any_flag=0), #7166 (OWNER: gh auth login as bob-duetto, then tm --account bob-duetto register duettoresearch/poc-hotel-supply; per-account dir 0700), #7139 (needs a real Linear board), #6847 (PushClient→console round-trip)
+
+## Next Steps
+- On resume: ListAgents FIRST (agents were all killed; none should be live), then gh pr view 7205 and gh pr list — do not re-dispatch anything that already has a PR
+- Run the two authorized reinstall chains (audit 0.14.3 bump+install; code/agents install from 93c40a174) via local-ops, with live checks, then close the six issues from status:tested with evidence
+- Re-run critic on PR #7205, arm only after APPROVE and every repo-owned check green (rustdoc + changelog included, even though not required)
+- Re-dispatch #7137 from origin/main (or salvage agent-ab137882d139358a7's 5 dirty files by committing on its branch first)
+- #7087: slice 1b lands → slices 2 (trusty-memory consumer, rung 5 + critic) and 3 (trusty-search consumer) wait on owner answers Q1–Q5 on the issue; slice 0's live effect and slices 2/3 need trusty-memory/trusty-search bumps+reinstalls (separate authorization)
+- Then priority order: remaining bugs (#6982 keep open), #7198 (P3, unclaimed), P1s, audit tier #7156 #5669 #5470+#5478 #5499, shunt reporting #7074 (per-commit average question open), console epics #6922/#6516 slices #6850-#6855, then P2
+- Every brief: never prune-worktrees; critic/security briefs use gh pr diff + git show origin/main (local main is stale); engineers CARGO_TARGET_DIR=<worktree>/target-worktree, stage by name, Refs #N never Fixes/Closes; //! module docs need fully-qualified crate:: links (PR #7202 lesson); link every #N in replies
+- Worktrees to keep: reinstall-20260908c/d, bump-tm-1519, verify-3764; agent-ab137882d139358a7 (dirty #7137 work); reclaim merged-PR trees PM-executed only
+- Parked owner decisions: rebase+push local main (snapshot commits, origin ahead); #6982 keep open; #7097 (c); staged deletion in agent-ae04f1dea8e90e2a5; saver hand-check #6838 #7112 #6900; log-drain 30-day prune default; #7074 per-commit average; #6144 token/cost totals left as follow-up (trusty-audit cannot see trusty-review child billing)
+
+## Git Context
+Branch: main
+Last commit: 241c0b855 chore(sessions): pause snapshot for trusty-tools-ec, 2026-09-08 18:20Z
+Uncommitted changes: 6 file(s) changed
+

--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-122733.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-122733.md
@@ -1,0 +1,39 @@
+# Session Pause - 2026-09-09T12:27:33.501147+00:00
+
+## Summary
+Owner-invoked pause 2026-09-09 ~09:0xZ, session trusty-tools-95 (tmux tm-dogfood:0:@1), resumed from ec's 2026-09-08 21:05Z snapshot. OWNER DIRECTIVES THIS LEG, verbatim: "let's tackle open bugs and P1s"; "accept all three scope calls" (#2063 keep P1 done-when-#6637-2c-lands, #2075 parked behind #2063, #2892 P1→P2); "restart the daemon now"; "close out the verified issues once the restart lands"; "keep going, merge them when green" (standing); nine-option ruling "1. Option -, 2. Do. 3. Do. 4. Recommend. 5. Proceed. 6. Do. 7. Do. 8. Do. 9. Do."; "yes, do the trusty-audit and saver reinstalls". INSTALLED: tm 1.5.20 (964215152), daemon com.trusty.mpm restarted onto it (pid 91296→57385, 14 sessions intact). API SESSION LIMIT (429, resets 01:40 America/New_York) killed nine agents mid-task ~08:3xZ; a fresh local-ops install dispatch launched after that, so the limit has lifted. Palace resume board: drawer 4ba16004 (ws:trusty-tools-95/resume) — authoritative for the stranded worktree map.
+
+## Completed
+- PR #7223 tm 1.5.20 bump merged 964215152; tm installed+signed; daemon restarted connection-safe (drawer 0f4c682f discharges the e6 chain 29eeeb8a)
+- PR #7225 merged abd70b49e (#6982 pinning tests + CLAUDE.md harness correction; #6982 stays OPEN at status:merged as upstream harness tracker per owner)
+- PR #7227 merged 3842be484 (#7217 write_stream peer-EOF, critic APPROVE; #7217 status:merged pending trusty-code/console rebuild)
+- PR #7233 merged 3025b2bf1 (trusty-audit 0.14.6 + trusty-console 0.11.1 bumps)
+- CLOSED status:tested with live evidence: #7209 #7198 #7180 #7172 #7160 #7128 #5499
+- #6433 → status:coded then reclaimed status:in-progress (owner pulled slice 2 in); #7190 round-4 critic BLOCK, branch fix/7190-heredoc-allowlist e77886044 pushed no PR, parked at status:in-progress
+- Filed #7224 (tm ls TUI, owner request), #7226 (trusty-search defer_embed_queue flake); #7156 relabelled tga
+- Rulings by delegation recorded on issues: #7087 Q1a Q2c Q5b (Q3a Q4a shipped); #6637 option (1) joint trusty-code+gui release, PR 2c proceeds; #7074 PM recommends (A) — owner to confirm
+- 11 NOT-VERIFIABLE issues left at status:merged with a comment each: #7196 #7185 #7166 #7139 #7137 #7112 #6900 #6847 #6839 #6838 #5220
+
+## In Progress
+- local-ops (dispatched ~09:0xZ, may finish after this pause): install trusty-audit 0.14.6 + saver 0.11.1 from detached worktree .claude/worktrees/install-audit-saver-3025b2b, then live-check #7137 (no /Users path in gaps text) and #6839 (thumbnail.png + @2x) → on PASS ticketing closes both from status:tested
+- STRANDED, uncommitted, agents dead — `git -C <wt> status --short` first; salvage via a fresh agent using git -C, or re-dispatch from origin/main using the stranded diff as a start: #6851 SSE fan-out → agent-ac1c1547947ea726f (writing tests); #5478 generator → agent-afa3b92c98c9c16b7 (writing engagement.rs); #7224 tm ls TUI → agent-ad3d7de08f9f443c0 (writing test file); #6637 PR 2c → agent-a2a5e75558f15229a (HTTP removal underway, tests breaking); #6850 events route → agent-a538bc0c7660801b5 (module written, route unmounted for the red run); #7226 flake → agent-a989696d29e3e0456 (furthest: inverted-order failure shown, was restoring); #5669 watchdog → agent-a01877360155704eb (writing cli.rs render test); #6433 slice 2 → agent-ab7109e66ec24b732 (server half done, client half in progress)
+- All eight issues above remain status:in-progress claimed by trusty-tools-95
+- #5470 PARTIAL: instructions land in package.toml not manifest.toml; PM recommends accept; owner word pending
+
+## Next Steps
+- On resume: ListAgents FIRST; check the install agent's outcome by artifact (`trusty-audit --version` = 0.14.6; saver Info.plist 0.11.1) before re-dispatching it
+- Resume the stranded eight in bounded waves (≤4 concurrent cargo builds): each → credential scan (security, three-dot diff) → version-control push+PR → critic for rung ≥5 (#6637 2c, #5669, #6433, #6851) → merge on green (standing authorization)
+- Next wave after those: #7087 slices 2 (trusty-memory) + 3 (trusty-search) under Q1a Q2c Q5b, rung 5 + critic; #6854 producer wiring (end-to-end gate waits on #6851); #7156 (tga); #6852 + #6853 (svelte, after #6851 merges, ui/dist re-stamp mandatory); #6855 last
+- Owner decisions still open: #7190 A (doc residual, open PR for WARN re-review) or B (close not-planned, keep Write-tool workaround); #7074 A/B (rec A); #5470 accept
+- #6637 2c ships only in a joint trusty-code + trusty-code-gui bump+reinstall release; #7217 live check rides that rebuild
+- Every brief: never prune-worktrees; CARGO_TARGET_DIR absolute literal path (never $PWD); scan before push; Refs never Closes; read the issue's latest root-cause/disposition comment before writing a bug brief (PM error on #6982, drawer f0fa5b79); conditional pre-fix-failure ACs
+- Worktrees to keep: install-tm-1520, install-audit-saver-3025b2b, bump-audit-saver-20260909 (branch merged; PM-executed reclaim only), the eight stranded agent trees, agent-a358d8c5 (#7190 parked)
+- Owner note: #6850–#6855 cite DOC-73; neither epic #6922 nor #6516 lists them as children
+
+## Git Context
+Branch: main
+Last commit: 5da796033 chore(sessions): pause snapshot for trusty-tools-ec, 2026-09-08 21:05Z
+Uncommitted changes: 6 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-164445.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-164445.md
@@ -1,0 +1,46 @@
+# Session Pause - 2026-09-09T16:44:45.434809+00:00
+
+## Summary
+Owner-invoked pause 2026-09-09 ~18:2xZ, session trusty-tools-95 (tmux tm-dogfood:0:@1), resumed from the 12:27Z snapshot. OWNER DIRECTIVES THIS LEG, verbatim: "7190 option 1, (a), 5470 accpt"; "7074 - A"; "I don't see the token counts/model in the commit messages" (→ #7074 criterion 1 amended: footer carries tokens-in/out, savings %, model id); "yes, docs-only issues can close from merged" (→ #7243 filed); "there still are a number of bugs, let's close these"; "the shunt status has disappeared again". Standing: "keep going, merge them when green". PM-EXECUTED REPAIR: `.claude/settings.json` had every tm hook pointing at cargo test binaries (target-7224/target-7074 `test_session_lifecycle`); both paths replaced with /Users/masa/.cargo/bin/tm, pm-guard proven live again; duplicate hook blocks remain (harmless); corrupt copies in the session scratchpad. Cause tracked as #7244 (P1). NINE untracked `target-<N>/` dirs at repo root are agent CARGO_TARGET_DIRs (gitignored? no — untracked; leave them, they are build caches). Background agents DIE with the session: on resume, verify each branch by `git log`, never assume.
+
+## Completed
+- #7137, #6839 closed status:tested (trusty-audit 0.14.6 + saver 0.11.1 installed from 3025b2bf1, live checks PASS)
+- #7190 closed under the docs-only ruling (PR #7235 squash 0024aa7af); skill amendment filed #7243
+- #7226 flake fix merged PR #7236 (status:merged; awaits main shards)
+- #5478 engagement generator: PR #7242 ARMED auto-merge (critic APPROVE r2; follow-ups #7241); issue status:coded
+- #5669 clone watchdog: critic r3 APPROVE; version-control pushing fix/5669-clone-budget-watchdog 7057aaee1 + PR + auto-merge + status:coded at pause time — VERIFY on resume with `gh pr list --head fix/5669-clone-budget-watchdog`
+- #7234 pm-guard tilde and #7232 removal re-check / phantom claim: root-caused, claimed, engineers dispatched
+- #7237 UDS index registration (owner bug report): filed, claimed, engineer dispatched (moves trusty-mpm search socket client down into trusty-common)
+- #7244 hooks writer accepts target-<N> test binary (P1) + #7245 #7209 regression (instruction-compression rows keyed pre-spawn): filed, claimed, engineers dispatched
+- Recommendations routed: #6982 comment (six guard false-positive shapes), #7238 (BASE-AGENT scratchpad/heredoc), #7239 (critic cites enclosing fn), #7240 (salvage brief → `tm session adopt-worktree`)
+- Dead worktrees reclaimed by PM: agent-a989696d29e3e0456, agent-a01877360155704eb, agent-afa3b92c98c9c16b7, agent-ad3d7de08f9f443c0, agent-a56c5d9577cd06226
+
+## In Progress
+- #7074 savings average + commit trailers: branch feat/7074-savings-footer-and-average 81d81811f (worktree agent-a03c52fefe231efed), scan PASS, critic RUNNING at pause — on resume read its verdict from the task output or re-run critic; then version-control push+PR+auto-merge+status:coded. Deviation for owner: surface (a) tga-collectible field in the squash body NOT implemented (body validator requires footer last) → follow-up issue
+- #7224 tm ls TUI: branch feat/7224-tm-ls-tui 5325fb0ef (critic WARN: no TERM=dumb check; terminal::enter not atomic), scan PASS; round-2 engineer RUNNING in agent-adf0b0b2dc84d6cdf — on resume check that worktree for a new commit on the branch; if none, re-dispatch the two findings from origin/main+5325fb0ef
+- #7245 engineer RUNNING (agent-a6ed0ab8e30601b5e, branch fix/7245-instruction-savings-keying) — check for commit
+- #7244 engineer RUNNING (agent-af3092dd9c2cfc884, branch fix/7244-hooks-writer-ephemeral-target-dir, P1) — check for commit; its brief also owes the DETECTION-side fix (tm hooks clean / doctor blind to non-tm stems) which may need a second issue or round
+- #7234 engineer RUNNING (agent-af31b5ac227b0eacb, branch fix/7234-pm-guard-tilde-unresolved) — check for commit
+- #7232 engineer RUNNING (agent-a2603175500a3cccf, branch fix/7232-removal-recheck-stale-claim) — check for commit; failing input = phantom session 51786c9c-478f-5b3f-83a7-cbe63e3d5958 blocking every reclaim
+- #7237 engineer RUNNING (agent-a2309f762e459980f, branch fix/7237-search-index-uds) — check for commit
+- PR #7242 (#5478) armed; #5669 PR being opened — both land unattended on green
+- #5470 at status:merged, owes a live trusty-audit 0.14.6 run before close
+
+## Next Steps
+- On resume: ListAgents FIRST; then for each in-progress branch `git log --oneline -1 <branch>` and `git -C .claude/worktrees/<agent> status --short` — salvage uncommitted work with a fresh engineer + `tm session adopt-worktree` (#6497), never by naming the dead tree
+- For each landed branch: security three-dot scan → version-control push + PR + `gh pr merge --squash --delete-branch --auto` → `tm issue transition N status:coded`; critic first for rung ≥5 (#7244 #7234 #7232 #7237 all rung 5)
+- After #7244 + #7245 + #7074 + #7237 merge: tm patch bump + reinstall (owner ruling: every reinstall bumps) + daemon restart; then live checks: #7237 (fresh session launch, no 7878 in log), #7245/#7074 (💸 segment renders with avg; commit in a tm session carries Tokens-In/Out/Savings/Model trailers), #5470 (live trusty-audit run), then close from status:tested
+- After #7232 merges + reinstall: re-run `tm session prune-worktrees --merged-prs` dry run; the phantom claim must be gone; then close #7185 #7196 from status:tested
+- Owner-attended saver checks still owed for #6838 #6900 #7112 (Touch ID unlock with log stream; two rotations)
+- #7217 closes via the trusty-code rebuild that rides #6637 2c
+- Wave 2 salvage: #6851 → #6850 (sequential, both console event bus), #6637 PR 2c, #6433 slice 2 — worktrees agent-ac1c1547947ea726f, agent-a538bc0c7660801b5, agent-a2a5e75558f15229a, agent-ab7109e66ec24b732 still hold uncommitted diffs; use adopt-worktree
+- Follow-ups to file: #7074 surface (a) squash-body field (PR body contract change); #5669 MEDIUM doc (library embedders spawn stop_clones_on_interrupt); #7244 detection side if the engineer scoped it out
+- Every brief: `isolation: "worktree"` EXPLICIT + STOP-if-main-checkout line; CARGO_TARGET_DIR absolute literal; scan before push; Refs never Closes; no heredocs/loops under isolation (#6982); single tests via check_test_count.sh; record settings.json mtime around trusty-mpm test runs until #7244 lands
+
+## Git Context
+Branch: main
+Last commit: d6bce1a58 chore(sessions): pause snapshot for trusty-tools-95, 2026-09-09 12:27Z
+Uncommitted changes: 15 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-192518.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-192518.md
@@ -1,0 +1,42 @@
+# Session Pause - 2026-09-09T19:25:18.095691+00:00
+
+## Summary
+Owner-invoked pause 2026-09-09 ~19:4xZ, session trusty-tools-95 (tmux tm-dogfood:0:@1), resumed from the 16:44Z snapshot after a /clear; the six pre-pause engineers survived and all reported. OWNER DIRECTIVES THIS LEG, verbatim: "kill the safe ones" (zsh storm: 217 orphaned spinner shells from the #7226 engineer, reaped; third incident of never-generate-CPU-load); "fold the backup into #7244" (done, round 3); "when the tm ls TUI is ready, it should be the default" (PR #7248 merged, already default); "bare tm should also open the TUI" (#7263, PR #7272 armed); "we have a number of bugs open, let's close them" + "several look to have been coded already (and merged), but issues not closed" (census: 19 open bugs, 1 untouched → #7247 fixed; 8 merged-unverified under QA verdicts; 4 coded = armed PRs); "let's use sonnet for ticketing agent and version control agent" + "sync the labels/projects/milestones guidance for both" (#7274 engineer running; every ticketing/version-control dispatch passes model sonnet from now); "according to mac, there's still overlap between claude code and trusty-mpm configs" (research audit running); "make sure version control cleans up remote branches when they're merged" (#7275 filed; version-control sweep of 282 remote branches running: deletes MERGED-ANCESTOR and PR-MERGED only, lists PR-CLOSED-UNMERGED and NO-PR for the owner). Standing: "keep going, merge them when green". INCIDENT: a #7263 engineer's bare-tm pty smoke relaunched THIS PM session (duplicate ran ~4 min, committed 619d0da49 on the #7244 r3 branch, pushed nothing); rule now absolute: no subagent runs bare tm. settings.json corrupted EIGHT times today by trusty-mpm test runs in agent worktrees (#7244); PM repaired each by Edit replace_all to /Users/masa/.cargo/bin/tm; last repair at pause time; #7244 rounds 2-3 (PR #7273) keep it byte-identical. Every background agent below DIES with the session: verify each branch by `git log` on resume, never assume.
+
+## Completed
+- 217 orphaned zsh spinner shells reaped (local-ops); load 670→594 and falling
+- MERGED today: #7246 (#5669), #7248 (#7224 tm ls TUI), #7268 (#7253), #7269 (#7247) — issues at status:merged
+- ARMED, land unattended on green: #7242 (#5478), #7256 (#7234, 20b5f9256), #7257 (#7237, 2eacfe7f1), #7258 (#7232 -r2, 65d31525b), #7260 (#7245 -r2, 27b2fb849), #7261 (#7074, 7016aa5b9), #7272 (#7263, 9913981bf), #7273 (#7244 -r3, 1ba38636c, critic APPROVE)
+- Critic rounds: #7237 WARN→fixed, #7245 WARN→fixed, #7234 APPROVE, #7232 APPROVE, #7244 WARN→fixed→APPROVE, #7074 WARN→fixed; every push preceded by a security three-dot scan (three HITs caught and fixed: real home paths in tests)
+- FILED: #7249 #7250 #7251 #7252 #7253 #7254 #7255 #7259 #7262 #7263 #7270 #7271 #7274 #7275; comments on #7074 #7244 #6982 #7234 #7262
+- QA verdicts on merged set: #7196 #7185 BLOCKED on #7258; #7217 needs reinstall + daemon restart; #7226 needs one clean main push run; #6982 stays open by ruling; #7112 #6900 #6838 owner-attended saver checks
+- Owner rulings recorded in the palace: settings backup into #7244; tm ls and bare tm TUI default; sonnet for ticketing+version-control; labels/projects/milestones one standard for issues and PRs; version-control cleans remote branches on merge
+
+## In Progress
+- #7262 (P1) detection/repair of corrupted settings.json: rust-engineer running in fresh isolation worktree, branch fix/7262-hooks-detect-build-tree-commands off 1ba38636c — on resume `git log --oneline -1 fix/7262-hooks-detect-build-tree-commands`; if a commit exists: scan → critic (rung 5) → version-control (sonnet)
+- #7249 commit-source-aware trailers: engineer running, branch fix/7249-commit-source-aware-trailers off 7016aa5b9 — check for commit; scan → version-control
+- #7250 transcript_path containment: engineer running, branch fix/7250-transcript-path-containment off 7016aa5b9 — check for commit; scan → version-control
+- #7259 tm doctor worktree-disk liveness: engineer running, branch fix/7259-doctor-worktree-disk-liveness off 65d31525b — check for commit; scan → version-control
+- #7274 sonnet defaults + shared PR label standard (tm pr open applies component labels, project, milestone from the Refs issue): engineer running, branch feat/7274-agent-models-and-pr-label-standard off origin/main — check for commit; critic (prompt+code) → scan → version-control
+- Config-overlap audit (research, read-only, isolation worktree): ten shared surfaces between Claude Code and trusty-mpm; result was not seen before pause — re-run if no output file is found in the session scratchpad tasks dir
+- Remote-branch sweep (version-control, sonnet): classifying 282 origin branches, deleting MERGED-ANCESTOR + PR-MERGED only; result not seen before pause — on resume `git fetch --prune origin` and count `refs/remotes/origin`; re-run the sweep if still ~282
+- #7275 (version-control remote-branch cleanup rule + `tm pr` sweep subcommand): filed, NOT dispatched; lands after #7274 merges (both edit version-control.md)
+
+## Next Steps
+- On resume: ListAgents FIRST (agents may survive a /clear but not a process exit); then per branch above `git log --oneline -1 <branch>` and `git -C .claude/worktrees/<agent> status --short`; salvage uncommitted work with a fresh engineer via a fresh -rN branch off the committed head, never by naming the dead tree
+- Check `.claude/settings.json`: `grep -c 'target-'` must be 0; if not, Edit replace_all every `target-<N>/debug/deps/test_session_lifecycle-… hook` to `/Users/masa/.cargo/bin/tm hook`
+- For each landed branch: security three-dot scan → critic for rung ≥5 → version-control (model sonnet) push + PR + `gh pr merge --squash --delete-branch --auto` + `tm issue transition N status:coded`; after merge confirm the remote head is gone (`git ls-remote --heads origin <b>`), delete round-N siblings
+- After #7273 (#7244), #7257 (#7237), #7260 (#7245), #7261 (#7074), #7272 (#7263), #7258 (#7232) merge: local-ops does tm patch bump (owner rule: every reinstall bumps) + reinstall via cargo install from a clean checkout + daemon restart; then live checks: fresh session launch shows no 7878 (#7237); 💸 segment shows the average and a commit in a tm session carries Tokens-In/Out/Savings/Model trailers (#7245/#7074); `tm ls` and bare `tm` open the TUI in a real pane — owner or PM runs it, NEVER a subagent (#7224/#7263); `tm session prune-worktrees --merged-prs` dry run shows no phantom claim 51786c9c (#7232) → then #7185 #7196 close; #7217 daemon-restart repro; #5470 live trusty-audit 0.14.6 run; settings.json stays byte-identical across a trusty-mpm test run (#7244); then ticketing closes each from status:tested with the evidence
+- #7226 closes when one push-to-main CI run completes clean (last three: two preempted, one apt-mirror fault); the bump PR's push provides it
+- Owner-attended: #7112 #6900 #6838 console saver (Touch ID unlock + two rotations) — cannot be automated
+- Dispatch #7275 after #7274 merges; dispatch #7270 (rust-engineer.md repo-specific literals) and #7271 (BASE-ENGINEER commit-first revert recipe) as a pair after #7269's asset edits are on main (they are)
+- Wave 2 salvage still queued: #6851 → #6850, #6637 2c, #6433 slice 2 via `tm session adopt-worktree`
+- Every brief: NEVER generate machine-wide CPU load, trap-EXIT reaping; `isolation: "worktree"` explicit + STOP-if-main-checkout line; CARGO_TARGET_DIR absolute literal target-<N>; scan before the PR opens; Refs never Closes; `./scripts/<name>.sh` not `bash scripts/…`; no heredocs/loops under isolation; single tests via check_test_count.sh; record settings.json sha1 + target- count around trusty-mpm test runs; round-N branches use a -rN suffix off the committed head; never bare tm from a subagent; ticketing and version-control pass model sonnet
+
+## Git Context
+Branch: main
+Last commit: 2340df023 chore(sessions): pause snapshot for trusty-tools-95, 2026-09-09 16:44Z
+Uncommitted changes: 27 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/1a34a4fe-20f6-4bd7-8591-0141411dc6a5/INSTRUCTIONS-COMPILED.md
+++ b/.trusty-mpm/sessions/1a34a4fe-20f6-4bd7-8591-0141411dc6a5/INSTRUCTIONS-COMPILED.md
@@ -375,8 +375,150 @@ appears there. What is bundled at all, and what deploys each:
 ## Delegation Authority
 
 The harness's own `Available agent types for the Agent tool` listing is the
-authoritative routing surface: the 38 agents it carries are not repeated
+authoritative routing surface: the 5 agents it carries are not repeated
 here. Route from that listing.
+
+Below are the agents resolved from a tier the harness does not load, which
+appear in no other listing.
+
+### api-qa
+- **Role:** qa
+- **Model:** sonnet
+
+### code-analyzer
+- **Model:** sonnet
+
+### code-critic
+- **Role:** qa
+- **Model:** sonnet
+
+### dart-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### data-engineer
+- **Model:** sonnet
+
+### documentation
+- **Model:** haiku
+
+### dotnet-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### elixir-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### engineer
+- **Model:** sonnet
+
+### gcp-ops
+- **Role:** ops
+- **Model:** sonnet
+
+### golang-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### java-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### javascript-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### local-ops
+- **Role:** ops
+- **Model:** sonnet
+
+### memory-manager
+- **Model:** haiku
+
+### mpm-agent-manager
+- **Model:** sonnet
+
+### mpm-skills-manager
+- **Model:** sonnet
+
+### nextjs-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### ops
+- **Model:** sonnet
+
+### phoenix-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### php-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### prompt-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### python-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### qa
+- **Model:** sonnet
+
+### react-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### refactoring-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### research
+- **Model:** sonnet
+
+### ruby-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### rust-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### security
+- **Model:** sonnet
+
+### svelte-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### tauri-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### ticketing
+- **Model:** sonnet
+
+### typescript-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### vercel-ops
+- **Role:** ops
+- **Model:** sonnet
+
+### version-control
+- **Model:** haiku
+
+### web-qa
+- **Role:** qa
+- **Model:** sonnet
+
+### web-ui-engineer
+- **Role:** engineer
+- **Model:** sonnet
 
 ---
 

--- a/.trusty-mpm/sessions/c3b595ae-d80f-43f6-a9d3-39611ff0e126/INSTRUCTIONS-COMPILED.md
+++ b/.trusty-mpm/sessions/c3b595ae-d80f-43f6-a9d3-39611ff0e126/INSTRUCTIONS-COMPILED.md
@@ -375,8 +375,150 @@ appears there. What is bundled at all, and what deploys each:
 ## Delegation Authority
 
 The harness's own `Available agent types for the Agent tool` listing is the
-authoritative routing surface: the 38 agents it carries are not repeated
+authoritative routing surface: the 5 agents it carries are not repeated
 here. Route from that listing.
+
+Below are the agents resolved from a tier the harness does not load, which
+appear in no other listing.
+
+### api-qa
+- **Role:** qa
+- **Model:** sonnet
+
+### code-analyzer
+- **Model:** sonnet
+
+### code-critic
+- **Role:** qa
+- **Model:** sonnet
+
+### dart-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### data-engineer
+- **Model:** sonnet
+
+### documentation
+- **Model:** haiku
+
+### dotnet-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### elixir-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### engineer
+- **Model:** sonnet
+
+### gcp-ops
+- **Role:** ops
+- **Model:** sonnet
+
+### golang-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### java-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### javascript-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### local-ops
+- **Role:** ops
+- **Model:** sonnet
+
+### memory-manager
+- **Model:** haiku
+
+### mpm-agent-manager
+- **Model:** sonnet
+
+### mpm-skills-manager
+- **Model:** sonnet
+
+### nextjs-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### ops
+- **Model:** sonnet
+
+### phoenix-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### php-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### prompt-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### python-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### qa
+- **Model:** sonnet
+
+### react-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### refactoring-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### research
+- **Model:** sonnet
+
+### ruby-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### rust-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### security
+- **Model:** sonnet
+
+### svelte-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### tauri-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### ticketing
+- **Model:** sonnet
+
+### typescript-engineer
+- **Role:** engineer
+- **Model:** sonnet
+
+### vercel-ops
+- **Role:** ops
+- **Model:** sonnet
+
+### version-control
+- **Model:** haiku
+
+### web-qa
+- **Role:** qa
+- **Model:** sonnet
+
+### web-ui-engineer
+- **Role:** engineer
+- **Model:** sonnet
 
 ---
 

--- a/.trusty-mpm/sessions/local/INSTRUCTIONS-COMPILED.md
+++ b/.trusty-mpm/sessions/local/INSTRUCTIONS-COMPILED.md
@@ -19,6 +19,9 @@
   memory-index file — this overrides any harness default.
 - Never cite `MEMORY.md`; cite the palace.
 - Durable facts go to the palace (`memory_remember` / `memory_note`).
+- Record your own self-improvement hypotheses in the palace under the tag
+  `self-improvement-hypothesis`, the same one every agent uses; a post-mortem
+  run coalesces by that tag (#6937).
 - `CLAUDE.md` is the only non-dynamic instruction source. Never create another.
 
 ## PM Allowlist (unbudgeted; everything else is budgeted or delegated)
@@ -57,8 +60,10 @@ Anything not listed above is delegated.
 
 ## Agent Routing
 
-The Agent Delegation section is the single routing surface; the generated
-Delegation Authority roster below it is authoritative for which agents exist.
+The Agent Delegation section is the single routing surface. The harness's own
+`Available agent types for the Agent tool` listing is authoritative for which
+agents exist; the generated Delegation Authority roster below adds only the
+agents that listing does not carry (#4513).
 
 ## Delegating Well
 
@@ -202,7 +207,9 @@ gate is blocking.
 A **task-completion report** carries four things: what was delegated and to
 whom, the QA evidence (actual output, not claims), the files tracked with their
 commits, and each claim mapped to its evidence source. In-flight responses
-answer the question instead.
+answer the question instead. Route each agent's **Improvement recommendations**
+block to `bobmatnyc/trusty-tools` issues through the `ticketing` agent, whatever
+project the agent ran in (#6935).
 
 ## Prose Style — Write Plainly
 
@@ -361,161 +368,26 @@ appears there. What is bundled at all, and what deploys each:
 `framework-manifest.toml`, rendered in `tm-capabilities`'s
 `references/agents.md`.
 
-> The live roster below is authoritative for WHICH agents exist and what each handles; the tables above are routing doctrine only. Where the two disagree, trust the roster.
+> The harness's own `Available agent types for the Agent tool` listing is authoritative for WHICH agents exist; the tables above are routing doctrine only. Where the two disagree, trust the harness listing. The roster below adds only the agents that listing does not carry (#4513).
 >
 > Depending on how this session was launched, a listed agent may not be loadable. If a dispatch fails with an unknown agent type, re-route to the closest listed alternative — do not retry the same agent.
 
 ## Delegation Authority
 
-The following agents are available for delegation. Route work to the
-appropriate agent based on task type.
+The harness's own `Available agent types for the Agent tool` listing is the
+authoritative routing surface: the 38 agents it carries are not repeated
+here. Route from that listing.
 
-### api-qa
-- **Role:** qa
-- **Model:** sonnet
-
-### code-analyzer
-- **Model:** sonnet
-
-### code-critic
-- **Role:** qa
-- **Model:** sonnet
+Below are the agents resolved from a tier the harness does not load, which
+appear in no other listing.
 
 ### copyeditor
-- **Model:** sonnet
-
-### dart-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### data-engineer
-- **Model:** sonnet
-
-### documentation
-- **Model:** haiku
-
-### dotnet-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### elixir-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### engineer
-- **Model:** sonnet
-
-### gcp-ops
-- **Role:** ops
-- **Model:** sonnet
-
-### golang-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### java-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### javascript-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### local-ops
-- **Role:** ops
-- **Model:** sonnet
-
-### memory-manager
-- **Model:** haiku
-
-### mpm-agent-manager
-- **Model:** sonnet
-
-### mpm-skills-manager
-- **Model:** sonnet
-
-### nextjs-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### ops
 - **Model:** sonnet
 
 ### pangram-editor
 - **Model:** sonnet
 
-### phoenix-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### php-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### prompt-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
 ### proofreader
-- **Model:** sonnet
-
-### python-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### qa
-- **Model:** sonnet
-
-### react-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### refactoring-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### research
-- **Model:** sonnet
-
-### ruby-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### rust-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### security
-- **Model:** sonnet
-
-### svelte-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### tauri-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### ticketing
-- **Model:** sonnet
-
-### typescript-engineer
-- **Role:** engineer
-- **Model:** sonnet
-
-### vercel-ops
-- **Role:** ops
-- **Model:** sonnet
-
-### version-control
-- **Model:** haiku
-
-### web-qa
-- **Role:** qa
-- **Model:** sonnet
-
-### web-ui-engineer
-- **Role:** engineer
 - **Model:** sonnet
 
 ### writer

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -96,3 +96,4 @@
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260906-213223.md","timestamp":"2026-09-06T21:32:23.203795+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260907-002504.md","timestamp":"2026-09-07T00:25:04.149016+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260907-020817.md","timestamp":"2026-09-07T02:08:17.059305+00:00"}
+{"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260908-034205.md","timestamp":"2026-09-08T03:42:05.894611+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -103,3 +103,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-182026.md","timestamp":"2026-09-08T18:20:26.045905+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-210516.md","timestamp":"2026-09-08T21:05:16.395055+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-122733.md","timestamp":"2026-09-09T12:27:33.501147+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-164445.md","timestamp":"2026-09-09T16:44:45.434809+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -98,3 +98,4 @@
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260907-020817.md","timestamp":"2026-09-07T02:08:17.059305+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260908-034205.md","timestamp":"2026-09-08T03:42:05.894611+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260908-105451.md","timestamp":"2026-09-08T10:54:51.065340+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-131700.md","timestamp":"2026-09-08T13:17:00.123786+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -102,3 +102,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-150858.md","timestamp":"2026-09-08T15:08:58.420269+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-182026.md","timestamp":"2026-09-08T18:20:26.045905+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-210516.md","timestamp":"2026-09-08T21:05:16.395055+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-122733.md","timestamp":"2026-09-09T12:27:33.501147+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -101,3 +101,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-131700.md","timestamp":"2026-09-08T13:17:00.123786+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-150858.md","timestamp":"2026-09-08T15:08:58.420269+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-182026.md","timestamp":"2026-09-08T18:20:26.045905+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-210516.md","timestamp":"2026-09-08T21:05:16.395055+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -99,3 +99,4 @@
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260908-034205.md","timestamp":"2026-09-08T03:42:05.894611+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260908-105451.md","timestamp":"2026-09-08T10:54:51.065340+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-131700.md","timestamp":"2026-09-08T13:17:00.123786+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-150858.md","timestamp":"2026-09-08T15:08:58.420269+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -104,3 +104,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-210516.md","timestamp":"2026-09-08T21:05:16.395055+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-122733.md","timestamp":"2026-09-09T12:27:33.501147+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-164445.md","timestamp":"2026-09-09T16:44:45.434809+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-192518.md","timestamp":"2026-09-09T19:25:18.095691+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -100,3 +100,4 @@
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260908-105451.md","timestamp":"2026-09-08T10:54:51.065340+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-131700.md","timestamp":"2026-09-08T13:17:00.123786+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-150858.md","timestamp":"2026-09-08T15:08:58.420269+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260908-182026.md","timestamp":"2026-09-08T18:20:26.045905+00:00"}

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -97,3 +97,4 @@
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260907-002504.md","timestamp":"2026-09-07T00:25:04.149016+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260907-020817.md","timestamp":"2026-09-07T02:08:17.059305+00:00"}
 {"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260908-034205.md","timestamp":"2026-09-08T03:42:05.894611+00:00"}
+{"session_id":"tmux-window-1","event":"pause","snapshot":"tmux-window-1/session-20260908-105451.md","timestamp":"2026-09-08T10:54:51.065340+00:00"}

--- a/.trusty-mpm/sessions/tmux-window-1/session-20260908-034205.md
+++ b/.trusty-mpm/sessions/tmux-window-1/session-20260908-034205.md
@@ -1,0 +1,47 @@
+# Session Pause - 2026-09-08T03:42:05.894611+00:00
+
+## Summary
+Owner-invoked pause 2026-09-08 ~03:4xZ (session trusty-tools-ec, tmux tm-dogfood:0:@1, session_id tmux-window-1). Supersedes the 02:24Z pause. Owner directives this leg, in order: "let's get bugs fixed before moving on" (bugs before console enhancements); "fix the memory growth bug first" (#7106 ahead of everything); orphan debug daemons: kill them and fix #7085 first (done: 109 killed, pid 72070 untouched). origin/main = 0f57622db. MERGED THIS LEG: #7096 (#6928 console memory tab), #7101 (#6155 feed batching), #7105 (#7036 severity floor), #7107 (#6900 saver honours stop), #7109 (#7097 tm issue audit). CLOSED status:tested: #6155, #6928. status:merged awaiting live check: #6929 (live check FAILED: Disk view /api/console/disk/tree 503, fix engineer running), #7036 (needs trusty-review reinstall + one real review run), #6900 (owner triggered the saver twice: shows first and second screens then blanks/disappears at the third — #6838 class; owner has NOT yet said whether the Touch ID prompt was immediate), #7097 (needs tm reinstall; pm_guard deny item (c) is an owner decision). ARMED auto-merge, landing on green: #7110 (#7102 doctor/install skills tier), #7111 (#7098 #7100 pm-guard; #6982 tests only). BLOCKED: PR #7108 (#7085 parent-death watchdog) — critic BLOCK (CRITICAL pid reuse on the detached-grandchild path, HIGH test covers only direct child, HIGH env stamp leaks via spawn_detached, MEDIUM process::exit skips graceful shutdown); fix round re-engaged on the original engineer in worktree agent-ae3b2b4642d80730a. INSTALLED: console 0.11.0 + memory 0.26.0 from 5987145ca (pids 18240 / 16929); TrustyConsole.saver from 8ebb5d664 installed, legacyScreenSaver killed for reload; tm still 1.5.18 from 464e1da58 (predates #7097/#7102). builders.max_concurrent raised 8→10 in ~/.trusty-mpm/config.toml on owner instruction. ~/.trusty-tools/trusty-mpm/config.yaml now has the agents.ticketing block (seed-config run). Root causes recorded in palace: #7092/#7093 filed by a direct gh issue create outside the ticketing agent; #7106 is heap high-water (redb 1 GiB default cache × 3 files × 64 palaces, inline Louvain on every roster/graph call, unbounded startup sweep). Issues filed this leg: #7097, #7102, #7106 (P1, sub-issue of #6802). #6982 back to open (upstream Claude Code classifier; /feedback draft queued locally). Untracked in main checkout, not this session's: docs/design/trusty-agents/, docs/trusty-agents/comparables/{chatgpt,hermes}/, .pnpm-store/, .claude/settings.json.bak, .mcp.json.bak-*, two other session dirs; leave them.
+
+## Completed
+- PR #7096 rebased and merged (02:41Z); #6928 live PASS → closed tested
+- PR #7101 #6155 feed batching: critic WARN fixed (cold-start health bypass), merged 02:53Z; live PASS (0 long tasks) → #6155 closed tested
+- PR #7105 #7036 TestCoverage advisory ceiling merged 03:15Z → status:merged
+- PR #7107 #6900 saver .stopped state merged 03:24Z (critic APPROVE) → status:merged; saver built from 8ebb5d664 and installed
+- PR #7109 #7097 tm issue audit merged 03:35Z → status:merged
+- 109 orphan target/debug trusty-memory daemons killed (SIGTERM, 0 survivors); pid 72070 untouched
+- #7093 and #7092 repaired (project 25, milestone Backlog · mpm/core); root cause: direct gh issue create bypassing ticketing
+- Legacy ~/.claude/skills tm-* copies refreshed by tm install; tm issue seed-config wrote agents.ticketing block
+- Console 0.11.0 + memory 0.26.0 reinstalled from 5987145ca, daemons restarted (pids 18240/16929), doctor clean
+- Bug census taken (216 open, 9 bug + 8 P0/P1); bug wave dispatched
+- #7106 filed (P1) with per-step diagnosis: heap high-water mark, redb cache ceiling + inline Louvain + startup sweep
+- #7102 filed and fixed at 9a29cec1b (PR #7110 armed); #7098 #7100 fixed at ac70c484f (PR #7111 armed); #6982 confirmed upstream, reopened
+- builders.max_concurrent 8→10 (owner)
+
+## In Progress
+- #7106 (P1, owner: fix first): rust-engineer a11f9640a1c7a8bde on fix/7106-memory-footprint-bounds — redb set_cache_size helper in trusty-common memory-core, cached community_count under spawn_blocking with write invalidation, throttled startup sweep; four regression tests; before/after footprint on a copied palace store. On return: security scan → PR (Refs #7106, #6802) → code-critic rung 5 → arm → status:coded/merged → memory reinstall + footprint measurement → tested
+- #7085: PR #7108 open NOT armed, critic BLOCK; fix round re-engaged on engineer ae3b2b4642d80730a in worktree agent-ae3b2b4642d80730a (pid-reuse start-time check, grandchild SIGKILL test, spawn_detached scrubs the stamp, graceful shutdown instead of process::exit, changelog wording). On return: scan → second critic round → arm → status:merged
+- #6929 Disk view 503: rust-engineer aa75df45e6fce699f on fix/6929-disk-tree-503 diagnosing live (/api/console/disk/tree → 503 after ~15–20 s; UI prints 502). On return: scan → PR (Refs #6929) → status:coded → arm → console reinstall → web-qa Disk view → tested
+- #6900 saver: owner triggered twice; renders screen 1 and 2 then blanks/disappears at the third. research a44108108153374a5 pulling com.trusty.console.saver + loginwindow logs for both attempts and reading TrustyConsoleSaver.swift draw()/webContentProcessDidTerminate; question is whether this is #6838 recurring (status:merged, reopened once) or a new rotation-step failure. Touch ID immediacy still unanswered by owner
+- PR #7110 (#7102) and PR #7111 (#7098 #7100) armed with Monitor watches; on merge → status:merged + comments
+- Owner question outstanding: '(trusty console screen saver needs a static image)' — asked whether it means a static image instead of the live web view (no network, no retry loop) or a Settings thumbnail (already embedded); not filed yet
+
+## Next Steps
+- On resume: ListAgents FIRST; verify worktrees agent-a11f9640a1c7a8bde (7106), agent-ae3b2b4642d80730a (7085), agent-aa75df45e6fce699f (6929) before any re-dispatch; check PR #7108 #7110 #7111 state with gh
+- 1. Land #7106 (chain above) — owner's top priority
+- 2. Land #7085 fix round → critic → arm PR #7108
+- 3. Land #6929 fix → console reinstall → live Disk view check → close #6929 #6928-adjacent items
+- 4. Saver blank at third screen: act on the diagnosis (likely #6838 recurrence → status:coded on a fix PR, or new issue via ticketing); get the owner's Touch ID answer to close #6900 as tested; get the owner's 'static image' ruling and file it
+- 5. Batch reinstall from main once #7106/#7085/#6929 merge: tm (for #7097 audit + #7102 install tier), trusty-review (for #7036 live check), trusty-memory (for #7106 footprint check), console; then live checks → status:tested → close #7036 #7097 #7102 #7098 #7100 #7106
+- 6. Owner decisions parked: #7097 item (c) deny gh issue create for the PM too (recommended yes); #6982 close as upstream or keep as tracking issue; #7087 (blocked on #6288); 84→0 orphans done
+- 7. Remaining bug census items: #6812 (tga jira sync, status:merged, needs live jira run) and #6838 (saver black, status:merged) need live verification; epics #2063 #2075 #2892 and design-blocked #6637 #7087 are not fix batches; #6611 #6533 are stale in-progress epics from a departed session
+- 8. Then console enhancements #6930 #7086 #7084 #7087 per the bugs-first ordering
+- Worktrees to reclaim after their PRs merge: agent-acd23ec47a2e1102f (stale 6928 branch), agent-ab948033f867bc26e (stale 6155 branch, behind remote), review-6900-critic, console-saver-build-7107, reinstall-console-memory, agent-ab0fa9456e89d9ec7, agent-aaaae1f2c2644d62c, agent-a0eb97268e7fb94b4, agent-ac7475f13e3010252, agent-a02fb807578341180
+
+## Git Context
+Branch: main
+Last commit: 8ebb5d664 fix(trusty-console): saver honours loginwindow's stop request immediately so Touch ID unlock is not blocked (#7107)
+Uncommitted changes: 3 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/tmux-window-1/session-20260908-105451.md
+++ b/.trusty-mpm/sessions/tmux-window-1/session-20260908-105451.md
@@ -1,0 +1,32 @@
+# Session Pause - 2026-09-08T10:54:51.065340+00:00
+
+## Summary
+Owner-invoked pause 2026-09-08 ~09:1xZ (session trusty-tools-ec, tmux tm-dogfood:0:@1, session_id tmux-window-1). Supersedes the 03:42Z pause. Owner directives unchanged: "keep going, merge them when green"; bugs before console enhancements; #7106 first. origin/main = 70fe125f7. ZERO agents in flight, zero armed PRs, no monitors. MERGED THIS LEG (8): #7110 (#7102), #7111 (#7098 #7100), #7113 (#6929 follow-up, cf3d869), #7114 (#7112 saver NotVisible recovery, 42e18ad), #7108 (#7085 parent-death watchdog, 37a3fa3), #7115 (#7106 redb cache/Louvain memo/startup gate, 8ed6337), #7124 (#7106 dream scheduler cap/stagger/chunk, 56d43c2), #7126 (#7106 ONNX embed batch bound 16, 70fe125). CLOSED status:tested (7): #6929, #7097, #7102, #7098, #7100, #7085, #7106. #7106 root causes, in order: redb 1 GiB page cache per db + inline Louvain + unbounded startup sweep; cold-start dream herd (all 61 palaces' first cycle at launch+300 s → 43 GB); dream dedup pass embedding 256×512-token ONNX batches (quadratic attention → 20 GB per cycle, size-independent). Final live check on 70fe125f7 with dreaming ON: touched palaces' cycles ran, peak 2,458 MB (two cycles overlapping), settle 844 MB; reported 11.4 GB symptom gone; residual filed as #7127. INSTALLED from main: tm 1.5.18 @ 37a3fa3db (pid 25583), trusty-console 0.11.0 @ 37a3fa3db (pid 27562), TrustyConsole.saver @ 37a3fa3db (not activated), trusty-memory 0.26.0 @ 70fe125f7 (pid 69430). trusty-memory launchd plist restored to pristine + RUST_LOG=info (no TRUSTY_DREAM_DISABLED); backup in the session scratchpad. Reinstall worktree kept: .claude/worktrees/reinstall-tm-console-20260908. NEW ISSUES: #7116 (console graph "load everything" freezes the tab, P2), #7123 (tm issue audit component-label list only trusty-mpm, P3), #7125 (recall-all holds every palace open, P2, sub of #6802), #7127 (residual dream-cycle footprint, P3, sub of #6802). Repo fact: next trusty-common release is a MINOR bump (pre-existing RemoteEmbedderClient break + Dreamer::start removed in #7124). Harness friction for #6982 this leg: read-only git and `source` refused in isolated worktrees; detached-HEAD explicit-refspec push refused (TM_ALLOW_CROSS_BRANCH_PUSH=1 works); heredoc bodies silently altered; pre-clear agents cannot be SendMessage-resumed (use a fresh isolated agent + fetch + detached HEAD + push-by-ref). Doc nits for a docs PR: CLAUDE.md `--staged` caveat (ignores fragments already committed on the branch); heredoc mangling. Main checkout untouched: same three pre-existing untracked/modified files as at resume (INSTRUCTIONS-COMPILED.md, .claude/settings.json.bak, crates/trusty-memory/ui/); leave them.
+
+## Completed
+- #7106 (P1): three fixes merged (#7115, #7124, #7126), installed, live-verified, closed status:tested; residual → #7127
+- #7085: PR #7108 merged after two critic rounds, installed, SIGKILL scenario zero orphans, closed
+- #6929: PR #7113 merged, tm+console reinstalled, Disk view 200 + web-qa PASS, closed
+- #7097 #7102 #7098 #7100: PRs #7109/#7110/#7111 merged, tm reinstalled, each reproduced from its original failing input, closed
+- #7112: filed (saver blanks — WebContent suspended NotVisible; NOT #6838), PR #7114 merged, saver installed; awaits owner activation
+- Orphan trusty-memory test daemons reaped (two tt6155 daemons); only launchd daemon remains
+- Root causes and lessons recorded in the palace (dream herd, ONNX batch, live-verification-spans-every-daemon, correlate-background-cadence-first)
+
+## In Progress
+- None. Zero agents, zero armed PRs, zero monitors. A harmless footprint sampler (pid 70898) exits on its own ~09:20Z.
+
+## Next Steps
+- #7112 → tested: owner activates the saver once with `log stream --predicate 'subsystem == "com.trusty.console.saver"'`; expected 'visibility lost, recovering'; the 'waiting — occluded window' line + recovery within ~70 s is the forced-deadline path; then close
+- Owner decisions parked: saver 'static image' meaning (static image vs Settings thumbnail); #7097 item (c) deny gh issue create for the PM; #6982 close-as-upstream or keep (add this leg's four guard refusals); Touch ID immediacy on #6900; #7127 accept the 2.5 GB dream transient or schedule it
+- Then bugs-first ordering continues: #7125 (recall-all estate-wide open, P2), #7116 (graph load-everything freeze, P2), #7123 (audit labels, P3), #7127 (P3); #6812 and #6838 status:merged still need live verification
+- Then console enhancements #6930 #7086 #7084 #7087 per the owner's ordering
+- Release note for local-ops: trusty-common next bump is MINOR; widen the root [workspace.dependencies] row
+- Worktrees to reclaim after their PRs merged: agent-a11f9640a1c7a8bde, agent-ae3b2b4642d80730a, agent-aa75df45e6fce699f, agent-a04c81ba55c827378, agent-aab7c7e82fea4550b, agent-a2a4bbbf58e549f1e, agent-aaa51963902e86a4b, agent-a0bc1506f7210d53d, plus the earlier list (agent-acd23ec47a2e1102f, agent-ab948033f867bc26e, review-6900-critic, console-saver-build-7107, reinstall-console-memory, agent-ab0fa9456e89d9ec7, agent-aaaae1f2c2644d62c, agent-a0eb97268e7fb94b4, agent-ac7475f13e3010252, agent-a02fb807578341180); keep reinstall-tm-console-20260908
+
+## Git Context
+Branch: main
+Last commit: d4d5bd292 chore(sessions): pause snapshot for trusty-tools-ec, 2026-09-08 03:42Z
+Uncommitted changes: 3 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1


### PR DESCRIPTION
## Summary

One-time backfill of session snapshot commits that accumulated on local
`main` (ahead 8, behind 77 of `origin/main`) because `main` is PR-only and
the pause skill commits directly to local `main`.

Refs: none — owner-directed one-time backfill, no linked issue.

## Changes

`.trusty-mpm/sessions/**` snapshot and log updates only: new session
snapshot files, updated `INSTRUCTIONS-COMPILED.md` copies, and appended
`sessions-log.jsonl` entries. Nothing outside `.trusty-mpm/sessions/` is
touched, and no crate source changed.

## Risk

None. Session-state markdown/jsonl only; no behavior change to any
crate, binary, or build.

## Test evidence

Docs-only, rung 1 — no Cargo gate is owed. `git diff origin/main...HEAD
--stat` confirms every changed path is under `.trusty-mpm/sessions/`.

## Baseline

No gate run against this change; docs-only diff with no code path to
exercise. No pre-existing failures to report.

## Docs

No changelog fragment owed — this PR touches no crate `src/**`.

## Review

No review findings yet. Owner ruling (2026-09-09) authorizes this
backfill directly; standard PR review/merge gates still apply.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
