### PR TITLE
chore(trusty-mpm): regenerate tm-capabilities for the commit-trailers command (Refs #7074)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7074-capabilities-regen.md
+++ b/crates/trusty-mpm/changelog.d/7074-capabilities-regen.md
@@ -1,0 +1,3 @@
+Changed
+
+- The `tm-capabilities` skill lists `tm commit-trailers`.

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
@@ -37,7 +37,7 @@ relevant `references/*.md` file here when you need an exact answer.
 
 | Question | Load |
 |---|---|
-| "What are the exact `tm <command>` subcommands / flags?" | `references/cli.md` (61 top-level commands) |
+| "What are the exact `tm <command>` subcommands / flags?" | `references/cli.md` (62 top-level commands) |
 | "What MCP tools exist and what parameters do they take?" | `references/mcp-tools.md` (35 tools, plus sibling-daemon pointers) |
 | "What agents can I delegate to, and what do they declare?" | `references/agents.md` (37 concrete agents) |
 | "What skills exist, and are they user-invocable?" | `references/skills.md` (51 bundled skills) |

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -2,7 +2,7 @@
 
 Generated from `Cli::command()` (clap's command-tree introspection) — every `tm <command>` and its nested subcommands, verbatim. Source: `crates/trusty-mpm/src/bin/tm/cli/mod.rs` (top-level `Command` enum) plus one action enum per group under `cli/actions/*.rs`. Regenerate with `tm generate capabilities`.
 
-61 top-level commands.
+62 top-level commands.
 
 - `agent` — Inspect the deployed agent roster's declared skills (DOC-42, issue #2889)
   - `list` — List every deployed agent with its declared skills
@@ -18,6 +18,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `ls` — List the cached agents and skills
   - `status` — Report whether the deployed content has drifted from the synced catalog
   - `sync` — Fetch or refresh the agent/skill catalog from the claude-mpm repo
+- `commit-trailers` — Print this session's commit-stats trailers, or splice them into a commit message file (#7074)
 - `compress` — Compress a piped command's stdout — the `tm hook` PreToolUse Bash command-rewrite spike's filter stage (issue #1956, Option 0)
 - `config` — Manage inference provider configuration (API keys) — the universal `config keys set/list/test/unset` surface shared by every trusty-* binary (epic #2400 Wave 1, #2405)
   - `keys` — Manage inference provider API keys (set / list / test / unset)


### PR DESCRIPTION
## Outcome

PR #7261 added `tm commit-trailers` without regenerating the capabilities
skill, so `scripts/check_capabilities.sh` (the non-required capabilities-drift
workflow) is red on main. This PR is the regeneration.

Refs bobmatnyc/trusty-tools#7074

## Changes

`tm-capabilities.md` and its `references/cli.md` now list `tm commit-trailers`,
produced by `tm generate capabilities` — three files, six lines. Out of scope:
any change to `tm commit-trailers` itself, or to any other capability entry.

## Risk

Minimal — documentation-only content inside a bundled skill asset; no code
path changes.

## Tests

Rung 1 (docs/asset-only): `bash scripts/check_capabilities.sh` exits 0, and the
three prompt goldens pass.

## Baseline

None — no pre-existing red gate touches this path.

## Docs

`crates/trusty-mpm/changelog.d/7074-capabilities-regen.md` added in this PR.

## Review

No findings raised yet.

Refs #7074

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
