### PR TITLE
chore(trusty-mpm): bump to 1.5.22 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11917,7 +11917,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.21"
+version = "1.5.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -31,7 +31,10 @@ name = "trusty-mpm"
 # 1.5.21 (owner-authorized reinstall, refs #7244 #7237 #7262 #7274): patch,
 # version-only — 1.5.20 is already published and this bump exists solely so
 # `tm --version` identifies the reinstalled build.
-version = "1.5.21"
+# 1.5.22 (owner-authorized reinstall, refs #7295 #7294 #7296): patch,
+# version-only — 1.5.21 is already published and this bump exists solely so
+# `tm --version` identifies the reinstalled build.
+version = "1.5.22"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome
Patch bump so `tm --version` identifies the build carrying #7295 (post-merge cleanup), #7294 (session pause via PR), and #7296 (hermetic hook-writer tests). Owner ruling: every reinstall carries a patch bump.

## Changes
`crates/trusty-mpm/Cargo.toml` version 1.5.21 -> 1.5.22, `Cargo.lock` matching entry.

## Risk
Low, rung 1.

## Tests
`scripts/check_workspace_dep_versions.sh` EXIT 0. `scripts/check-pr-version-bump.sh` EXIT 0. `scripts/check_changelog_fragment.sh --staged` OK (no source change).

## Baseline
main red on `pm_guard_cost::tests::allows_a_healthy_agent` (tracker #7028, fix in flight); this PR does not touch it.

## Docs
None.

## Review
None needed (version-only).

Refs #7292

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
