### PR TITLE
chore(sessions): pause snapshot trusty-tools-95 2026-09-09 23:38Z

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-233853.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-233853.md
@@ -1,0 +1,40 @@
+# Session Pause - 2026-09-09T23:38:53.886440+00:00
+
+## Summary
+Board snapshot 2026-09-10 ~00:0xZ, session trusty-tools-95 (tmux tm-dogfood:0:@1), taken mid-wave as the #7282 live acceptance test (this pause must publish its own chore/sessions-* PR with auto-merge armed on tm 1.5.22). Standing: "keep going, merge them when green"; owner 2026-09-10: "still have 247 issues, including bugs -- we should be driving to close them" and "close them" (the nine automation-filed self-improvement issues). tm/trusty-mpm 1.5.22 INSTALLED and signed from 1aca2355d (PR #7304), daemon pid 51160, health 1.5.22. MERGED this leg: #7295 (547f75421, #7275 r2), #7294 (93034ca79, #7282 r3), #7296 (d54a5a667, #7244 hermetic hook-writer tests), #7304 (1aca2355d bump); #7305 (#7028 pm_guard_cost budget) merging now on green rows. Main was red on three causes (rustdoc cleanup.rs:202, hook-writer shard panic, pm_guard_cost 0-token read); all three fixes are on main once #7305 lands — the next push-to-main run should be green and closes #7226 and the #7028 tracker. #7275 acceptance on 1.5.22: tm pr cleanup works for clean registered worktrees (43→40) but refuses squash-merged worktrees as 'unpushed commits' (#7257 #7285 #7286 #7281 #7260 #7294 #7296) — defect recorded on #7275, needs round 3 judging landed by MERGED PR + merge-tree no-op vs baseRefName, not ahead-count. Census (247/247): 26 at status:merged (drain), 5 open bugs all with engineers in flight, 9 self-improvement issues being closed with fold-in comments, 7 stale in-progress claims being reset.
+
+## Completed
+- Closed from status:tested on 1.5.21: #7262 #7232 #7185 #7196 #7217 #7274 (and #7244 once, then reopened for the CI regression, now status:merged via #7296)
+- Hooks diagnosis: harness launch-time hook snapshot pointed at a test binary; files were correct; owner ran /hooks; double registration (user `trusty-mpm hook` + project `tm hook`) commented on #7276
+- #7263 #7234 advanced coded→merged (PRs #7272/#7256 had landed)
+- pm_guard_cost root cause: EVAL_TIMEOUT 200 ms bounded test reads and fails open to (Ok,0); fix PR #7305 critic WARN (silent fail-open arm, fold into next guard touch)
+
+## In Progress
+- version-control merging #7305 (head b4c626082) after raw-row check → then ticketing: #7028 and #7226 close when the push-to-main run for its squash is green (Monitor b245t702c watches d54a5a667; start one for the #7305 squash)
+- rust-engineer #7267 fix/7267-prune-worktrees-merged-pr-match (isolation worktree; reuse #7275 r2 landing_evidence/strip_round_suffix)
+- rust-engineer #7278+#7290 fix/7278-transcript-path-screening (reuse #7250 helper)
+- rust-engineer #7270+#7271+#7287 fix/7270-agent-prompt-literals (trusty-agents-common assets + regression grep test)
+- engineer #7288 fix/7288-apt-infra-failure-token (CI script, no cargo)
+- rust-engineer #7266 fix/7266-pm-guard-secret-file-line-reads
+- local-ops A: live-verify on 1.5.22 #6982 #7166 #7247 #7249 #7250 #7259 #7234 #7245/#7074 #7224/#7263; local-ops B: #5220 #5470 #5478 #5669 #7139 (taudit), #6847, #7253, saver #6838 #6900 #7112 (owner-attended) → ticketing closes each PASS from status:tested with evidence
+- ticketing: closing #7264 #7265 #7297 #7298 #7299 #7300 #7301 #7302 (+1 extra self-improvement if exactly one) with fold-in comments; resetting stale claims #6875 #6802 #6611 #6533 #6288 #4358 #6761 to open
+- Monitor b245t702c: main CI for d54a5a667 (#7296 merge) — expect only pm_guard_cost red
+
+## Next Steps
+- On resume: ListAgents FIRST; then `git log --oneline -1` on each fix branch above; salvage uncommitted work with a fresh engineer on a fresh -rN branch off the committed head
+- Each fix branch when reported: critic round only if >100 lines or guard/security path (#7266 #7278 yes; #7267 yes, destructive path; #7270 #7288 skip) → security scan → version-control opens PR UNARMED → Monitor settle (scratchpad watch-pr-settle.sh <pr> <sha>) → version-control verifies raw rows and merges → ticketing status:coded→merged
+- #7275 round 3 (dispatch AFTER #7267 reports to avoid overlapping edits in worktree_remove_rechecks/pr_cleanup): tm pr cleanup must treat a squash-merged branch as landed via MERGED PR + merge-tree no-op against baseRefName; then `tm pr cleanup` again over the seven refused PRs as the live test; then #7275 → tested → closed
+- #7282 acceptance = THIS pause: confirm a chore/sessions-* PR opened with auto-merge armed (or a named skip reason / auto_merge_error in the response); if it did, ticketing closes #7282 from status:tested with the PR link; if not, comment the failure on #7282
+- After the verification reports: ticketing closes every PASS (status:tested → closed with evidence); OWNER-ATTENDED items (saver #6838 #6900 #7112, tm ls TUI #7224/#7263, 💸 segment #7245/#7074) get a comment listing exactly what to look at and stay at status:merged until the owner confirms
+- After all fix PRs merge: one more patch bump (1.5.23) + reinstall only if a fix changes installed behaviour (#7266 #7267 #7278 do; #7270 asset deploys at run; #7288 CI-only) — reinstall prompt after the wave per owner ruling
+- Second-pass worktree reclaim after #7275 r3: `tm session prune-worktrees --merged-prs` dry run first; decide install-tm-1520 and install-tm-1522 (both detached install trees, removable once 1.5.22 is confirmed stable)
+- Fold, never file: improvement recs in the palace board drawer (check_capabilities.sh branch binary; doctor.md drift→cargo test; BASE-AGENT exact-name scratch reads + per-task subdir; check_line_cap --report; #6982 shapes incl. HOME=, zsh script, python3 -c; tm compress exit-code masking; cross-branch push guard fast-forward allowance; StableHookExeError wording; pm_guard_cost fail-open logging)
+- Every brief: NEVER generate machine-wide CPU load; isolation worktree + STOP-if-main-checkout; CARGO_TARGET_DIR absolute literal target-<N>; scan before PR; Refs never Closes; no heredocs/loops/pathspec'd git diff/HOME=/zsh script/python3 -c under isolation (#6982); rustdoc gate `bash scripts/check_rustdoc_links.sh` in EVERY rust brief; -rN branches off the committed head; detached-HEAD push to an existing branch only as strict fast-forward with the documented override; arm auto-merge only after raw rows green; ticketing/version-control on sonnet
+
+## Git Context
+Branch: main
+Last commit: c7e38dbfa chore(trusty-mpm): bump to 1.5.21 for owner-authorized reinstall (#7292)
+Uncommitted changes: 83 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -105,4 +105,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-122733.md","timestamp":"2026-09-09T12:27:33.501147+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-164445.md","timestamp":"2026-09-09T16:44:45.434809+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-192518.md","timestamp":"2026-09-09T19:25:18.095691+00:00"}
-{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-214646.md","timestamp":"2026-09-09T21:46:46.799069+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-233853.md","timestamp":"2026-09-09T23:38:53.886440+00:00"}


### PR DESCRIPTION
## Outcome
Publishes the session-pause snapshot for session `0b318c84-bae9-4a50-8832-65ed61f8ab22` taken at 2026-09-09 23:38Z, finishing a publish that stalled: the pause publisher (tm 1.5.22) committed 698a0707 on this branch but `gh pr create` ran without `--head` while the checkout sat on `main`, so no PR was opened. This PR opens it.

## Changes
- `.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-233853.md` — new pause snapshot
- `.trusty-mpm/sessions/sessions-log.jsonl` — appended log entry for the snapshot

## Risk
None — additive session-tracking data only, no source or behavior change.

## Tests
N/A — docs/session-data only, no code path touched.

## Baseline
N/A — no gates apply to session-snapshot data.

## Docs
Session snapshot is self-documenting; no other docs affected.

## Review
Rung 1 (docs-only). This PR is itself the live acceptance test for #7282 — it exposed the missing `--head` flag in the pause publisher's `gh pr create` invocation, which left the commit stranded on an unpublished branch.

Refs #7282

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
