### PR TITLE
fix(trusty-mpm): screen every hook transcript path through the one containment boundary

### DIFF
--- a/crates/trusty-mpm/changelog.d/7278-transcript-path-screening.md
+++ b/crates/trusty-mpm/changelog.d/7278-transcript-path-screening.md
@@ -1,0 +1,4 @@
+Fixed
+
+- The Stop-hook parking detector and the `tm hook --pm-guard` cost evaluator now screen the hook payload's `transcript_path` for containment under the Claude config directory before reading it, closing the two call sites #7250 left unscreened. A refused path is never opened, and the cost evaluator reports the refusal alongside its fail-open verdict instead of allowing on a 0-token reading it never took.
+- Folded in #7290: the containment boundary resolves through `FrameworkPaths::under(dirs::home_dir()?)`, never `FrameworkPaths::default()` or `home_base()`, whose `"."` fallback would silently re-scope containment to the process's working directory.

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -376,16 +376,56 @@ pub(crate) async fn read_transcript_tail(path: &std::path::Path, max_bytes: u64)
 /// from ending their turn to "wait" for a self-spawned monitor. This is the
 /// mechanical back-stop: on a turn-end event, check what the agent actually said
 /// last and flag the stall so it can be surfaced (and later auto-nudged).
-/// What: reads `transcript_path` from the hook payload, tail-reads the transcript
-/// (bounded to `MAX_TRANSCRIPT_TAIL`) under a short `DETECT_TIMEOUT` so the
-/// hook stays within its non-blocking budget, then runs
-/// [`trusty_mpm::core::idle_parking::detect_idle_parking_in_transcript`]. Returns
-/// the matched phrase, or `None` on any missing field / timeout / I/O error /
-/// clean message. Entirely fail-open.
+/// What: resolves the Claude config directory this session runs under via
+/// [`trusty_mpm::core::session_record::claude_config_dir`] and delegates to
+/// [`detect_idle_parking_from_payload_in`].
 /// Test: the pure detection is covered by `core::idle_parking` tests;
-/// `hook_flags_idle_parking_final_message` (integration) drives this end to end.
+/// `hook_flags_idle_parking_final_message_on_subagent_stop` (integration)
+/// drives this end to end.
 async fn detect_idle_parking_from_payload(
     payload: Option<&serde_json::Value>,
+) -> Option<&'static str> {
+    // #7278: the payload's `transcript_path` is attacker-influenceable, so the
+    // boundary it is screened against is resolved here and threaded in.
+    detect_idle_parking_from_payload_in(
+        payload,
+        trusty_mpm::core::session_record::claude_config_dir().as_deref(),
+    )
+    .await
+}
+
+/// [`detect_idle_parking_from_payload`] against an explicit config directory.
+///
+/// Why (#7278): the payload's `transcript_path` arrives from the Stop /
+/// SubagentStop hook's stdin JSON and was handed to `read_transcript_tail`
+/// verbatim, so `{"hook_event_name":"Stop","transcript_path":"/etc/passwd"}`
+/// read any regular file the `tm` user could read. The screen belongs on the
+/// value, and the directory it is screened against is resolved from the
+/// process environment — which this bin target may not write (#5544), so the
+/// rule is only assertable when that directory arrives as an argument.
+/// What: refuses the path unless
+/// [`trusty_mpm::core::session_record::contained_transcript_path`] accepts it
+/// against `claude_config_dir` — absolute, no `..`, canonicalizing under the
+/// canonicalized config directory — and reads nothing at all when it does not.
+/// A `None` `claude_config_dir` refuses outright: with no directory to contain
+/// the path there is nothing to screen against. Only the accepted CANONICAL
+/// path is opened, so the read cannot re-resolve to a different file than the
+/// one that was checked. On acceptance, tail-reads the transcript (bounded to
+/// `MAX_TRANSCRIPT_TAIL`) under a short `DETECT_TIMEOUT` so the hook stays
+/// within its non-blocking budget, then runs
+/// [`trusty_mpm::core::idle_parking::detect_idle_parking_in_transcript`].
+/// Returns the matched phrase, or `None` on a refused path / missing field /
+/// timeout / I/O error / clean message. Entirely fail-open: detection is
+/// advisory, so a refusal costs a warning that would have been shown, never a
+/// blocked prompt.
+/// Test: `refuses_a_transcript_path_outside_the_config_dir`,
+/// `refuses_a_relative_transcript_path`,
+/// `refuses_a_traversing_transcript_path`,
+/// `refuses_every_transcript_path_without_a_config_dir`,
+/// `detects_parking_in_a_transcript_under_the_config_dir`.
+async fn detect_idle_parking_from_payload_in(
+    payload: Option<&serde_json::Value>,
+    claude_config_dir: Option<&std::path::Path>,
 ) -> Option<&'static str> {
     /// Cap on transcript bytes read from the tail (256 KiB is far more than one
     /// final assistant turn, yet bounds cost on a multi-MB session transcript).
@@ -393,8 +433,10 @@ async fn detect_idle_parking_from_payload(
     /// Hard ceiling on the whole detection so the hook never blocks the prompt.
     const DETECT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(300);
 
-    let path = payload?.get("transcript_path")?.as_str()?;
-    let path = std::path::PathBuf::from(path);
+    let raw = payload?.get("transcript_path")?.as_str()?;
+    // #7278: screen before any read — a refused path is never opened.
+    let path =
+        trusty_mpm::core::session_record::contained_transcript_path(claude_config_dir?, raw)?;
     let jsonl = tokio::time::timeout(
         DETECT_TIMEOUT,
         read_transcript_tail(&path, MAX_TRANSCRIPT_TAIL),
@@ -803,5 +845,125 @@ pub(crate) async fn attach_cmd(
             }
             std::process::exit(1);
         }
+    }
+}
+
+// #7278: the parking detector opens a path the hook payload chose, so these
+// cover the screen that decides whether it opens anything at all. Temp dirs
+// come from `crate::test_support::hermetic_temp_dir`, never a bare
+// `tempfile::tempdir()` — the bare constructor honors `$TMPDIR`, which a
+// sibling test may repoint.
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    /// One assistant turn whose text is unambiguous parking language, so any
+    /// `None` these tests see comes from the screen and not the detector.
+    const PARKING_TEXT: &str =
+        "I've started a background polling monitor for the checks and will report back once green.";
+
+    /// Write a one-line transcript under `dir` and return its path.
+    fn parking_transcript(dir: &Path) -> PathBuf {
+        let path = dir.join("session.jsonl");
+        let line = serde_json::json!({
+            "type": "assistant",
+            "message": { "content": [{ "type": "text", "text": PARKING_TEXT }] }
+        });
+        std::fs::write(&path, format!("{line}\n")).expect("write transcript");
+        path
+    }
+
+    fn payload(transcript_path: &str) -> serde_json::Value {
+        serde_json::json!({
+            "hook_event_name": "Stop",
+            "session_id": "sess-7278",
+            "transcript_path": transcript_path,
+        })
+    }
+
+    /// Why (#7278): the positive control. Every refusal below is only evidence
+    /// of a screen if the same fixture, moved inside the boundary, is still
+    /// detected — otherwise a broken detector would read as a passing screen.
+    /// Test: itself.
+    #[tokio::test]
+    async fn detects_parking_in_a_transcript_under_the_config_dir() {
+        let config = crate::test_support::hermetic_temp_dir();
+        let transcript = parking_transcript(config.path());
+        let payload = payload(&transcript.to_string_lossy());
+        assert!(
+            super::detect_idle_parking_from_payload_in(Some(&payload), Some(config.path()))
+                .await
+                .is_some(),
+            "an in-boundary transcript must still be scanned"
+        );
+    }
+
+    /// Why (#7278): the reported attack. A `transcript_path` naming a file the
+    /// `tm` user can read but that Claude Code never wrote must not be opened.
+    /// Test: itself.
+    #[tokio::test]
+    async fn refuses_a_transcript_path_outside_the_config_dir() {
+        let config = crate::test_support::hermetic_temp_dir();
+        let elsewhere = crate::test_support::hermetic_temp_dir();
+        let transcript = parking_transcript(elsewhere.path());
+        let payload = payload(&transcript.to_string_lossy());
+        assert_eq!(
+            super::detect_idle_parking_from_payload_in(Some(&payload), Some(config.path())).await,
+            None,
+            "a transcript outside the config directory must never be read"
+        );
+    }
+
+    /// Why (#7278): a relative path resolves against the hook process's cwd,
+    /// which the payload's author does not control but also cannot be screened
+    /// against a fixed boundary — it is refused before canonicalization.
+    /// Test: itself.
+    #[tokio::test]
+    async fn refuses_a_relative_transcript_path() {
+        let config = crate::test_support::hermetic_temp_dir();
+        let _ = parking_transcript(config.path());
+        let payload = payload("session.jsonl");
+        assert_eq!(
+            super::detect_idle_parking_from_payload_in(Some(&payload), Some(config.path())).await,
+            None,
+            "a relative transcript_path must be refused"
+        );
+    }
+
+    /// Why (#7278): `..` is the shape that walks out of a boundary the prefix
+    /// check would otherwise accept, so it is refused on its own.
+    /// Test: itself.
+    #[tokio::test]
+    async fn refuses_a_traversing_transcript_path() {
+        let config = crate::test_support::hermetic_temp_dir();
+        let elsewhere = crate::test_support::hermetic_temp_dir();
+        let transcript = parking_transcript(elsewhere.path());
+        let traversing = config
+            .path()
+            .join("..")
+            .join(elsewhere.path().file_name().expect("temp dir name"))
+            .join(transcript.file_name().expect("file name"));
+        let payload = payload(&traversing.to_string_lossy());
+        assert_eq!(
+            super::detect_idle_parking_from_payload_in(Some(&payload), Some(config.path())).await,
+            None,
+            "a `..` component must be refused before the path is resolved"
+        );
+    }
+
+    /// Why (#7290): with no config directory there is no boundary, and a
+    /// resolver that fell back to `FrameworkPaths::default()` would silently
+    /// re-scope containment to `<cwd>/.claude`. The refusal must be total.
+    /// Test: itself.
+    #[tokio::test]
+    async fn refuses_every_transcript_path_without_a_config_dir() {
+        let config = crate::test_support::hermetic_temp_dir();
+        let transcript = parking_transcript(config.path());
+        let payload = payload(&transcript.to_string_lossy());
+        assert_eq!(
+            super::detect_idle_parking_from_payload_in(Some(&payload), None).await,
+            None,
+            "no boundary means no read, even for a path that would have passed"
+        );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -818,7 +818,11 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
     // a missing usage record, or a disabled config all reach `Ok`.
     if caller_is_subagent {
         let cost_config = MpmConfig::load_default().agent_cost;
-        let (status, tokens) = pm_guard_cost::evaluate_agent_cost(&payload, &cost_config).await;
+        let cost = pm_guard_cost::evaluate_agent_cost(&payload, &cost_config).await;
+        // #7278: allowing without measuring stays correct, but must not read
+        // as a healthy agent at 0 tokens.
+        pm_guard_cost::warn_if_transcript_refused(session_id, &cost);
+        let (status, tokens) = (cost.status, cost.tokens);
         match status {
             // The stop keeps a narrow allowlist open so a stopped agent can
             // still save and report what it has — see

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_cost.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_cost.rs
@@ -24,6 +24,13 @@
 //! [`BudgetStatus::Ok`]. The PM is never a subagent and so is never evaluated
 //! at all — a bug here cannot halt orchestration.
 //!
+//! #7278 added the one thing that path was missing: the resolved transcript is
+//! screened for containment under the Claude config directory before a byte of
+//! it is read, because every candidate field comes from the payload. Fail-open
+//! is unchanged, but a REFUSAL is no longer silent — [`AgentCost`] carries it
+//! back so the caller says out loud that it allowed without measuring, rather
+//! than reporting a 0 it never read.
+//!
 //! Test: `resolves_*`/`fails_open_*` below cover path resolution and the
 //! fail-open matrix; the threshold policy is pinned in
 //! [`trusty_mpm::core::agent_cost`]'s own suite.
@@ -98,7 +105,7 @@ const EVAL_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(200);
 /// `resolves_a_transcript_path_already_under_subagents`,
 /// `derives_the_subagent_path_from_agent_id`,
 /// `fails_open_without_any_transcript_field`.
-pub(crate) fn resolve_agent_transcript(payload: &serde_json::Value) -> Option<PathBuf> {
+fn agent_transcript_candidate(payload: &serde_json::Value) -> Option<PathBuf> {
     let field = |k: &str| {
         payload
             .get(k)
@@ -137,6 +144,165 @@ pub(crate) fn resolve_agent_transcript(payload: &serde_json::Value) -> Option<Pa
     derived.is_file().then_some(derived)
 }
 
+/// What [`resolve_agent_transcript_in`] concluded about the payload's path.
+///
+/// Why (#7278): "no transcript" and "a transcript this guard refuses to open"
+/// were the same answer — `None` — and both reached [`evaluate_agent_cost`]'s
+/// fail-open arm as a silent `(Ok, 0)`. They are not the same event. The first
+/// is the ordinary case for a PM or a fresh agent; the second means a payload
+/// aimed the guard's read at a file outside the Claude config directory, which
+/// nothing legitimate does. Keeping them distinct is what lets the caller say
+/// so out loud instead of allowing on a number it never measured.
+/// What: `Contained` carries the CANONICAL screened path — the only variant
+/// whose bytes are ever read. `Refused` carries the candidate's own spelling,
+/// unread, for callers that need an identity string rather than a file (see
+/// [`warn_notice_key`]). `Absent` is no candidate at all.
+/// Test: `refuses_a_transcript_outside_the_config_dir`,
+/// `refuses_every_transcript_without_a_config_dir`,
+/// `fails_open_without_any_transcript_field`,
+/// `resolves_explicit_agent_transcript_path`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AgentTranscript {
+    /// Screened and contained — safe to read.
+    Contained(PathBuf),
+    /// A candidate the containment screen rejected. Never opened.
+    Refused(PathBuf),
+    /// No candidate field resolved to an existing file.
+    Absent,
+}
+
+impl AgentTranscript {
+    /// The path whose bytes may be read, if any.
+    fn contained(&self) -> Option<&Path> {
+        match self {
+            Self::Contained(p) => Some(p),
+            Self::Refused(_) | Self::Absent => None,
+        }
+    }
+
+    /// The path a candidate named, screened or not — for identity only.
+    ///
+    /// Why: [`warn_notice_key`] needs a per-agent string, not a file, and
+    /// derives it from the transcript's stem. A refused path still identifies
+    /// the agent, and nothing here opens it, so refusing to hand it back would
+    /// re-introduce the #4850 collision (every sibling of one parent falling
+    /// back to the shared `session_id`) for no security gain.
+    /// Test: `warn_notice_is_claimed_per_sibling_not_per_parent_session`.
+    fn candidate(&self) -> Option<&Path> {
+        match self {
+            Self::Contained(p) | Self::Refused(p) => Some(p),
+            Self::Absent => None,
+        }
+    }
+}
+
+/// [`resolve_agent_transcript_in`] against the process's own config directory.
+///
+/// What: resolves the boundary through
+/// [`trusty_mpm::core::session_record::claude_config_dir`] and delegates.
+/// Test: `refuses_a_transcript_outside_the_config_dir`.
+pub(crate) fn resolve_agent_transcript(payload: &serde_json::Value) -> AgentTranscript {
+    resolve_agent_transcript_in(
+        payload,
+        trusty_mpm::core::session_record::claude_config_dir().as_deref(),
+    )
+}
+
+/// Find the calling subagent's transcript and screen it for containment.
+///
+/// Why (#7278): [`agent_transcript_candidate`] takes three path fields straight
+/// from the `PreToolUse` payload and checked only `is_file()`, so a crafted
+/// `transcript_path` steered [`evaluate_agent_cost`]'s read — and through it the
+/// guard's halt/warn/ok decision — at any regular file the `tm` user could
+/// read. The candidate logic is unchanged; what is added is the screen between
+/// finding a path and reading it. The boundary arrives as an argument because
+/// this bin target may not write `CLAUDE_CONFIG_DIR` or `HOME` (#5544), so the
+/// rule is otherwise unassertable.
+/// What: screens the candidate with
+/// [`trusty_mpm::core::session_record::contained_transcript_file`] — absolute,
+/// no `..`, canonicalizing under the canonicalized `claude_config_dir` — and
+/// returns [`AgentTranscript::Contained`] with the canonical path on success.
+/// A candidate that fails, and every candidate when `claude_config_dir` is
+/// `None` (no boundary, so nothing to contain against — #7290), comes back as
+/// [`AgentTranscript::Refused`] and is never opened.
+/// Test: `refuses_a_transcript_outside_the_config_dir`,
+/// `refuses_a_traversing_transcript_path`,
+/// `refuses_every_transcript_without_a_config_dir`,
+/// `resolves_explicit_agent_transcript_path`,
+/// `resolves_a_transcript_path_already_under_subagents`,
+/// `derives_the_subagent_path_from_agent_id`,
+/// `fails_open_without_any_transcript_field`.
+pub(crate) fn resolve_agent_transcript_in(
+    payload: &serde_json::Value,
+    claude_config_dir: Option<&Path>,
+) -> AgentTranscript {
+    let Some(candidate) = agent_transcript_candidate(payload) else {
+        return AgentTranscript::Absent;
+    };
+    let Some(root) = claude_config_dir else {
+        return AgentTranscript::Refused(candidate);
+    };
+    match trusty_mpm::core::session_record::contained_transcript_file(root, &candidate) {
+        Some(canonical) => AgentTranscript::Contained(canonical),
+        None => AgentTranscript::Refused(candidate),
+    }
+}
+
+/// What [`evaluate_agent_cost`] measured, and what it refused to measure.
+///
+/// Why (#7278 Fail-Open Check): the evaluator used to hand back a bare
+/// `(BudgetStatus, u64)`, so a refused transcript was indistinguishable from a
+/// healthy agent at 0 tokens — the guard allowed on a number it had never read.
+/// Fail-open is still the right decision (a broken counter must not halt real
+/// work), but it has to be a decision the caller can SEE. `refused_transcript`
+/// is that signal: `Some(path)` means "allowed without measuring, because the
+/// payload named a file outside the Claude config directory".
+/// What: `status` and `tokens` as before, plus the refused candidate when one
+/// existed. `refused_transcript` is `None` on every ordinary path, including a
+/// genuinely absent transcript.
+/// Test: `refusal_is_surfaced_not_silently_allowed`,
+/// `fails_open_when_the_transcript_is_missing`,
+/// `allows_a_healthy_agent`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct AgentCost {
+    pub(crate) status: BudgetStatus,
+    pub(crate) tokens: u64,
+    pub(crate) refused_transcript: Option<PathBuf>,
+}
+
+impl AgentCost {
+    /// The fail-open answer with nothing to report.
+    fn allow() -> Self {
+        Self {
+            status: BudgetStatus::Ok,
+            tokens: 0,
+            refused_transcript: None,
+        }
+    }
+}
+
+/// Say out loud that this call was allowed without being measured.
+///
+/// Why (#7278): the refusal is only useful if someone sees it. A loud,
+/// greppable stderr line is the same channel the idle-parking back-stop uses,
+/// so an operator reading a session log finds both the same way. It lives here
+/// rather than at the [`super::pm_guard`] call site because that file sits one
+/// line under the 500-SLOC production cap, and because the wording belongs with
+/// the type that carries the refusal.
+/// What: prints nothing on an ordinary verdict; on a refusal, names the session
+/// and the rejected path and states that the guard allowed the call anyway.
+/// Test: `refusal_is_surfaced_not_silently_allowed` pins the signal this reads.
+pub(crate) fn warn_if_transcript_refused(session_id: &str, cost: &AgentCost) {
+    if let Some(path) = &cost.refused_transcript {
+        eprintln!(
+            "trusty-mpm: AGENT-COST TRANSCRIPT REFUSED (#7278) session={session_id} \
+             path={} — the payload named a transcript outside the Claude config \
+             directory; the guard ALLOWED this call without measuring its context.",
+            path.display()
+        );
+    }
+}
+
 /// Measure and classify the calling subagent's context spend.
 ///
 /// Why: split from [`resolve_agent_transcript`] so the (I/O-bound, timeout-
@@ -146,8 +312,8 @@ pub(crate) fn resolve_agent_transcript(payload: &serde_json::Value) -> Option<Pa
 /// What: resolves the transcript, tail-reads it under [`EVAL_TIMEOUT`] —
 /// [`MAX_TRANSCRIPT_TAIL`] first, retried once at [`RETRY_TRANSCRIPT_TAIL`]
 /// when that window holds no complete usage record — extracts the newest
-/// context size, and returns `(status, context_tokens)`. Any failure returns
-/// `(`[`BudgetStatus::Ok`]`, 0)` — fail open.
+/// context size, and returns an [`AgentCost`]. Any failure returns
+/// [`AgentCost::allow`] — fail open.
 /// Test: `fails_open_when_the_transcript_is_missing`,
 /// `reports_exceeded_for_an_over_ceiling_transcript`,
 /// `respects_a_disabled_config`,
@@ -156,21 +322,56 @@ pub(crate) fn resolve_agent_transcript(payload: &serde_json::Value) -> Option<Pa
 pub(crate) async fn evaluate_agent_cost(
     payload: &serde_json::Value,
     config: &AgentCostConfig,
-) -> (BudgetStatus, u64) {
+) -> AgentCost {
+    // #7278: the boundary the payload's transcript_path is screened against.
+    evaluate_agent_cost_in(
+        payload,
+        config,
+        trusty_mpm::core::session_record::claude_config_dir().as_deref(),
+    )
+    .await
+}
+
+/// [`evaluate_agent_cost`] against an explicit Claude config directory.
+///
+/// Why (#7278): the containment boundary is resolved from the process
+/// environment, and this bin target may not write `CLAUDE_CONFIG_DIR` or `HOME`
+/// (#5544) — so every test of the screen, and every test that must still reach
+/// the read past it, needs that directory as an argument.
+/// What: as [`evaluate_agent_cost`], with the boundary supplied. A disabled
+/// config still short-circuits before any resolution, so a disabled guard
+/// touches the filesystem no more than it did. A refused transcript returns the
+/// fail-open verdict with `refused_transcript` set, having read nothing.
+/// Test: `refusal_is_surfaced_not_silently_allowed`,
+/// `refuses_a_transcript_outside_the_config_dir`, and every
+/// `evaluate_agent_cost` test in this module, which all drive this.
+pub(crate) async fn evaluate_agent_cost_in(
+    payload: &serde_json::Value,
+    config: &AgentCostConfig,
+    claude_config_dir: Option<&Path>,
+) -> AgentCost {
     if !config.enabled {
-        return (BudgetStatus::Ok, 0);
+        return AgentCost::allow();
     }
-    let Some(path) = resolve_agent_transcript(payload) else {
-        return (BudgetStatus::Ok, 0);
+    let resolved = resolve_agent_transcript_in(payload, claude_config_dir);
+    let Some(path) = resolved.contained() else {
+        return AgentCost {
+            refused_transcript: resolved.candidate().map(Path::to_path_buf),
+            ..AgentCost::allow()
+        };
     };
-    let Some(tokens) = tokio::time::timeout(EVAL_TIMEOUT, read_latest_context(&path))
+    let Some(tokens) = tokio::time::timeout(EVAL_TIMEOUT, read_latest_context(path))
         .await
         .ok()
         .flatten()
     else {
-        return (BudgetStatus::Ok, 0);
+        return AgentCost::allow();
     };
-    (evaluate_cost(tokens, config), tokens)
+    AgentCost {
+        status: evaluate_cost(tokens, config),
+        tokens,
+        refused_transcript: None,
+    }
 }
 
 /// Two-pass tail read yielding the newest context size, or `None`.
@@ -315,9 +516,13 @@ fn warn_notice_key(payload: &serde_json::Value) -> Option<String> {
             .filter(|s| !s.is_empty())
             .map(str::to_string)
     };
+    // #7278: identity only — `candidate()` hands back a REFUSED path too,
+    // because nothing here opens it and dropping it would re-introduce #4850's
+    // sibling collision on `session_id`.
     let raw = field("agent_id")
         .or_else(|| {
             resolve_agent_transcript(payload)
+                .candidate()
                 .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().into_owned()))
         })
         .or_else(|| field("session_id"))?;
@@ -360,6 +565,16 @@ mod tests {
         (parent, sub)
     }
 
+    /// The `Contained` answer for `path`, spelled canonically.
+    ///
+    /// #7278: the screen returns the CANONICAL path, and on macOS a temp
+    /// directory's own spelling (`/var/folders/…`) differs from it
+    /// (`/private/var/folders/…`), so a resolution test must compare against
+    /// the resolved form or it fails for the wrong reason.
+    fn contained(path: &Path) -> AgentTranscript {
+        AgentTranscript::Contained(path.canonicalize().expect("canonicalize fixture"))
+    }
+
     #[test]
     fn derives_the_subagent_path_from_agent_id() {
         // The load-bearing case: PreToolUse inside a subagent carries the
@@ -371,7 +586,10 @@ mod tests {
             "transcript_path": parent.to_str().expect("utf8"),
             "agent_id": "a1d57cf5a7f59b877",
         });
-        assert_eq!(resolve_agent_transcript(&payload).as_ref(), Some(&sub));
+        assert_eq!(
+            resolve_agent_transcript_in(&payload, Some(tmp.path())),
+            contained(&sub)
+        );
     }
 
     #[test]
@@ -383,7 +601,10 @@ mod tests {
             "agent_transcript_path": sub.to_str().expect("utf8"),
             "agent_id": "abc123",
         });
-        assert_eq!(resolve_agent_transcript(&payload).as_ref(), Some(&sub));
+        assert_eq!(
+            resolve_agent_transcript_in(&payload, Some(tmp.path())),
+            contained(&sub)
+        );
     }
 
     #[test]
@@ -395,12 +616,17 @@ mod tests {
         let payload = serde_json::json!({
             "transcript_path": sub.to_str().expect("utf8"),
         });
-        assert_eq!(resolve_agent_transcript(&payload).as_ref(), Some(&sub));
+        assert_eq!(
+            resolve_agent_transcript_in(&payload, Some(tmp.path())),
+            contained(&sub)
+        );
     }
 
     #[test]
     fn fails_open_without_any_transcript_field() {
-        // Every indeterminate payload shape must resolve to None (→ ALLOW).
+        // Every indeterminate payload shape must resolve to Absent (→ ALLOW),
+        // and Absent specifically — #7278 distinguishes "no transcript" from
+        // "a transcript this guard refuses to open", and these are the first.
         for payload in [
             serde_json::json!({}),
             serde_json::json!({"tool_name": "Bash"}),
@@ -414,24 +640,129 @@ mod tests {
                 "agent_id": "ghost",
             }),
         ] {
+            let tmp = crate::test_support::hermetic_temp_dir();
             assert_eq!(
-                resolve_agent_transcript(&payload),
-                None,
+                resolve_agent_transcript_in(&payload, Some(tmp.path())),
+                AgentTranscript::Absent,
                 "expected fail-open for {payload}"
             );
         }
     }
 
+    // ── #7278: the payload chose the path, so the guard screens it ──
+
+    /// Why (#7278): the reported attack. `resolve_agent_transcript` checked
+    /// only `is_file()`, so a `PreToolUse` payload naming any regular file the
+    /// `tm` user could read steered the guard's read — and through it its
+    /// halt/warn/ok decision. Refusing means the bytes are never touched.
+    /// Test: itself.
+    #[test]
+    fn refuses_a_transcript_outside_the_config_dir() {
+        let config = crate::test_support::hermetic_temp_dir();
+        let elsewhere = crate::test_support::hermetic_temp_dir();
+        let (_, sub) = transcript_tree(elsewhere.path(), "outside", 100_000);
+        let payload = serde_json::json!({
+            "transcript_path": sub.to_str().expect("utf8"),
+        });
+        assert_eq!(
+            resolve_agent_transcript_in(&payload, Some(config.path())),
+            AgentTranscript::Refused(sub),
+            "a transcript outside the config directory must be refused, not read"
+        );
+    }
+
+    /// Why (#7278): `..` walks out of a boundary the prefix check would
+    /// otherwise accept, so it is refused before the path is resolved at all.
+    /// Test: itself.
+    #[test]
+    fn refuses_a_traversing_transcript_path() {
+        let config = crate::test_support::hermetic_temp_dir();
+        let elsewhere = crate::test_support::hermetic_temp_dir();
+        let (_, sub) = transcript_tree(elsewhere.path(), "traverse", 100_000);
+        let traversing = config
+            .path()
+            .join("..")
+            .join(elsewhere.path().file_name().expect("temp dir name"))
+            .join(sub.strip_prefix(elsewhere.path()).expect("under fixture"));
+        let payload = serde_json::json!({
+            "transcript_path": traversing.to_str().expect("utf8"),
+        });
+        assert_eq!(
+            resolve_agent_transcript_in(&payload, Some(config.path())),
+            AgentTranscript::Refused(traversing),
+            "a `..` component must be refused"
+        );
+    }
+
+    /// Why (#7290): with no config directory there is no boundary at all, and
+    /// a resolver falling back to `FrameworkPaths::default()` would silently
+    /// re-scope containment to `<cwd>/.claude`. Refuse instead.
+    /// Test: itself.
+    #[test]
+    fn refuses_every_transcript_without_a_config_dir() {
+        let tmp = crate::test_support::hermetic_temp_dir();
+        let (_, sub) = transcript_tree(tmp.path(), "nodir", 100_000);
+        let payload = serde_json::json!({
+            "transcript_path": sub.to_str().expect("utf8"),
+        });
+        assert_eq!(
+            resolve_agent_transcript_in(&payload, None),
+            AgentTranscript::Refused(sub),
+            "no boundary means no read, even for a path that would have passed"
+        );
+    }
+
+    /// Why (#7278 Fail-Open Check): a refusal and a healthy agent at 0 tokens
+    /// used to be the same `(Ok, 0)`, so the guard allowed on a number it had
+    /// never read and nothing said so. The verdict stays ALLOW — a broken
+    /// counter must not halt real work — but the refusal now rides back with
+    /// it, and the same fixture placed INSIDE the boundary still measures, so
+    /// the contrast is the screen and not a broken fixture.
+    /// Test: itself.
+    #[tokio::test]
+    async fn refusal_is_surfaced_not_silently_allowed() {
+        let config = crate::test_support::hermetic_temp_dir();
+        let elsewhere = crate::test_support::hermetic_temp_dir();
+        let (parent, sub) = transcript_tree(elsewhere.path(), "loud", 622_200);
+        let payload = serde_json::json!({
+            "transcript_path": parent.to_str().expect("utf8"),
+            "agent_id": "loud",
+        });
+
+        let refused = evaluate_agent_cost_in(&payload, &opted_in_stop(), Some(config.path())).await;
+        assert_eq!(
+            refused,
+            AgentCost {
+                status: BudgetStatus::Ok,
+                tokens: 0,
+                refused_transcript: Some(sub),
+            },
+            "an out-of-boundary transcript must allow, and say that it was refused"
+        );
+
+        // The contrast: the identical 622.2k transcript inside the boundary is
+        // measured and stopped, so the refusal above is the screen at work.
+        let measured =
+            evaluate_agent_cost_in(&payload, &opted_in_stop(), Some(elsewhere.path())).await;
+        assert_eq!(measured.tokens, 622_200);
+        assert_eq!(measured.status, BudgetStatus::Exceeded);
+        assert_eq!(measured.refused_transcript, None);
+    }
+
     #[tokio::test]
     async fn fails_open_when_the_transcript_is_missing() {
         // The core safety property: a broken counter allows the work.
+        let config = crate::test_support::hermetic_temp_dir();
         let payload = serde_json::json!({
             "transcript_path": "/tmp/definitely-not-here/p.jsonl",
             "agent_id": "ghost",
         });
-        let (status, tokens) = evaluate_agent_cost(&payload, &AgentCostConfig::default()).await;
-        assert_eq!(status, BudgetStatus::Ok);
-        assert_eq!(tokens, 0);
+        assert_eq!(
+            evaluate_agent_cost_in(&payload, &AgentCostConfig::default(), Some(config.path()))
+                .await,
+            AgentCost::allow(),
+            "a missing transcript is Absent, not Refused — nothing to report"
+        );
     }
 
     /// A config with the hard stop opted in. The shipped default is warn-only
@@ -452,7 +783,8 @@ mod tests {
             "transcript_path": parent.to_str().expect("utf8"),
             "agent_id": "big",
         });
-        let (status, tokens) = evaluate_agent_cost(&payload, &opted_in_stop()).await;
+        let AgentCost { status, tokens, .. } =
+            evaluate_agent_cost_in(&payload, &opted_in_stop(), Some(tmp.path())).await;
         assert_eq!(status, BudgetStatus::Exceeded);
         assert_eq!(tokens, 622_200);
         // And the reason handed back must carry the measured number.
@@ -469,7 +801,8 @@ mod tests {
             "transcript_path": parent.to_str().expect("utf8"),
             "agent_id": "big",
         });
-        let (status, tokens) = evaluate_agent_cost(&payload, &AgentCostConfig::default()).await;
+        let AgentCost { status, tokens, .. } =
+            evaluate_agent_cost_in(&payload, &AgentCostConfig::default(), Some(tmp.path())).await;
         assert_eq!(status, BudgetStatus::Warning);
         assert_eq!(tokens, 622_200);
     }
@@ -489,8 +822,8 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            evaluate_agent_cost(&payload, &disabled).await,
-            (BudgetStatus::Ok, 0)
+            evaluate_agent_cost_in(&payload, &disabled, Some(tmp.path())).await,
+            AgentCost::allow()
         );
     }
 
@@ -502,9 +835,15 @@ mod tests {
             "transcript_path": parent.to_str().expect("utf8"),
             "agent_id": "small",
         });
-        let (status, tokens) = evaluate_agent_cost(&payload, &AgentCostConfig::default()).await;
-        assert_eq!(status, BudgetStatus::Ok);
-        assert_eq!(tokens, 71_540);
+        let measured =
+            evaluate_agent_cost_in(&payload, &AgentCostConfig::default(), Some(tmp.path())).await;
+        // #7278: assert on the refusal channel too. Before it existed, a
+        // reading of 0 here was indistinguishable from a transcript the guard
+        // had declined to open — which is exactly the ambiguity that made the
+        // 0-token sighting on #7028 unattributable.
+        assert_eq!(measured.refused_transcript, None);
+        assert_eq!(measured.status, BudgetStatus::Ok);
+        assert_eq!(measured.tokens, 71_540);
     }
 
     // ── #4837 review MEDIUM: the 64 KiB window misses the largest transcripts ──
@@ -559,12 +898,13 @@ mod tests {
         // assertion is unchanged: the record must be found, and a guard that
         // genuinely could not find it still fails at the deadline.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-        let mut measured = evaluate_agent_cost(&payload, &opted_in_stop()).await;
-        while measured == (BudgetStatus::Ok, 0) && std::time::Instant::now() < deadline {
+        let mut measured =
+            evaluate_agent_cost_in(&payload, &opted_in_stop(), Some(tmp.path())).await;
+        while measured == AgentCost::allow() && std::time::Instant::now() < deadline {
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-            measured = evaluate_agent_cost(&payload, &opted_in_stop()).await;
+            measured = evaluate_agent_cost_in(&payload, &opted_in_stop(), Some(tmp.path())).await;
         }
-        let (status, tokens) = measured;
+        let AgentCost { status, tokens, .. } = measured;
         assert_eq!(tokens, 500_000, "the larger window must find the record");
         assert_eq!(status, BudgetStatus::Exceeded);
     }
@@ -581,8 +921,8 @@ mod tests {
             "agent_id": "norec",
         });
         assert_eq!(
-            evaluate_agent_cost(&payload, &opted_in_stop()).await,
-            (BudgetStatus::Ok, 0)
+            evaluate_agent_cost_in(&payload, &opted_in_stop(), Some(tmp.path())).await,
+            AgentCost::allow()
         );
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs
@@ -148,9 +148,12 @@ pub(crate) fn record_session_facts(session_id: &str, model_id: &str, transcript_
     let Some(root) = savings_root() else {
         return;
     };
+    // #7278: the boundary resolver moved to `core::session_record` beside the
+    // screen it feeds, so the parking detector and the pm-guard cost evaluator
+    // compare against the same directory this recorder does.
     record_session_facts_at(
         &root,
-        claude_config_dir().as_deref(),
+        trusty_mpm::core::session_record::claude_config_dir().as_deref(),
         session_id,
         model_id,
         transcript_path,
@@ -197,33 +200,6 @@ fn record_session_facts_at(
         session_id,
         &transcript.to_string_lossy(),
     );
-}
-
-/// The Claude config directory this session's transcript must sit under.
-///
-/// Why (#7250): the payload's `transcript_path` is only trustworthy relative to
-/// the config directory the session itself runs under, and `CLAUDE_CONFIG_DIR`
-/// relocates that for every daemon-managed tm session. The neighbouring
-/// [`super::account::claude_json_path`] reads the same variable but resolves a
-/// different shape — `.claude.json` sits INSIDE `CLAUDE_CONFIG_DIR` and BESIDE
-/// `~/.claude` — so the two cannot share one resolver.
-/// What: `CLAUDE_CONFIG_DIR` when set and non-blank, else `~/.claude` from
-/// [`trusty_mpm::core::paths::FrameworkPaths::claude_home_dir`] rather than a
-/// second `home.join(".claude")`. `None` when neither is available, and the
-/// caller then records no transcript path at all — that is what makes the
-/// screen fail closed. `FrameworkPaths::default()` cannot stand in here: with
-/// no home directory it resolves against `"."`, which canonicalizes to the
-/// process's working directory, so the containment check would silently
-/// re-scope to whatever `<cwd>/.claude` happens to be (#7250 critic round 2).
-/// Test: `a_transcript_path_is_not_recorded_without_a_config_dir`; the fallback
-/// resolver has its own tests (`claude_home_dir_matches_default_home`).
-fn claude_config_dir() -> Option<PathBuf> {
-    match std::env::var_os("CLAUDE_CONFIG_DIR") {
-        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
-        _ => Some(
-            trusty_mpm::core::paths::FrameworkPaths::under(dirs::home_dir()?).claude_home_dir(),
-        ),
-    }
 }
 
 /// Resolve the framework root the ledger lives under.

--- a/crates/trusty-mpm/src/core/paths.rs
+++ b/crates/trusty-mpm/src/core/paths.rs
@@ -128,6 +128,15 @@ impl FrameworkPaths {
     /// `session_launch::mod.rs` writes `last-instructions.md` into — that is
     /// a bare `project_dir.join(".trusty-mpm")`, not a `FrameworkPaths` value
     /// at all.
+    ///
+    /// **Never back a path-containment check with this** (#7290). It inherits
+    /// [`home_base`](Self::home_base)'s `"."` fallback, so with no home
+    /// directory it resolves against the process's working directory and a
+    /// boundary built from it silently follows the caller's cwd instead of
+    /// refusing. A containment check takes
+    /// [`under(dirs::home_dir()?)`](Self::under) so "no home" is a `None` the
+    /// caller must handle — see
+    /// [`crate::core::session_record::claude_config_dir`].
     /// Test: `default_resolves_under_trusty_mpm`,
     /// `default_is_a_single_global_path_never_project_relative`.
     #[allow(clippy::should_implement_trait)] // Intentional: no meaningful Default without I/O.
@@ -146,6 +155,12 @@ impl FrameworkPaths {
     /// drift the common-entry-point rule forbids.
     /// What: `dirs::home_dir()`, falling back to `.` when the home directory
     /// cannot be determined — the identical resolution `default()` performs.
+    ///
+    /// **Never back a path-containment check with this** (#7290). That `.`
+    /// fallback canonicalizes to the process's working directory, so a
+    /// boundary built from it re-scopes to `<cwd>/…` rather than refusing —
+    /// the exact silent re-scope the #7250 critic round caught. A containment
+    /// check wants an explicit `dirs::home_dir()?` so "no home" answers `None`.
     /// Test: `home_base_is_what_default_resolves_against`.
     pub fn home_base() -> PathBuf {
         dirs::home_dir().unwrap_or_else(|| PathBuf::from("."))

--- a/crates/trusty-mpm/src/core/session_record.rs
+++ b/crates/trusty-mpm/src/core/session_record.rs
@@ -26,6 +26,14 @@
 //! same attacker-influenceable payload: [`is_safe_session_id`] the file NAME,
 //! [`contained_transcript_path`] the value (#7250).
 //!
+//! #7278 widened that second screen past this module's own writer. Every `tm`
+//! entry point that opens a `transcript_path` taken from a hook payload — the
+//! statusline recorder here, the Stop-hook parking detector, and the pm-guard
+//! cost evaluator — routes through [`contained_transcript_path`] /
+//! [`contained_transcript_file`], and resolves the boundary it screens against
+//! through [`claude_config_dir`]. One screen and one boundary resolver, because
+//! a second copy of either is what drifts.
+//!
 //! Test: the inline suite in `session_record_tests.rs` —
 //! `a_recorded_value_reads_back`, `rejects_a_path_traversal_session_id`,
 //! `an_unchanged_value_leaves_the_file_untouched`,
@@ -33,7 +41,8 @@
 //! `rejects_a_transcript_path_outside_the_config_dir`,
 //! `rejects_a_traversing_transcript_path`,
 //! `rejects_a_symlink_under_the_config_dir_aimed_outside_it`,
-//! `accepts_a_transcript_path_under_the_config_dir`.
+//! `accepts_a_transcript_path_under_the_config_dir`,
+//! `the_containment_screen_never_leans_on_frameworkpaths_default`.
 
 use std::path::{Component, Path, PathBuf};
 
@@ -92,25 +101,46 @@ pub fn contained_transcript_path(
     if raw.is_empty() {
         return None;
     }
-    let raw = Path::new(raw);
-    if !raw.is_absolute() || raw.components().any(|c| c == Component::ParentDir) {
+    contained_transcript_file(claude_config_dir, Path::new(raw))
+}
+
+/// [`contained_transcript_path`] for a candidate already held as a [`Path`].
+///
+/// Why (#7278): the pm-guard cost evaluator DERIVES a subagent transcript path
+/// (`<dir>/<parent-stem>/subagents/agent-<id>.jsonl`) rather than reading one
+/// field verbatim, so it holds a `PathBuf` and not a `&str`. Round-tripping
+/// that through `to_str()` would drop a non-UTF-8 path on the floor at the
+/// screen instead of at the read — a silently different answer — and a second
+/// copy of the containment rule to avoid the round trip is exactly what the
+/// common-entry-point rule forbids. This is the one implementation; the `&str`
+/// entry point above trims and delegates here.
+/// What: the checks [`contained_transcript_path`] documents — absolute, no
+/// `..` component, canonicalizes under the canonicalized `claude_config_dir` —
+/// returning the CANONICAL path so the caller opens the file that was checked.
+/// Test: `rejects_a_transcript_path_outside_the_config_dir`,
+/// `rejects_a_traversing_transcript_path`,
+/// `rejects_a_symlink_under_the_config_dir_aimed_outside_it`,
+/// `accepts_a_transcript_path_under_the_config_dir`,
+/// `screens_a_path_valued_candidate_the_same_way`.
+pub fn contained_transcript_file(claude_config_dir: &Path, candidate: &Path) -> Option<PathBuf> {
+    if !candidate.is_absolute() || candidate.components().any(|c| c == Component::ParentDir) {
         tracing::debug!(
-            path = %raw.display(),
-            "statusline transcript_path is relative or traverses; not recorded"
+            path = %candidate.display(),
+            "transcript_path is relative or traverses; refused"
         );
         return None;
     }
     let Ok(root) = claude_config_dir.canonicalize() else {
         tracing::debug!(
             dir = %claude_config_dir.display(),
-            "Claude config directory does not resolve; transcript_path not recorded"
+            "Claude config directory does not resolve; transcript_path refused"
         );
         return None;
     };
-    let Ok(canonical) = raw.canonicalize() else {
+    let Ok(canonical) = candidate.canonicalize() else {
         tracing::debug!(
-            path = %raw.display(),
-            "statusline transcript_path does not resolve; not recorded"
+            path = %candidate.display(),
+            "transcript_path does not resolve; refused"
         );
         return None;
     };
@@ -118,11 +148,46 @@ pub fn contained_transcript_path(
         tracing::debug!(
             path = %canonical.display(),
             dir = %root.display(),
-            "statusline transcript_path resolves outside the Claude config directory; not recorded"
+            "transcript_path resolves outside the Claude config directory; refused"
         );
         return None;
     }
     Some(canonical)
+}
+
+/// The Claude config directory a payload's `transcript_path` must sit under.
+///
+/// Why (#7250, widened #7278): the boundary every containment screen in this
+/// module compares against. `CLAUDE_CONFIG_DIR` relocates it for every
+/// daemon-managed `tm` session, so a resolver that only knew `~/.claude` would
+/// refuse every legitimate managed transcript. Three call sites need this
+/// answer — the statusline recorder, the Stop-hook parking detector, and the
+/// pm-guard cost evaluator — and three copies of the fallback chain would
+/// drift apart; this is the one copy.
+///
+/// Why not [`FrameworkPaths::default`](crate::core::paths::FrameworkPaths::default)
+/// (#7290): with no home directory it resolves against `"."`, which
+/// canonicalizes to the process's working directory, so containment would
+/// silently re-scope to whatever `<cwd>/.claude` happens to be instead of
+/// refusing. A boundary that moves with the caller's cwd is not a boundary.
+/// [`FrameworkPaths::under`](crate::core::paths::FrameworkPaths::under) over an
+/// explicit `dirs::home_dir()?` is what makes "no home" a `None` the caller
+/// must handle.
+/// What: `CLAUDE_CONFIG_DIR` when set and non-blank, else `~/.claude` via
+/// `FrameworkPaths::under(dirs::home_dir()?).claude_home_dir()`. `None` when
+/// neither resolves, and every caller then refuses the path outright — that is
+/// what makes the screen fail closed.
+/// Test: `the_containment_screen_never_leans_on_frameworkpaths_default` pins
+/// the #7290 rule this resolver exists to keep; the `~/.claude` fallback shape
+/// has its own coverage in `claude_home_dir_matches_default_home`. The env-var
+/// branch is exercised end to end by `tm_hook_idle_parking`, which points
+/// `CLAUDE_CONFIG_DIR` at its fixture directory rather than mutating this
+/// process's environment.
+pub fn claude_config_dir() -> Option<PathBuf> {
+    match std::env::var_os("CLAUDE_CONFIG_DIR") {
+        Some(dir) if !dir.is_empty() => Some(PathBuf::from(dir)),
+        _ => Some(crate::core::paths::FrameworkPaths::under(dirs::home_dir()?).claude_home_dir()),
+    }
 }
 
 /// The record's path under an explicit framework root.

--- a/crates/trusty-mpm/src/core/session_record_tests.rs
+++ b/crates/trusty-mpm/src/core/session_record_tests.rs
@@ -199,3 +199,62 @@ fn two_kinds_do_not_collide() {
         Some("/tmp/s.jsonl")
     );
 }
+
+/// Why (#7278): the pm-guard cost evaluator DERIVES a subagent transcript path
+/// and so screens a `Path`, not a `&str`. Both entry points must reach the same
+/// verdict, or the guard and the statusline would disagree about the same file.
+/// Test: itself.
+#[test]
+fn screens_a_path_valued_candidate_the_same_way() {
+    let config = tempfile::tempdir().expect("temp dir");
+    let outside_dir = tempfile::tempdir().expect("temp dir");
+
+    let inside = config.path().join("in.jsonl");
+    std::fs::write(&inside, "{}\n").expect("write");
+    let outside = outside_dir.path().join("out.jsonl");
+    std::fs::write(&outside, "{}\n").expect("write");
+
+    for candidate in [&inside, &outside] {
+        assert_eq!(
+            contained_transcript_file(config.path(), candidate),
+            contained_transcript_path(config.path(), &candidate.to_string_lossy()),
+            "the two entry points must agree on {}",
+            candidate.display()
+        );
+    }
+    assert!(contained_transcript_file(config.path(), &inside).is_some());
+    assert_eq!(contained_transcript_file(config.path(), &outside), None);
+}
+
+/// Why (#7290): `FrameworkPaths::home_base()` falls back to `"."` when there is
+/// no home directory, and `FrameworkPaths::default()` inherits that fallback —
+/// so a containment boundary built from either canonicalizes to the process's
+/// working directory and silently re-scopes to `<cwd>/.claude` instead of
+/// refusing. That is not a property a unit test can observe without mutating
+/// the process's environment, which corrupts every sibling test in the binary.
+/// Reading the source of the module that OWNS the screen is what makes the rule
+/// mechanical instead of a comment nobody rereads.
+/// Test: itself.
+#[test]
+fn the_containment_screen_never_leans_on_frameworkpaths_default() {
+    let source = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/core/session_record.rs"
+    ))
+    .expect("read this module's own source");
+    // The doc comment on `claude_config_dir` names both, explaining why they
+    // are refused — so only CALLS count, not the prose.
+    for banned in ["FrameworkPaths::default()", "FrameworkPaths::home_base()"] {
+        assert!(
+            !source
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("//"))
+                .any(|l| l.contains(banned)),
+            "{banned} must never back the containment boundary (#7290)"
+        );
+    }
+    assert!(
+        source.contains("FrameworkPaths::under") && source.contains("dirs::home_dir()?"),
+        "the boundary resolver must take an explicit, fallible home directory"
+    );
+}

--- a/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
+++ b/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
@@ -19,12 +19,18 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 
 /// Run `tm hook` with the given stdin JSON, returning `(exit_ok, stderr)`.
-fn run_hook(stdin_json: &str) -> (bool, String) {
+///
+/// #7278: `config_dir` becomes the child's `CLAUDE_CONFIG_DIR`, which is the
+/// boundary the parking detector screens `transcript_path` against. Set on the
+/// spawned process, never on this one — a `std::env::set_var` here would leak
+/// into every other test in the binary.
+fn run_hook_in(stdin_json: &str, config_dir: &std::path::Path) -> (bool, String) {
     let bin = env!("CARGO_BIN_EXE_tm");
     let mut child = Command::new(bin)
         .args(["--url", "http://127.0.0.1:1", "hook"])
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")
+        .env("CLAUDE_CONFIG_DIR", config_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -63,12 +69,16 @@ fn run_hook(stdin_json: &str) -> (bool, String) {
 /// than looping.
 /// Test: used by `hook_flags_idle_parking_final_message_on_subagent_stop` and
 /// `hook_flags_idle_parking_on_main_stop`.
-fn run_hook_until_stderr_contains(stdin_json: &str, want: &str) -> String {
+fn run_hook_until_stderr_contains(
+    stdin_json: &str,
+    config_dir: &std::path::Path,
+    want: &str,
+) -> String {
     const DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
     let start = std::time::Instant::now();
     let mut attempts = 0usize;
     loop {
-        let (ok, stderr) = run_hook(stdin_json);
+        let (ok, stderr) = run_hook_in(stdin_json, config_dir);
         attempts += 1;
         assert!(
             ok,
@@ -86,17 +96,30 @@ fn run_hook_until_stderr_contains(stdin_json: &str, want: &str) -> String {
     }
 }
 
-/// Write a single-line JSONL transcript with one assistant message and return
-/// the temp file (kept alive by the caller so the path stays valid).
-fn transcript_with_assistant(text: &str) -> tempfile::NamedTempFile {
-    let mut f = tempfile::NamedTempFile::new().expect("create temp transcript");
+/// A directory standing in for `CLAUDE_CONFIG_DIR`, holding one transcript.
+///
+/// #7278: the detector refuses any `transcript_path` that does not canonicalize
+/// under the config directory, so the fixture has to be a DIRECTORY the child
+/// can be pointed at rather than a bare `NamedTempFile` in the system temp
+/// root. The returned `TempDir` keeps both alive.
+struct ConfigFixture {
+    dir: tempfile::TempDir,
+    transcript: std::path::PathBuf,
+}
+
+/// Write a single-line JSONL transcript with one assistant message into a fresh
+/// config-directory fixture.
+fn transcript_with_assistant(text: &str) -> ConfigFixture {
+    let dir = tempfile::tempdir().expect("create temp config dir");
+    let transcript = dir.path().join("session-2610.jsonl");
+    let mut f = std::fs::File::create(&transcript).expect("create temp transcript");
     let line = serde_json::json!({
         "type": "assistant",
         "message": { "content": [{ "type": "text", "text": text }] }
     });
     writeln!(f, "{line}").expect("write transcript line");
     f.flush().expect("flush transcript");
-    f
+    ConfigFixture { dir, transcript }
 }
 
 fn payload(event: &str, transcript_path: &std::path::Path) -> String {
@@ -116,7 +139,8 @@ fn hook_flags_idle_parking_final_message_on_subagent_stop() {
     // #6161: poll for the warning rather than racing the hook's fail-open
     // internal timeouts — see `run_hook_until_stderr_contains`.
     let stderr = run_hook_until_stderr_contains(
-        &payload("SubagentStop", tf.path()),
+        &payload("SubagentStop", &tf.transcript),
+        tf.dir.path(),
         "IDLE-PARKING WARNING (#2610)",
     );
     assert!(
@@ -129,8 +153,11 @@ fn hook_flags_idle_parking_final_message_on_subagent_stop() {
 fn hook_flags_idle_parking_on_main_stop() {
     let tf = transcript_with_assistant("Standing by for the CI run to complete.");
     // #6161: same fail-open-timeout race as the SubagentStop case above.
-    let _stderr =
-        run_hook_until_stderr_contains(&payload("Stop", tf.path()), "IDLE-PARKING WARNING (#2610)");
+    let _stderr = run_hook_until_stderr_contains(
+        &payload("Stop", &tf.transcript),
+        tf.dir.path(),
+        "IDLE-PARKING WARNING (#2610)",
+    );
 }
 
 #[test]
@@ -138,7 +165,7 @@ fn hook_stays_silent_for_clean_final_message() {
     let tf = transcript_with_assistant(
         "I ran `gh pr checks 2606 --watch --fail-fast` in the foreground; all checks passed. Done.",
     );
-    let (ok, stderr) = run_hook(&payload("SubagentStop", tf.path()));
+    let (ok, stderr) = run_hook_in(&payload("SubagentStop", &tf.transcript), tf.dir.path());
 
     assert!(ok, "hook must exit 0, stderr={stderr}");
     assert!(
@@ -152,12 +179,36 @@ fn hook_does_not_scan_non_turn_end_events() {
     // A PreToolUse/PostToolUse event must never trigger the transcript scan,
     // even if the transcript happens to contain parking language.
     let tf = transcript_with_assistant("standing by for the monitor to report back");
-    let (ok, stderr) = run_hook(&payload("PostToolUse", tf.path()));
+    let (ok, stderr) = run_hook_in(&payload("PostToolUse", &tf.transcript), tf.dir.path());
 
     assert!(ok, "hook must exit 0, stderr={stderr}");
     assert!(
         !stderr.contains("IDLE-PARKING WARNING"),
         "non-turn-end event must not scan for parking, got: {stderr:?}"
+    );
+}
+
+/// #7278: end to end, through the real binary and the real
+/// `CLAUDE_CONFIG_DIR` resolver — a transcript full of parking language that
+/// sits OUTSIDE the config directory is never opened, so no warning appears.
+///
+/// The paired positive case is `hook_flags_idle_parking_final_message_on_
+/// subagent_stop`, which uses the identical fixture text and DOES warn; without
+/// that contrast a silent run here would also be satisfied by a detector that
+/// simply stopped working. A single `run_hook_in` (not the polling helper) is
+/// correct because a negative cannot be polled for.
+#[test]
+fn hook_refuses_a_transcript_outside_the_config_dir() {
+    let tf = transcript_with_assistant(
+        "I've started a background polling monitor for the checks and will report back once green.",
+    );
+    let elsewhere = tempfile::tempdir().expect("create temp config dir");
+    let (ok, stderr) = run_hook_in(&payload("SubagentStop", &tf.transcript), elsewhere.path());
+
+    assert!(ok, "hook must exit 0 (fail-open), stderr={stderr}");
+    assert!(
+        !stderr.contains("IDLE-PARKING WARNING"),
+        "a transcript outside CLAUDE_CONFIG_DIR must never be read, got: {stderr:?}"
     );
 }
 
@@ -195,6 +246,11 @@ fn rejects_fifo_without_blocking() {
         .args(["--url", "http://127.0.0.1:1", "hook"])
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")
+        // #7278: the FIFO sits INSIDE the config directory, so the containment
+        // screen accepts it and the `stat`-before-`open` guard is what this
+        // test still exercises. Pointing elsewhere would make the screen refuse
+        // first and the FIFO guard would go untested.
+        .env("CLAUDE_CONFIG_DIR", dir.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
Refs #7278
Refs #7290

## Outcome

Every hook transcript path is screened through one containment boundary
before it is read.

## Changes

The idle-parking detector (`commands/misc.rs`) and the pm-guard cost
evaluator (`commands/pm_guard_cost.rs`) previously read a transcript path
from the hook payload with no containment check. Per #7290, nothing may
resolve the boundary through `FrameworkPaths::default()`/`home_base()`,
whose `.` fallback rescopes containment to the current working directory.
Both call sites now route through `core::session_record::contained_transcript_path`
and the new `contained_transcript_file(&Path)`; `claude_config_dir()` moves
beside the screen. A refused transcript is surfaced
(`AgentCost.refused_transcript` plus a stderr warning) while the guard
still allows the operation, so a broken counter never halts real work. Out
of scope: the pre-existing stat-only `is_file()` probes that run before the
screen (see Review below).

## Risk

Low, localized to two hook call sites in `trusty-mpm`. The screen is
strictly additive: unreachable/uncontained paths are now refused instead
of read; every previously-valid path still resolves the same way.

## Tests

Rung 3, `-p trusty-mpm`: fmt/clippy/`test --no-fail-fast` — 56 targets ok,
largest target 6557 passed. Six tests that failed before the fix now pass.
A new integration test drives the real binary with `CLAUDE_CONFIG_DIR` set
via child env.

## Baseline

No pre-existing red encountered on this crate for this change.

## Docs

Doc gates pass: rustdoc links, line-cap, test-pointers. Changelog fragment
added: `crates/trusty-mpm/changelog.d/7278-transcript-path-screening.md`.

## Review

code-critic APPROVE. MEDIUM noted, not fixed here:
`the_containment_screen_never_leans_on_frameworkpaths_default` greps source
text, so a `use … as` alias would bypass it — a behavioural assertion is the
better shape. LOW: the three candidate `is_file()` probes run before the
screen (stat-only existence oracle, pre-existing). Both are follow-up
candidates, not fixed in this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
