### PR TITLE
feat(trusty-mpm): 💸 renders <session>%/<avg>% and tm compress writes a savings row

### DIFF
--- a/crates/trusty-mpm/README.md
+++ b/crates/trusty-mpm/README.md
@@ -157,15 +157,19 @@ tm telegram pair
 
 The `tm statusline` bar ends with a 💸 segment showing the whole-number percent
 of tokens this session avoided sending, as a **session share**: `tokens_saved /
-(session_actual_tokens + tokens_saved)`. Two producers write the saved side to
-a ledger: instruction sources folded into one compiled prompt, and bulk reads
-diverted to a cheap worker. A `divert` row's tokens are the diverted files'
-count minus the returned summary's. `session_actual_tokens` is a cumulative
+(session_actual_tokens + tokens_saved)`. Three producers write the saved side to
+a ledger: instruction sources folded into one compiled prompt, bulk reads
+diverted to a cheap worker, and bash or gate output shrunk by `tm compress`. A
+`divert` row's tokens are the diverted files' count minus the returned
+summary's; a `compress` row's are the input's minus the compressed form's, and a
+run that returned its input unchanged writes none. `session_actual_tokens` is a cumulative
 counter the statusline's compaction tracker keeps per session — it survives
 `total_input_tokens` resetting on every auto-compaction, unlike a raw read of
 that figure would. Before a session's first `statusLine` tick, the percent
-falls back to each row's own pre-saving token count instead. It reads `💸34%`,
-and is absent entirely when nothing has been recorded. It never renders `0%`.
+falls back to each row's own pre-saving token count instead. It reads
+`💸34%/29%` — this session, then the average across every session on the
+ledger — and is absent entirely when nothing has been recorded. It never
+renders `0%`.
 
 Rows live in `~/.trusty-mpm/usage/savings.jsonl` and are folded at read time.
 The figure is an estimate, and it is NOT subtractable from the cost segment

--- a/crates/trusty-mpm/changelog.d/statusline-savings-slash-format.md
+++ b/crates/trusty-mpm/changelog.d/statusline-savings-slash-format.md
@@ -1,0 +1,4 @@
+Changed
+
+- statusline savings segment renders `💸<session>%/<avg>%` instead of `💸<session>% (avg <avg>%)`
+- `tm compress` is now a savings producer: a run that shrinks its input appends one `compress` row to `usage/savings.jsonl`, so the `💸` segment includes bash and gate output alongside instruction folding and bulk-read diversion. A passthrough run — output under the size gate, returned unchanged — writes no row, so a zero-saving run cannot drag the average down. The row's `basis` names the `compression_path` (`rtk_binary` / `native_fallback`) the run took.

--- a/crates/trusty-mpm/src/bin/tm/commands/compress.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/compress.rs
@@ -21,7 +21,10 @@
 //! shaped record (issue #3867's schema, plus issue #3870's additive
 //! `compression_path`) to `~/.trusty-mpm/compression.jsonl` (issue #3870,
 //! epic #3866 Slice D — this doc comment's own former "will eventually
-//! consume" note is now discharged), and writes the compressed text to
+//! consume" note is now discharged), appends one `compress` savings row for a
+//! run that actually shrank its input (see
+//! [`trusty_mpm::core::savings_compress`], which is what puts bash and gate
+//! output into the `💸` statusline segment), and writes the compressed text to
 //! stdout.
 //! Test: `run_compress_shrinks_repetitive_cargo_test_output`,
 //! `log_compression_stats_pct_reduction_is_zero_for_empty_input`,
@@ -102,6 +105,9 @@ pub(crate) async fn run_compress(tool: &str) -> anyhow::Result<()> {
         duration_ms,
     )
     .await;
+    // The 💸 statusline segment folds this technique too, so the same run that
+    // writes the telemetry record also writes one savings row.
+    record_compress_savings(input.len(), compressed.len(), path.as_str());
 
     // Explicit `.flush()` (trusty-review finding, PR #1968): `write_all`
     // hands the bytes to Tokio's stdout writer but does not itself guarantee
@@ -113,6 +119,46 @@ pub(crate) async fn run_compress(tool: &str) -> anyhow::Result<()> {
     stdout.write_all(compressed.as_bytes()).await?;
     stdout.flush().await?;
     Ok(())
+}
+
+/// Append this run's savings row to the ledger the `💸` statusline segment folds.
+///
+/// Why: `tm compress` avoids sending tokens exactly the way instruction folding
+/// and bulk-read diversion do, but until this call it wrote only its own
+/// `compression.jsonl` telemetry — so the segment reported everything the
+/// harness saves EXCEPT bash and gate output. The two writes live side by side
+/// because they describe the same event and must never disagree about its byte
+/// counts.
+/// What: resolves the session id Claude Code exports and the framework root the
+/// statusline reads from — the same `--root` / `TRUSTY_MPM_ROOT` / config chain
+/// [`crate::commands::divert`] uses — then hands both byte counts and the
+/// compression-path label to
+/// [`trusty_mpm::core::savings_compress::record_compress`], which declines a
+/// passthrough run rather than writing a zero-saving row. Declines quietly with
+/// no session id or no resolvable root; never fails the compression.
+/// Test: the producer's own suite in `savings_compress_tests.rs`.
+fn record_compress_savings(bytes_before: usize, bytes_after: usize, compression_path: &str) {
+    let Some(session_id) = trusty_mpm::core::savings::claude_code_session_id() else {
+        tracing::debug!("no claude session id: writing no compress savings row");
+        return;
+    };
+    let root = match crate::commands::managed_root::resolve_managed_paths(None) {
+        Ok(paths) => paths.root,
+        Err(source) => {
+            tracing::warn!(
+                %source,
+                "cannot resolve the framework root: writing no compress savings row"
+            );
+            return;
+        }
+    };
+    trusty_mpm::core::savings_compress::record_compress(
+        &root,
+        &session_id,
+        bytes_before,
+        bytes_after,
+        compression_path,
+    );
 }
 
 /// Install a stderr-only tracing subscriber for short-lived `tm compress`

--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs
@@ -23,8 +23,8 @@
 //!
 //! | Fold | Renders |
 //! |---|---|
-//! | `tokens_saved > 0`, a percent denominator, and other sessions on the ledger | `💸34% (avg 29%)` |
-//! | the same, but the ledger holds only this session | `💸34% (avg 34%)` |
+//! | `tokens_saved > 0`, a percent denominator, and other sessions on the ledger | `💸34%/29%` |
+//! | the same, but the ledger holds only this session | `💸34%/34%` |
 //! | zero fold, or no denominator at all (every row predates #7179 and no compaction tick has landed) | nothing at all |
 //!
 //! The average is the arithmetic mean of each session's OWN percentage
@@ -249,8 +249,9 @@ fn savings_root() -> Option<PathBuf> {
 /// `0%`, never a fabricated figure.
 /// What: `💸<N>%` from [`SavingsTotal::percent_saved`] against
 /// `session_actual_tokens` (#7179's session-share denominator, or its
-/// pre-ruling `tokens_before` fallback on `None`), followed by ` (avg <M>%)`
-/// when an average exists (#7074). `None` on [`SavingsTotal::is_zero`] or when
+/// pre-ruling `tokens_before` fallback on `None`), followed by `/<M>%`
+/// when an average exists (#7074, slash form since the owner's 2026-09-10
+/// ruling). `None` on [`SavingsTotal::is_zero`] or when
 /// that method itself returns `None` (no denominator on either path) — and in
 /// that case the average is not rendered on its own, because a session with no
 /// figure of its own shows neither (criterion 3).
@@ -268,7 +269,8 @@ pub(crate) fn render_savings_segment(
     }
     let pct = total.percent_saved(session_actual_tokens)?;
     Some(match average_percent {
-        Some(avg) => format!("\u{1f4b8}{pct}% (avg {avg}%)"),
+        // Owner ruling 2026-09-10: session percent, slash, average percent.
+        Some(avg) => format!("\u{1f4b8}{pct}%/{avg}%"),
         None => format!("\u{1f4b8}{pct}%"),
     })
 }
@@ -330,7 +332,7 @@ mod tests {
     fn savings_segment_renders_the_average_beside_the_session_figure() {
         assert_eq!(
             render_savings_segment(&total(5_000, 20_000), None, Some(29)).as_deref(),
-            Some("\u{1f4b8}25% (avg 29%)")
+            Some("\u{1f4b8}25%/29%")
         );
     }
 
@@ -447,7 +449,7 @@ mod tests {
         write_row(&ledger, "sess-1", 12_000, 60_000);
         assert_eq!(
             savings_segment_at(&ledger, "sess-1", |_| None).as_deref(),
-            Some("\u{1f4b8}20% (avg 20%)")
+            Some("\u{1f4b8}20%/20%")
         );
         // A different session's bar reads nothing from the same file.
         assert_eq!(savings_segment_at(&ledger, "sess-2", |_| None), None);
@@ -467,7 +469,7 @@ mod tests {
 
         assert_eq!(
             savings_segment_at(&ledger, "sess-a", |_| None).as_deref(),
-            Some("\u{1f4b8}10% (avg 30%)")
+            Some("\u{1f4b8}10%/30%")
         );
     }
 

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -193,6 +193,9 @@ pub mod reinstall;
 // #6958: the per-session token-savings ledger every producer appends to, and
 // the instruction/language-compression producer that writes the first row.
 pub mod savings;
+// The `tm compress` tool-output producer, the ledger's third row source — what
+// makes the 💸 segment include bash and gate output, not just prompts and reads.
+pub mod savings_compress;
 // #6959: the bulk-read diversion producer, the ledger's second row source.
 pub mod savings_divert;
 pub mod savings_instructions;

--- a/crates/trusty-mpm/src/core/savings.rs
+++ b/crates/trusty-mpm/src/core/savings.rs
@@ -79,6 +79,15 @@ pub const TECHNIQUE_INSTRUCTION_COMPRESSION: &str = "instruction-compression";
 /// Test: `divert_row_carries_the_named_technique`.
 pub const TECHNIQUE_DIVERT: &str = "divert";
 
+/// `technique` value written by the tool-output compression producer.
+///
+/// Why: `tm compress` shrinks a gate's output before an agent reads it, which
+/// avoids sending tokens exactly the way the other two producers do. Until it
+/// wrote a row, the `💸` segment reported everything the harness saves EXCEPT
+/// bash and tool output.
+/// Test: `a_compress_row_carries_the_named_technique`.
+pub const TECHNIQUE_COMPRESS: &str = "compress";
+
 /// The environment variable Claude Code exports carrying the session's own id.
 ///
 /// Why (#7209): every row on this ledger is folded back by

--- a/crates/trusty-mpm/src/core/savings_compress.rs
+++ b/crates/trusty-mpm/src/core/savings_compress.rs
@@ -1,0 +1,194 @@
+//! The tool-output compression savings producer.
+//!
+//! Why: `tm compress` is the third technique the harness spends effort on — it
+//! shrinks a gate's or a bash command's output before an agent ever reads it.
+//! Until this module existed it wrote only its own `compression.jsonl`
+//! telemetry, so the `💸` statusline segment reported instruction folding and
+//! bulk-read diversion but never bash output. The owner asked whether bash
+//! compression was included; it is, from here on.
+//!
+//! What: [`record_compress`], called from `tm compress`'s success arm beside
+//! the durable `CompressionRecord` append. It prices the byte delta the agent
+//! never read at the session's own input rate and appends one
+//! [`crate::core::savings::SavingsRow`] with `technique = "compress"`. The
+//! row's `basis` carries the `compression_path` the run took (`rtk_binary` or
+//! `native_fallback`) so a later attribution pass can split the two.
+//!
+//! Three properties it shares with the divert producer, deliberately:
+//!
+//! - **A non-positive delta writes nothing.** `tm compress` passes short output
+//!   through unchanged, and that run avoided nothing. A zero-saving row would
+//!   still carry a `tokens_before` into the fold and drag the average down, so
+//!   the run declines instead.
+//! - **The price comes from the session, not a default.**
+//!   [`crate::core::savings_divert::resolve_session_price`] is the one resolver
+//!   both producers call, so a compress row and a divert row in the same session
+//!   can never be priced at two different models.
+//! - **A ledger failure is not a compression failure.** The compressed text is
+//!   the caller's return value; an unwritable ledger logs a `warn!` and nothing
+//!   else.
+//!
+//! Test: the inline suite in `savings_compress_tests.rs` —
+//! `a_compress_run_appends_exactly_one_row`,
+//! `a_compress_row_carries_the_named_technique`,
+//! `a_hand_computed_byte_delta_matches_the_row`,
+//! `passthrough_output_writes_no_row`,
+//! `an_expanded_output_writes_no_row`,
+//! `the_basis_names_the_compression_path`,
+//! `no_row_without_a_session_id`,
+//! `no_row_when_the_session_model_cannot_be_priced`,
+//! `a_ledger_write_failure_does_not_fail_the_compression`.
+
+use std::path::Path;
+
+use crate::core::savings::{BYTES_PER_TOKEN, SavingsRow, TECHNIQUE_COMPRESS, append_row, now_ts};
+use crate::core::savings_divert::{MIN_COST_SAVED_USD, ParentModel, resolve_session_price};
+
+/// Append one `compress` row for a run that actually shrank its input.
+///
+/// Why: the caller holds the two byte counts and the path label and nothing
+/// else — it should not also have to know the price table, the row shape, or
+/// which runs are worth a row. Taking the framework `root` as an argument (not
+/// resolving it here) keeps this writer and the statusline reader on the SAME
+/// root, the way [`crate::core::savings_divert::record_divert`] does.
+/// What: declines on an empty `session_id`, an unpriceable session model, or a
+/// non-positive byte delta; otherwise appends to
+/// [`crate::core::savings::savings_log_in`]. Every failure is a log line and a
+/// return — never an error to the caller.
+/// Test: `a_compress_run_appends_exactly_one_row`, `passthrough_output_writes_no_row`.
+pub fn record_compress(
+    root: &Path,
+    session_id: &str,
+    bytes_before: usize,
+    bytes_after: usize,
+    compression_path: &str,
+) {
+    record_compress_with(
+        root,
+        session_id,
+        bytes_before,
+        bytes_after,
+        compression_path,
+        || resolve_session_price(root, session_id),
+    );
+}
+
+/// [`record_compress`] with the price lookup injected.
+///
+/// Why: the decline branches and the fail-open write branch are assertable from
+/// a tempdir this way, with no configured model and no process-wide env
+/// mutation (#5544).
+/// What: see [`record_compress`]. `price` resolves the session's model, its
+/// USD-per-million input rate, and which source named it.
+/// Test: `no_row_without_a_session_id`,
+/// `a_ledger_write_failure_does_not_fail_the_compression`.
+fn record_compress_with(
+    root: &Path,
+    session_id: &str,
+    bytes_before: usize,
+    bytes_after: usize,
+    compression_path: &str,
+    price: impl FnOnce() -> Option<ParentModel>,
+) {
+    if session_id.trim().is_empty() {
+        tracing::debug!("no session id: writing no compress savings row");
+        return;
+    }
+    let Some(row) = compress_row(
+        session_id,
+        bytes_before,
+        bytes_after,
+        compression_path,
+        price,
+    ) else {
+        return;
+    };
+    let ledger = crate::core::savings::savings_log_in(root);
+    // The compressed text is already the caller's return value — a ledger
+    // failure must not turn a compression that worked into one that failed.
+    if let Err(source) = append_row(&ledger, &row) {
+        tracing::warn!(
+            ledger = %ledger.display(),
+            %source,
+            "could not append the compress savings row"
+        );
+    }
+}
+
+/// Build the row, or decline to.
+///
+/// Why: separating the arithmetic from the IO makes every decline a unit test
+/// rather than a filesystem assertion, and it is where the "never fabricate a
+/// positive" rule lives for this technique.
+/// What: before-tokens FLOOR and after-tokens CEIL, so rounding can only
+/// understate the saving — the same divisor and the same direction the divert
+/// producer uses, so the two techniques' figures stay comparable. Declines when
+/// the compressed output is not smaller than the input (the passthrough case),
+/// when the session's model cannot be priced, or when the priced delta rounds
+/// below [`MIN_COST_SAVED_USD`].
+/// Test: `a_hand_computed_byte_delta_matches_the_row`,
+/// `passthrough_output_writes_no_row`, `an_expanded_output_writes_no_row`,
+/// `no_row_when_the_session_model_cannot_be_priced`.
+fn compress_row(
+    session_id: &str,
+    bytes_before: usize,
+    bytes_after: usize,
+    compression_path: &str,
+    price: impl FnOnce() -> Option<ParentModel>,
+) -> Option<SavingsRow> {
+    let before_tokens = (bytes_before as f64 / BYTES_PER_TOKEN).floor() as i64;
+    let after_tokens = (bytes_after as f64 / BYTES_PER_TOKEN).ceil() as i64;
+    let tokens_saved = before_tokens - after_tokens;
+    if tokens_saved <= 0 {
+        tracing::debug!(
+            session_id,
+            before_tokens,
+            after_tokens,
+            compression_path,
+            "the run returned no smaller than it read; writing no savings row"
+        );
+        return None;
+    }
+    let Some(ParentModel {
+        id: model,
+        input_per_million,
+        source,
+    }) = price()
+    else {
+        tracing::warn!(
+            session_id,
+            "the session's model is unknown or unpriceable; writing no compress savings row"
+        );
+        return None;
+    };
+    let cost_saved_usd = (tokens_saved as f64 / 1_000_000.0) * input_per_million;
+    if !cost_saved_usd.is_finite() || cost_saved_usd < MIN_COST_SAVED_USD {
+        tracing::debug!(
+            session_id,
+            tokens_saved,
+            "the priced delta rounds to nothing; writing no savings row"
+        );
+        return None;
+    }
+    Some(SavingsRow {
+        ts: now_ts(),
+        session_id: session_id.to_string(),
+        technique: TECHNIQUE_COMPRESS.to_string(),
+        tokens_saved,
+        // #7179: the percent segment's denominator — what the agent would have
+        // read had the output not been compressed. A floor of a non-negative
+        // byte count, so never negative.
+        tokens_before: before_tokens as u64,
+        cost_saved_usd,
+        basis: format!(
+            "output {before_tokens} tok - compressed {after_tokens} tok, \
+             at {BYTES_PER_TOKEN} B/token, via {compression_path}, priced at \
+             {model} ({source}) input ${input_per_million}/Mtok"
+        ),
+        model_source: source.to_string(),
+    })
+}
+
+#[cfg(test)]
+#[path = "savings_compress_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/savings_compress_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_compress_tests.rs
@@ -1,0 +1,177 @@
+//! Tests for the tool-output compression savings producer.
+//!
+//! Why: the producer's contract is "claim only what the compression genuinely
+//! avoided". The passthrough case is the one that matters most: `tm compress`
+//! returns short output unchanged, and a row written for such a run would carry
+//! a `tokens_before` into the fold while saving nothing — dragging the `💸`
+//! segment's per-session percentage, and therefore its average, down.
+//! What: the row builder is driven with hand-supplied byte counts and an
+//! injected price, so every decline branch is asserted with no configured model
+//! and no process-wide env mutation; the write path is driven against a tempdir.
+//! Test: this file.
+
+use super::*;
+
+use crate::core::savings::{fold_session, savings_log_in};
+use crate::core::session_model::MODEL_SOURCE_STATUSLINE;
+
+/// A price stand-in: Sonnet's published input rate, as the shared table carries
+/// it. Used so the arithmetic below is hand-checkable.
+fn sonnet_price() -> Option<ParentModel> {
+    Some(ParentModel {
+        id: "claude-sonnet-4-6".to_string(),
+        input_per_million: 3.0,
+        source: MODEL_SOURCE_STATUSLINE,
+    })
+}
+
+/// Why: the hand-computed delta is the whole claim. 400,000 bytes of gate output
+/// are 100,000 tokens at four bytes each; the 40,000-byte compressed form is
+/// 10,000; the delta is 90,000 tokens, which at Sonnet's $3/Mtok input rate is
+/// $0.27.
+/// Test: itself.
+#[test]
+fn a_hand_computed_byte_delta_matches_the_row() {
+    let row = compress_row("sess-a", 400_000, 40_000, "rtk_binary", sonnet_price).expect("a row");
+    assert_eq!(row.session_id, "sess-a");
+    assert_eq!(row.tokens_saved, 90_000);
+    assert_eq!(row.tokens_before, 100_000);
+    assert!(
+        (row.cost_saved_usd - 0.27).abs() < 1e-9,
+        "expected $0.27, got {}",
+        row.cost_saved_usd
+    );
+}
+
+/// Why: the fold and any later attribution pass both key on this string, so it
+/// is pinned rather than left to whatever the format call happens to emit.
+/// Test: itself.
+#[test]
+fn a_compress_row_carries_the_named_technique() {
+    let row = compress_row("sess-a", 400_000, 40_000, "rtk_binary", sonnet_price).expect("a row");
+    assert_eq!(row.technique, TECHNIQUE_COMPRESS);
+    assert_eq!(row.technique, "compress");
+}
+
+/// Why: `rtk_binary` and `native_fallback` compress by different mechanisms and
+/// will need splitting apart later. Carrying the label in `basis` is what makes
+/// that possible off the ledger line alone.
+/// Test: itself.
+#[test]
+fn the_basis_names_the_compression_path() {
+    let row =
+        compress_row("sess-a", 400_000, 40_000, "native_fallback", sonnet_price).expect("a row");
+    assert!(
+        row.basis.contains("native_fallback"),
+        "basis must name the compression path, got: {}",
+        row.basis
+    );
+    assert!(
+        row.basis.contains("claude-sonnet-4-6"),
+        "basis must name the model it priced at, got: {}",
+        row.basis
+    );
+}
+
+/// Why: `tm compress` passes output under its size gate through unchanged. That
+/// run avoided nothing, and a zero-saving row would still fold a `tokens_before`
+/// into the percentage and pull the average down.
+/// Test: itself.
+#[test]
+fn passthrough_output_writes_no_row() {
+    assert!(compress_row("sess-a", 1_159, 1_159, "native_fallback", sonnet_price).is_none());
+}
+
+/// Why: compression can expand its input (a short, non-repetitive payload plus
+/// a header). Rounding must never turn that into a positive claim.
+/// Test: itself.
+#[test]
+fn an_expanded_output_writes_no_row() {
+    assert!(compress_row("sess-a", 4_000, 5_000, "native_fallback", sonnet_price).is_none());
+}
+
+/// Why: a row keyed by nothing is a row the statusline can never fold, so the
+/// producer declines rather than writing one.
+/// Test: itself.
+#[test]
+fn no_row_without_a_session_id() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    record_compress_with(
+        dir.path(),
+        "  ",
+        400_000,
+        40_000,
+        "rtk_binary",
+        sonnet_price,
+    );
+    assert!(!savings_log_in(dir.path()).exists());
+}
+
+/// Why: an unpriceable model must decline rather than substitute a guessed rate
+/// — the same rule the divert producer holds.
+/// Test: itself.
+#[test]
+fn no_row_when_the_session_model_cannot_be_priced() {
+    assert!(compress_row("sess-a", 400_000, 40_000, "rtk_binary", || None).is_none());
+}
+
+/// Why: proves the whole write path — one run, one row, folding back under the
+/// session it was keyed by.
+/// Test: itself.
+#[test]
+fn a_compress_run_appends_exactly_one_row() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let ledger = savings_log_in(dir.path());
+
+    record_compress_with(
+        dir.path(),
+        "sess-a",
+        400_000,
+        40_000,
+        "rtk_binary",
+        sonnet_price,
+    );
+
+    let contents = std::fs::read_to_string(&ledger).expect("read ledger");
+    assert_eq!(
+        contents.lines().filter(|l| !l.trim().is_empty()).count(),
+        1,
+        "one run must write exactly one row, got: {contents}"
+    );
+    let total = fold_session(&ledger, "sess-a");
+    assert_eq!(total.rows, 1);
+    assert_eq!(total.tokens_saved, 90_000);
+    assert_eq!(total.tokens_before, 100_000);
+}
+
+/// Why: the compressed text is already the caller's return value by the time
+/// this runs. An unwritable ledger must not turn a compression that worked into
+/// one that failed.
+/// Test: itself.
+#[test]
+fn a_ledger_write_failure_does_not_fail_the_compression() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    // A regular file where the `usage/` directory must go: `create_dir_all`
+    // inside the writer cannot succeed, so the append returns an IO error.
+    let blocker = dir.path().join("usage");
+    std::fs::write(&blocker, "not a directory").expect("write blocker");
+    let ledger = savings_log_in(dir.path());
+
+    record_compress_with(
+        dir.path(),
+        "sess-a",
+        400_000,
+        40_000,
+        "rtk_binary",
+        sonnet_price,
+    );
+
+    assert!(
+        !ledger.exists(),
+        "the unwritable ledger must stay unwritten, not partially created"
+    );
+    assert!(
+        blocker.is_file(),
+        "the blocking file must be left exactly as it was"
+    );
+}

--- a/crates/trusty-mpm/src/core/savings_divert.rs
+++ b/crates/trusty-mpm/src/core/savings_divert.rs
@@ -98,7 +98,7 @@ pub struct ParentModel {
 /// measurement to report.
 /// What: `1e-6` USD.
 /// Test: `no_row_when_the_worker_cost_exceeds_the_saving`.
-const MIN_COST_SAVED_USD: f64 = 1e-6;
+pub(crate) const MIN_COST_SAVED_USD: f64 = 1e-6;
 
 /// Append one `divert` row for a diversion that answered.
 ///
@@ -290,7 +290,7 @@ fn choose_parent_model(
 /// one `warn!` naming it, because that price is a guess the operator cannot
 /// otherwise see.
 /// Test: `resolve_session_price_agrees_with_the_shared_table`.
-fn resolve_session_price(root: &Path, session_id: &str) -> Option<ParentModel> {
+pub(crate) fn resolve_session_price(root: &Path, session_id: &str) -> Option<ParentModel> {
     let (model, source) = choose_parent_model(
         std::env::var(SESSION_MODEL_ENV).ok(),
         read_session_model(root, session_id),
@@ -306,7 +306,8 @@ fn resolve_session_price(root: &Path, session_id: &str) -> Option<ParentModel> {
             session_id,
             %model,
             env = SESSION_MODEL_ENV,
-            "no statusline model record for this session; pricing the divert row \
+            // Shared with the compress producer, so the message names no technique.
+            "no statusline model record for this session; pricing the savings row \
              from the config chain, which may not be the model the session runs"
         );
     }

--- a/docs/trusty-mpm/statusline-savings.md
+++ b/docs/trusty-mpm/statusline-savings.md
@@ -9,14 +9,14 @@ it. The `💸` segment on the `tm` statusline shows what percentage of tokens
 that would otherwise have been sent, this session avoided sending.
 
 ```
-TM 1.5.18 ● | trusty-tools ⎇ main | @bobmatnyc | ✻you@example.com | Opus | ctx 41% | $12.40 | ⏳24% 📅41% | 💸34% (avg 29%)
+TM 1.5.18 ● | trusty-tools ⎇ main | @bobmatnyc | ✻you@example.com | Opus | ctx 41% | $12.40 | ⏳24% 📅41% | 💸34%/29%
 ```
 
 It has one form and one absence:
 
 | Folded total | Segment |
 |---|---|
-| At least one accepted row, with a percent to report | `💸34% (avg 29%)` |
+| At least one accepted row, with a percent to report | `💸34%/29%` |
 | Nothing recorded for this session, or every accepted row predates #7179 | *the segment is not rendered at all* |
 
 The first figure is this session. The second is the **average across sessions**
@@ -32,7 +32,7 @@ row. That is the shape the owner ruled for on 2026-09-09: after the 2026-09-08
 ruling made the figure a percentage of tokens saved, percentages no longer sum
 into a lifetime total, but they do average cleanly — and a short session that
 avoided 60 % of its tokens counts as much as a long one that avoided 10 %.
-Three sessions at 10 %, 30 % and 50 % therefore show `avg 30%`, where a pooled
+Three sessions at 10 %, 30 % and 50 % therefore show `💸10%/30%`, where a pooled
 ratio over the same rows would show 29 %.
 
 A session contributes only when it has a percentage of its own — the same rule
@@ -104,7 +104,7 @@ interpret.
 ## The techniques, and what each one measures
 
 `technique` is an open string in the ledger, so a new producer needs no schema
-change. Today two producers ship.
+change. Today three producers ship.
 
 ### `instruction-compression`
 
@@ -190,12 +190,28 @@ running Opus, the status bar had not rendered yet.
 A model the price table does not recognise declines the row and logs a warning
 rather than pricing it at a guessed rate.
 
+### `compress`
+
+Written once per `tm compress` run that actually shrank its input — the filter a
+gate chain or a bash command pipes its output through before an agent reads it.
+This is what puts bash and tool output into the segment; before it shipped, the
+`💸` figure covered prompts and diverted reads only.
+
+`tokens_saved` is the input's token count minus the compressed form's, at the
+same four-bytes-per-token divisor the other two producers use, priced at the
+session's own input rate. The row's `basis` names the `compression_path` the run
+took — `rtk_binary` or `native_fallback` — so the two mechanisms can be split
+apart later off the ledger line alone.
+
+A run whose output is under the size gate passes through unchanged and writes no
+row. That case saved nothing, and a zero-saving row would still fold its
+before-figure into the percentage and pull both it and the average down.
+
 ### Adding another producer
 
 Any call site that can compute a before/after byte or token count appends a row
-with its own `technique` string. `tm compress`, which already knows the input
-and output size of every gate log it trims, is the obvious third one. No change
-to the ledger, the fold, or the segment is required.
+with its own `technique` string. No change to the ledger, the fold, or the
+segment is required.
 
 ## The same numbers on the commit
 
@@ -330,7 +346,8 @@ under whatever framework root your `--root` flag, `TRUSTY_MPM_ROOT`, or
 ```
 
 `model_source` names where the model the row was priced at came from. For a
-`divert` row it is one of the three values in the table above; for an
+`divert` or a `compress` row — both resolve the price the same way — it is one
+of the three values in the table above; for an
 `instruction-compression` row it is always `launch-config`, because that producer
 runs at session launch, off the very chain that produced the session's `--model`
 flag. Rows written before this field existed read back with it empty and still


### PR DESCRIPTION
## Outcome

Refs #7074
Refs #7245
Refs #7311

Owner ruling: the 💸 statusline segment reads `💸4%/21%`, session percent then average. `tm compress` now also writes a savings row, so bash/tool-output compression counts toward the segment; before this change 💸 folded only instruction-compression and divert rows.

## Changes

- `crates/trusty-mpm/src/bin/tm/commands/statusline/savings.rs`: one format arm renders `<session>%/<avg>%`.
- `crates/trusty-mpm/src/core/savings_compress.rs` (new): `tm compress` appends a `compress` `SavingsRow` whose basis carries `compression_path`.
- `crates/trusty-mpm/src/bin/tm/commands/compress.rs`: wires the new producer into the compress command.
- `crates/trusty-mpm/src/core/savings.rs`, `core/mod.rs`, `core/savings_divert.rs`: shared price resolver made `pub(crate)` for reuse by the new producer.
- `crates/trusty-mpm/README.md`, `docs/trusty-mpm/statusline-savings.md`: updated for the new format and the compress row (the flagship website page includes this doc).

## Risk

Rung 3, localized to `trusty-mpm`. A ledger write failure on the new path must not fail the compression itself — covered by a dedicated test.

## Tests

`-p trusty-mpm` fmt/check/clippy/test `--no-fail-fast`: 56 targets, 11866 passed, 0 failed. Nine new tests, including `a_ledger_write_failure_does_not_fail_the_compression` and `passthrough_output_writes_no_row`.

## Baseline

No pre-existing red encountered.

## Docs

Doc gates pass: line-cap, test-pointers, doc-paths, rustdoc links, changelog fragment `crates/trusty-mpm/changelog.d/statusline-savings-slash-format.md`.

## Review

No outstanding findings.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
