### PR TITLE
fix(trusty-mpm): match merged PRs by round stem and head ancestry in prune-worktrees

### DIFF
--- a/crates/trusty-mpm/changelog.d/7267-prune-worktrees-merged-pr-match.md
+++ b/crates/trusty-mpm/changelog.d/7267-prune-worktrees-merged-pr-match.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `tm session prune-worktrees --merged-prs` now matches a worktree to its merged pull request by round stem (`fix/x` and `fix/x-r2` are one workstream) and by head-commit ancestry, not by exact branch name alone — a renamed or re-cut branch left 11 of 11 stale worktrees unreclaimable. A branch with no merged pull request under any route is still refused, and every `gh`/`git` failure leaves that refusal standing (#7267).

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -72,6 +72,9 @@ pub(crate) mod worktree_reclaim_gh;
 // #6867: decides whether a `gh` poll may be spawned at all — one call in
 // flight per query, and no polling of a root that has hung three times running.
 pub(crate) mod worktree_reclaim_gh_gate;
+// #7267: which merged pull request carried a worktree's work, when the branch
+// it is on is not the name that pull request was opened from.
+pub(crate) mod worktree_reclaim_pr_match;
 // #6507: the verdict vocabulary, including which GATE refused a candidate.
 pub(crate) mod worktree_reclaim_verdict;
 // #6806: gate 2's claim resolution — WHICH session claims a candidate, and

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -435,26 +435,74 @@ impl PrIndex {
     /// when the index is complete, [`BranchPrState::LookupFailed`] when the
     /// lookup itself failed (#6561), and `Unknown` when the index merely ran
     /// past its page limit.
+    ///
+    /// #7267: a branch the index does not hold under its own name is asked for
+    /// again by ROUND STEM, via [`related_state`](Self::related_state) — a
+    /// review round renames `<branch>` to `<branch>-r2` while the pull request
+    /// keeps whichever spelling it was opened from, so the two names miss each
+    /// other by exact match in both directions.
     /// Test: `pr_index_detached_worktree_is_unknown`,
     /// `pr_index_absent_branch_is_no_pr_when_complete`,
-    /// `pr_index_reports_a_failed_lookup_with_its_reason`.
+    /// `pr_index_reports_a_failed_lookup_with_its_reason`,
+    /// `pr_index_resolves_a_round_sibling_by_stem`,
+    /// `pr_index_resolves_a_stem_branch_from_its_round_sibling`,
+    /// `pr_index_does_not_relate_an_unrelated_branch`.
     pub(crate) fn state_for(&self, branch: Option<&str>) -> BranchPrState {
         let Some(branch) = branch else {
             return BranchPrState::Unknown;
         };
-        match self.by_branch.get(branch) {
-            Some(state) => state.clone(),
-            None if self.complete => BranchPrState::NoPr,
-            // #6561: a branch the index could not answer BECAUSE the lookup
-            // failed reports the failure; a merely truncated index still
-            // reports `Unknown`.
-            None => match &self.failure {
-                Some(reason) => BranchPrState::LookupFailed {
-                    reason: reason.clone(),
-                },
-                None => BranchPrState::Unknown,
-            },
+        if let Some(state) = self.by_branch.get(branch) {
+            return state.clone();
         }
+        // #7267: before "absent" is read as an answer, the round siblings this
+        // index DOES hold are consulted.
+        if let Some(state) = self.related_state(branch) {
+            return state;
+        }
+        if self.complete {
+            return BranchPrState::NoPr;
+        }
+        // #6561: a branch the index could not answer BECAUSE the lookup failed
+        // reports the failure; a merely truncated index still reports
+        // `Unknown`.
+        match &self.failure {
+            Some(reason) => BranchPrState::LookupFailed {
+                reason: reason.clone(),
+            },
+            None => BranchPrState::Unknown,
+        }
+    }
+
+    /// The most blocking state this index holds for `branch`'s ROUND SIBLINGS
+    /// (#7267).
+    ///
+    /// Why: `tm session prune-worktrees --merged-prs` matched a worktree to its
+    /// pull request by exact branch name, and reclaimed 0 of 11 stale trees
+    /// because a review round had renamed every one of them. `foo` and `foo-r2`
+    /// are one workstream, related here by the same
+    /// [`strip_round_suffix`](crate::core::pr_cleanup::plan::strip_round_suffix)
+    /// stem `core::pr_cleanup` relates them by and the ADR-0057 removal guard
+    /// applies — one implementation of that equivalence, not a second matcher.
+    /// What: `None` when the index holds no sibling under a different name;
+    /// otherwise the sibling state with the highest
+    /// [`BranchPrState::block_rank`], so a MERGED sibling never outvotes an
+    /// OPEN one. The lookup costs no network call: it reads rows the bulk index
+    /// already holds.
+    /// Test: `pr_index_resolves_a_round_sibling_by_stem`,
+    /// `pr_index_resolves_a_stem_branch_from_its_round_sibling`,
+    /// `pr_index_does_not_relate_an_unrelated_branch`,
+    /// `pr_index_open_round_sibling_beats_a_merged_one`.
+    fn related_state(&self, branch: &str) -> Option<BranchPrState> {
+        let stem = crate::core::pr_cleanup::plan::strip_round_suffix(branch);
+        self.by_branch
+            .iter()
+            .filter(|(name, _)| {
+                name.as_str() != branch
+                    && crate::core::pr_cleanup::plan::strip_round_suffix(name) == stem
+            })
+            .map(|(_, state)| state)
+            .max_by_key(|state| state.block_rank())
+            .cloned()
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_pr_match.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_pr_match.rs
@@ -1,0 +1,443 @@
+//! Which MERGED pull request carried THIS worktree's work (#7267).
+//!
+//! Why: `tm session prune-worktrees --merged-prs --force` reclaimed 0 of 11
+//! stale worktrees whose content was fully on `main`. Every lookup keyed on the
+//! branch name git reports for the worktree, and none of the 11 branches was
+//! the name its pull request was opened from — a review round renames
+//! `<branch>` to `<branch>-r2`, and a re-cut branch takes a new name entirely
+//! before the pull request opens. A merged pull request that carried the work
+//! is landing evidence whatever the branch ended up being called, so the
+//! lookup has to reach it by more than one route.
+//!
+//! What: [`resolve_landing`] is a three-rung ladder over the answer the branch
+//! name already produced.
+//!
+//! 1. The branch's own pull request, from the caller. Any SETTLED answer —
+//!    merged, open, closed-unmerged, or a failed lookup — is returned as-is;
+//!    only `NoPr` and `Unknown` widen.
+//! 2. The round-stem sibling, related by
+//!    [`strip_round_suffix`] — the same equivalence `core::pr_cleanup::plan`
+//!    uses to relate `foo` and `foo-r2`, and the same one the ADR-0057 removal
+//!    guard's `landing_evidence` applies. Not a second matcher: that is the
+//!    one implementation of "these two branch names are the same workstream".
+//! 3. The head COMMIT. `gh pr list --state merged --search <sha>` finds the
+//!    merged pull requests GitHub knows contain this worktree's HEAD, and one
+//!    of them vouches for the tree when its `headRefOid` and that HEAD stand in
+//!    an ancestor relationship either way round — the pull request was opened
+//!    from this commit, from a descendant of it, or from an ancestor of it.
+//!
+//! **A widening rung may only ever produce `Merged`.** It never converts one
+//! refusal into a different one: a rung that cannot answer — no repository, no
+//! `gh`, a timeout, an unparseable reply, a commit git cannot resolve — leaves
+//! rung 1's answer standing and logs the reason. Rung 1's answer is already a
+//! refusal in every case that reaches here, so every failure path denies, which
+//! is what ADR-0045 asks of a gate whose grant deletes a checkout. It also
+//! keeps the operator-facing reason stable: a worktree with no pull request
+//! still reports "no pull request found for this branch" when the network is
+//! down, rather than a lookup failure that is really about the widening.
+//!
+//! The extra `gh` and `git` calls ride on `per_branch_fallback`, so the
+//! `tm doctor` probe — which runs on a three-second budget and passes `false` —
+//! pays for none of them. See [`resolve_with_index`].
+//!
+//! Test: `worktree_reclaim_pr_match_tests`.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use super::worktree_reclaim::{BranchPrState, PrIndex, pr_state_for_branch};
+use super::worktree_reclaim_gh::{
+    GH_TIMEOUT, gh_pr_list_command, resolve_daemon_gh_env, run_with_timeout,
+};
+use super::worktree_reclaim_gh_gate;
+use super::worktree_repo_slug::repo_slug_for;
+use super::worktree_safety::{git_command, git_stdout};
+use crate::core::pr_cleanup::plan::strip_round_suffix;
+
+/// How many merged pull requests one commit search may return.
+///
+/// Why: a commit is normally carried by one pull request; a handful is the
+/// realistic ceiling for a commit that was cherry-picked around. A bound keeps
+/// the ancestry probe below from turning into an unbounded run of `git` calls.
+/// What: 20.
+const COMMIT_SEARCH_LIMIT: usize = 20;
+
+/// The `--json` field set the commit search asks `gh` for.
+///
+/// Why: `isCrossRepository` is requested for the reason `PR_JSON_FIELDS`
+/// requests it — a fork's pull request says nothing about a local branch, and a
+/// `gh` too old to report the field must fail the whole call rather than return
+/// rows in which a fork is indistinguishable from this repository.
+const COMMIT_SEARCH_JSON_FIELDS: &str = "number,headRefOid,isCrossRepository";
+
+/// One MERGED pull request the commit search returned.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct MergedPrHead {
+    /// The pull request number.
+    pub number: u64,
+    /// The commit its head branch pointed at.
+    #[serde(default, rename = "headRefOid")]
+    pub head_ref_oid: String,
+    /// True when that head branch lives in a FORK, not this repository.
+    #[serde(default, rename = "isCrossRepository")]
+    pub is_cross_repository: bool,
+}
+
+/// The facts [`resolve_landing`] needs from GitHub and git (#7267).
+///
+/// Why: a trait rather than four free functions so the ladder — the part that
+/// decides what counts as landing evidence — is a pure function with unit
+/// tests, exactly as the ADR-0057 guard's `WorktreeRemovalProbe` makes its
+/// policy testable. The production implementation is [`GhLandingProbe`]; the
+/// tests drive a fake.
+/// What: every method that can fail returns `Err`, and the ladder treats an
+/// `Err` as "this rung did not answer", never as "there is nothing there".
+/// Test: `worktree_reclaim_pr_match_tests`.
+pub(crate) trait LandingProbe {
+    /// What GitHub says about the pull requests opened from `branch`.
+    fn state_for_head(&self, registry_root: &Path, branch: &str) -> BranchPrState;
+    /// The commit `worktree`'s HEAD points at, as a full object id.
+    fn head_commit(&self, worktree: &Path) -> Result<String, String>;
+    /// The MERGED pull requests GitHub reports as containing `sha`.
+    fn merged_prs_containing(
+        &self,
+        registry_root: &Path,
+        sha: &str,
+    ) -> Result<Vec<MergedPrHead>, String>;
+    /// Is `ancestor` an ancestor of — or the same commit as — `descendant`?
+    fn is_ancestor(
+        &self,
+        worktree: &Path,
+        ancestor: &str,
+        descendant: &str,
+    ) -> Result<bool, String>;
+}
+
+/// Widen a branch-name lookup to the pull request that actually carried the
+/// work (#7267).
+///
+/// Why: the module doc's whole subject. A renamed or re-cut branch has landing
+/// evidence that its NAME cannot reach.
+/// What: rung 1's `exact` answer unless it is `NoPr` or `Unknown`, in which
+/// case the round-stem sibling and then the head commit are asked. Only a
+/// `Merged` answer from a widening rung replaces `exact`; everything else —
+/// including every error — leaves it standing, so no path here can turn a
+/// refusal into a grant without positive evidence of a merge.
+/// Test: `a_round_sibling_with_a_merged_pr_is_reclaimable`,
+/// `a_detached_worktree_can_still_match_by_head_commit`,
+/// `a_renamed_branch_matches_the_pr_opened_from_its_head_commit`,
+/// `no_merged_pr_under_any_stem_is_still_refused`,
+/// `an_open_pr_on_the_branch_is_never_widened`,
+/// `a_failed_head_commit_read_leaves_the_refusal_standing`,
+/// `a_failed_commit_search_leaves_the_refusal_standing`,
+/// `a_failed_ancestry_probe_leaves_the_refusal_standing`.
+pub(crate) fn resolve_landing(
+    worktree: &Path,
+    registry_root: &Path,
+    branch: Option<&str>,
+    exact: BranchPrState,
+    probe: &dyn LandingProbe,
+) -> BranchPrState {
+    // Rung 1: a settled answer about this branch is the answer. An OPEN pull
+    // request on the branch itself is work in flight, and widening past it
+    // would be the one mistake this ladder must not make.
+    if !matches!(exact, BranchPrState::NoPr | BranchPrState::Unknown) {
+        return exact;
+    }
+    if let Some(pr) = merged_round_sibling(registry_root, branch, probe) {
+        return pr;
+    }
+    match merged_by_head_commit(worktree, registry_root, probe) {
+        Some(pr) => pr,
+        None => exact,
+    }
+}
+
+/// Rung 2 — the MERGED pull request of this branch's round-stem sibling.
+///
+/// Why (#7267, and #7275 for the guard's half of the same problem): a review
+/// round lands on `<branch>-r2` while the pull request keeps the name it was
+/// opened from, so neither name finds the other by exact match. Both spellings
+/// reduce to one stem, and asking GitHub for the OTHER spelling is one call.
+/// What: `Some(Merged)` when the sibling's own lookup reports a merge; `None`
+/// for every other answer, the failed lookup included — see the module doc on
+/// why a rung never returns a different refusal. Only branches whose name
+/// actually differs from their stem cost a call, and the reverse direction (a
+/// stem worktree whose pull request was opened from `-r2`) is answered by
+/// `PrIndex::state_for`'s own sibling scan without a network call at all.
+/// Test: `a_round_sibling_with_a_merged_pr_is_reclaimable`,
+/// `a_round_sibling_whose_stem_pr_is_open_is_not_widened`.
+fn merged_round_sibling(
+    registry_root: &Path,
+    branch: Option<&str>,
+    probe: &dyn LandingProbe,
+) -> Option<BranchPrState> {
+    let branch = branch?;
+    let stem = strip_round_suffix(branch);
+    if stem == branch {
+        return None;
+    }
+    match probe.state_for_head(registry_root, stem) {
+        BranchPrState::Merged { pr } => Some(BranchPrState::Merged { pr }),
+        other => {
+            tracing::debug!(
+                branch = %branch,
+                stem = %stem,
+                state = ?other,
+                "worktree-reclaim: the round-stem sibling carries no merged pull \
+                 request either (#7267)"
+            );
+            None
+        }
+    }
+}
+
+/// Rung 3 — the MERGED pull request GitHub reports as containing this HEAD.
+///
+/// Why: a branch that was re-cut under a new name before its pull request
+/// opened shares no name with it, and no stem relates them. The COMMIT does:
+/// GitHub's own search resolves a full object id to the pull requests carrying
+/// it, which is the evidence the manual salvage in #7267 reconstructed by hand
+/// for all 11 worktrees.
+/// What: `Some(Merged)` for the first returned pull request whose `headRefOid`
+/// and this worktree's HEAD stand in an ancestor relationship either way round
+/// — the pull request was opened from this commit, from a descendant of it, or
+/// from an ancestor of it. A fork's row is skipped for the reason
+/// `PrIndex::from_json` skips it. `None` on every failure, and on a search that
+/// returned nothing this tree's HEAD belongs to.
+///
+/// Content this tree holds BEYOND the matched pull request's head is not this
+/// gate's to catch and is not let through by it: `classify` gate 6 runs
+/// `inspect_dirt` afterwards, whose unpushed-commit count subtracts
+/// patch-equivalent commits (#6507) and refuses anything genuinely novel.
+/// Test: `a_renamed_branch_matches_the_pr_opened_from_its_head_commit`,
+/// `a_fork_pull_request_containing_the_commit_is_ignored`,
+/// `an_unrelated_merged_pr_containing_no_ancestor_is_not_a_match`,
+/// `a_failed_ancestry_probe_leaves_the_refusal_standing`.
+fn merged_by_head_commit(
+    worktree: &Path,
+    registry_root: &Path,
+    probe: &dyn LandingProbe,
+) -> Option<BranchPrState> {
+    let head = match probe.head_commit(worktree) {
+        Ok(head) if !head.trim().is_empty() => head.trim().to_string(),
+        Ok(_) => {
+            tracing::debug!(
+                path = %worktree.display(),
+                "worktree-reclaim: this worktree named no HEAD commit, so the \
+                 commit search cannot run (#7267)"
+            );
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %worktree.display(),
+                "worktree-reclaim: the HEAD commit could not be read, so the merged \
+                 pull request carrying this tree cannot be searched for — the \
+                 branch-name answer stands (#7267): {e}"
+            );
+            return None;
+        }
+    };
+    let rows = match probe.merged_prs_containing(registry_root, &head) {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(
+                path = %worktree.display(),
+                head = %head,
+                "worktree-reclaim: the merged-pull-request commit search did not \
+                 answer — the branch-name answer stands (#7267): {e}"
+            );
+            return None;
+        }
+    };
+    for row in rows {
+        // #7267: a fork's pull request from a branch that happens to contain a
+        // commit of this name is not this repository's landing evidence.
+        if row.is_cross_repository {
+            continue;
+        }
+        let oid = row.head_ref_oid.trim();
+        if oid.is_empty() {
+            continue;
+        }
+        if vouches_for_head(worktree, oid, &head, row.number, probe) {
+            tracing::info!(
+                path = %worktree.display(),
+                pr = row.number,
+                head = %head,
+                "worktree-reclaim: this worktree's HEAD is carried by a merged pull \
+                 request opened from a different branch name (#7267)"
+            );
+            return Some(BranchPrState::Merged { pr: row.number });
+        }
+    }
+    None
+}
+
+/// Does the pull request whose head sat on `oid` vouch for `head`?
+///
+/// Why: the two commits can relate in either direction and both are evidence.
+/// Equal means the pull request was opened from exactly this commit; `oid`
+/// descended from `head` means everything here is inside what merged; `head`
+/// descended from `oid` means the merge carried a prefix of this tree, and
+/// `classify` gate 6 refuses whatever is left over.
+/// What: true when the two commits are the same, and otherwise when either
+/// ancestry holds. An ancestry probe that ERRORS, which is what an object this
+/// checkout does not have looks like, answers false: the rung then finds no
+/// match and the branch-name refusal stands.
+/// Test: `a_renamed_branch_matches_the_pr_opened_from_its_head_commit`,
+/// `an_unrelated_merged_pr_containing_no_ancestor_is_not_a_match`,
+/// `a_failed_ancestry_probe_leaves_the_refusal_standing`.
+fn vouches_for_head(
+    worktree: &Path,
+    oid: &str,
+    head: &str,
+    pr: u64,
+    probe: &dyn LandingProbe,
+) -> bool {
+    // #7267: the commonest case — the pull request was opened from exactly this
+    // commit — is settled by a string comparison, so it costs no subprocess and
+    // no object this checkout might not hold.
+    if oid.eq_ignore_ascii_case(head) {
+        return true;
+    }
+    for (ancestor, descendant) in [(oid, head), (head, oid)] {
+        match probe.is_ancestor(worktree, ancestor, descendant) {
+            Ok(true) => return true,
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    path = %worktree.display(),
+                    pr = pr,
+                    "worktree-reclaim: whether `{ancestor}` is an ancestor of \
+                     `{descendant}` could not be established, so this pull request \
+                     vouches for nothing (#7267): {e}"
+                );
+                return false;
+            }
+        }
+    }
+    false
+}
+
+/// The pull-request state for one surveyed worktree, index first (#7267).
+///
+/// Why: the survey and the pre-delete re-check both need the same answer, and
+/// before this they each carried their own copy of the #6561 per-branch retry.
+/// One function is what keeps the widening from reaching only half the
+/// destructive path.
+/// What: the bulk index's answer, then — only when `per_branch_fallback` is set
+/// — the #6561 targeted retry for a branch a truncated or failed index could
+/// not resolve, then [`resolve_landing`]. With `per_branch_fallback` clear the
+/// index's answer is returned unchanged, which is what keeps the `tm doctor`
+/// probe inside its three-second budget.
+/// Test: `resolve_with_index_without_fallback_never_calls_the_probe`,
+/// `resolve_with_index_retries_a_truncated_index_per_branch`,
+/// `survey_reclaims_a_round_sibling_of_a_merged_pr`.
+pub(crate) fn resolve_with_index(
+    worktree: &Path,
+    registry_root: &Path,
+    branch: Option<&str>,
+    index: &PrIndex,
+    per_branch_fallback: bool,
+    probe: &dyn LandingProbe,
+) -> BranchPrState {
+    let mut pr = index.state_for(branch);
+    if !per_branch_fallback {
+        return pr;
+    }
+    // #6561: a truncated or FAILED bulk lookup retries per-branch. The bulk
+    // call and the targeted one can fail for different reasons (a page limit is
+    // not an auth failure), and only the targeted one resolves a branch older
+    // than the bulk window.
+    if matches!(
+        pr,
+        BranchPrState::Unknown | BranchPrState::LookupFailed { .. }
+    ) && !index.is_complete()
+        && let Some(branch) = branch
+    {
+        pr = probe.state_for_head(registry_root, branch);
+    }
+    resolve_landing(worktree, registry_root, branch, pr, probe)
+}
+
+/// The production [`LandingProbe`] — real `gh`, real `git` (#7267).
+///
+/// Why: every call it makes goes through the module that already owns that
+/// capability — `worktree_reclaim::pr_state_for_branch` for a branch's
+/// pull requests, `worktree_reclaim_gh` for spawning `gh` under the resolved
+/// identity and the hang gate, `worktree_safety::git_command` for a `git` that
+/// ambient config cannot steer. Nothing here re-implements one of those.
+/// What: the four probe methods, each failing with a string the ladder logs.
+/// Test: exercised through the reclaim sweep; the ladder's own decisions are
+/// unit-tested against a fake in `worktree_reclaim_pr_match_tests`.
+pub(crate) struct GhLandingProbe;
+
+impl LandingProbe for GhLandingProbe {
+    fn state_for_head(&self, registry_root: &Path, branch: &str) -> BranchPrState {
+        pr_state_for_branch(registry_root, branch)
+    }
+
+    fn head_commit(&self, worktree: &Path) -> Result<String, String> {
+        git_stdout(worktree, &["rev-parse", "HEAD"]).map(|s| s.trim().to_string())
+    }
+
+    fn merged_prs_containing(
+        &self,
+        registry_root: &Path,
+        sha: &str,
+    ) -> Result<Vec<MergedPrHead>, String> {
+        // #7057: the repository comes from this root's own `origin`, never from
+        // whatever `gh` would infer at this working directory.
+        let repo = repo_slug_for(registry_root)?;
+        // #6867: through the same hang gate every other `gh` poll uses, under a
+        // key naming the question — a commit search is not the per-branch query
+        // and the two must never share a reply.
+        let stdout = worktree_reclaim_gh_gate::shared()
+            .poll(registry_root, &format!("merged-sha:{repo}:{sha}"), || {
+                let gh_env = resolve_daemon_gh_env(registry_root);
+                let mut cmd = gh_pr_list_command(registry_root, &gh_env, &repo);
+                cmd.args(["--state", "merged", "--search", sha, "--limit"])
+                    .arg(COMMIT_SEARCH_LIMIT.to_string())
+                    .args(["--json", COMMIT_SEARCH_JSON_FIELDS]);
+                run_with_timeout(cmd, GH_TIMEOUT)
+            })
+            .map_err(|f| format!("{f} (repository searched: {repo})"))?;
+        serde_json::from_str(&stdout).map_err(|e| {
+            format!("`gh pr list --repo {repo} --search {sha}` JSON did not parse: {e}")
+        })
+    }
+
+    fn is_ancestor(
+        &self,
+        worktree: &Path,
+        ancestor: &str,
+        descendant: &str,
+    ) -> Result<bool, String> {
+        // `git merge-base --is-ancestor` answers by EXIT CODE — 0 yes, 1 no,
+        // anything else a fault — so this is the one git call in the module
+        // that cannot go through `git_stdout`, which reads a non-zero exit as
+        // an error.
+        let out = git_command(
+            worktree,
+            &["merge-base", "--is-ancestor", ancestor, descendant],
+        )
+        .output()
+        .map_err(|e| format!("`git merge-base --is-ancestor` could not be run: {e}"))?;
+        match out.status.code() {
+            Some(0) => Ok(true),
+            Some(1) => Ok(false),
+            _ => Err(format!(
+                "`git merge-base --is-ancestor {ancestor} {descendant}` failed ({}): {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "worktree_reclaim_pr_match_tests.rs"]
+mod worktree_reclaim_pr_match_tests;

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_pr_match_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_pr_match_tests.rs
@@ -1,0 +1,468 @@
+//! Tests for the merged-pull-request matcher (#7267).
+//!
+//! Why: this ladder's grant is what authorises deleting a checkout, so every
+//! rung needs a test that fails if the rung is removed, and every FAILURE path
+//! needs one proving it refuses rather than reclaims. The probe is faked
+//! because the real one is `gh` and `git`; what is under test is the policy —
+//! which answers count as landing evidence — not the subprocesses.
+//! What: one test per rung, one per failure mode of each rung, and the
+//! `resolve_with_index` wiring that decides when a rung may run at all.
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use super::*;
+
+/// The worktree's HEAD in every test that does not override it.
+const HEAD_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+/// A commit that is not this worktree's HEAD.
+const OTHER_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+/// The worktree directory under test — the fake probe never touches disk.
+fn worktree() -> &'static Path {
+    Path::new("/nonexistent/worktree-7267")
+}
+
+/// The registry root under test — likewise never touched.
+fn root() -> &'static Path {
+    Path::new("/nonexistent/root-7267")
+}
+
+/// A [`LandingProbe`] whose every answer is stated by the test.
+struct FakeProbe {
+    /// Branch name → what GitHub says about it.
+    heads: BTreeMap<String, BranchPrState>,
+    /// What `git rev-parse HEAD` answers.
+    head_commit: Result<String, String>,
+    /// What the commit search answers.
+    search: Result<Vec<MergedPrHead>, String>,
+    /// Ordered pairs for which `is_ancestor` answers true.
+    ancestors: BTreeSet<(String, String)>,
+    /// When set, `is_ancestor` fails with this reason instead of answering.
+    ancestry_error: Option<String>,
+    /// Every probe method called, in order — so a test can prove a rung was
+    /// NOT reached.
+    calls: RefCell<Vec<String>>,
+}
+
+impl Default for FakeProbe {
+    fn default() -> Self {
+        Self {
+            heads: BTreeMap::new(),
+            head_commit: Ok(HEAD_SHA.to_string()),
+            search: Ok(Vec::new()),
+            ancestors: BTreeSet::new(),
+            ancestry_error: None,
+            calls: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl FakeProbe {
+    /// State `branch`'s pull-request answer.
+    fn with_head(mut self, branch: &str, state: BranchPrState) -> Self {
+        self.heads.insert(branch.to_string(), state);
+        self
+    }
+
+    /// State what the commit search returns.
+    fn with_search(mut self, rows: Vec<MergedPrHead>) -> Self {
+        self.search = Ok(rows);
+        self
+    }
+
+    /// State that the commit search FAILS.
+    fn with_search_error(mut self, reason: &str) -> Self {
+        self.search = Err(reason.to_string());
+        self
+    }
+
+    /// State what `git rev-parse HEAD` answers.
+    fn with_head_commit(mut self, answer: Result<String, String>) -> Self {
+        self.head_commit = answer;
+        self
+    }
+
+    /// State that the ancestry probe FAILS — what an object this checkout does
+    /// not hold looks like.
+    fn with_ancestry_error(mut self, reason: &str) -> Self {
+        self.ancestry_error = Some(reason.to_string());
+        self
+    }
+
+    /// State that `ancestor` is an ancestor of `descendant`.
+    fn with_ancestor(mut self, ancestor: &str, descendant: &str) -> Self {
+        self.ancestors
+            .insert((ancestor.to_string(), descendant.to_string()));
+        self
+    }
+
+    /// Did any probe method get called?
+    fn calls(&self) -> Vec<String> {
+        self.calls.borrow().clone()
+    }
+}
+
+impl LandingProbe for FakeProbe {
+    fn state_for_head(&self, _registry_root: &Path, branch: &str) -> BranchPrState {
+        self.calls.borrow_mut().push(format!("head:{branch}"));
+        self.heads
+            .get(branch)
+            .cloned()
+            .unwrap_or(BranchPrState::NoPr)
+    }
+
+    fn head_commit(&self, _worktree: &Path) -> Result<String, String> {
+        self.calls.borrow_mut().push("head_commit".to_string());
+        self.head_commit.clone()
+    }
+
+    fn merged_prs_containing(
+        &self,
+        _registry_root: &Path,
+        sha: &str,
+    ) -> Result<Vec<MergedPrHead>, String> {
+        self.calls.borrow_mut().push(format!("search:{sha}"));
+        self.search.clone()
+    }
+
+    fn is_ancestor(
+        &self,
+        _worktree: &Path,
+        ancestor: &str,
+        descendant: &str,
+    ) -> Result<bool, String> {
+        self.calls
+            .borrow_mut()
+            .push(format!("ancestor:{ancestor}:{descendant}"));
+        if let Some(reason) = &self.ancestry_error {
+            return Err(reason.clone());
+        }
+        Ok(self
+            .ancestors
+            .contains(&(ancestor.to_string(), descendant.to_string())))
+    }
+}
+
+/// One row of the commit search, from this repository.
+fn row(number: u64, head_ref_oid: &str) -> MergedPrHead {
+    MergedPrHead {
+        number,
+        head_ref_oid: head_ref_oid.to_string(),
+        is_cross_repository: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rung 2 — the round-stem sibling
+// ---------------------------------------------------------------------------
+
+/// The reported defect, one rung at a time: a worktree left on `<branch>-r2`
+/// after a review round, whose pull request merged under `<branch>` (#7267).
+#[test]
+fn a_round_sibling_with_a_merged_pr_is_reclaimable() {
+    let probe = FakeProbe::default().with_head("fix/7267-thing", BranchPrState::Merged { pr: 91 });
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-thing-r2"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::Merged { pr: 91 });
+    assert_eq!(probe.calls(), vec!["head:fix/7267-thing".to_string()]);
+}
+
+/// A sibling whose pull request is still OPEN is work in flight — the rung
+/// produces nothing and the refusal stands (#7267).
+#[test]
+fn a_round_sibling_whose_stem_pr_is_open_is_not_widened() {
+    let probe = FakeProbe::default().with_head("fix/7267-thing", BranchPrState::Open { pr: 92 });
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-thing-r2"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::NoPr, "an open sibling grants nothing");
+}
+
+/// A branch with no round suffix costs no sibling lookup at all (#7267).
+#[test]
+fn a_branch_without_a_round_suffix_asks_for_no_sibling() {
+    let probe = FakeProbe::default();
+    let _ = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-thing"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert!(
+        !probe.calls().iter().any(|c| c.starts_with("head:")),
+        "no stem to ask about: {:?}",
+        probe.calls()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rung 3 — the head commit
+// ---------------------------------------------------------------------------
+
+/// A branch re-cut under a new name before its pull request opened: no name
+/// relates the two, but the COMMIT does (#7267).
+#[test]
+fn a_renamed_branch_matches_the_pr_opened_from_its_head_commit() {
+    let probe = FakeProbe::default().with_search(vec![row(93, HEAD_SHA)]);
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::Merged { pr: 93 });
+}
+
+/// A pull request opened from a DESCENDANT of this HEAD carried everything
+/// here, so it vouches for the tree too (#7267).
+#[test]
+fn a_pr_opened_from_a_descendant_of_this_head_also_vouches() {
+    let probe = FakeProbe::default()
+        .with_search(vec![row(94, OTHER_SHA)])
+        .with_ancestor(HEAD_SHA, OTHER_SHA);
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::Merged { pr: 94 });
+}
+
+/// A detached worktree has no branch to widen by name, and still reaches the
+/// commit rung (#7267).
+#[test]
+fn a_detached_worktree_can_still_match_by_head_commit() {
+    let probe = FakeProbe::default().with_search(vec![row(95, HEAD_SHA)]);
+    let out = resolve_landing(worktree(), root(), None, BranchPrState::Unknown, &probe);
+    assert_eq!(out, BranchPrState::Merged { pr: 95 });
+}
+
+/// A merged pull request the search returned whose head stands in no ancestry
+/// relationship to this HEAD vouches for nothing (#7267).
+#[test]
+fn an_unrelated_merged_pr_containing_no_ancestor_is_not_a_match() {
+    let probe = FakeProbe::default().with_search(vec![row(96, OTHER_SHA)]);
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::NoPr);
+}
+
+/// A fork's pull request that happens to contain a commit of this name is not
+/// this repository's landing evidence (#7267, the #2919 rule).
+#[test]
+fn a_fork_pull_request_containing_the_commit_is_ignored() {
+    let mut fork = row(97, HEAD_SHA);
+    fork.is_cross_repository = true;
+    let probe = FakeProbe::default().with_search(vec![fork]);
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::NoPr);
+}
+
+// ---------------------------------------------------------------------------
+// The refusals — every one of these would be a deleted checkout if it granted
+// ---------------------------------------------------------------------------
+
+/// The acceptance condition: no merged pull request under ANY route leaves the
+/// worktree refused, `--force` or not (#7267).
+#[test]
+fn no_merged_pr_under_any_stem_is_still_refused() {
+    let probe = FakeProbe::default();
+    for (branch, exact) in [
+        (Some("fix/7267-thing-r2"), BranchPrState::NoPr),
+        (Some("fix/7267-thing"), BranchPrState::NoPr),
+        (None, BranchPrState::Unknown),
+    ] {
+        let out = resolve_landing(worktree(), root(), branch, exact.clone(), &probe);
+        assert_eq!(out, exact, "branch {branch:?} must stay refused");
+    }
+}
+
+/// A settled answer about the branch ITSELF is never widened past — an open
+/// pull request means work in flight (#7267).
+#[test]
+fn an_open_pr_on_the_branch_is_never_widened() {
+    let probe = FakeProbe::default()
+        .with_head("fix/7267-thing", BranchPrState::Merged { pr: 98 })
+        .with_search(vec![row(99, HEAD_SHA)]);
+    for exact in [
+        BranchPrState::Open { pr: 1 },
+        BranchPrState::ClosedUnmerged { pr: 2 },
+        BranchPrState::LookupFailed {
+            reason: "`gh` exited 4".to_string(),
+        },
+    ] {
+        let out = resolve_landing(
+            worktree(),
+            root(),
+            Some("fix/7267-thing-r2"),
+            exact.clone(),
+            &probe,
+        );
+        assert_eq!(out, exact, "a settled answer is the answer");
+    }
+    assert!(probe.calls().is_empty(), "and costs no widening call");
+}
+
+/// A HEAD that git could not read denies — the branch-name refusal stands and
+/// nothing is reclaimed (#7267 fail-open check).
+#[test]
+fn a_failed_head_commit_read_leaves_the_refusal_standing() {
+    let probe = FakeProbe::default()
+        .with_search(vec![row(100, HEAD_SHA)])
+        .with_head_commit(Err("`git rev-parse HEAD` failed (128)".to_string()));
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::NoPr);
+    assert!(
+        !probe.calls().iter().any(|c| c.starts_with("search:")),
+        "and never searches on a HEAD it could not read: {:?}",
+        probe.calls()
+    );
+}
+
+/// A `gh` that could not answer the commit search denies (#7267 fail-open
+/// check).
+#[test]
+fn a_failed_commit_search_leaves_the_refusal_standing() {
+    let probe = FakeProbe::default().with_search_error("`gh` exited 4: gh auth login");
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::NoPr);
+}
+
+/// A git that could not settle the ancestry denies — an unresolvable object is
+/// exactly what a pull request head this checkout never fetched looks like
+/// (#7267 fail-open check).
+#[test]
+fn a_failed_ancestry_probe_leaves_the_refusal_standing() {
+    let probe = FakeProbe::default()
+        .with_search(vec![row(101, OTHER_SHA)])
+        .with_ancestry_error("bad object bbbbbbb");
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::NoPr);
+}
+
+/// A HEAD the probe reports as empty is not a commit to search for (#7267).
+#[test]
+fn an_empty_head_commit_reaches_no_search() {
+    let probe = FakeProbe::default().with_head_commit(Ok("   ".to_string()));
+    let out = resolve_landing(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        BranchPrState::NoPr,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::NoPr);
+    assert_eq!(probe.calls(), vec!["head_commit".to_string()]);
+}
+
+// ---------------------------------------------------------------------------
+// resolve_with_index — when a rung is allowed to run at all
+// ---------------------------------------------------------------------------
+
+/// A merged row keyed by a branch name.
+fn index(branch: &str, pr: u64, state: &str) -> PrIndex {
+    PrIndex::from_json(
+        &format!(r#"[{{"number": {pr}, "headRefName": "{branch}", "state": "{state}"}}]"#),
+        400,
+    )
+}
+
+/// The `tm doctor` probe passes `per_branch_fallback: false` and must pay for
+/// no network call — the index's own answer is the whole answer (#7267).
+#[test]
+fn resolve_with_index_without_fallback_never_calls_the_probe() {
+    let probe = FakeProbe::default().with_head("fix/7267-thing", BranchPrState::Merged { pr: 102 });
+    let out = resolve_with_index(
+        worktree(),
+        root(),
+        Some("fix/7267-unrelated"),
+        &index("fix/7267-thing", 102, "MERGED"),
+        false,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::NoPr);
+    assert!(probe.calls().is_empty(), "{:?}", probe.calls());
+}
+
+/// #6561's per-branch retry survives the move into this function: a TRUNCATED
+/// index still asks `gh` about the branch itself before any widening.
+#[test]
+fn resolve_with_index_retries_a_truncated_index_per_branch() {
+    // A one-row reply against a limit of 1 is indistinguishable from a
+    // truncated page, so the index reports incomplete.
+    let truncated = PrIndex::from_json(
+        r#"[{"number": 103, "headRefName": "someone/else", "state": "MERGED"}]"#,
+        1,
+    );
+    let probe = FakeProbe::default().with_head("fix/7267-mine", BranchPrState::Merged { pr: 104 });
+    let out = resolve_with_index(
+        worktree(),
+        root(),
+        Some("fix/7267-mine"),
+        &truncated,
+        true,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::Merged { pr: 104 });
+    assert_eq!(probe.calls(), vec!["head:fix/7267-mine".to_string()]);
+}
+
+/// A COMPLETE index that answers `NoPr` is still widened — the renamed-branch
+/// case has nothing to do with the index being truncated (#7267).
+#[test]
+fn resolve_with_index_widens_a_complete_index_no_pr_answer() {
+    let probe = FakeProbe::default().with_search(vec![row(105, HEAD_SHA)]);
+    let out = resolve_with_index(
+        worktree(),
+        root(),
+        Some("fix/7267-recut"),
+        &index("someone/else", 103, "MERGED"),
+        true,
+        &probe,
+    );
+    assert_eq!(out, BranchPrState::Merged { pr: 105 });
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep.rs
@@ -40,8 +40,11 @@ use std::time::{Duration, Instant};
 use super::worktree_reclaim::{
     AgentStateProbe, BranchPrState, KeepList, LiveClaims, NOT_INSPECTED_REASON, PrIndex,
     ReclaimCandidate, ReclaimGate, ReclaimMode, ReclaimOutcome, ReclaimSurvey, ReclaimVerdict,
-    agent_ownership_blocks, classify, measure_bytes_until, pr_state_for_branch, tm_provisioned,
+    agent_ownership_blocks, classify, measure_bytes_until, tm_provisioned,
 };
+// #7267: the merged-pull-request matcher — round stem and head commit, not the
+// branch name alone.
+use super::worktree_reclaim_pr_match::{GhLandingProbe, resolve_with_index};
 use super::worktree_registry::{list_registered_worktrees, scan_registered_worktrees};
 use super::worktree_safety::inspect_dirt;
 
@@ -95,11 +98,12 @@ impl SurveyBudget {
 /// automatic runs. It opens no destructive path.
 /// What: enumerates via [`scan_registered_worktrees`] (git-authoritative,
 /// ADR-0023), builds ONE [`PrIndex`] per registry root, and runs [`classify`].
-/// When the bulk index was truncated and `per_branch_fallback` is set, a branch
-/// the index cannot answer is resolved with a targeted
-/// [`pr_state_for_branch`] call — without that, no worktree older than the last
+/// When `per_branch_fallback` is set, [`resolve_with_index`] adds the targeted
+/// per-branch lookup a truncated index cannot answer — without that, no
+/// worktree older than the last
 /// [`PR_INDEX_LIMIT`](super::worktree_reclaim::PR_INDEX_LIMIT) pull requests
-/// could ever be reclaimed, which on this repository is nearly all of them.
+/// could ever be reclaimed, which on this repository is nearly all of them —
+/// and the #7267 widening onto the round-stem sibling and the head commit.
 /// `index_for` is injectable so the classification paths are testable
 /// without `gh`.
 /// Test: `survey_reports_a_merged_worktree_as_reclaimable`,
@@ -134,21 +138,17 @@ pub(crate) fn survey_with_index(
         let index = indexes
             .entry(scanned.registry_root.clone())
             .or_insert_with(|| index_for(&scanned.registry_root));
-        let mut pr = index.state_for(scanned.branch.as_deref());
-        // #6561: a FAILED bulk lookup retries per-branch too. The bulk call and
-        // the targeted one can fail for different reasons (a page limit is not
-        // an auth failure), and only the targeted one resolves a branch older
-        // than the bulk window.
-        if per_branch_fallback
-            && matches!(
-                pr,
-                BranchPrState::Unknown | BranchPrState::LookupFailed { .. }
-            )
-            && !index.is_complete()
-            && let Some(branch) = scanned.branch.as_deref()
-        {
-            pr = pr_state_for_branch(&scanned.registry_root, branch);
-        }
+        // #6561 (the per-branch retry) and #7267 (the round-stem and head-commit
+        // widening) both live in `resolve_with_index`, so this call site and the
+        // pre-delete re-check below cannot drift apart.
+        let pr = resolve_with_index(
+            &scanned.path,
+            &scanned.registry_root,
+            scanned.branch.as_deref(),
+            index,
+            per_branch_fallback,
+            &GhLandingProbe,
+        );
         // #6806: WHOSE claim, not merely whether one exists.
         let claim = in_use.claim_state(&scanned.path);
         // #7232: a claim that stopped blocking has to be visible, or the change
@@ -446,16 +446,17 @@ pub(crate) fn reclaim_with_probes(
         let index = fresh_indexes
             .entry(candidate.registry_root.clone())
             .or_insert_with(|| (probes.index_for)(&candidate.registry_root));
-        let mut pr_now = index.state_for(candidate.branch.as_deref());
-        // #6561: same widening as the survey — a failed bulk lookup retries.
-        if matches!(
-            pr_now,
-            BranchPrState::Unknown | BranchPrState::LookupFailed { .. }
-        ) && !index.is_complete()
-            && let Some(branch) = candidate.branch.as_deref()
-        {
-            pr_now = pr_state_for_branch(&candidate.registry_root, branch);
-        }
+        // #6561, #7267: the same resolution the survey ran, re-run FRESH — the
+        // survey's answer is minutes old, and a widening applied only there
+        // would propose a candidate this re-check could not confirm.
+        let pr_now = resolve_with_index(
+            &path,
+            &candidate.registry_root,
+            candidate.branch.as_deref(),
+            index,
+            true,
+            &GhLandingProbe,
+        );
         // FRESH, per candidate, and now genuinely immediately before the
         // re-check that judges it.
         let in_use_now = (probes.in_use_now)();

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
@@ -414,6 +414,64 @@ fn survey_reports_a_merged_worktree_as_reclaimable() {
     assert!(s.total_bytes > 0);
 }
 
+/// #7267, the reported defect end to end: a worktree left on `<branch>-r2` by
+/// a review round, whose pull request merged under `<branch>`.
+///
+/// Why: `prune-worktrees --merged-prs --force` reclaimed 0 of 11 stale trees
+/// because the lookup keyed on the exact branch name. On `origin/main` this
+/// candidate comes back blocked at gate 5 with "no pull request found for this
+/// branch"; the index resolves it by round stem, with no network call.
+#[test]
+fn survey_reclaims_a_round_sibling_of_a_merged_pr() {
+    let fx = GitWorktreeFixture::new();
+    let path = fx.add_worktree("survey-7267-r2");
+    land(&path);
+    let s = survey_with_index(
+        &fx.repos_root,
+        &nobody(),
+        // The pull request merged under the pre-round name.
+        &|_: &Path| merged_index("session/survey-7267", 71),
+        &no_agents,
+        SurveyBudget::default(),
+        false,
+        &KeepList::default(),
+    );
+    let found = s
+        .candidates
+        .iter()
+        .find(|c| c.path == path)
+        .unwrap_or_else(|| panic!("survey missed {}", path.display()));
+    assert_eq!(found.verdict, ReclaimVerdict::Reclaimable { pr: 71 });
+}
+
+/// The other half of #7267: a branch with no merged pull request under ANY
+/// stem is still refused, so the widening did not become a sweep.
+#[test]
+fn survey_still_blocks_a_branch_no_merged_pr_relates_to() {
+    let fx = GitWorktreeFixture::new();
+    let path = fx.add_worktree("survey-7267-none");
+    land(&path);
+    let s = survey_with_index(
+        &fx.repos_root,
+        &nobody(),
+        &|_: &Path| merged_index("session/somebody-else", 72),
+        &no_agents,
+        SurveyBudget::default(),
+        false,
+        &KeepList::default(),
+    );
+    let found = s
+        .candidates
+        .iter()
+        .find(|c| c.path == path)
+        .unwrap_or_else(|| panic!("survey missed {}", path.display()));
+    assert!(
+        !found.verdict.is_reclaimable(),
+        "an unrelated merged PR must not vouch for this tree: {:?}",
+        found.verdict
+    );
+}
+
 /// #6806, the reported defect end to end: a session surveying from inside its
 /// own workspace must reclaim the merged worktrees it created under it. On
 /// `origin/main` every one of these came back `gate 2 (liveness)`.

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
@@ -813,6 +813,70 @@ fn pr_index_truncated_reply_makes_absent_branches_unknown() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// PrIndex — round siblings (#7267)
+// ---------------------------------------------------------------------------
+
+/// The rows a review round leaves behind: the pull request keeps the name it
+/// was opened from, and the worktree sits on the other spelling.
+const ROUND_ROWS: &str = r#"[
+  {"number": 11, "headRefName": "fix/7267-thing", "state": "MERGED"},
+  {"number": 12, "headRefName": "feat/other-r2", "state": "MERGED"}
+]"#;
+
+/// A worktree on `<branch>-r2` resolves the merged pull request opened from
+/// `<branch>` (#7267).
+///
+/// Why: `prune-worktrees --merged-prs --force` reclaimed 0 of 11 stale trees
+/// because every one of them had been renamed before its pull request opened.
+#[test]
+fn pr_index_resolves_a_round_sibling_by_stem() {
+    let idx = PrIndex::from_json(ROUND_ROWS, 400);
+    assert_eq!(
+        idx.state_for(Some("fix/7267-thing-r3")),
+        BranchPrState::Merged { pr: 11 }
+    );
+}
+
+/// And the same in reverse: the worktree kept the stem, the pull request was
+/// opened from the round-suffixed branch (#7267).
+#[test]
+fn pr_index_resolves_a_stem_branch_from_its_round_sibling() {
+    let idx = PrIndex::from_json(ROUND_ROWS, 400);
+    assert_eq!(
+        idx.state_for(Some("feat/other")),
+        BranchPrState::Merged { pr: 12 }
+    );
+}
+
+/// A branch that shares no stem is still unrelated — the widening relates round
+/// siblings and nothing else (#7267).
+#[test]
+fn pr_index_does_not_relate_an_unrelated_branch() {
+    let idx = PrIndex::from_json(ROUND_ROWS, 400);
+    assert_eq!(idx.state_for(Some("fix/7267-other")), BranchPrState::NoPr);
+    // A suffix that is not `-r<digits>` is not a round suffix.
+    assert_eq!(
+        idx.state_for(Some("fix/7267-thing-rework")),
+        BranchPrState::NoPr
+    );
+}
+
+/// An OPEN sibling outranks a MERGED one, so a workstream with work still in
+/// flight is refused rather than reclaimed (#7267).
+#[test]
+fn pr_index_open_round_sibling_beats_a_merged_one() {
+    const ROWS_WITH_OPEN: &str = r#"[
+  {"number": 21, "headRefName": "fix/x", "state": "MERGED"},
+  {"number": 22, "headRefName": "fix/x-r2", "state": "OPEN"}
+]"#;
+    let idx = PrIndex::from_json(ROWS_WITH_OPEN, 400);
+    assert_eq!(
+        idx.state_for(Some("fix/x-r5")),
+        BranchPrState::Open { pr: 22 }
+    );
+}
+
 /// A `gh` call that FAILED reports its reason for every branch it cannot
 /// answer, rather than a cause-free `Unknown` (#6561).
 ///


### PR DESCRIPTION
## Outcome

Refs #7267

`tm session prune-worktrees --merged-prs` matched a merged PR by exact branch name only, so a worktree whose PR was opened from a round sibling (`-r2`) or a renamed branch was refused as unmerged.

## Changes

New `session_manager/worktree_reclaim_pr_match.rs`, a three-rung ladder (exact name → round stem via `strip_round_suffix` → `gh pr list --state merged --search <head-sha>` filtered by `headRefOid` with an ancestry check); `PrIndex::state_for` stem scan; both sweep call sites share `resolve_with_index`. A widening rung only ever produces Merged; every failure leaves the branch-name refusal standing. The unchanged dirty/unpushed gate still runs before any delete. Out of scope: no change to what counts as dirty/unpushed.

## Risk

Localized to `trusty-mpm`'s worktree-reclaim matching path (rung 3). A false-positive match would let a still-relevant worktree be reclaimed, but the pre-existing dirty/unpushed gate still runs before any delete, bounding the blast radius.

## Tests

Rung 3 `-p trusty-mpm`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --no-fail-fast` → 56 targets ok, largest target 6578 passed. Nine tests observed failing-then-passing during development, now stable.

## Baseline

No pre-existing red observed on this crate at the branch point; change-specific gates pass clean.

## Docs

Doc gates: rustdoc intra-doc links, `check_line_cap.sh`, `check_test_pointers.sh` all pass. Changelog fragment added: `crates/trusty-mpm/changelog.d/7267-prune-worktrees-merged-pr-match.md`.

## Review

code-critic APPROVE. One MEDIUM noted: stem equality alone can relate two independent branches that share a `-r<N>` shape; mitigated by the unchanged dirty/unpushed gate that still runs before any delete. No change required.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
