### PR TITLE
chore(trusty-mpm): bump to 1.5.21 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11917,7 +11917,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.20"
+version = "1.5.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -28,7 +28,10 @@ name = "trusty-mpm"
 # 1.5.20 (owner-authorized reinstall, refs #7209 #7198 #7180 #7185 #7196
 # #7172): patch, version-only — 1.5.19 is already published and this bump
 # exists solely so `tm --version` identifies the reinstalled build.
-version = "1.5.20"
+# 1.5.21 (owner-authorized reinstall, refs #7244 #7237 #7262 #7274): patch,
+# version-only — 1.5.20 is already published and this bump exists solely so
+# `tm --version` identifies the reinstalled build.
+version = "1.5.21"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome

Bump `trusty-mpm` to 1.5.21, version-only, so `tm --version` identifies the
reinstalled build after this session's install. Refs #7244 #7237 #7262 #7274.

## Changes

`crates/trusty-mpm/Cargo.toml` version 1.5.20 -> 1.5.21, plus the matching
`Cargo.lock` update. No source changes. Out of scope: any behavior change.

## Risk

None — version string only, no code touched.

## Tests

Rung 1 (docs/version-only). `bash scripts/check_workspace_dep_versions.sh` —
all 12 internal rows accept their member crate version (PATCH needs no root
table change). `bash scripts/check_changelog_fragment.sh --staged` — no crate
source changed, gate passes.

## Baseline

None applicable — no test suite run for a version-only change.

## Docs

No changelog fragment required: per the release workflow, a version-only
reinstall bump carries no user-visible change. Confirmed via
`check_changelog_fragment.sh --staged`.

## Review

Not applicable — no prior review findings to disposition.

Refs #7244

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
