### PR TITLE
chore(sessions): pause snapshot for trusty-tools-95, 2026-09-09 21:46Z

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-214646.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-214646.md
@@ -1,0 +1,34 @@
+# Session Pause - 2026-09-09T21:46:46.799069+00:00
+
+## Summary
+Owner-invoked pause 2026-09-10 ~00:3xZ, session trusty-tools-95 (tmux tm-dogfood:0:@1), resumed from the 2026-09-09 19:25Z snapshot after a /clear; all five snapshot agents survived and reported. origin/main = c7e38dbfa; main checkout == origin/main, clean. tm 1.5.21 INSTALLED and signed from 2a34525d8, daemon restarted (pid 48669, health 1.5.21). ZERO PRs ARMED — every armed PR landed. OWNER RULINGS THIS LEG, verbatim and in the palace: "sessions should be a 'live' state so it should be merged and pushed as it is created" (#7282); "let's script post merge cleanup, it should be deterministic unless it errors. It should be run as the final step after merge confirmation" and "merge completion should trigger agent decommissioning, worktree removal, branch removal" (#7275); "I'm not sure how we keep increasing in issues when our goal is to close them" (256 open vs <200 target; 44 filed today across sessions, 9 closed; I filed 8 — STOP filing agent recommendations as issues, fold into the next PR or an existing issue; reinstall promptly after each merge wave so status:merged drains). Standing: "keep going, merge them when green". INCIDENTS: settings.json corrupted a 9th time by a pre-#7273 test run (repaired by PM Edit; post-#7273 runs contributed zero rows); #7275 round 1 got a CRITICAL from MY amendment (guard relaxed on empty merge-tree with no merged PR) — lesson in palace. Every background agent below DIES with the session: verify each branch by `git log` on resume, never assume.
+
+## Completed
+- MERGED this leg (issues at status:merged): #7242 (#5478), #7277 (#7259), #7279 (#7249), #7281 (#7250), #7284 (#7074 regen), #7283 (sessions backfill; local main repointed), #7257 (#7237, 8 reds were one apt-mirror hash mismatch), #7285 (#7274 sonnet + labels standard + tm pr open auto-apply), #7286 (#7262 P1 build-tree hook detect/repair), #7260 (#7245), #7292 (tm 1.5.21 bump)
+- #7258 CLOSED as absorbed by #7277's squash d38e17477 (merge-tree empty; git cherry is a false negative under squash); #7232 at status:merged
+- Config-overlap audit delivered (ten surfaces) → #7276; #7278 filed (Stop-hook + pm-guard transcript_path unscreened, promoted from #7250 critic)
+- Consolidation after owner pushback: #7287 #7290 #7291 closed into #7271 #7278 #7239; #7288 narrowed to two CI-infra items; #7289 kept (home-literal gate); open count 256→253
+- Post-merge cleanup by hand for 11 PRs: remote refs 177→166, worktrees 37→36; ten clean sibling/gone-upstream worktrees REFUSED by the ADR-0057 guard (content proven on main) — cleared by #7275 when it lands
+- Palace: rulings, boards, two PM-error lessons (mid-flight amendments; guard relaxation without merge evidence), settings.json diagnosis
+
+## In Progress
+- #7275 r2 rust-engineer (opus) on feat/7275-post-merge-cleanup-r2 off 615ec562b, rebasing over #7285's Preflight conflict in pr/open.rs + pr/tests.rs; fixing critic BLOCK: guard must deny with no MERGED PR (merge-tree relaxation only for a confirmed related PR), base tied to the PR's baseRefName, remove_one consults live-writer registry, gap stated in changelog/version-control.md — on resume `git log --oneline -1 feat/7275-post-merge-cleanup-r2`; if a commit exists: critic re-verify (rung 5, destructive path) → scan → version-control (sonnet) PR; then `tm pr cleanup` against the ten refused worktrees is the live acceptance test
+- #7282 r3 rust-engineer (opus) on fix/7282-session-pause-via-pr-r3 off 4f4ac715e (critic WARN after BLOCK cleared): parent-segment symlink check in allowlisted(), auto-merge failure reason captured + tested — on resume check for a commit; if present: scan → version-control PR (no fourth critic round; three is the fold line)
+- local-ops live checks on tm 1.5.21: skill_staleness fix via tm doctor --fix-skills, then PASS/FAIL for #7262 #7237 #7244 #7232 #7274 #7217 #7245/#7074 #7226 — result not seen before pause; if no report, re-run the brief (throwaway worktree verify-7244 may exist)
+
+## Next Steps
+- On resume: ListAgents FIRST; then per branch above `git log --oneline -1 <branch>`; salvage uncommitted work with a fresh engineer on a fresh -rN branch off the committed head, never by naming the dead tree
+- Check `.claude/settings.json`: `grep -c 'target-'` must be 0; if not, Edit replace_all the target-<N>/debug/deps/... prefix to /Users/masa/.cargo/bin/tm; #7262's `tm doctor --fix` is now installed and should handle it
+- When the live checks report: ticketing (sonnet) closes each PASSING issue from status:tested with the evidence via `tm issue transition N status:tested` then `closed --note`; #7185 #7196 close after #7232 passes; #7226 closes on one clean push-to-main CI run (the #7292 bump push is that run: `gh run list --branch main --limit 1`); owner-attended: 💸 segment (#7245/#7074), tm ls / bare tm TUI (#7224/#7263), #7112 #6900 #6838 console saver
+- After #7275 merges: run `tm pr cleanup <n>` for #7257 #7285 #7286 #7242 #7281 #7277/#7258 #7260 to reclaim the ten refused worktrees; then reinstall (patch bump) so the supervisor sweep and `tm pr merge` chain are live
+- After #7282 merges: reinstall so pauses publish via PR; until then pauses still write only the file and the PM commits by hand on a chore/sessions-* branch off origin/main, never on local main
+- Queued: #7270+#7271 pair (agent prompt literals; fold the #7287 checklist in); #7278 (two unscreened transcript_path call sites, fold #7290 in); #7289 home-literal gate; #7276 audit gaps
+- Every brief: NEVER generate machine-wide CPU load; `isolation: "worktree"` + STOP-if-main-checkout; CARGO_TARGET_DIR absolute literal target-<N>; scan before the PR opens; Refs never Closes; no heredocs/loops/pathspec'd git diff under isolation (#6982); round-N branches use -rN off the committed head; never bare tm from a subagent; ticketing and version-control pass model sonnet; a guard relaxation brief states the PRECONDITION (confirmed MERGED PR), never just the cheaper test; agent Improvement recommendations → comment on an existing issue or fold into the next PR, NEVER a new issue
+
+## Git Context
+Branch: main
+Last commit: c7e38dbfa chore(trusty-mpm): bump to 1.5.21 for owner-authorized reinstall (#7292)
+Uncommitted changes: 49 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -105,3 +105,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-122733.md","timestamp":"2026-09-09T12:27:33.501147+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-164445.md","timestamp":"2026-09-09T16:44:45.434809+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-192518.md","timestamp":"2026-09-09T19:25:18.095691+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-214646.md","timestamp":"2026-09-09T21:46:46.799069+00:00"}


### PR DESCRIPTION
## Outcome
Commits the pause snapshot for session trusty-tools-95 (2026-09-09 21:46Z) to tracked `.trusty-mpm/sessions/**`, per the owner ruling that session snapshots reach origin/main via a docs-only PR at pause time, never as commits on local main.

## Changes
- Adds `.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-214646.md`
- Updates `.trusty-mpm/sessions/sessions-log.jsonl`

## Risk
None — tracked session-log data only, no source or config changes.

## Tests
N/A — docs-only change, rung 1.

## Baseline
N/A — no code gates apply to this change.

## Docs
N/A — the changed files are themselves the documentation artifact (session snapshots).

## Review
tm 1.5.21 predates #7282's auto-publish of pause-snapshot PRs, so this PR was opened by hand following the same convention.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
