### PR TITLE
chore(trusty-mpm): bump to 1.5.23 for owner-authorized reinstall (rtk pipe mode)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11917,7 +11917,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.22"
+version = "1.5.23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -34,7 +34,10 @@ name = "trusty-mpm"
 # 1.5.22 (owner-authorized reinstall, refs #7295 #7294 #7296): patch,
 # version-only — 1.5.21 is already published and this bump exists solely so
 # `tm --version` identifies the reinstalled build.
-version = "1.5.22"
+# 1.5.23 (owner-authorized reinstall, refs #7311 #7314): patch,
+# version-only — 1.5.22 is already published and this bump exists solely so
+# `tm --version` identifies the reinstalled build (rtk pipe-mode fix).
+version = "1.5.23"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome

Refs #7311
Refs #7314

Version-only bump so the reinstall carrying PR #7314 (tm compress invokes rtk in pipe mode) is identifiable by `--version`. Mirrors #7304.

## Changes

Bump `trusty-mpm` to 1.5.23 in `crates/trusty-mpm/Cargo.toml` and `Cargo.lock`. No behavior change.

## Risk

Rung 1 — version-only bump, no source change.

## Tests

None required at rung 1; no code changed.

## Baseline

Not applicable — no gate run for a version-only bump.

## Docs

Not applicable — no user-visible behavior change.

## Review

None outstanding.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
