### PR TITLE
chore(sessions): pause snapshot trusty-tools-95 2026-09-10 00:19Z

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-001911.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-001911.md
@@ -1,0 +1,34 @@
+# Session Pause - 2026-09-10T00:19:11.961807+00:00
+
+## Summary
+Owner-invoked pause 2026-09-10 ~00:2xZ, session trusty-tools-95 (tmux tm-dogfood:0:@1), mid close-drive; supersedes the 23:38Z snapshot (PR #7306). Owner directives this leg: "still have 247 issues, including bugs -- we should be driving to close them"; "close them" (nine automation-filed self-improvement issues — done); "Quick change do shunt reporting, do 💸4%/21% -- does this include bash compression as well? Are we using RTK? If not we should be." ANSWERED: 💸 folds only usage/savings.jsonl (instruction-compression + divert); tm compress writes to a separate compression.jsonl and never feeds the segment — being wired now; RTK binary is NOT installed but tm compress is already RTK-first with native fallback (compress_via_rtk, rtk.rs:60-151); recommendation: install rtk on PATH, never run `rtk init` (would add a competing PreToolUse Bash rewriter, and tm launches with --setting-sources project,local so a user-tier hook never fires). OWNER DECISION PENDING: install rtk binary. INSTALLED: tm 1.5.22 (daemon pid 51160); trusty-audit 0.15.0 reinstall in flight (PR #7308 merged 02159fc2c; 0.14.7 re-cut to 0.15.0 because semver gate found 4 breaking changes vs 0.14.2). MERGED this leg: #7295 #7294 #7296 #7304 #7305 #7306 #7307 #7308. Main red-main causes all fixed on main as of 453aa394; watches on main runs 453aa394 and 7d9421bb5 — green closes #7226 and the #7028 tracker. CLOSED this leg: 21 from status:tested (#7262 #7232 #7185 #7196 #7217 #7274 #5470 #7139 #6847 #6982 #7234 #7247 #7249 #7250 #7259 #7245 #7074 #7166 #7253 and earlier #7244 once) + 8 fold-in closes (#7264 #7265 #7297 #7298 #7299 #7300 #7301 #7302); stale claims #6875 #6802 #6288 #6761 reset to open.
+
+## In Progress
+- rust-engineer feat/statusline-savings-slash-format: render 💸<session>%/<avg>%, PLUS make `tm compress` append a SavingsRow (technique compress, basis carries compression_path) to usage/savings.jsonl — on report: scan → version-control PR unarmed → settle → merge; then reinstall tm (bump 1.5.23) so the owner sees the new format
+- rust-engineer #7267 fix/7267-prune-worktrees-merged-pr-match (reuse #7275 r2 landing_evidence) — on report: critic (destructive path) → scan → PR
+- rust-engineer #7278+#7290 fix/7278-transcript-path-screening (reuse #7250 helper) — critic → scan → PR
+- rust-engineer #7266 fix/7266-pm-guard-secret-file-line-reads — critic → scan → PR
+- rust-engineer #7282 r4 fix/7282-session-pause-via-pr-r4: pr-open must pass explicit --head/--base (branch push already happens) — critic → scan → PR; #7282 is at status:coded
+- #7270+#7271+#7287 DONE at 964502b57 on fix/7270-agent-prompt-literals (7 literals removed, regression test general_purpose_assets_state_no_repo_specific_literal, all gates green): security scan running; then version-control opens PR (no critic, assets only) → arm after settle
+- local-ops: reinstall trusty-audit 0.15.0 from 02159fc2c, verify #5478 #5669 live, remove throwaway worktrees verify-1522 verify-7244 install-tm-1520 install-audit-0150 — on report ticketing closes #5478 #5669 from status:tested
+- ticketing: #7270/#7271/#7287 → status:in-progress + open-count report
+- Monitors: main CI 453aa394 (bh7stt9zw), main CI 7d9421bb5 (bd2v7m9l0) — on green: ticketing closes #7226 and comments/closes #7028 tracker; #7288 → tested → closed on the clean run
+
+## Next Steps
+- On resume: ListAgents FIRST (agents survive pause); then `git log --oneline -1` per branch above; salvage uncommitted work with a fresh engineer on a fresh -rN branch off the committed head
+- #7275 round 3 — dispatch AFTER #7267 reports (overlapping files worktree_remove_rechecks / pr_cleanup): tm pr cleanup must treat a squash-merged branch as landed via MERGED PR + merge-tree no-op vs baseRefName, not ahead-count (comment 5610265795); then `tm pr cleanup` over #7257 #7285 #7286 #7281 #7260 #7294 #7296 #7305 #7307 #7308 as the live test; #7275 → tested → closed
+- #7282 acceptance after r4 merges + reinstall: a pause must open its own PR with auto-merge armed; then #7282 → tested → closed
+- After the fix wave merges: ONE tm bump 1.5.23 + reinstall (#7266 #7267 #7278 #7282 statusline change installed behaviour); live-verify each; ticketing closes
+- HELD status:merged, owner-attended: #5220 (Bitbucket creds), #6838 #6900 #7112 (saver 0.11.1 visual), #7224 #7263 (tm ls TUI); close each on the owner's word
+- Worktree hygiene second pass after #7275 r3: `tm session prune-worktrees --merged-prs` dry run; install-tm-1522 removable after 1.5.23 lands
+- Owner decision: install rtk binary (`cargo install --git https://github.com/rtk-ai/rtk`), NOT `rtk init`; if yes → local-ops installs, then a `tm compress` run must show compression_path rtk_binary
+- Fold, never file: check_rustdoc_links.sh needs --crate mode (interrupted run poisons the doc cache → NOT-EXAMINED); check_capabilities.sh should use the branch binary; BASE-AGENT exact-name scratch reads + per-task subdir (partly landed in #7270); check_line_cap --report; #6982 shapes (bash script → ./script, git diff no pathspec, grep pattern with git, HOME=, zsh script, python3 -c, $'…' quoting); tm compress wrapper masks exit codes; cross-branch push guard fast-forward allowance; StableHookExeError wording; pm_guard_cost fail-open arm should log; hooks double registration (#7276)
+- Every brief: NEVER generate machine-wide CPU load; isolation worktree + STOP-if-main-checkout; CARGO_TARGET_DIR absolute literal target-<N>; scan before PR; Refs never Closes; rustdoc gate in every rust brief; arm auto-merge only after raw rows green (Public API / SemVer counts even though not required); -rN branches off the committed head; ticketing/version-control on sonnet; agent recs fold into PRs, never new issues
+
+## Git Context
+Branch: main
+Last commit: c7e38dbfa chore(trusty-mpm): bump to 1.5.21 for owner-authorized reinstall (#7292)
+Uncommitted changes: 117 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -106,3 +106,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-164445.md","timestamp":"2026-09-09T16:44:45.434809+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-192518.md","timestamp":"2026-09-09T19:25:18.095691+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-233853.md","timestamp":"2026-09-09T23:38:53.886440+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-001911.md","timestamp":"2026-09-10T00:19:11.961807+00:00"}


### PR DESCRIPTION
## Outcome
Pause snapshot for session `0b318c84-bae9-4a50-8832-65ed61f8ab22` at 2026-09-10 00:19Z (trusty-tools-95), committed on this branch but never opened as a PR — the publisher ran `gh pr create` without `--head` and failed. This is the second live occurrence of that gap; refs #7282.

## Changes
- `.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-001911.md` (new snapshot)
- `.trusty-mpm/sessions/sessions-log.jsonl` (append)

## Risk
Low, rung 1 — docs-only session-snapshot data, no crate source touched.

## Tests
None required at rung 1.

## Baseline
None.

## Docs
None beyond the snapshot itself.

## Review
No code-critic needed — docs-only snapshot.

Refs #7282

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
