### PR TITLE
fix(ci): classify apt mirror failures as one infra event with retry and a distinct token (Refs #7288)

### DIFF
--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -724,15 +724,40 @@ DPKG_STUB
 # that asserts an exact attempt COUNT raises the ceiling first: at 2s a loaded
 # machine can take long enough to start the stub that a healthy attempt is
 # killed as a stall, which would add an attempt the case did not ask for.
+#
+# CI_APT_LISTS_DIR is pinned to the stub directory for EVERY case, not only the
+# ones that assert on it (#7288). The wrapper purges that directory after a hash
+# mismatch, and this file runs on Linux developer machines where the default
+# would be the host's real /var/lib/apt/lists.
+#
+# GITHUB_OUTPUT is likewise pinned per case, so the rows the wrapper writes for
+# a workflow to read are observable here instead of landing in the runner's real
+# output file.
 apt_run() {
   local dir="$1" rc=0
+  # Actions creates $GITHUB_OUTPUT before the step runs and the wrapper only
+  # ever appends, so create it here too — a case that asserts NOTHING was
+  # written needs a file to read, not a missing one.
+  : >"${dir}/github-output"
   PATH="${dir}:${PATH}" CI_APT_RETRY_DELAY_S=0 CI_APT_ATTEMPTS=3 \
     CI_APT_UPDATE_TIMEOUT_S="${CI_APT_UPDATE_TIMEOUT_S:-2}" \
     CI_APT_INSTALL_TIMEOUT_S="${CI_APT_INSTALL_TIMEOUT_S:-2}" \
+    CI_APT_LISTS_DIR="${dir}/lists" \
+    GITHUB_OUTPUT="${dir}/github-output" \
     bash scripts/ci-apt-install.sh build-essential \
     >"${dir}/out" 2>&1 || rc=$?
   echo "$rc"
 }
+
+# Every case that asserts an exact attempt COUNT, or an exact classified
+# REASON, runs at a 6s ceiling rather than the 2s default — the same reason the
+# dpkg case below already raises it. These stubs exit instantly, so the wider
+# ceiling costs nothing, while a healthy attempt killed at a tight ceiling on a
+# loaded machine adds an attempt the case did not ask for and, since #7288, is
+# classified `stall` instead of the signature under test. The stall case resets
+# it, because the ceiling is the thing it tests.
+CI_APT_UPDATE_TIMEOUT_S=6
+CI_APT_INSTALL_TIMEOUT_S=6
 
 # Always succeeds — the ordinary path, and proof the wrapper is transparent.
 ok_dir="$(apt_stub_dir 'exit 0')"
@@ -764,11 +789,16 @@ assert_eq "  and says so as a CI error"         "1" \
 # THE ISSUE'S OWN CASE: a mirror that accepts the connection and then says
 # nothing. Unwrapped this is the 30-minute silent stall; here each attempt must
 # die at its 2s ceiling and be reported as a stall, not as a plain failure.
+unset CI_APT_UPDATE_TIMEOUT_S CI_APT_INSTALL_TIMEOUT_S
 if command -v timeout >/dev/null 2>&1 || command -v gtimeout >/dev/null 2>&1; then
   stall_dir="$(apt_stub_dir 'sleep 300')"
-  assert_eq "a stalled mirror is killed at the ceiling" "1" "$(apt_run "${stall_dir}")"
+  # 75, not 1, since #7288: a mirror that accepts the connection and then stops
+  # answering is an infrastructure failure, and the exit code is what says so.
+  assert_eq "a stalled mirror is killed at the ceiling" "75" "$(apt_run "${stall_dir}")"
   assert_eq "  reported as a stall, not a plain failure" "3" \
     "$(grep -c 'STALLED — killed at the 2s ceiling' "${stall_dir}/out" || true)"
+  assert_eq "  and classified as infra, reason 'stall'" "1" \
+    "$(grep -c '::error::apt-infra: stall ' "${stall_dir}/out" || true)"
   rm -rf "${stall_dir}"
 
   # #6064: the stall's aftermath. Killing `apt-get install` mid-unpack leaves
@@ -807,6 +837,103 @@ else
 fi
 
 rm -rf "${ok_dir}" "${flaky_dir}" "${dead_dir}"
+
+# ---------------------------------------------------------------------------
+# ci-apt-install.sh — apt-infrastructure classification (#7288)
+#
+# One Chrome-mirror `Hash Sum mismatch` killed 8 jobs on PR #7257 inside a
+# 24-second window, and each one read as its own code red. The classification
+# only ever runs while a mirror is already broken, so every arm is driven here
+# against stubbed apt output rather than waited for.
+#
+# The negative case is the one that matters most: a genuinely broken step must
+# keep exiting 1 with no infra token, or the distinction launders real failures.
+# ---------------------------------------------------------------------------
+
+CI_APT_UPDATE_TIMEOUT_S=6
+CI_APT_INSTALL_TIMEOUT_S=6
+
+# infra_case <label> <stub-body> <expected-reason> — assert that this apt output
+# is classified as infrastructure, with the reason, both tokens, and the rows a
+# workflow reads.
+infra_case() {
+  local label="$1" body="$2" reason="$3" dir
+  dir="$(apt_stub_dir "${body}")"
+  assert_eq "${label}: exits 75, not 1"       "75" "$(apt_run "${dir}")"
+  assert_eq "  reason is ${reason}"           "1" \
+    "$(grep -c "::error::apt-infra: ${reason} " "${dir}/out" || true)"
+  assert_eq "  carries the INFRA-FAIL token"  "1" \
+    "$(grep -c 'INFRA-FAIL: apt' "${dir}/out" || true)"
+  assert_eq "  one annotation, not one per attempt" "1" \
+    "$(grep -c '::error::apt-infra:' "${dir}/out" || true)"
+  assert_eq "  \$GITHUB_OUTPUT carries the reason" "1" \
+    "$(grep -c "^apt_infra_reason=${reason}\$" "${dir}/github-output" || true)"
+  rm -rf "${dir}"
+}
+
+# The #7288 failure itself: dl.google.com served an index whose hash did not
+# match the Release file every job had.
+infra_case "hash sum mismatch" '
+[ "$1" = "update" ] || exit 0
+echo "E: Failed to fetch https://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages  Hash Sum mismatch" >&2
+exit 100' "hash-mismatch"
+
+infra_case "DNS will not resolve" '
+[ "$1" = "update" ] || exit 0
+echo "Err:1 http://archive.ubuntu.com/ubuntu jammy InRelease" >&2
+echo "  Temporary failure resolving '"'"'archive.ubuntu.com'"'"'" >&2
+exit 100' "dns"
+
+infra_case "connection refused" '
+[ "$1" = "update" ] || exit 0
+echo "Err:1 http://archive.ubuntu.com/ubuntu jammy InRelease" >&2
+echo "  Could not connect to archive.ubuntu.com:80 (185.125.190.36), connection refused" >&2
+exit 100' "connect"
+
+infra_case "mirror answers 4xx" '
+[ "$1" = "update" ] || exit 0
+echo "Err:5 https://dl.google.com/linux/chrome/deb stable Release" >&2
+echo "  403  Forbidden [IP: 142.250.72.174 443]" >&2
+exit 100' "mirror-http"
+
+# THE NEGATIVE CASE. A bad package name is not the mirror's fault and must not
+# be reported as one: exit 1, the original annotation, and nothing an infra
+# classifier would group on.
+bad_pkg_dir="$(apt_stub_dir '
+[ "$1" = "update" ] && exit 0
+echo "E: Unable to locate package build-essential" >&2
+exit 100')"
+assert_eq "a bad package name is NOT infra: exits 1" "1" "$(apt_run "${bad_pkg_dir}")"
+assert_eq "  no apt-infra annotation"                "0" \
+  "$(grep -c '::error::apt-infra:' "${bad_pkg_dir}/out" || true)"
+assert_eq "  no INFRA-FAIL token"                    "0" \
+  "$(grep -c 'INFRA-FAIL: apt' "${bad_pkg_dir}/out" || true)"
+assert_eq "  the original annotation still names the phase" "1" \
+  "$(grep -c '::error::ci-apt-install: apt-get install failed 3 time' "${bad_pkg_dir}/out" || true)"
+assert_eq "  and \$GITHUB_OUTPUT stays empty"        "0" \
+  "$(grep -c '^apt_infra=' "${bad_pkg_dir}/github-output" || true)"
+rm -rf "${bad_pkg_dir}"
+
+# The purge that makes the retry able to succeed. apt re-reads its cached index,
+# so without dropping the lists every attempt reproduces the same mismatch — the
+# stub mismatches only while the stale index file is present.
+purge_dir="$(apt_stub_dir '
+d="${0%/*}"
+[ "$1" = "update" ] || exit 0
+if [ -e "${d}/lists/stale-index" ]; then
+  echo "E: Failed to fetch https://dl.google.com/linux/chrome/deb/dists/stable/InRelease  Hash Sum mismatch" >&2
+  exit 100
+fi
+exit 0')"
+mkdir -p "${purge_dir}/lists"
+: > "${purge_dir}/lists/stale-index"
+assert_eq "a mismatch clears once the lists are purged" "0" "$(apt_run "${purge_dir}")"
+assert_eq "  the purge ran, and said so"               "1" \
+  "$(grep -c 'purging .* so the retry re-fetches' "${purge_dir}/out" || true)"
+assert_eq "  the stale index is gone"                  "absent" \
+  "$([ -e "${purge_dir}/lists/stale-index" ] && echo present || echo absent)"
+rm -rf "${purge_dir}"
+unset CI_APT_UPDATE_TIMEOUT_S CI_APT_INSTALL_TIMEOUT_S
 
 # Wiring: the wrapper helps nobody while a job still inlines the raw pair.
 assert_eq "no raw apt-get left in ci.yml" "0" \

--- a/scripts/ci-apt-install.sh
+++ b/scripts/ci-apt-install.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # ci-apt-install.sh — install apt packages on a CI runner with a bounded,
-# observable retry (issue #5999).
+# observable retry (issue #5999), and report an apt INFRASTRUCTURE failure as
+# one classifiable event rather than N unrelated code reds (issue #7288).
 #
 # Why: every "Install system dependencies" / "Install Tauri system
 #   dependencies" step in ci.yml ran `sudo apt-get update -qq` with no retry and
@@ -12,11 +13,46 @@
 #   `trusty-code-gui clippy` on PR #5992 at 30m21s/30m22s (run 32158580446).
 #   The PR reads red on code that is fine, and the whole run has to be redone.
 #
+#   #7288 is the second half of the same complaint. The retry bounded the cost
+#   but said nothing about the CAUSE, so a single Chrome-mirror `Hash Sum
+#   mismatch` killed 8 jobs on PR #7257 inside a 24-second window and each one
+#   read as its own code red. `notify-main-failure` and `red-main-notify.yml`
+#   compose their verdict from job conclusions alone (see
+#   scripts/classify-ci-results.sh), and GitHub gives them nothing but
+#   `failure` — so eight jobs that died on one mirror get reported, and
+#   re-diagnosed by a human, eight times.
+#
 # What: runs `apt-get update` then `apt-get install`, each attempt wrapped in
 #   `timeout` and each phase retried up to ATTEMPTS times, with the whole thing
 #   capped by a total budget. A stall now dies at the per-attempt timeout with
 #   an `::error::` line naming the phase, the attempt, and the elapsed seconds,
 #   instead of stalling silently until the job is cancelled.
+#
+#   Each attempt's output is also matched against the signatures of an apt
+#   infrastructure failure — hash-sum mismatch, a mirror answering 4xx/5xx, DNS
+#   that will not resolve, a connection that will not open, and the stall
+#   itself. When a phase exhausts its attempts on one of those, the script
+#   exits 75 (not 1) and prints ONE annotation carrying two greppable tokens:
+#
+#     ::error::apt-infra: <reason> — INFRA-FAIL: apt — <details>
+#
+#   `apt-infra:` is what a log scan matches; `INFRA-FAIL: apt` is the token
+#   named in #7288's closure condition. Both are on the same line on purpose,
+#   so a consumer may grep for either. When `$GITHUB_OUTPUT` is set the same
+#   verdict is written there as `apt_infra=true` / `apt_infra_reason=<reason>`,
+#   which is the machine channel a job needs to lift the fact into a job output
+#   and hand `classify-ci-results.sh` one infra event instead of N reds. Wiring
+#   that through ci.yml's jobs is not done here.
+#
+#   A failure with NO infra signature — `Unable to locate package`, a held
+#   dependency, a bad package name — still exits 1 under the original
+#   `::error::ci-apt-install:` line. That is the case the distinction exists to
+#   protect: a genuinely broken step must not be waved through as "the mirror".
+#
+#   A `hash-mismatch` reason also purges CI_APT_LISTS_DIR before the retry.
+#   Retrying `apt-get update` against the stale index that mismatched
+#   reproduces the same mismatch every time, so without the purge the two
+#   remaining attempts are spent proving it.
 #
 #   Defaults (each overridable by environment variable, which is also how the
 #   self-test drives every branch without waiting on a real mirror):
@@ -27,6 +63,7 @@
 #     CI_APT_RETRY_DELAY_S=5     backoff unit; attempt N waits N*this seconds
 #     CI_APT_TOTAL_BUDGET_S=600  hard ceiling across both phases
 #     CI_APT_DPKG_REPAIR_TIMEOUT_S=120  ceiling for the between-attempt repair
+#     CI_APT_LISTS_DIR=/var/lib/apt/lists  purged after a hash mismatch
 #
 #   The total budget is the number that answers the issue: worst case is ten
 #   minutes, not thirty, and the ten minutes are spent visibly. Each attempt's
@@ -48,10 +85,11 @@
 #
 # Usage: bash scripts/ci-apt-install.sh <package> [<package> ...]
 #
-# Exit: 0 when the packages are installed. 1 when a phase exhausted its
-#   attempts or the total budget; the last apt exit code is reported (124 is
-#   `timeout`'s "the command was still running", i.e. the stall this exists
-#   for). 2 on usage error.
+# Exit: 0 when the packages are installed. 75 when a phase exhausted its
+#   attempts on an apt INFRASTRUCTURE failure (the `apt-infra:` annotation says
+#   which); the job is red but the commit is unjudged. 1 when a phase exhausted
+#   its attempts or the total budget on anything else; the last apt exit code is
+#   reported. 2 on usage error.
 #
 # Scope: `.github/workflows/ci.yml` routes every apt step through this. The
 #   release and pre-publish workflows still inline the raw two-liner; they can
@@ -60,7 +98,9 @@
 # Test: scripts/check-ci-helpers-selftest.sh (`ci-apt-install:` cases) drives
 #   the succeeds-first-try, succeeds-after-a-retry, exhausts-attempts,
 #   stalls-then-times-out, and stall-breaks-dpkg-then-recovers branches against
-#   a stubbed `apt-get` and `dpkg` on PATH.
+#   a stubbed `apt-get` and `dpkg` on PATH, plus every #7288 classification
+#   arm — each infra signature, the non-infra failure that must NOT be
+#   classified as one, the lists purge, and the `$GITHUB_OUTPUT` rows.
 
 set -uo pipefail
 
@@ -75,10 +115,21 @@ INSTALL_TIMEOUT_S="${CI_APT_INSTALL_TIMEOUT_S:-420}"
 RETRY_DELAY_S="${CI_APT_RETRY_DELAY_S:-5}"
 TOTAL_BUDGET_S="${CI_APT_TOTAL_BUDGET_S:-600}"
 DPKG_REPAIR_TIMEOUT_S="${CI_APT_DPKG_REPAIR_TIMEOUT_S:-120}"
+LISTS_DIR="${CI_APT_LISTS_DIR:-/var/lib/apt/lists}"
+
+# Exit code for "the mirror failed, not this commit". 75 is EX_TEMPFAIL, whose
+# sysexits.h meaning — a temporary failure, the operation should be retried —
+# is exactly the claim being made.
+INFRA_EXIT=75
 
 STARTED_AT="$(date +%s)"
 
 elapsed() { echo "$(( $(date +%s) - STARTED_AT ))"; }
+
+# One attempt's combined output, re-read by apt_infra_reason. Recreated per
+# attempt; removed on exit however the script leaves.
+ATTEMPT_LOG="$(mktemp "${TMPDIR:-/tmp}/ci-apt-attempt.XXXXXX")"
+trap 'rm -f "${ATTEMPT_LOG}"' EXIT
 
 TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
 if [ -z "$TIMEOUT_BIN" ]; then
@@ -89,6 +140,60 @@ SUDO=""
 if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
   SUDO="sudo"
 fi
+
+# apt_infra_reason <exit-code> — echo a one-word reason when this attempt failed
+# the way an apt MIRROR fails, and nothing when it failed the way a package
+# request fails (#7288).
+#
+# The reasons are the four signatures #7288 names plus the stall the wrapper
+# already detects. Order matters only in that the first match wins; each arm is
+# a distinct remediation, so the label is worth keeping distinct.
+#
+# The HTTP arm requires BOTH a fetch error and a 4xx/5xx status, because a bare
+# three-digit number appears in package names and versions. Fail closed the
+# other way here: an unmatched failure is reported as a code failure, so a real
+# break is never laundered into "the mirror was flaky".
+apt_infra_reason() {
+  local rc="$1"
+
+  # A killed attempt is a mirror that accepted the connection and then stopped
+  # answering. There is usually no output at all to match on.
+  if [ "$rc" -eq 124 ]; then
+    echo "stall"
+    return 0
+  fi
+
+  [ -s "$ATTEMPT_LOG" ] || return 0
+
+  if grep -qiE 'hash sum mismatch|file has unexpected size' "$ATTEMPT_LOG"; then
+    echo "hash-mismatch"
+  elif grep -qiE 'temporary failure resolving|could not resolve' "$ATTEMPT_LOG"; then
+    echo "dns"
+  elif grep -qiE 'could not connect|unable to connect|connection (failed|refused|reset|timed out)' "$ATTEMPT_LOG"; then
+    echo "connect"
+  elif grep -qiE 'err:|failed to fetch|some index files failed to download' "$ATTEMPT_LOG"; then
+    if grep -qE '(^|[^0-9])(4[0-9]{2}|5[0-9]{2})([^0-9]|$)' "$ATTEMPT_LOG"; then
+      echo "mirror-http"
+    else
+      echo "mirror-fetch"
+    fi
+  fi
+}
+
+# clear_apt_lists — drop the cached package indexes before a hash-mismatch retry.
+#
+# #7288: a mismatch is between the Release file apt has and the index the mirror
+# served, and apt keeps serving itself the cached copy, so every retry
+# reproduces it. Deleting the lists forces a clean fetch. Never fatal — the
+# retry is still worth making — and `:?` refuses to expand an empty variable
+# into `rm -rf /*`.
+clear_apt_lists() {
+  [ -d "$LISTS_DIR" ] || return 0
+
+  echo "ci-apt-install: purging ${LISTS_DIR} so the retry re-fetches the indexes instead of re-reading the mismatched ones." >&2
+  ${SUDO:+"$SUDO"} rm -rf -- "${LISTS_DIR:?}"/* 2>/dev/null
+  return 0
+}
 
 # repair_dpkg — clear a dpkg database left "interrupted" by a killed apt-get.
 #
@@ -112,19 +217,40 @@ repair_dpkg() {
   return 0
 }
 
+# report_infra <label> <reason> <attempts-made> <last-exit> — the single
+# annotation every consumer greps, plus the same verdict on the $GITHUB_OUTPUT
+# channel.
+report_infra() {
+  local label="$1" reason="$2" made="$3" rc="$4"
+
+  echo "::error::apt-infra: ${reason} — INFRA-FAIL: apt — ${label} failed ${made} time(s) over $(elapsed)s, last exit ${rc}. The apt mirror failed, not this commit; every job installing packages in this window fails the same way. Re-run the jobs."
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "apt_infra=true" >>"${GITHUB_OUTPUT}"
+    echo "apt_infra_reason=${reason}" >>"${GITHUB_OUTPUT}"
+  fi
+}
+
 # run_phase <label> <per-attempt-timeout-s> <apt-get args...>
 #
-# Returns 0 on the first attempt that succeeds; 1 once the attempts or the total
-# budget are exhausted, having printed a GitHub `::error::` annotation naming
-# which of the two ran out.
+# Returns 0 on the first attempt that succeeds; 75 once the attempts are
+# exhausted on an apt infrastructure failure; 1 once the attempts or the total
+# budget are exhausted on anything else. Either failure prints a GitHub
+# `::error::` annotation naming what ran out.
 run_phase() {
   local label="$1" per_attempt="$2"
   shift 2
 
-  local attempt=1 rc=0 spent delay=0 ceiling="$per_attempt"
+  local attempt=1 rc=0 spent delay=0 ceiling="$per_attempt" reason="" last_reason=""
   while [ "$attempt" -le "$ATTEMPTS" ]; do
     spent="$(elapsed)"
     if [ "$spent" -ge "$TOTAL_BUDGET_S" ]; then
+      # #7288: an earlier attempt that already showed a mirror signature makes
+      # this the same infra event, reported once, rather than a second verdict.
+      if [ -n "$last_reason" ]; then
+        report_infra "$label" "$last_reason" "$(( attempt - 1 ))" "$rc"
+        return "$INFRA_EXIT"
+      fi
       echo "::error::ci-apt-install: ${label} abandoned after ${spent}s — over the ${TOTAL_BUDGET_S}s total budget. The apt mirror is not responding; re-run the job."
       return 1
     fi
@@ -138,10 +264,14 @@ run_phase() {
 
     echo "ci-apt-install: ${label}, attempt ${attempt}/${ATTEMPTS} (${spent}s elapsed, ${ceiling}s ceiling)" >&2
     rc=0
+    # #7288: the attempt's output is teed so it stays visible AND can be matched
+    # for an infrastructure signature. `pipefail` (set at the top) is what keeps
+    # apt's exit code rather than tee's.
+    : >"${ATTEMPT_LOG}"
     if [ -n "$TIMEOUT_BIN" ]; then
-      "$TIMEOUT_BIN" "$ceiling" ${SUDO:+"$SUDO"} "$@" || rc=$?
+      "$TIMEOUT_BIN" "$ceiling" ${SUDO:+"$SUDO"} "$@" 2>&1 | tee -a "${ATTEMPT_LOG}" >&2 || rc=$?
     else
-      ${SUDO:+"$SUDO"} "$@" || rc=$?
+      ${SUDO:+"$SUDO"} "$@" 2>&1 | tee -a "${ATTEMPT_LOG}" >&2 || rc=$?
     fi
 
     if [ "$rc" -eq 0 ]; then
@@ -149,8 +279,13 @@ run_phase() {
       return 0
     fi
 
+    reason="$(apt_infra_reason "$rc")"
+    [ -z "$reason" ] || last_reason="$reason"
+
     if [ "$rc" -eq 124 ]; then
       echo "ci-apt-install: ${label} attempt ${attempt} STALLED — killed at the ${ceiling}s ceiling." >&2
+    elif [ -n "$reason" ]; then
+      echo "ci-apt-install: ${label} attempt ${attempt} failed (exit ${rc}) — apt infrastructure signature: ${reason}." >&2
     else
       echo "ci-apt-install: ${label} attempt ${attempt} failed (exit ${rc})." >&2
     fi
@@ -161,16 +296,22 @@ run_phase() {
       # #6064: repair before the retry, not after the phase — the poisoned
       # attempts are the ones inside this loop.
       repair_dpkg
+      [ "$reason" = "hash-mismatch" ] && clear_apt_lists
       [ "$delay" -gt 0 ] && sleep "$delay"
     fi
   done
+
+  if [ -n "$last_reason" ]; then
+    report_infra "$label" "$last_reason" "$ATTEMPTS" "$rc"
+    return "$INFRA_EXIT"
+  fi
 
   echo "::error::ci-apt-install: ${label} failed ${ATTEMPTS} time(s), last exit ${rc}, $(elapsed)s elapsed. Exit 124 means the mirror stalled and the attempt was killed at its ${ceiling}s ceiling."
   return 1
 }
 
-run_phase "apt-get update" "$UPDATE_TIMEOUT_S" apt-get update -qq || exit 1
+run_phase "apt-get update" "$UPDATE_TIMEOUT_S" apt-get update -qq || exit $?
 run_phase "apt-get install" "$INSTALL_TIMEOUT_S" \
-  apt-get install -y --no-install-recommends "$@" || exit 1
+  apt-get install -y --no-install-recommends "$@" || exit $?
 
 echo "ci-apt-install: installed $* in $(elapsed)s" >&2


### PR DESCRIPTION
## Outcome
One transient Chrome-mirror hash mismatch killed 8 jobs and reported as 8 separate reds; `scripts/ci-apt-install.sh` now classifies apt-infra failures (hash-mismatch, dns, connect, mirror-http/fetch, stall), retries with backoff, purges the stale apt lists on a hash mismatch, and on exhaustion emits one `::error::apt-infra: <reason> — INFRA-FAIL: apt` annotation, writes `apt_infra=true` / `apt_infra_reason` to `$GITHUB_OUTPUT`, and exits 75 (EX_TEMPFAIL); a non-infra failure still exits 1 under the original annotation.

## Changes
`scripts/ci-apt-install.sh` (+169/-15), `scripts/check-ci-helpers-selftest.sh` (+129/-7, 26 new cases; exact-count cases raised to a 6 s ceiling to stop a load flake).

## Risk
Low, CI-only (rung 1-2).

## Tests
`bash -n` both scripts 0; shellcheck: ci-apt-install.sh clean, selftest same warning classes as baseline; `./scripts/check-ci-helpers-selftest.sh` -> all 245 cases passed (3 consecutive runs); `./scripts/check-red-main-coverage.sh` 22 workflows covered; `check_sld.sh` 0 errors; `check_changelog_fragment.sh --staged` OK (CI-only, no fragment).

## Baseline
Second closure condition of #7288 (classify-ci-results grouping on the token) needs per-job `outputs:` wiring in ci.yml — not in this PR; the `$GITHUB_OUTPUT` rows here make that a one-liner per job.

## Docs
Token contract documented in the script header; `docs/reference/ci-scripts.md` does not list this helper.

## Review
CI-only, no critic round; credential scan PASS.

Refs #7288

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
