### PR TITLE
chore(sessions): pause snapshot 2026-09-10 02:12Z (session trusty-tools-95)

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-021238.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-021238.md
@@ -1,0 +1,40 @@
+# Session Pause - 2026-09-10T02:12:38.784069+00:00
+
+## Summary
+Owner-invoked pause 2026-09-10 ~02:5xZ, session trusty-tools-95 (tmux tm-dogfood:0:@1); supersedes the 00:19Z snapshot. Owner directives this leg: "can we include rtk installation as part of the install process?" (→ #7311); "Disk usage is high, let's see if there are worktrees we can clean up. We should report disk usage by session on the mpm console" (→ cleanup done, #7313 filed); "let's prioritize the RTK fix since it's eating up tokens now" (DISCHARGED: tm 1.5.23 installed+signed from 0a7de5e65, `tm compress` proven compression_path=rtk_binary by marker round-trip; daemon still 1.5.22, not bounced); "drop the ones that have pushed/merged work" (done: 11 merged + 10 sibling-merged + abec7ce0 + wt-rustdoc + install-tm-1522 + rtk worktree removed; 41→22 worktrees). MERGED this leg: #7309 snapshot, #7310 (#7270 #7271, a4176897), #7314 rtk pipe mode (d5429ee8), #7316 (#7267 prune matching, 8160d048), #7318 tm 1.5.23 bump (0a7de5e6), #7319 💸 <s>%/<avg>% + tm compress savings row (1141b43c; NOT in the installed binary). OPEN PR #7320 (#7311 install surfaces, acb3c689d, watched, arm on green rows). DISK: 26 dead target-<N> dirs deleted (~507G), free 475G→964G, volume 88%→74%; `target` (299G, other workstream's uncommitted trusty-agents work in main checkout) and target-statusline kept. HOOKS: 8 projects' .claude/settings.json repaired (test-binary hook paths; backups .corrupt-20260910); root cause a stale pre-fix test binary run after #7273 merged (recorded on #7244); #7262 REOPENED (tm doctor --fix has no repair arm for hooks_build_tree_binary); THIS session and all peers still run the stale hook snapshot until /hooks is reopened or relaunched (4 peers messaged). RED MAIN: sole remaining cause is #7312 (trusty-code uds bind-failure test hangs on Linux: ECONNREFUSED on connect-to-regular-file read as dead socket → unlink+bind+serve forever); fix at 5334a6b42 critic APPROVE, symlink-test round in flight. PM ERROR recorded: my first rtk brief's root cause was wrong (rtk is a command runner; `rtk pipe` is the stdin mode) — verify stdin filters by output correspondence, never exit code. Issues: #5669 #5478 closed; #7270 #7271 #7267 status:merged; #7278 #7311 status:coded; #7282 status:coded; #7311 #7312 #7313 in-progress; #7262 reopened; open count ~233.
+
+## Completed
+- tm 1.5.23 installed+signed from 0a7de5e65; rtk pipe mode live (compression_path=rtk_binary)
+- rtk 0.48.0 installed via brew (no rtk init)
+- PRs merged: #7309 #7310 #7314 #7316 #7318 #7319
+- Disk: 26 target-<N> dirs (~507G) + 24 worktrees removed; 41→22 worktrees; free 475G→964G
+- 8 corrupted settings.json repaired machine-wide; #7262 reopened; #7244 mechanism comment
+- Issues filed: #7311 (rtk install), #7312 (uds hang), #7313 (console disk by session); closed #5669 #5478
+- Owner ruling 'drop pushed/merged worktrees' executed
+
+## In Progress
+- PR #7320 (#7311 install surfaces, feat/7311-rtk-install-surfaces acb3c689d, worktree agent-ad848d22d214be469): Monitor bmedocfg8 watching; on settle → version-control verify raw rows + arm; on merge → ticketing #7311 status:merged
+- #7312 rust-engineer a7748d4b68780e85e (worktree agent-a7748d4b68780e85e, fix/7219-uds-bind-failure-test-hang, base 5334a6b42): adding symlink refusal tests + is_socket short-circuit (critic APPROVE, scan PASS) → on report: version-control opens PR (Refs #7312 #7219, rung 4 trusty-common+trusty-code; consumers tested), arm on green; ticketing #7312 status:coded → merged; green main closes #7226 + #7028 tracker + #7288
+- #7313 slice 1 feat/7313-disk-survey-by-session 510af357b (worktree agent-aca4808ada7c0fbf8): security scan aae7be44d35938c2a running → version-control PR (Refs #7313, rung 3; MCP schema live-verify after next reinstall) → ticketing #7313 status:coded
+- #7278 rebase: rust-engineer a3bff84550521e8d1 rebasing fix/7278-transcript-path-screening (853908aa, PR #7317 DIRTY) as fix/7278-transcript-path-screening-r2 onto main → on report: version-control force-push-with-lease to the PR branch or open a replacement PR, close #7317 if replaced; arm on green
+- #7282 r5: rust-engineer a12c815171ea9c426 on fix/7282-session-pause-via-pr-r5 off f996e91f4 (--head requires --docs-only; pause publishes from any non-detached checkout) → critic re-check optional (WARN round) → scan → PR (Refs #7282) → arm → #7282 status:coded
+- #7266 r2: rust-engineer a82dd85cf1f151b2c on fix/7266-pm-guard-secret-file-line-reads-r2 off 11c08ed44 (Grep arm, base64/diff verbs, copy-to-source-name seam; critic BLOCK round) → critic re-review REQUIRED → scan → PR → arm → #7266 status:coded
+- #7275 r3: rust-engineer aa509f09676ece92b on fix/7275-pr-cleanup-landed-r3 off main (merged PR + merge-tree no-op, never ahead-count; reuses #7316 resolve_landing; dry-run over 12 merged PRs) → critic (destructive path) → scan → PR → arm; then live `tm pr cleanup` test after reinstall → #7275 tested → closed
+
+## Next Steps
+- On resume: ListAgents FIRST (agents survive pause); reconcile each in-progress branch with `git log --oneline -1`; salvage uncommitted work with a fresh engineer on a fresh -rN branch off the committed head (prior engineers were unresumable once)
+- OWNER ACTION: reopen /hooks or relaunch this session (and peers) — stale hook snapshot means no compression and no 💸 row until then
+- After the fix wave merges (#7312 #7313 #7278 #7282 #7266 #7275 #7320): ONE tm bump 1.5.24 + reinstall (carries #7319 💸 format, #7316, #7278, #7282, #7266, #7267 behaviour); live-verify each; ticketing closes from status:tested; daemon bounce only on owner word
+- Owner rulings pending: dirty worktrees agent-a03c52fefe231efed (#7074, 9 uncommitted source files, PR #7261 merged) and agent-a2309f762e459980f (#7237, 5 uncommitted trusty-common files, PR #7257 merged) — drop or keep; the four dirty other-session trees (feat/6433 6850 6851 6637) untouched
+- #7313 slices 2 (tm session disk CLI, rung 4) and 3 (console by-session tab, rung 6) after slice 1 merges
+- HELD status:merged, owner-attended: #5220 #6838 #6900 #7112 #7224 #7263
+- Fold, never file: .gitignore `**/target-*/`; CLAUDE.md exit-137 note (+ -j 4; shell 137 = same pressure); cargo fmt -p not paths; spell gates ./scripts/ not bash scripts/; BASE-AGENT wait-sentinel append form; stdin-filter verification by marker; gh empty output under sandbox = sandbox block; trusty-agents socket.rs ENOTSOCK=38 comment wrong (Linux 88); errno tests via pure decision fn; #6982 re-refusal of a previously-allowed git check-ignore; machine-wide cargo lease idea; #7278 critic MEDIUM (source-grep test bypassable by alias); #7267 critic MEDIUM (stem equality relates independent -rN branches)
+- Every brief: isolation worktree + STOP-if-main-checkout; CARGO_TARGET_DIR=<worktree>/target-<N> absolute, -j 4, --test-threads=4; run shell gates AFTER cargo gates never concurrently; scan before PR; Refs never Closes; arm only after raw rows green; -rN off the committed head; ticketing/version-control on sonnet, never mix issue ops into a version-control brief; agent recs fold, never new issues
+
+## Git Context
+Branch: main
+Last commit: c7e38dbfa chore(trusty-mpm): bump to 1.5.21 for owner-authorized reinstall (#7292)
+Uncommitted changes: 135 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -107,3 +107,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-192518.md","timestamp":"2026-09-09T19:25:18.095691+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260909-233853.md","timestamp":"2026-09-09T23:38:53.886440+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-001911.md","timestamp":"2026-09-10T00:19:11.961807+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-021238.md","timestamp":"2026-09-10T02:12:38.784069+00:00"}


### PR DESCRIPTION
Docs-only session snapshot. Rung 1. Published by hand: `tm pr open` in 1.5.23 lacks `--head` (Refs #7282).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
