### PR TITLE
fix(trusty-mpm): detect and repair settings.json hooks that point at a Cargo build-tree binary (Refs #7262)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7262-detect-build-tree-hook-commands.md
+++ b/crates/trusty-mpm/changelog.d/7262-detect-build-tree-hook-commands.md
@@ -1,0 +1,15 @@
+Fixed
+
+- A hook command whose executable lives in a Cargo build tree is now recognised
+  as tm's own contamination whatever the binary is named, so `tm doctor` reports
+  it, `tm hooks clean` removes it, and the hooks writer REPLACES it instead of
+  adding a correct group beside it. Both name-based branches of
+  `is_mpm_hook_command` asked what the binary was called, so
+  `<repo>/target-7247/debug/deps/test_session_lifecycle-<hash> hook --pm-guard` —
+  what #7244 wrote into a real project's `settings.json` seven times in one day —
+  was invisible to every one of the three. The new branch asks WHERE the
+  executable lives instead, and covers the `--pm-guard` and `--divert-check`
+  argv shapes the old ` hook` suffix check could not reach. A build-tree path
+  alone is not enough: the argv must also be one tm itself writes, so a
+  project's own hook that happens to live under `target/debug` is left alone
+  (#7262).

--- a/crates/trusty-mpm/changelog.d/7262-doctor-build-tree-check-added.md
+++ b/crates/trusty-mpm/changelog.d/7262-doctor-build-tree-check-added.md
@@ -1,0 +1,8 @@
+Added
+
+- `tm doctor` gains a `hooks_build_tree_binary` check naming each offending
+  file and the exact command inside it, including a `statusLine.command` that
+  points into a build tree. `hooks_contamination` counts files, which says
+  nothing useful when the entry is tm's own and the fault is the path inside it.
+  The `statusLine` key is reported but not repaired here — the hooks writer does
+  not own it, and the next managed launch upgrades it in place (#7262).

--- a/crates/trusty-mpm/changelog.d/7262-doctor-build-tree-check-added.md
+++ b/crates/trusty-mpm/changelog.d/7262-doctor-build-tree-check-added.md
@@ -6,3 +6,9 @@ Added
   nothing useful when the entry is tm's own and the fault is the path inside it.
   The `statusLine` key is reported but not repaired here — the hooks writer does
   not own it, and the next managed launch upgrades it in place (#7262).
+
+- `tm doctor --fix`'s `hooks_contamination` step now says what removing the
+  PM-guard entry costs: enforcement is absent until the project's next managed
+  `tm` launch re-renders the hook. The step named the events it cleaned, which
+  reads as a tidy-up and left an operator unguarded with nothing on screen
+  saying so (#7262).

--- a/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
+++ b/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
@@ -158,6 +158,10 @@ pub(crate) const DOCTOR_CHECKS: &[(&str, &str)] = &[
         "Informational: warns when a project's `.claude/settings*.json` carries foreign (claude-mpm) hook entries that would fire inside a tm session — never auto-removed (issue #2940).",
     ),
     (
+        "hooks_build_tree_binary",
+        "Warns when a hook or `statusLine` command in a project's `.claude/settings*.json` runs a binary that lives in a Cargo build tree, naming the file and each offending command. Such a command stops working the moment the artifact is rebuilt away, which silently disables PM-guard enforcement; the hook entries are removed by `tm doctor --fix --yes` / `tm hooks clean` and re-rendered from the installed binary on the next managed launch (issue #7262).",
+    ),
+    (
         "tcc_taint",
         "macOS: whether managed panes spawn `claude` with TCC responsibility disclaimed so its data-access prompts aren't attributed to the shared tmux server (issue #2997).",
     ),

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -228,7 +228,7 @@ async fn execute_doctor_against_test_daemon() {
     match executor.execute(TrustyCommand::Doctor).await {
         CommandResult::Doctor(report) => {
             // This test owns the EXECUTOR round-trip, not the check roster.
-            // The exact count is pinned by `run_doctor_produces_forty_two_checks`
+            // The exact count is pinned by `run_doctor_produces_forty_three_checks`
             // and `doctor_endpoint_returns_report`, both of which derive it from
             // their own name list — duplicating a bare literal here just made it a
             // fourth place to forget (#4090 review LOW-1).

--- a/crates/trusty-mpm/src/core/doctor_repair.rs
+++ b/crates/trusty-mpm/src/core/doctor_repair.rs
@@ -131,6 +131,23 @@ impl RepairStep {
     }
 }
 
+/// Appended to a `hooks_contamination` step that removes the PM guard.
+///
+/// Why (#7262): the base message names the EVENTS it cleans, which reads as a
+/// tidy-up. Removing the `PreToolUse` PM-guard entry is not a tidy-up — it
+/// takes PM enforcement offline, and this repair does not put it back. Only
+/// the project's next managed `tm` launch re-renders the hook, so an operator
+/// who runs `--fix` and then keeps working in an unmanaged session is
+/// unguarded with nothing on screen saying so.
+/// What: one clause, in both dry-run and apply wording (the step's `what` is
+/// mode-independent by [`RepairStep`]'s contract), appended to the base
+/// message when
+/// [`crate::core::standalone::hooks::cleanup::CleanOutcome::removed_pm_guard`]
+/// is set.
+/// Test: `hooks_repair_warns_when_it_removes_the_pm_guard`.
+const PM_GUARD_REMOVAL_CLAUSE: &str =
+    "; pm-guard enforcement is absent until the project's next managed `tm` launch re-renders it";
+
 /// Remove tm's own hook entries from a project's `.claude/settings*.json`.
 ///
 /// Why (#2940, #4948): a pre-#2940 `tm install` wired tm hooks into every
@@ -153,7 +170,9 @@ impl RepairStep {
 /// than on every diagnostic.
 /// Test: `hooks_repair_applies_and_backs_up`,
 /// `hooks_repair_dry_run_changes_nothing`,
-/// `hooks_repair_leaves_foreign_entries_alone`.
+/// `hooks_repair_leaves_foreign_entries_alone`,
+/// `hooks_repair_warns_when_it_removes_the_pm_guard`,
+/// `hooks_repair_omits_the_pm_guard_clause_for_other_entries`.
 pub fn repair_hooks_contamination(project_dir: &Path, mode: RepairMode) -> Vec<RepairStep> {
     let claude = project_dir.join(".claude");
     let mut steps = Vec::new();
@@ -162,10 +181,15 @@ pub fn repair_hooks_contamination(project_dir: &Path, mode: RepairMode) -> Vec<R
         match clean_settings_file(&path, mode == RepairMode::Apply) {
             Ok(None) => {}
             Ok(Some(outcome)) => {
-                let what = format!(
+                let mut what = format!(
                     "remove tm hook entries under [{}]",
                     outcome.removed_events.join(", ")
                 );
+                // #7262: removing the guard is not self-describing — say what
+                // it costs and when it comes back.
+                if outcome.removed_pm_guard {
+                    what.push_str(PM_GUARD_REMOVAL_CLAUSE);
+                }
                 let status = match mode {
                     RepairMode::DryRun => StepStatus::Planned,
                     RepairMode::Apply => StepStatus::Applied {

--- a/crates/trusty-mpm/src/core/doctor_repair_tests.rs
+++ b/crates/trusty-mpm/src/core/doctor_repair_tests.rs
@@ -147,6 +147,52 @@ fn hooks_repair_leaves_foreign_entries_alone() {
 }
 
 #[test]
+fn hooks_repair_warns_when_it_removes_the_pm_guard() {
+    // #7262: the step text must say what the removal COSTS. An operator who
+    // reads "remove tm hook entries under [PreToolUse]" has no way to know PM
+    // enforcement just went offline until the next managed launch.
+    let tmp = tempfile::tempdir().unwrap();
+    let claude = tmp.path().join(".claude");
+    fs::create_dir_all(&claude).unwrap();
+    let settings =
+        crate::core::standalone::hooks::build_tree::tests::incident_settings().to_string();
+    fs::write(claude.join("settings.json"), &settings).unwrap();
+
+    for mode in [RepairMode::DryRun, RepairMode::Apply] {
+        fs::write(claude.join("settings.json"), &settings).unwrap();
+        let steps = repair_hooks_contamination(tmp.path(), mode);
+        assert_eq!(steps.len(), 1, "{steps:?}");
+        assert!(
+            steps[0].what.contains("pm-guard enforcement is absent"),
+            "{mode:?} step must name the consequence: {}",
+            steps[0].what
+        );
+        // The clause is an ADDITION, never a replacement.
+        assert!(
+            steps[0].what.starts_with("remove tm hook entries under ["),
+            "{}",
+            steps[0].what
+        );
+    }
+}
+
+#[test]
+fn hooks_repair_omits_the_pm_guard_clause_for_other_entries() {
+    // The mixed fixture's only tm entry is the lifecycle triad, so the guard
+    // clause would be false there.
+    let tmp = tempfile::tempdir().unwrap();
+    write_mixed_settings(tmp.path());
+
+    let steps = repair_hooks_contamination(tmp.path(), RepairMode::DryRun);
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert!(
+        !steps[0].what.contains("pm-guard"),
+        "no guard was removed, so nothing may claim one was: {}",
+        steps[0].what
+    );
+}
+
+#[test]
 fn push_guard_repair_installs_when_missing() {
     let Some((_dir, repo)) = temp_repo() else {
         return;

--- a/crates/trusty-mpm/src/core/session_launch/divert_hooks.rs
+++ b/crates/trusty-mpm/src/core/session_launch/divert_hooks.rs
@@ -28,10 +28,13 @@ use super::settings::resolve_statusline_binary;
 ///
 /// Why: the identity predicate and the command builder must agree on one
 /// spelling, or the strip stops recognising what the writer wrote and every
-/// relaunch appends a duplicate group (the #2948 failure mode).
+/// relaunch appends a duplicate group (the #2948 failure mode). #7262 added a
+/// THIRD reader — the build-tree classifier, which must recognise this shape
+/// too — so the literal now lives in the lower layer beside the other argv
+/// tails and is re-exported here rather than spelled out twice.
 /// What: the literal suffix, including its leading space.
 /// Test: `is_project_managed_hook_command_recognises_divert_check`.
-pub(super) const DIVERT_CHECK_SUFFIX: &str = " hook --divert-check";
+pub(super) use crate::core::standalone::hooks::build_tree::DIVERT_CHECK_SUFFIX;
 
 /// Tool names the diversion hook is registered for.
 ///

--- a/crates/trusty-mpm/src/core/session_launch/project_hooks.rs
+++ b/crates/trusty-mpm/src/core/session_launch/project_hooks.rs
@@ -24,7 +24,7 @@
 //! Test: `project_hooks_tests.rs`.
 
 use super::divert_hooks::{divert_hook_groups, is_divert_hook_command};
-use super::settings::{TRUSTY_MEMORY_HOOKS, pm_guard_hook_value};
+use super::settings::{PM_GUARD_SUFFIX, TRUSTY_MEMORY_HOOKS, pm_guard_hook_value};
 use crate::core::standalone::hooks::{is_mpm_hook_command, mpm_hook_additions_with_exe};
 
 /// Build the full set of trusty-mpm-owned hook additions for the project tier.
@@ -178,14 +178,14 @@ const EVENT_KEY_PROBE_EXE: &str = "/usr/local/bin/tm";
 /// `trusty-memory`/PM-guard groups on every launch instead of replacing them.
 /// What: returns `true` for a lifecycle-triad command
 /// ([`is_mpm_hook_command`]), a `trusty-memory ` command, a PM-guard command
-/// (ends with ` hook --pm-guard`), or a diversion-check command (#6887,
+/// (ends with [`PM_GUARD_SUFFIX`]), or a diversion-check command (#6887,
 /// [`is_divert_hook_command`]).
 /// Test: `is_project_managed_hook_command_recognises_all_three_sources`,
 /// `is_project_managed_hook_command_recognises_divert_check`.
 pub(super) fn is_project_managed_hook_command(cmd: &str) -> bool {
     is_mpm_hook_command(cmd)
         || cmd.starts_with("trusty-memory ")
-        || cmd.ends_with(" hook --pm-guard")
+        || cmd.ends_with(PM_GUARD_SUFFIX)
         // #6887: without this arm the strip never removes a stale divert group.
         || is_divert_hook_command(cmd)
 }

--- a/crates/trusty-mpm/src/core/session_launch/project_hooks_tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/project_hooks_tests.rs
@@ -1076,3 +1076,58 @@ fn write_project_hooks_aborts_when_the_snapshot_fails() {
         "the settings file must be untouched when its snapshot could not be taken"
     );
 }
+
+/// A build-tree executable path the #7262 classifier must always reject.
+const EPHEMERAL_EXE: &str = "/repo/target-7247/debug/deps/test_session_lifecycle-cd3ba8f03938239b";
+
+/// The argv shapes this crate's writers produce must stay inside the list
+/// [`crate::core::standalone::hooks::build_tree`] classifies (#7262).
+///
+/// Why: the classifier keeps its own copy of the argv vocabulary, and a writer
+/// that grows a new sub-flag without adding it there goes back to being
+/// invisible to `tm doctor` and unstrippable by the writer — the exact #7244
+/// failure, one flag later. This test derives each shape from the writer's OWN
+/// output rather than restating the literal, so the two cannot drift.
+/// What: strips the resolved binary off each writer-produced command, re-attaches
+/// the same argv to a build-tree binary, and asserts the classifier claims it.
+#[test]
+fn pm_guard_and_divert_commands_end_in_a_known_argv_tail() {
+    use crate::core::standalone::hooks::{
+        is_build_tree_hook_command, is_build_tree_statusline_command,
+    };
+
+    let bin = super::super::settings::resolve_statusline_binary();
+    let mut produced: Vec<String> = vec![
+        super::super::settings::pm_guard_hook_value()[0]["hooks"][0]["command"]
+            .as_str()
+            .expect("the PM-guard command is a string")
+            .to_string(),
+    ];
+    for group in super::super::divert_hooks::divert_hook_groups() {
+        produced.push(
+            group["hooks"][0]["command"]
+                .as_str()
+                .expect("a divert command is a string")
+                .to_string(),
+        );
+    }
+
+    for cmd in &produced {
+        let argv = cmd
+            .strip_prefix(&bin)
+            .unwrap_or_else(|| panic!("{cmd} must start with the resolved binary {bin}"));
+        assert!(
+            is_build_tree_hook_command(&format!("{EPHEMERAL_EXE}{argv}")),
+            "argv {argv:?} is not in the #7262 classifier's vocabulary"
+        );
+    }
+
+    let statusline = super::super::settings::resolve_statusline_command();
+    let argv = statusline
+        .strip_prefix(&bin)
+        .unwrap_or_else(|| panic!("{statusline} must start with the resolved binary {bin}"));
+    assert!(
+        is_build_tree_statusline_command(&format!("{EPHEMERAL_EXE}{argv}")),
+        "statusLine argv {argv:?} is not in the #7262 classifier's vocabulary"
+    );
+}

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -14,6 +14,20 @@ use std::path::{Path, PathBuf};
 use super::PrepError;
 use crate::core::standalone::hooks::backup;
 
+/// The `tm hook` sub-flag the PM enforcement guard is invoked with.
+///
+/// Why: [`pm_guard_hook_value`] writes this shape and
+/// [`super::project_hooks::is_project_managed_hook_command`] must recognise
+/// exactly what was written, or the replace-by-identity strip stops matching
+/// and every relaunch appends a duplicate group (#2948). #7262 added a third
+/// reader — the build-tree classifier — so the literal now lives in the lower
+/// layer beside the other argv tails and is re-exported here rather than
+/// spelled out in each module, mirroring
+/// [`super::divert_hooks::DIVERT_CHECK_SUFFIX`].
+/// What: the literal suffix, including its leading space.
+/// Test: `pm_guard_and_divert_commands_end_in_a_known_argv_tail`.
+pub(super) use crate::core::standalone::hooks::build_tree::PM_GUARD_SUFFIX;
+
 /// Default Claude Code output style applied to launched sessions.
 ///
 /// Why: the Claude Code status bar renders `style:<outputStyle>`; when no style
@@ -444,7 +458,7 @@ pub(super) fn pm_guard_hook_value() -> serde_json::Value {
             "hooks": [
                 {
                     "type": "command",
-                    "command": format!("{} hook --pm-guard", resolve_statusline_binary()),
+                    "command": format!("{}{PM_GUARD_SUFFIX}", resolve_statusline_binary()),
                     "timeout": 10
                 }
             ]

--- a/crates/trusty-mpm/src/core/standalone/hooks/build_tree.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/build_tree.rs
@@ -41,17 +41,17 @@ use std::path::Path;
 ///
 /// Why (#7262): the second half of the two-part test above. Each entry is a
 /// shape one of tm's writers produces: `" hook"` is the six-event lifecycle
-/// triad ([`super::mpm_hook_additions_with_exe`]), `" hook --pm-guard"` the PM
+/// triad ([`super::mpm_hook_additions_with_exe`]), [`PM_GUARD_SUFFIX`] the PM
 /// enforcement guard, and [`DIVERT_CHECK_SUFFIX`] the #6887 bulk-read diversion
 /// groups. Anything else is not tm's to classify.
 /// What: the three tails, matched as exact string suffixes so the whole prefix
 /// is the executable path — spaces in that path included. They are mutually
-/// exclusive: a command ending in `" hook --pm-guard"` cannot also end in
+/// exclusive: a command ending in [`PM_GUARD_SUFFIX`] cannot also end in
 /// `" hook"`.
 /// Test: `build_tree_hook_command_matches_every_tm_argv_shape`,
 /// `pm_guard_and_divert_commands_end_in_a_known_argv_tail` (the drift guard, in
 /// `session_launch::project_hooks_tests`).
-const TM_HOOK_ARGV_TAILS: &[&str] = &[" hook", " hook --pm-guard", DIVERT_CHECK_SUFFIX];
+const TM_HOOK_ARGV_TAILS: &[&str] = &[" hook", PM_GUARD_SUFFIX, DIVERT_CHECK_SUFFIX];
 
 /// The `statusLine.command` argv tail (`#4492`, `#7262`).
 ///
@@ -74,6 +74,23 @@ const STATUSLINE_ARGV_TAIL: &str = " statusline";
 /// What: the suffix `divert_hook_groups` appends to the resolved binary.
 /// Test: `is_project_managed_hook_command_recognises_divert_check`.
 pub(crate) const DIVERT_CHECK_SUFFIX: &str = " hook --divert-check";
+
+/// The `hook --pm-guard` argv tail (#1914, #7262).
+///
+/// Why: three modules read or write this exact shape — the writer
+/// (`session_launch::settings::pm_guard_hook_value`), the strip's identity
+/// predicate (`session_launch::project_hooks::is_project_managed_hook_command`),
+/// and [`TM_HOOK_ARGV_TAILS`] here. Each spelled the literal itself, so a
+/// change to the sub-flag would have silently split them: the writer would
+/// persist a shape the strip no longer recognises, and every relaunch would
+/// append a duplicate group instead of replacing one — the #2948 failure mode.
+/// One definition in the lowest layer, re-used upward, is the same fix
+/// [`DIVERT_CHECK_SUFFIX`] already applies to the sibling shape.
+/// What: the literal suffix, including its leading space.
+/// Test: `pm_guard_and_divert_commands_end_in_a_known_argv_tail` (the drift
+/// guard, in `session_launch::project_hooks_tests`),
+/// `build_tree_hook_command_matches_every_tm_argv_shape`.
+pub(crate) const PM_GUARD_SUFFIX: &str = " hook --pm-guard";
 
 /// Does `cmd` invoke a hook from a binary inside a Cargo build tree?
 ///

--- a/crates/trusty-mpm/src/core/standalone/hooks/build_tree.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/build_tree.rs
@@ -1,0 +1,131 @@
+//! Recognise a persisted hook (or `statusLine`) command whose executable lives
+//! in a Cargo build tree, whatever the binary is named (issue #7262).
+//!
+//! Why: [`super::is_mpm_hash_suffixed_artifact`] asks two questions at once —
+//! is the stem one of ours, and is the path a `deps/` directory — and answers
+//! "not ours" when either fails. #7244 wrote
+//! `<repo>/target-7247/debug/deps/test_session_lifecycle-<hash> hook --pm-guard`
+//! into a real project's `settings.json` seven times in one day: the stem is a
+//! test binary's, so neither `tm hooks clean` nor `tm doctor` could see it, and
+//! [`super::write_project_hooks`]'s strip-by-identity step added a correct
+//! group BESIDE the broken one instead of replacing it. The corruption is not
+//! about the stem. Nothing tm persists may ever point into a build tree, so
+//! asking WHERE the executable lives — and nothing about its name — closes the
+//! whole class, including stems nobody has produced yet.
+//!
+//! What: [`is_build_tree_hook_command`] and [`is_build_tree_statusline_command`]
+//! split the command string at one of [`TM_HOOK_ARGV_TAILS`] /
+//! [`STATUSLINE_ARGV_TAIL`] and ask
+//! [`trusty_common::bin_resolve::is_ephemeral_build_path`] about the executable
+//! half. [`super::is_mpm_hook_command`] consults the first, so the ONE
+//! classifier every consumer already shares — the doctor probe, `tm hooks
+//! clean`, and both writers' replace-by-identity strips — sees this shape
+//! without a second predicate to keep in sync.
+//!
+//! **Where the line is drawn.** A build-tree path ALONE is not enough: a
+//! project may legitimately register its own hook that happens to live under
+//! `target/debug`, and tm must not delete another owner's entry. Both halves
+//! must hold — the executable is in a Cargo build tree AND the argv after it is
+//! one of the four shapes tm itself writes. A command tm never writes
+//! (`<build-tree>/mytool --check`, `<build-tree>/tm lint`) is left untouched no
+//! matter where it lives. The residual overlap is a foreign binary invoked with
+//! tm's exact argv from inside a Cargo build tree; that command is already dead
+//! (the artifact is deleted by the next `cargo build`), and `tm hooks clean`'s
+//! dry run prints every matched command before `--force` removes anything.
+//!
+//! Test: `build_tree_tests.rs`.
+
+use std::path::Path;
+
+/// The `hook` sub-command argv tails tm persists into a settings file.
+///
+/// Why (#7262): the second half of the two-part test above. Each entry is a
+/// shape one of tm's writers produces: `" hook"` is the six-event lifecycle
+/// triad ([`super::mpm_hook_additions_with_exe`]), `" hook --pm-guard"` the PM
+/// enforcement guard, and [`DIVERT_CHECK_SUFFIX`] the #6887 bulk-read diversion
+/// groups. Anything else is not tm's to classify.
+/// What: the three tails, matched as exact string suffixes so the whole prefix
+/// is the executable path — spaces in that path included. They are mutually
+/// exclusive: a command ending in `" hook --pm-guard"` cannot also end in
+/// `" hook"`.
+/// Test: `build_tree_hook_command_matches_every_tm_argv_shape`,
+/// `pm_guard_and_divert_commands_end_in_a_known_argv_tail` (the drift guard, in
+/// `session_launch::project_hooks_tests`).
+const TM_HOOK_ARGV_TAILS: &[&str] = &[" hook", " hook --pm-guard", DIVERT_CHECK_SUFFIX];
+
+/// The `statusLine.command` argv tail (`#4492`, `#7262`).
+///
+/// Why: `statusLine.command` is written by a different code path than the hook
+/// groups (`session_launch::settings::resolve_statusline_binary_with`) and is
+/// not repaired by the hooks writer, so it is deliberately NOT in
+/// [`TM_HOOK_ARGV_TAILS`] — a strip that removed it would silently drop a key
+/// no writer here puts back. Detection still has to name it, which is what this
+/// separate tail is for.
+/// What: the one tail `resolve_statusline_command` appends.
+/// Test: `build_tree_statusline_command_flags_a_build_tree_binary`.
+const STATUSLINE_ARGV_TAIL: &str = " statusline";
+
+/// The `hook --divert-check` argv tail (#6887).
+///
+/// Why (#7262): `session_launch::divert_hooks` used to own this literal and
+/// this module needs the same string. Defining it in the lower layer and
+/// re-using it there keeps ONE definition, so the diversion shape cannot drift
+/// out of [`TM_HOOK_ARGV_TAILS`] the way a copied literal would.
+/// What: the suffix `divert_hook_groups` appends to the resolved binary.
+/// Test: `is_project_managed_hook_command_recognises_divert_check`.
+pub(crate) const DIVERT_CHECK_SUFFIX: &str = " hook --divert-check";
+
+/// Does `cmd` invoke a hook from a binary inside a Cargo build tree?
+///
+/// Why (#7262): the predicate [`super::is_mpm_hook_command`] consults so every
+/// consumer — the `tm doctor` hook-hygiene probe, `tm hooks clean`, and the
+/// replace-by-identity strip in both writers — classifies the #7244 corruption
+/// identically, without any of them growing its own copy of the rule.
+/// What: `true` when `cmd` ends with one of [`TM_HOOK_ARGV_TAILS`] and the
+/// remaining prefix is an ABSOLUTE path that
+/// [`trusty_common::bin_resolve::is_ephemeral_build_path`] rejects (any
+/// `target*/{debug,release}` layout, a `CARGO_TARGET_DIR` tree, a
+/// `.claude/worktrees/` checkout, or a system temp root). A relative prefix is
+/// never matched: tm always persists an absolute path, so a bare `tm hook`
+/// belongs to the exact-name branch, not this one.
+/// Test: `build_tree_hook_command_flags_the_incident_shape`,
+/// `build_tree_hook_command_matches_every_tm_argv_shape`,
+/// `build_tree_hook_command_ignores_an_installed_binary`,
+/// `build_tree_hook_command_ignores_a_foreign_argv_shape`.
+pub fn is_build_tree_hook_command(cmd: &str) -> bool {
+    exe_in_build_tree(cmd, TM_HOOK_ARGV_TAILS)
+}
+
+/// Does `cmd` invoke `statusline` from a binary inside a Cargo build tree?
+///
+/// Why (#7262, #4492): the `statusLine.command` half of the same corruption.
+/// `tm doctor` must NAME it — an operator whose statusline points at a deleted
+/// test harness sees a blank segment and no error anywhere — but the hooks
+/// writer does not own that key, so nothing here removes it.
+/// What: [`is_build_tree_hook_command`]'s rule against
+/// [`STATUSLINE_ARGV_TAIL`] instead of the hook tails.
+/// Test: `build_tree_statusline_command_flags_a_build_tree_binary`,
+/// `build_tree_statusline_command_ignores_an_installed_binary`.
+pub fn is_build_tree_statusline_command(cmd: &str) -> bool {
+    exe_in_build_tree(cmd, &[STATUSLINE_ARGV_TAIL])
+}
+
+/// Shared rule behind both predicates above.
+///
+/// Why: the two differ only in which argv tails they accept; the path test is
+/// the same question and must not be answered twice.
+/// What: finds the first `tails` entry that is a suffix of `cmd`, then returns
+/// whether the remaining prefix is an absolute build-tree path.
+fn exe_in_build_tree(cmd: &str, tails: &[&str]) -> bool {
+    let Some(exe) = tails.iter().find_map(|tail| cmd.strip_suffix(tail)) else {
+        return false;
+    };
+    let path = Path::new(exe);
+    path.is_absolute() && trusty_common::bin_resolve::is_ephemeral_build_path(path)
+}
+
+// `pub(crate)` so the #7244 incident fixture below is written ONCE and shared
+// by the cleanup, writer, and `tm doctor` regression tests (#7262).
+#[cfg(test)]
+#[path = "build_tree_tests.rs"]
+pub(crate) mod tests;

--- a/crates/trusty-mpm/src/core/standalone/hooks/build_tree_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/build_tree_tests.rs
@@ -1,0 +1,144 @@
+//! Unit tests for [`super`] (the #7262 build-tree hook-command classifier).
+//!
+//! Why: split out of `build_tree.rs` to keep the production file focused;
+//! mirrors the `hooks/{cleanup.rs,cleanup_tests.rs}` split already used here.
+//! What: pins the incident shape from #7244, the four argv shapes, the
+//! installed-binary negative, and the argv restriction that keeps a project's
+//! own build-tree hook out of tm's hands.
+//! Test: this module IS the test suite for `super`.
+
+use super::*;
+
+/// The exact executable #7244 wrote into `.claude/settings.json`, seven times
+/// on 2026-09-09.
+pub(crate) const INCIDENT_EXE: &str = "/Users/masa/trusty-mpm-projects/bobmatnyc/trusty-tools/target-7247/debug/deps/test_session_lifecycle-cd3ba8f03938239b";
+
+/// A `hooks` group wrapping one command, in Claude Code's settings shape.
+fn group(cmd: &str) -> serde_json::Value {
+    serde_json::json!({
+        "matcher": "*",
+        "hooks": [{ "type": "command", "command": cmd, "timeout": 5 }]
+    })
+}
+
+/// The settings file `.claude/settings.json` actually carried after #7244.
+///
+/// Why: the ONE fixture behind every #7262 regression test — the doctor probe,
+/// `clean_settings_file`, and the writer's replace-by-identity strip. Written
+/// once so the three cannot drift onto slightly different shapes and each claim
+/// to cover "the incident".
+/// What: the six lifecycle events plus the PM-guard group, every one pointing
+/// at [`INCIDENT_EXE`]; a `statusLine.command` pointing at the same binary; and
+/// a correct `trusty-memory prompt-context` entry under `UserPromptSubmit` that
+/// every consumer must leave alone.
+/// Test: used by `build_tree_hook_commands_lists_the_incident_commands`,
+/// `clean_settings_file_force_removes_the_build_tree_incident`,
+/// `write_project_hooks_replaces_a_build_tree_group_instead_of_duplicating_it`,
+/// `check_hooks_hygiene_reports_the_build_tree_incident_shape`.
+pub(crate) fn incident_settings() -> serde_json::Value {
+    let hook = format!("{INCIDENT_EXE} hook");
+    serde_json::json!({
+        "outputStyle": "trusty-mpm",
+        "statusLine": {
+            "type": "command",
+            "command": format!("{INCIDENT_EXE} statusline"),
+            "padding": 0
+        },
+        "hooks": {
+            "PreToolUse": [
+                group(&hook),
+                group(&format!("{INCIDENT_EXE} hook --pm-guard")),
+            ],
+            "PostToolUse": [group(&hook)],
+            "Stop": [group(&hook)],
+            "SubagentStop": [group(&hook)],
+            "SessionStart": [group(&hook)],
+            "SessionEnd": [group(&hook)],
+            "UserPromptSubmit": [group("trusty-memory prompt-context")],
+        }
+    })
+}
+
+#[test]
+fn build_tree_hook_command_flags_the_incident_shape() {
+    assert!(is_build_tree_hook_command(&format!(
+        "{INCIDENT_EXE} hook --pm-guard"
+    )));
+    assert!(is_build_tree_hook_command(&format!("{INCIDENT_EXE} hook")));
+}
+
+#[test]
+fn build_tree_hook_command_matches_every_tm_argv_shape() {
+    for tail in TM_HOOK_ARGV_TAILS {
+        assert!(
+            is_build_tree_hook_command(&format!("{INCIDENT_EXE}{tail}")),
+            "tail {tail:?} was not recognised"
+        );
+    }
+}
+
+#[test]
+fn build_tree_hook_command_flags_other_build_layouts() {
+    for exe in [
+        "/repo/target/debug/deps/whatever-0123456789abcdef",
+        "/repo/target/release/some_bin",
+        "/repo/target-7224/debug/tm",
+        "/home/me/.claude/worktrees/agent-abc/target/debug/deps/x-0123456789abcdef",
+    ] {
+        assert!(
+            is_build_tree_hook_command(&format!("{exe} hook")),
+            "{exe} was not recognised as a build-tree path"
+        );
+    }
+}
+
+#[test]
+fn build_tree_hook_command_ignores_an_installed_binary() {
+    assert!(!is_build_tree_hook_command("/usr/local/bin/tm hook"));
+    assert!(!is_build_tree_hook_command(
+        "/Users/masa/.cargo/bin/tm hook --pm-guard"
+    ));
+    // Relative/bare names are the exact-name branch's business, not this one's.
+    assert!(!is_build_tree_hook_command("tm hook"));
+}
+
+#[test]
+fn build_tree_hook_command_ignores_a_foreign_argv_shape() {
+    // The line drawn in the module doc: a build-tree path alone never suffices.
+    for cmd in [
+        format!("{INCIDENT_EXE} --check"),
+        format!("{INCIDENT_EXE} lint --fix"),
+        format!("{INCIDENT_EXE} hookup"),
+        format!("{INCIDENT_EXE} hook --pm-guard --extra"),
+    ] {
+        assert!(
+            !is_build_tree_hook_command(&cmd),
+            "{cmd} should not be claimed"
+        );
+    }
+}
+
+#[test]
+fn build_tree_statusline_command_flags_a_build_tree_binary() {
+    assert!(is_build_tree_statusline_command(&format!(
+        "{INCIDENT_EXE} statusline"
+    )));
+}
+
+#[test]
+fn build_tree_statusline_command_ignores_an_installed_binary() {
+    assert!(!is_build_tree_statusline_command(
+        "/usr/local/bin/tm statusline"
+    ));
+    assert!(!is_build_tree_statusline_command("tm statusline"));
+}
+
+#[test]
+fn statusline_tail_is_not_a_hook_tail() {
+    // The two lists must stay disjoint: a strip driven by the hook predicate
+    // must never claim a `statusLine` command it does not put back.
+    assert!(!is_build_tree_hook_command(&format!(
+        "{INCIDENT_EXE} statusline"
+    )));
+    assert!(!TM_HOOK_ARGV_TAILS.contains(&STATUSLINE_ARGV_TAIL));
+}

--- a/crates/trusty-mpm/src/core/standalone/hooks/build_tree_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/build_tree_tests.rs
@@ -9,9 +9,19 @@
 
 use super::*;
 
-/// The exact executable #7244 wrote into `.claude/settings.json`, seven times
+/// The executable SHAPE #7244 wrote into `.claude/settings.json`, seven times
 /// on 2026-09-09.
-pub(crate) const INCIDENT_EXE: &str = "/Users/masa/trusty-mpm-projects/bobmatnyc/trusty-tools/target-7247/debug/deps/test_session_lifecycle-cd3ba8f03938239b";
+///
+/// Why: the repository prefix is synthetic. What the predicate reads is the
+/// Cargo layout — a `target-<n>` build root, a `debug` profile under it, a
+/// `deps` directory under that, and a hash-suffixed test-harness stem — and
+/// none of those components is the home directory the incident happened to
+/// occur in. Baking a real `$HOME` into a fixture leaks an operator path into
+/// the repository for no test value, so the prefix is a placeholder and the
+/// four load-bearing components are preserved verbatim.
+/// Test: every test in this file, plus the `incident_settings` consumers.
+pub(crate) const INCIDENT_EXE: &str =
+    "/srv/projects/acme/target-7247/debug/deps/test_session_lifecycle-cd3ba8f03938239b";
 
 /// A `hooks` group wrapping one command, in Claude Code's settings shape.
 fn group(cmd: &str) -> serde_json::Value {
@@ -96,7 +106,7 @@ fn build_tree_hook_command_flags_other_build_layouts() {
 fn build_tree_hook_command_ignores_an_installed_binary() {
     assert!(!is_build_tree_hook_command("/usr/local/bin/tm hook"));
     assert!(!is_build_tree_hook_command(
-        "/Users/masa/.cargo/bin/tm hook --pm-guard"
+        "/opt/tm/bin/tm hook --pm-guard"
     ));
     // Relative/bare names are the exact-name branch's business, not this one's.
     assert!(!is_build_tree_hook_command("tm hook"));

--- a/crates/trusty-mpm/src/core/standalone/hooks/cleanup.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/cleanup.rs
@@ -15,6 +15,10 @@
 //! entries; [`foreign_hook_event_names`] detects a DIFFERENT harness's hooks
 //! (informational only — never removed); [`clean_settings_file`] performs the
 //! actual scan-or-apply pass over one file, always backing up before writing.
+//! [`build_tree_hook_commands`] / [`build_tree_statusline_command`] (#7262)
+//! name the individual commands whose executable lives in a Cargo build tree,
+//! so `tm doctor` can report WHICH command is broken rather than only how many
+//! files are affected.
 //!
 //! Known limitations:
 //! - **Mixed hook groups (issue #2948, RESOLVED).** [`event_names_matching`]
@@ -40,6 +44,15 @@
 //!   the same pre-existing residual risk. Dry-run mode always prints the
 //!   exact matched command strings before any deletion (see `commands::hooks::clean`)
 //!   so an operator can review before applying `--force`.
+//! - **Both name branches miss a stem they do not ship (issue #7262, RESOLVED
+//!   for the build-tree case).** [`super::is_mpm_hook_command`] now consults
+//!   [`super::is_build_tree_hook_command`] first, which asks WHERE the
+//!   executable lives instead of what it is called, so a `cargo test` harness
+//!   wired in as a hook — the #7244 incident shape — is classified and removed.
+//!   A build-tree path alone is not enough: the argv must also be one tm
+//!   writes. A foreign binary named neither ours nor build-tree-hosted is still
+//!   invisible here, which is the correct answer for one this crate does not
+//!   own.
 //!
 //! Test: `cargo test -p trusty-mpm standalone::hooks::cleanup` — see
 //! `cleanup_tests.rs`.
@@ -48,7 +61,10 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
-use super::{is_claude_mpm_hook_command, is_mpm_hook_command, strip_mpm_hook_entries};
+use super::{
+    is_build_tree_hook_command, is_build_tree_statusline_command, is_claude_mpm_hook_command,
+    is_mpm_hook_command, strip_mpm_hook_entries,
+};
 
 /// Per-file outcome of a [`clean_settings_file`] pass.
 ///
@@ -119,6 +135,71 @@ pub fn tm_hook_event_names(val: &Value) -> Vec<String> {
 /// `foreign_hook_event_names_flags_mixed_group`.
 pub fn foreign_hook_event_names(val: &Value) -> Vec<String> {
     event_names_matching(val, is_claude_mpm_hook_command)
+}
+
+/// Every hook command in `val` whose executable lives in a Cargo build tree
+/// (issue #7262).
+///
+/// Why: `tm doctor` has to NAME the damage. `hooks_contamination` reports only
+/// how many files carry tm entries, which is the right report for a pre-#2940
+/// install writing a working `tm hook` where it did not belong — and useless
+/// for #7244's corruption, where the entry is tm's own and the fault is the
+/// path inside it. An operator needs to see the exact command before deciding
+/// to let `--fix` remove it.
+/// What: walks every `hooks.<event>[*].hooks[*].command` and collects the
+/// distinct strings [`is_build_tree_hook_command`] claims, in first-seen order.
+/// Empty when `hooks` is absent or not an object. These are the commands the
+/// strip removes, since [`is_mpm_hook_command`] consults the same predicate.
+/// Test: `build_tree_hook_commands_lists_the_incident_commands`,
+/// `build_tree_hook_commands_is_empty_for_an_installed_binary`.
+pub fn build_tree_hook_commands(val: &Value) -> Vec<String> {
+    let Some(hooks) = val.get("hooks").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    let mut found: Vec<String> = Vec::new();
+    for groups in hooks.values() {
+        let Some(groups) = groups.as_array() else {
+            continue;
+        };
+        for group in groups {
+            let Some(inner) = group.get("hooks").and_then(Value::as_array) else {
+                continue;
+            };
+            for cmd in inner
+                .iter()
+                .filter_map(|e| e.get("command").and_then(Value::as_str))
+                .filter(|c| is_build_tree_hook_command(c))
+            {
+                if !found.iter().any(|seen| seen == cmd) {
+                    found.push(cmd.to_string());
+                }
+            }
+        }
+    }
+    found
+}
+
+/// The `statusLine.command` when it points into a Cargo build tree (#7262).
+///
+/// Why: the same corruption reaches `statusLine.command` (#4492 is the earlier
+/// instance), where it costs the operator their whole statusline with no error
+/// printed anywhere. Detection must name it. Repair does not follow: the hooks
+/// writer does not own this key, and stripping it would leave the file with no
+/// statusline at all rather than a corrected one — `session_launch::settings`
+/// upgrades it in place on the next managed launch, via its
+/// `is_stale_statusline_command`, which already treats an ephemeral binary as
+/// stale.
+/// What: reads `statusLine.command` and returns it when
+/// [`is_build_tree_statusline_command`] claims it; `None` for any other shape,
+/// a missing key, or a non-string value.
+/// Test: `build_tree_statusline_command_in_settings_is_reported`,
+/// `build_tree_statusline_command_in_settings_ignores_an_installed_binary`.
+pub fn build_tree_statusline_command(val: &Value) -> Option<String> {
+    val.get("statusLine")
+        .and_then(|s| s.get("command"))
+        .and_then(Value::as_str)
+        .filter(|c| is_build_tree_statusline_command(c))
+        .map(str::to_string)
 }
 
 /// Shared walker behind [`tm_hook_event_names`] / [`foreign_hook_event_names`].

--- a/crates/trusty-mpm/src/core/standalone/hooks/cleanup.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/cleanup.rs
@@ -62,8 +62,8 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use super::{
-    is_build_tree_hook_command, is_build_tree_statusline_command, is_claude_mpm_hook_command,
-    is_mpm_hook_command, strip_mpm_hook_entries,
+    build_tree::PM_GUARD_SUFFIX, is_build_tree_hook_command, is_build_tree_statusline_command,
+    is_claude_mpm_hook_command, is_mpm_hook_command, strip_mpm_hook_entries,
 };
 
 /// Per-file outcome of a [`clean_settings_file`] pass.
@@ -72,8 +72,9 @@ use super::{
 /// did (`--force`) per file, without re-deriving the event list from the
 /// mutated value after the fact.
 /// What: the scanned file's path, the `hooks` event keys that carried at
-/// least one tm-owned group, and — only when the caller passed `force: true`
-/// and a write actually happened — the backup file's path.
+/// least one tm-owned group, whether one of the removed entries was the PM
+/// enforcement guard, and — only when the caller passed `force: true` and a
+/// write actually happened — the backup file's path.
 /// Test: `clean_settings_file_dry_run_reports_without_writing`,
 /// `clean_settings_file_force_writes_backup_and_strips`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,6 +83,14 @@ pub struct CleanOutcome {
     pub path: PathBuf,
     /// `hooks` event keys (e.g. `PreToolUse`) that contained a tm-owned group.
     pub removed_events: Vec<String>,
+    /// Whether one of those entries was the `PreToolUse` PM-guard command.
+    ///
+    /// Why (#7262): removing it takes PM enforcement offline, and nothing puts
+    /// it back until the project's next managed `tm` launch re-renders the
+    /// hooks. That consequence is invisible in an event-name list, so a caller
+    /// reporting the repair cannot warn about it without this flag.
+    /// What: see [`strips_pm_guard_entry`], computed before the strip.
+    pub removed_pm_guard: bool,
     /// The backup file written before mutating `path`, when `force` was set.
     pub backup_path: Option<PathBuf>,
 }
@@ -153,30 +162,56 @@ pub fn foreign_hook_event_names(val: &Value) -> Vec<String> {
 /// Test: `build_tree_hook_commands_lists_the_incident_commands`,
 /// `build_tree_hook_commands_is_empty_for_an_installed_binary`.
 pub fn build_tree_hook_commands(val: &Value) -> Vec<String> {
-    let Some(hooks) = val.get("hooks").and_then(Value::as_object) else {
-        return Vec::new();
-    };
     let mut found: Vec<String> = Vec::new();
-    for groups in hooks.values() {
-        let Some(groups) = groups.as_array() else {
-            continue;
-        };
-        for group in groups {
-            let Some(inner) = group.get("hooks").and_then(Value::as_array) else {
-                continue;
-            };
-            for cmd in inner
-                .iter()
-                .filter_map(|e| e.get("command").and_then(Value::as_str))
-                .filter(|c| is_build_tree_hook_command(c))
-            {
-                if !found.iter().any(|seen| seen == cmd) {
-                    found.push(cmd.to_string());
-                }
-            }
+    for cmd in hook_commands(val).filter(|c| is_build_tree_hook_command(c)) {
+        if !found.iter().any(|seen| seen == cmd) {
+            found.push(cmd.to_string());
         }
     }
     found
+}
+
+/// Every `hooks.<event>[*].hooks[*].command` string in `val`, in document
+/// order.
+///
+/// Why (#7262): two readers here — [`build_tree_hook_commands`] and
+/// [`strips_pm_guard_entry`] — ask different questions of the SAME traversal.
+/// Walking the four nesting levels twice would let the two drift onto
+/// different notions of where a command lives.
+/// What: yields the `command` string of every entry, skipping any level whose
+/// JSON shape is not the expected object/array. A missing or non-object
+/// `hooks` key yields nothing.
+/// Test: exercised through both callers'
+/// tests (`build_tree_hook_commands_lists_the_incident_commands`,
+/// `clean_settings_file_flags_a_removed_pm_guard_entry`).
+fn hook_commands(val: &Value) -> impl Iterator<Item = &str> {
+    val.get("hooks")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|hooks| hooks.values())
+        .filter_map(Value::as_array)
+        .flatten()
+        .filter_map(|group| group.get("hooks").and_then(Value::as_array))
+        .flatten()
+        .filter_map(|entry| entry.get("command").and_then(Value::as_str))
+}
+
+/// Would a strip of `val` remove the PM enforcement guard's entry?
+///
+/// Why (#7262): `tm doctor --fix` prints one line per repair, and "remove tm
+/// hook entries under [PreToolUse]" does not tell the operator that PM
+/// enforcement just went offline. Nothing re-registers the guard until the
+/// project's next managed `tm` launch, so the consequence outlives the repair
+/// and has to be said out loud.
+/// What: `true` when any hook command ends with [`PM_GUARD_SUFFIX`] AND
+/// [`is_mpm_hook_command`] claims it — the same predicate
+/// [`strip_mpm_hook_entries`] removes by, so this can never report a removal
+/// that will not happen. In practice that pairing is only satisfiable by a
+/// build-tree executable (the #7244 shape): an INSTALLED
+/// `<abs>/tm hook --pm-guard` is left in place, and correctly reports `false`.
+/// Test: `strips_pm_guard_entry_is_true_only_for_a_removable_guard`.
+pub fn strips_pm_guard_entry(val: &Value) -> bool {
+    hook_commands(val).any(|cmd| cmd.ends_with(PM_GUARD_SUFFIX) && is_mpm_hook_command(cmd))
 }
 
 /// The `statusLine.command` when it points into a Cargo build tree (#7262).
@@ -256,7 +291,8 @@ fn event_names_matching(val: &Value, matches_cmd: impl Fn(&str) -> bool) -> Vec<
 /// What: reads `path` (missing file → `Ok(None)`, malformed/non-object JSON →
 /// `Ok(None)` — never touched), returns `Ok(None)` when
 /// [`contains_tm_hooks`] is `false`. Otherwise computes the contaminated
-/// event list, and when `force` is `true`: writes a byte-identical backup of
+/// event list and the [`CleanOutcome::removed_pm_guard`] flag (both BEFORE any
+/// mutation), and when `force` is `true`: writes a byte-identical backup of
 /// the pre-clean text to `<path>.bak-<unix-epoch-seconds>` (this crate's own
 /// backup, reported via [`CleanOutcome::backup_path`]; `write_json_atomic`
 /// additionally maintains its own internal `<path>.bak`, a harmless second
@@ -289,6 +325,8 @@ pub fn clean_settings_file(path: &Path, force: bool) -> anyhow::Result<Option<Cl
     if removed_events.is_empty() {
         return Ok(None);
     }
+    // #7262: computed BEFORE the strip below mutates the entry away.
+    let removed_pm_guard = strips_pm_guard_entry(&val);
 
     let mut backup_path = None;
     if force {
@@ -310,6 +348,7 @@ pub fn clean_settings_file(path: &Path, force: bool) -> anyhow::Result<Option<Cl
     Ok(Some(CleanOutcome {
         path: path.to_path_buf(),
         removed_events,
+        removed_pm_guard,
         backup_path,
     }))
 }

--- a/crates/trusty-mpm/src/core/standalone/hooks/cleanup_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/cleanup_tests.rs
@@ -313,3 +313,100 @@ fn clean_settings_file_non_object_json_is_noop() {
         "a non-object JSON file must never get a backup written"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #7262: the build-tree classifier's reporting and repair surface. Every test
+// below FAILS on 1ba38636c, where `is_mpm_hook_command` judged a hook command
+// purely by the binary's NAME.
+// ---------------------------------------------------------------------------
+
+use super::super::build_tree::tests::{INCIDENT_EXE, incident_settings};
+
+#[test]
+fn build_tree_hook_commands_lists_the_incident_commands() {
+    let found = build_tree_hook_commands(&incident_settings());
+    assert_eq!(
+        found,
+        vec![
+            format!("{INCIDENT_EXE} hook"),
+            format!("{INCIDENT_EXE} hook --pm-guard"),
+        ],
+        "every distinct build-tree hook command must be named, once each"
+    );
+}
+
+#[test]
+fn build_tree_hook_commands_is_empty_for_an_installed_binary() {
+    assert!(build_tree_hook_commands(&tm_settings()).is_empty());
+    assert!(build_tree_hook_commands(&claude_mpm_settings()).is_empty());
+}
+
+#[test]
+fn build_tree_statusline_command_in_settings_is_reported() {
+    assert_eq!(
+        build_tree_statusline_command(&incident_settings()),
+        Some(format!("{INCIDENT_EXE} statusline"))
+    );
+}
+
+#[test]
+fn build_tree_statusline_command_in_settings_ignores_an_installed_binary() {
+    let val = json!({
+        "statusLine": { "type": "command", "command": "/usr/local/bin/tm statusline" }
+    });
+    assert_eq!(build_tree_statusline_command(&val), None);
+    assert_eq!(build_tree_statusline_command(&tm_settings()), None);
+}
+
+#[test]
+fn tm_hook_event_names_flags_the_build_tree_incident() {
+    // Before #7262 this returned an empty list: neither name branch recognises
+    // the `test_session_lifecycle` stem, so `tm doctor` saw nothing at all.
+    let mut events = tm_hook_event_names(&incident_settings());
+    events.sort();
+    assert_eq!(
+        events,
+        vec![
+            "PostToolUse",
+            "PreToolUse",
+            "SessionEnd",
+            "SessionStart",
+            "Stop",
+            "SubagentStop",
+        ]
+    );
+}
+
+#[test]
+fn clean_settings_file_force_removes_the_build_tree_incident() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&incident_settings()).unwrap(),
+    )
+    .unwrap();
+
+    let outcome = clean_settings_file(&path, true)
+        .unwrap()
+        .expect("the incident shape must be reported as contamination");
+    assert!(outcome.backup_path.is_some(), "a --force pass must back up");
+
+    let cleaned: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert!(
+        build_tree_hook_commands(&cleaned).is_empty(),
+        "no build-tree hook command may survive: {cleaned}"
+    );
+    // The project's own entry, and every unrelated key, survive untouched.
+    assert_eq!(
+        cleaned["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
+        json!("trusty-memory prompt-context")
+    );
+    assert_eq!(cleaned["outputStyle"], json!("trusty-mpm"));
+    // statusLine is detection-only: `clean_settings_file` does not own that key
+    // and must not strip what it cannot put back.
+    assert_eq!(
+        build_tree_statusline_command(&cleaned),
+        Some(format!("{INCIDENT_EXE} statusline"))
+    );
+}

--- a/crates/trusty-mpm/src/core/standalone/hooks/cleanup_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/cleanup_tests.rs
@@ -359,6 +359,46 @@ fn build_tree_statusline_command_in_settings_ignores_an_installed_binary() {
 }
 
 #[test]
+fn strips_pm_guard_entry_is_true_only_for_a_removable_guard() {
+    // The incident file's `PreToolUse` guard is build-tree-rooted, so the strip
+    // takes it and the caller must be told.
+    assert!(strips_pm_guard_entry(&incident_settings()));
+
+    // An INSTALLED guard carries the same argv but survives the strip, so
+    // reporting it removed would be a lie.
+    let installed = json!({
+        "hooks": {
+            "PreToolUse": [{
+                "hooks": [{ "command": "/usr/local/bin/tm hook --pm-guard" }]
+            }]
+        }
+    });
+    assert!(!strips_pm_guard_entry(&installed));
+
+    // A contaminated file with no guard at all.
+    assert!(!strips_pm_guard_entry(&tm_settings()));
+    assert!(!strips_pm_guard_entry(&json!({})));
+}
+
+#[test]
+fn clean_settings_file_flags_a_removed_pm_guard_entry() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("settings.json");
+
+    std::fs::write(&path, incident_settings().to_string()).unwrap();
+    let outcome = clean_settings_file(&path, false).unwrap().unwrap();
+    assert!(
+        outcome.removed_pm_guard,
+        "the incident file's guard is removable: {outcome:?}"
+    );
+
+    // Same reader, a file whose only tm entry is the lifecycle triad.
+    std::fs::write(&path, tm_settings().to_string()).unwrap();
+    let outcome = clean_settings_file(&path, false).unwrap().unwrap();
+    assert!(!outcome.removed_pm_guard, "{outcome:?}");
+}
+
+#[test]
 fn tm_hook_event_names_flags_the_build_tree_incident() {
     // Before #7262 this returned an empty list: neither name branch recognises
     // the `test_session_lifecycle` stem, so `tm doctor` saw nothing at all.

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -40,7 +40,10 @@
 mod tests;
 
 pub(crate) mod backup;
+pub mod build_tree;
 pub mod cleanup;
+
+pub use build_tree::{is_build_tree_hook_command, is_build_tree_statusline_command};
 
 use std::path::{Path, PathBuf};
 
@@ -470,7 +473,17 @@ fn is_mpm_hash_suffixed_artifact(path: &Path) -> bool {
 /// `"/opt/bin/trusty-mpm hook"`) OR the full prefix is recognised by
 /// [`is_mpm_hash_suffixed_artifact`] (hash-suffixed build artifacts under a
 /// `deps/` directory — `".../deps/trusty_mpm-<hash> hook"`).
+///
+/// #7262: BEFORE either of those, [`build_tree::is_build_tree_hook_command`]
+/// claims any command whose executable lives in a Cargo build tree and whose
+/// argv is one of tm's hook shapes — regardless of stem. Both name branches ask
+/// what the binary is called, so neither could see
+/// `".../target-7247/debug/deps/test_session_lifecycle-<hash> hook --pm-guard"`,
+/// and the strip below therefore duplicated rather than replaced it. That arm
+/// also widens this predicate past the ` hook` suffix, to the `--pm-guard` and
+/// `--divert-check` shapes, but ONLY for a build-tree executable.
 /// Test: `remove_global_hooks_at_strips_only_the_two_global_files`,
+/// `is_mpm_hook_command_claims_the_build_tree_incident_shape`,
 /// `test_is_mpm_hook_command_recognises_tm_bin_name`,
 /// `test_is_mpm_hook_command_recognises_stale_hash_and_mvp_variants`,
 /// `test_is_mpm_hook_command_rejects_hash_suffixed_binary_outside_deps_dir`,
@@ -482,6 +495,13 @@ fn is_mpm_hash_suffixed_artifact(path: &Path) -> bool {
 /// contamination scan and the removal logic can never classify a command
 /// differently.
 pub fn is_mpm_hook_command(cmd: &str) -> bool {
+    // #7262: a build-tree executable is contamination whatever it is named, and
+    // it carries the `--pm-guard` / `--divert-check` argv shapes the ` hook`
+    // suffix check below cannot reach. Asked first so the answer never depends
+    // on a stem this crate happens to recognise.
+    if build_tree::is_build_tree_hook_command(cmd) {
+        return true;
+    }
     // The command must end with " hook" (with exactly one trailing sub-command word).
     let Some(binary) = cmd.strip_suffix(" hook") else {
         return false;

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -1324,3 +1324,87 @@ fn write_project_hooks_aborts_the_rewrite_when_the_snapshot_fails() {
         "the settings file must be untouched when its snapshot could not be taken"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #7262: the writer's replace-by-identity strip against the #7244 incident
+// shape. Both FAIL on 1ba38636c, where the strip could not recognise the
+// `test_session_lifecycle` stem and appended a correct group beside the broken
+// one on every launch.
+// ---------------------------------------------------------------------------
+
+use build_tree::tests::{INCIDENT_EXE, incident_settings};
+
+#[test]
+fn is_mpm_hook_command_claims_the_build_tree_incident_shape() {
+    assert!(is_mpm_hook_command(&format!("{INCIDENT_EXE} hook")));
+    assert!(is_mpm_hook_command(&format!(
+        "{INCIDENT_EXE} hook --pm-guard"
+    )));
+    assert!(is_mpm_hook_command(&format!(
+        "{INCIDENT_EXE} hook --divert-check"
+    )));
+    // Unchanged: a foreign harness's command is still foreign, and an
+    // installed-binary command is still judged by name.
+    assert!(!is_mpm_hook_command("claude-mpm hooks fire PreToolUse"));
+    assert!(is_mpm_hook_command("/usr/local/bin/tm hook"));
+}
+
+#[test]
+fn write_project_hooks_replaces_a_build_tree_group_instead_of_duplicating_it() {
+    let tmp = TempDir::new().unwrap();
+    let settings = tmp.path().join("settings.json");
+    std::fs::write(
+        &settings,
+        serde_json::to_string_pretty(&incident_settings()).unwrap(),
+    )
+    .unwrap();
+
+    let exe = PathBuf::from(STABLE_TEST_EXE);
+    assert!(write_project_hooks(&settings, Some(&exe)).unwrap());
+
+    let val: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&settings).unwrap()).unwrap();
+
+    // One group per lifecycle event, and it names the installed binary.
+    for event in [
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "SubagentStop",
+        "SessionStart",
+        "SessionEnd",
+    ] {
+        let groups = val["hooks"][event].as_array().unwrap();
+        assert_eq!(
+            groups.len(),
+            1,
+            "{event} must collapse to one group, got {groups:?}"
+        );
+        assert_eq!(
+            groups[0]["hooks"][0]["command"],
+            serde_json::json!(format!("{STABLE_TEST_EXE} hook"))
+        );
+    }
+    assert!(
+        !val["hooks"].to_string().contains("test_session_lifecycle"),
+        "no build-tree command may survive the rewrite: {}",
+        val["hooks"]
+    );
+
+    // The project's own entry survives; so does the `statusLine` key, which
+    // this writer does not own (#7262 scope boundary).
+    assert_eq!(
+        val["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
+        serde_json::json!("trusty-memory prompt-context")
+    );
+    assert_eq!(
+        val["statusLine"]["command"],
+        serde_json::json!(format!("{INCIDENT_EXE} statusline"))
+    );
+
+    // Idempotent: further writes are no-ops, so the corruption cannot come back
+    // as a duplicate on the next launch.
+    for _ in 0..3 {
+        assert!(!write_project_hooks(&settings, Some(&exe)).unwrap());
+    }
+}

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1241,6 +1241,7 @@ async fn doctor_endpoint_returns_report() {
         "oauth_token",
         "hooks_contamination",
         "hooks_foreign_conflict",
+        "hooks_build_tree_binary",
         "tcc_taint",
         "scaffold_tracking",
         "push_guard",

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -362,7 +362,7 @@ const PROBE_RETRY_DELAY: Duration = Duration::from_millis(500);
 /// the one tm-managed `CLAUDE_CONFIG_DIR` tier and nowhere else, so
 /// `check_agents`/`check_agent_skills` probe `paths.agent_deploy_dir()`, which
 /// is the same directory whether or not a `project_dir` was supplied.
-/// Test: `run_doctor_produces_forty_two_checks`,
+/// Test: `run_doctor_produces_forty_three_checks`,
 /// `agents_check_probes_the_managed_config_tier_not_the_workspace`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
@@ -476,10 +476,13 @@ pub async fn run_doctor(
     // since an audit that did not run has not found the tickets clean.
     checks.push(check_issue_audit_recent(project_dir).await);
     checks.push(check_oauth_token_config());
-    let (hooks_contamination, hooks_foreign_conflict) =
+    // #7262: the third check names each hook/statusLine command whose binary
+    // lives in a Cargo build tree, which the file-counting check above cannot.
+    let (hooks_contamination, hooks_foreign_conflict, hooks_build_tree_binary) =
         check_hooks_hygiene(project_dir, active_workspace_paths);
     checks.push(hooks_contamination);
     checks.push(hooks_foreign_conflict);
+    checks.push(hooks_build_tree_binary);
     // Issue #2997: surface whether managed panes disclaim TCC responsibility so
     // the "trusty-mpm/tmux would like to access data…" prompt class is
     // diagnosable rather than silent. Synchronous + instantaneous (no log scan).

--- a/crates/trusty-mpm/src/daemon/doctor_hooks_hygiene.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_hooks_hygiene.rs
@@ -13,18 +13,22 @@
 //! (informational only — tm never touches another harness's hooks).
 //! What: [`check_hooks_hygiene`] scans `project_dir` (when given) plus every
 //! currently-live `active_workspace_paths` — the SAME bounded scope
-//! `check_agents`/`check_skills` use — and returns TWO checks:
-//! `hooks_contamination` (`Warn` when any file carries a tm-owned hook group)
-//! and `hooks_foreign_conflict` (`Warn` when any file carries a foreign
-//! claude-mpm hook group).
-//! Test: the `tests` module below covers both checks against temp
+//! `check_agents`/`check_skills` use — and returns THREE checks:
+//! `hooks_contamination` (`Warn` when any file carries a tm-owned hook group),
+//! `hooks_foreign_conflict` (`Warn` when any file carries a foreign claude-mpm
+//! hook group), and `hooks_build_tree_binary` (#7262 — `Warn` naming each hook
+//! or `statusLine` command whose executable lives in a Cargo build tree).
+//! Test: the `tests` module below covers all three checks against temp
 //! directories.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use crate::core::doctor::{CheckStatus, DoctorCheck};
-use crate::core::standalone::hooks::cleanup::{foreign_hook_event_names, tm_hook_event_names};
+use crate::core::standalone::hooks::cleanup::{
+    build_tree_hook_commands, build_tree_statusline_command, foreign_hook_event_names,
+    tm_hook_event_names,
+};
 
 /// Every `.claude/settings*.json` this probe should inspect.
 ///
@@ -87,18 +91,27 @@ pub(crate) fn read_settings(path: &Path) -> Option<serde_json::Value> {
 /// foreign claude-mpm hook group, else `Warn` naming up to 3 affected files
 /// (plus a count), purely informational (never suggests removal — that is
 /// the operator's call).
+/// #7262: a THIRD check, `hooks_build_tree_binary`, names every hook or
+/// `statusLine` command whose executable lives in a Cargo build tree, with its
+/// file path and the command string itself. `hooks_contamination` counts files
+/// and cannot say which command is broken, which is the only fact that matters
+/// for this shape: the entry is tm's own, and the fault is the path inside it.
 /// Test: `check_hooks_hygiene_ok_when_clean`,
 /// `check_hooks_hygiene_warns_on_tm_contamination`,
 /// `check_hooks_hygiene_warns_on_foreign_conflict`,
-/// `check_hooks_hygiene_never_double_counts_active_workspace_dupes`.
+/// `check_hooks_hygiene_never_double_counts_active_workspace_dupes`,
+/// `check_hooks_hygiene_reports_the_build_tree_incident_shape`,
+/// `check_hooks_hygiene_reports_a_build_tree_statusline`,
+/// `check_hooks_hygiene_build_tree_check_is_ok_for_an_installed_binary`.
 pub(super) fn check_hooks_hygiene(
     project_dir: Option<&Path>,
     active_workspace_paths: &[PathBuf],
-) -> (DoctorCheck, DoctorCheck) {
+) -> (DoctorCheck, DoctorCheck, DoctorCheck) {
     let files = candidate_settings_files(project_dir, active_workspace_paths);
 
     let mut contaminated: Vec<PathBuf> = Vec::new();
     let mut foreign: Vec<PathBuf> = Vec::new();
+    let mut build_tree: Vec<(PathBuf, String)> = Vec::new();
     for path in &files {
         let Some(val) = read_settings(path) else {
             continue;
@@ -108,6 +121,14 @@ pub(super) fn check_hooks_hygiene(
         }
         if !foreign_hook_event_names(&val).is_empty() {
             foreign.push(path.clone());
+        }
+        // #7262: hooks first, then the statusLine key, so the report reads in
+        // the order the file does.
+        for cmd in build_tree_hook_commands(&val) {
+            build_tree.push((path.clone(), cmd));
+        }
+        if let Some(cmd) = build_tree_statusline_command(&val) {
+            build_tree.push((path.clone(), cmd));
         }
     }
 
@@ -159,7 +180,61 @@ pub(super) fn check_hooks_hygiene(
         )
     };
 
-    (contamination_check, foreign_check)
+    (
+        contamination_check,
+        foreign_check,
+        build_tree_check(&build_tree),
+    )
+}
+
+/// Render the `hooks_build_tree_binary` check from the collected offenders
+/// (issue #7262).
+///
+/// Why: split out of [`check_hooks_hygiene`] so the message construction — the
+/// part with a real contract, since an operator acts on the exact command
+/// string — is readable on its own and the scan loop stays a scan loop.
+/// What: `Ok` when `offenders` is empty. Otherwise `Warn`, listing up to 5
+/// `<path>: <command>` pairs plus an overflow count, and naming
+/// `tm doctor --fix` / `tm hooks clean` as the repair. A `statusLine` command is
+/// listed too but not repaired by either — the message says so, because
+/// silently under-delivering on a named remedy is how #4948 happened.
+/// Test: `check_hooks_hygiene_reports_the_build_tree_incident_shape`,
+/// `check_hooks_hygiene_reports_a_build_tree_statusline`,
+/// `check_hooks_hygiene_build_tree_check_is_ok_for_an_installed_binary`.
+fn build_tree_check(offenders: &[(PathBuf, String)]) -> DoctorCheck {
+    if offenders.is_empty() {
+        return DoctorCheck::new(
+            "hooks_build_tree_binary",
+            CheckStatus::Ok,
+            "no hook or statusLine command points into a Cargo build tree",
+        );
+    }
+    let shown: Vec<String> = offenders
+        .iter()
+        .take(5)
+        .map(|(path, cmd)| format!("{}: `{cmd}`", path.display()))
+        .collect();
+    let overflow = if offenders.len() > 5 {
+        format!(" (+{} more)", offenders.len() - 5)
+    } else {
+        String::new()
+    };
+    DoctorCheck::new(
+        "hooks_build_tree_binary",
+        CheckStatus::Warn,
+        format!(
+            "{} command{} point into a Cargo build tree and stop working the moment that \
+             artifact is rebuilt away — `tm doctor --fix` previews the removal of the hook \
+             entries for this project and `--yes` applies it, `tm hooks clean` sweeps every \
+             project under $HOME, and the correct command is re-rendered from the installed \
+             binary on the next managed launch. A `statusLine` command is reported here but \
+             repaired only by that relaunch. {}{}",
+            offenders.len(),
+            if offenders.len() == 1 { "" } else { "s" },
+            shown.join("; "),
+            overflow,
+        ),
+    )
 }
 
 /// Render up to 3 paths plus an overflow count for a check message.

--- a/crates/trusty-mpm/src/daemon/doctor_hooks_hygiene_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_hooks_hygiene_tests.rs
@@ -50,7 +50,7 @@ fn check_hooks_hygiene_ok_when_clean() {
         &serde_json::json!({ "outputStyle": "trusty-mpm" }),
     );
 
-    let (contamination, foreign) = check_hooks_hygiene(Some(&project), &[]);
+    let (contamination, foreign, _build_tree) = check_hooks_hygiene(Some(&project), &[]);
     assert_eq!(contamination.status, CheckStatus::Ok);
     assert_eq!(foreign.status, CheckStatus::Ok);
 }
@@ -61,7 +61,7 @@ fn check_hooks_hygiene_warns_on_tm_contamination() {
     let project = dir.path().join("contaminated-project");
     write_settings(&project, &tm_hooks_value());
 
-    let (contamination, foreign) = check_hooks_hygiene(Some(&project), &[]);
+    let (contamination, foreign, _build_tree) = check_hooks_hygiene(Some(&project), &[]);
     assert_eq!(contamination.status, CheckStatus::Warn);
     assert!(contamination.message.contains("tm hooks clean"));
     assert_eq!(foreign.status, CheckStatus::Ok);
@@ -73,7 +73,7 @@ fn check_hooks_hygiene_warns_on_foreign_conflict() {
     let project = dir.path().join("foreign-project");
     write_settings(&project, &claude_mpm_hooks_value());
 
-    let (contamination, foreign) = check_hooks_hygiene(Some(&project), &[]);
+    let (contamination, foreign, _build_tree) = check_hooks_hygiene(Some(&project), &[]);
     assert_eq!(contamination.status, CheckStatus::Ok);
     assert_eq!(foreign.status, CheckStatus::Warn);
     assert!(foreign.message.contains("informational"));
@@ -101,7 +101,7 @@ fn check_hooks_hygiene_warns_on_mixed_group_both_checks() {
         }),
     );
 
-    let (contamination, foreign) = check_hooks_hygiene(Some(&project), &[]);
+    let (contamination, foreign, _build_tree) = check_hooks_hygiene(Some(&project), &[]);
     assert_eq!(
         contamination.status,
         CheckStatus::Warn,
@@ -122,7 +122,7 @@ fn check_hooks_hygiene_never_double_counts_active_workspace_dupes() {
 
     // The SAME project is passed as BOTH `project_dir` and an active
     // workspace path — it must be counted once, not twice.
-    let (contamination, _foreign) =
+    let (contamination, _foreign, _build_tree) =
         check_hooks_hygiene(Some(&project), std::slice::from_ref(&project));
     assert_eq!(contamination.status, CheckStatus::Warn);
     assert_eq!(
@@ -144,11 +144,90 @@ fn check_hooks_hygiene_covers_active_workspace_paths_beyond_project_dir() {
     std::fs::create_dir_all(&project).unwrap();
     write_settings(&other_workspace, &tm_hooks_value());
 
-    let (contamination, _foreign) =
+    let (contamination, _foreign, _build_tree) =
         check_hooks_hygiene(Some(&project), std::slice::from_ref(&other_workspace));
     assert_eq!(
         contamination.status,
         CheckStatus::Warn,
         "a live workspace outside project_dir must still be scanned"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #7262: `hooks_build_tree_binary`. These FAIL on 1ba38636c, where no check
+// existed and `tm_hook_event_names` could not see the incident shape either.
+// ---------------------------------------------------------------------------
+
+use crate::core::standalone::hooks::build_tree::tests::{INCIDENT_EXE, incident_settings};
+
+#[test]
+fn check_hooks_hygiene_reports_the_build_tree_incident_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().join("corrupted-project");
+    let settings = write_settings(&project, &incident_settings());
+
+    let (contamination, _foreign, build_tree) = check_hooks_hygiene(Some(&project), &[]);
+    assert_eq!(build_tree.status, CheckStatus::Warn);
+    assert!(
+        build_tree.message.contains(&*settings.to_string_lossy()),
+        "the report must name the file: {}",
+        build_tree.message
+    );
+    for cmd in [
+        format!("{INCIDENT_EXE} hook"),
+        format!("{INCIDENT_EXE} hook --pm-guard"),
+    ] {
+        assert!(
+            build_tree.message.contains(&cmd),
+            "the report must name `{cmd}`: {}",
+            build_tree.message
+        );
+    }
+    // The pre-existing check must see it now too, so `--fix` has something to
+    // repair rather than a finding with no remedy.
+    assert_eq!(contamination.status, CheckStatus::Warn);
+}
+
+#[test]
+fn check_hooks_hygiene_reports_a_build_tree_statusline() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().join("statusline-only-project");
+    write_settings(
+        &project,
+        &serde_json::json!({
+            "statusLine": {
+                "type": "command",
+                "command": format!("{INCIDENT_EXE} statusline")
+            }
+        }),
+    );
+
+    let (contamination, _foreign, build_tree) = check_hooks_hygiene(Some(&project), &[]);
+    assert_eq!(build_tree.status, CheckStatus::Warn);
+    assert!(
+        build_tree
+            .message
+            .contains(&format!("{INCIDENT_EXE} statusline")),
+        "the statusLine command must be named: {}",
+        build_tree.message
+    );
+    assert_eq!(
+        contamination.status,
+        CheckStatus::Ok,
+        "a statusLine command is not a hook entry and must not be reported as one"
+    );
+}
+
+#[test]
+fn check_hooks_hygiene_build_tree_check_is_ok_for_an_installed_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path().join("installed-binary-project");
+    write_settings(&project, &tm_hooks_value());
+
+    let (_contamination, _foreign, build_tree) = check_hooks_hygiene(Some(&project), &[]);
+    assert_eq!(
+        build_tree.status,
+        CheckStatus::Ok,
+        "an installed `/usr/local/bin/tm hook` is not build-tree contamination"
     );
 }

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -423,7 +423,7 @@ fn an_absent_path_still_matches_the_recorded_spelling_of_itself() {
 }
 
 #[tokio::test]
-async fn run_doctor_produces_forty_two_checks() {
+async fn run_doctor_produces_forty_three_checks() {
     // Issue #2158 added the `deployment` probe (nine → ten); issue #2246
     // adds `oauth_token` (ten → eleven); issue #2876 adds `skill_staleness`
     // and `legacy_sources` (eleven → thirteen); DOC-42 / issue #2889 adds
@@ -496,6 +496,7 @@ async fn run_doctor_produces_forty_two_checks() {
         "oauth_token",
         "hooks_contamination",
         "hooks_foreign_conflict",
+        "hooks_build_tree_binary",
         "tcc_taint",
         "scaffold_tracking",
         "push_guard",


### PR DESCRIPTION
## Summary

`settings.json` files corrupted by the pre-#7273 hooks writer — every hook
pointing at `target-<N>/debug/deps/test_session_lifecycle-<hash> hook …`, plus
a build-tree `statusLine` — had no detection or repair path. `tm doctor` never
flagged them and `tm doctor --fix` left them in place.

## What Changed

- `is_mpm_hook_command` now classifies a hook command's shape via
  `is_ephemeral_build_path` plus tm's own argv tails, so a build-tree binary is
  recognized as tm's regardless of which cargo test target produced it.
- `tm doctor` reports the condition as `hooks_build_tree_binary`.
- `tm doctor --fix` and `tm hooks clean` strip the corrupted entries.
- The settings.json writer replaces the hook group in place instead of
  duplicating it on the next managed launch.
- The repair step states explicitly that pm-guard is absent until the next
  managed launch re-renders it.
- `PM_GUARD_SUFFIX` is now one constant, replacing three separate spellings
  that had drifted across the hooks/doctor modules.

Intentionally out of scope: re-rendering pm-guard from the repair path itself
— reasons are in the round-2 commit message.

## Risk

Rung 5 (security control, persisted config). Blast radius is the hooks
detection/repair path in `trusty-mpm` only: `is_mpm_hook_command`,
`doctor_repair`, `standalone/hooks/*`, and the settings.json writer. No change
to session launch behavior for a healthy `settings.json`.

## Test Evidence

```
cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4
```

56 targets, 11661 passed, 0 failed, run by the implementing engineer.

## Baseline

The new regression tests fail on the pre-fix commit: three hook groups present
where one should be (`none currently reclaimable`-class evidence), confirming
the detection gap this PR closes.

## Docs

Two changelog fragments added under
`crates/trusty-mpm/changelog.d/`: `7262-detect-build-tree-hook-commands.md`
and `7262-doctor-build-tree-check-added.md`.

## Review

code-critic: APPROVE on round 1. Two LOW findings from that round (real home
paths in a fixture, and the `PM_GUARD_SUFFIX` duplication) were fixed in round
2 — this branch's head.

Refs #7262
Refs #7244

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
