### PR TITLE
fix(trusty-mpm): tm pr open --head requires --docs-only; session pause publishes from any non-detached checkout (Refs #7282)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7282-pause-publish-explicit-head.md
+++ b/crates/trusty-mpm/changelog.d/7282-pause-publish-explicit-head.md
@@ -1,0 +1,4 @@
+Fixed
+
+- `session_context_pause` now opens its snapshot PR with an explicit `--head <branch>`, so the publish no longer depends on which branch the project checkout happens to be on. The chore branch is built with git plumbing and never checked out, so `gh pr create` read the checkout's own branch and aborted with "you must first push the current branch to a remote, or use the --head flag", stranding the commit locally.
+- `tm pr open` takes a `--head <branch>` flag, and derives the component-label diff from that branch rather than the checkout's `HEAD`.

--- a/crates/trusty-mpm/changelog.d/7282-pause-publish-explicit-head.md
+++ b/crates/trusty-mpm/changelog.d/7282-pause-publish-explicit-head.md
@@ -1,4 +1,6 @@
 Fixed
 
 - `session_context_pause` now opens its snapshot PR with an explicit `--head <branch>`, so the publish no longer depends on which branch the project checkout happens to be on. The chore branch is built with git plumbing and never checked out, so `gh pr create` read the checkout's own branch and aborted with "you must first push the current branch to a remote, or use the --head flag", stranding the commit locally.
+- A pause snapshot publishes from any checkout that has a branch, not only from the project's default branch. The commit is plumbing against `origin/<default>` and the PR names its own head, so the checkout's branch reaches neither. A detached HEAD is still refused, because `rev-parse --abbrev-ref HEAD` names no branch there.
 - `tm pr open` takes a `--head <branch>` flag, and derives the component-label diff from that branch rather than the checkout's `HEAD`.
+- `tm pr open --head` now requires `--docs-only` and exits 2 without calling `gh` otherwise. `scripts/check_changelog_fragment.sh` accepts only `--base`, so the fragment gate could diff nothing but the CHECKOUT's `HEAD` — a source PR opened with `--head` from another branch cleared the gate against a diff it did not contain.

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/pr.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/pr.rs
@@ -135,14 +135,19 @@ pub(crate) struct PrOpenArgs {
     #[arg(long, default_value = "main")]
     pub(crate) base: String,
 
-    /// Head branch to open FROM. Defaults to the checkout's current branch.
+    /// Head branch to open FROM; requires --docs-only. Defaults to the
+    /// checkout's current branch.
     ///
     /// Why (#7282): `gh pr create` infers the head from the checkout's current
     /// branch, so a caller that built its branch with git plumbing — the
     /// session-pause publisher does exactly that — had `gh` read `main` and
     /// abort with "you must first push the current branch to a remote, or use
     /// the --head flag". Naming the head makes the caller's checkout state
-    /// irrelevant.
+    /// irrelevant. `--docs-only` is required with it because the changelog gate
+    /// can only diff the CHECKOUT's HEAD, so a source PR opened this way would
+    /// clear the gate against a diff it does not contain (#7282 round 5). The
+    /// pairing is enforced in `commands::pr::open::head_docs_only_conflict`,
+    /// which names the obligation instead of a bare clap message.
     #[arg(long)]
     pub(crate) head: Option<String>,
 

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/pr.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/pr.rs
@@ -135,6 +135,17 @@ pub(crate) struct PrOpenArgs {
     #[arg(long, default_value = "main")]
     pub(crate) base: String,
 
+    /// Head branch to open FROM. Defaults to the checkout's current branch.
+    ///
+    /// Why (#7282): `gh pr create` infers the head from the checkout's current
+    /// branch, so a caller that built its branch with git plumbing — the
+    /// session-pause publisher does exactly that — had `gh` read `main` and
+    /// abort with "you must first push the current branch to a remote, or use
+    /// the --head flag". Naming the head makes the caller's checkout state
+    /// irrelevant.
+    #[arg(long)]
+    pub(crate) head: Option<String>,
+
     /// Skip the changelog-fragment gate — docs-only / CI-only PRs may.
     #[arg(long = "docs-only")]
     pub(crate) docs_only: bool,

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/open.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/open.rs
@@ -119,8 +119,8 @@ impl Preflight for RealPreflight {
             return Ok(ChangelogVerdict::Skipped);
         }
         // #7282: the script takes `--base` and always diffs it against the
-        // checkout's HEAD — it has no `--head` of its own, so a `--head` caller
-        // whose branch is not checked out must pass `--docs-only`.
+        // checkout's HEAD — it has no `--head` of its own, which is why
+        // `head_docs_only_conflict` refuses `--head` without `--docs-only`.
         let out = std::process::Command::new("bash")
             .arg(&script)
             .arg("--base")
@@ -178,6 +178,35 @@ fn head_branch(args: &PrOpenArgs) -> Option<&str> {
         .filter(|h| !h.is_empty())
 }
 
+/// The refusal a `--head` earns when it is not paired with `--docs-only`.
+///
+/// Why (#7282 round 5): `scripts/check_changelog_fragment.sh` accepts only
+/// `--base`, `--staged` and `--file`, so [`Preflight::changelog_gate`] can
+/// diff nothing but `origin/<base>...HEAD` — the CHECKOUT's HEAD. A caller who
+/// names `--head other-branch` from a checkout sitting on a different branch
+/// therefore has the fragment gate judge a diff the PR does not contain, and a
+/// source PR with no fragment passes it. Until the script can diff an explicit
+/// head, refusing the pair is the only sound answer; `--docs-only` is the one
+/// case where the gate's verdict does not matter, because it is skipped.
+/// What: `Some(message)` when a non-blank `--head` was named without
+/// `--docs-only`, else `None`.
+/// Test: `open_head_without_docs_only_is_refused`,
+/// `open_head_without_docs_only_never_calls_gh`,
+/// `open_head_with_docs_only_plans`.
+fn head_docs_only_conflict(args: &PrOpenArgs) -> Option<String> {
+    let head = head_branch(args)?;
+    if args.docs_only {
+        return None;
+    }
+    Some(format!(
+        "--head requires --docs-only until the changelog gate can diff an explicit head: \
+         scripts/check_changelog_fragment.sh takes only --base, so it would judge \
+         origin/{}...HEAD — this checkout — rather than `{head}`. \
+         Run tm pr open from a checkout of `{head}` for a source PR.",
+        args.base
+    ))
+}
+
 /// The revision the pre-flight diffs against `origin/<base>`.
 ///
 /// Why (#7282): the changelog gate and the component-label diff both asked
@@ -228,15 +257,18 @@ pub(crate) struct OpenPlan {
 /// pure function of (args, body text, session name, changelog verdict) — which
 /// is what makes "each missing field exits 2" testable without a `gh` or a
 /// repository.
-/// What: in order — the body contract and footer ([`body::validate`]), the
-/// `Refs`/`Closes` rule ([`body::apply_issue_link`]), the workstream label,
-/// and the changelog gate. Returns every failure found, not just the first,
-/// so one run fixes them all. Both labels and the assignee come from
-/// `core::policy_labels` and the resolved `agents.ticketing` block (#6918),
-/// never from constants spelled here.
+/// What: in order — the `--head`/`--docs-only` pairing
+/// ([`head_docs_only_conflict`]), the body contract and footer
+/// ([`body::validate`]), the `Refs`/`Closes` rule ([`body::apply_issue_link`]),
+/// the workstream label, and the changelog gate. Returns every failure found,
+/// not just the first, so one run fixes them all. Both labels and the assignee
+/// come from `core::policy_labels` and the resolved `agents.ticketing` block
+/// (#6918), never from constants spelled here.
 /// Test: `open_reports_each_missing_field`, `open_rejects_bad_footer`,
 /// `open_requires_a_session_name`, `open_reports_changelog_failure`,
 /// `open_docs_only_skips_the_changelog_gate`,
+/// `open_head_without_docs_only_is_refused`,
+/// `open_head_with_docs_only_plans`,
 /// `open_labels_come_from_the_policy_table`,
 /// `open_assignee_comes_from_the_ticketing_block`.
 pub(crate) fn plan(
@@ -248,6 +280,10 @@ pub(crate) fn plan(
     ticketing: &ResolvedTicketing,
 ) -> Result<OpenPlan, Vec<String>> {
     let mut failures: Vec<String> = Vec::new();
+
+    // #7282 round 5: `--head` and the changelog gate cannot both be honoured,
+    // so the pair is refused here — before `run` reaches `gh`.
+    failures.extend(head_docs_only_conflict(args));
 
     let report = body::validate(body_text);
     failures.extend(report.failures());

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/open.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/open.rs
@@ -47,7 +47,7 @@ pub(crate) trait Preflight {
     fn session_name(&self) -> Option<String>;
     /// Run the changelog-fragment gate for `origin/<base>...HEAD`.
     fn changelog_gate(&self, base: &str) -> anyhow::Result<ChangelogVerdict>;
-    /// Paths `git diff --name-only origin/<base>...HEAD` reports (#7274).
+    /// Paths `git diff --name-only origin/<base>...<head>` reports (#7274).
     ///
     /// Why: the PR's component labels are the crates these paths belong to, so
     /// this probe is what makes the label derivation real. It sits behind the
@@ -55,7 +55,7 @@ pub(crate) trait Preflight {
     /// driving one fake.
     /// What: repository-relative paths. An error means the diff could not be
     /// read, which downgrades the label derivation to a warning.
-    fn changed_paths(&self, base: &str) -> anyhow::Result<Vec<String>>;
+    fn changed_paths(&self, base: &str, head: &str) -> anyhow::Result<Vec<String>>;
     /// The workspace crate ownership used to label those paths (#7274).
     fn ownership(&self) -> CrateOwnership;
     /// Where the PR just opened is recorded for post-merge cleanup (#7275).
@@ -118,6 +118,9 @@ impl Preflight for RealPreflight {
         if !script.exists() {
             return Ok(ChangelogVerdict::Skipped);
         }
+        // #7282: the script takes `--base` and always diffs it against the
+        // checkout's HEAD — it has no `--head` of its own, so a `--head` caller
+        // whose branch is not checked out must pass `--docs-only`.
         let out = std::process::Command::new("bash")
             .arg(&script)
             .arg("--base")
@@ -133,17 +136,19 @@ impl Preflight for RealPreflight {
         Ok(ChangelogVerdict::Fail(text.trim().to_string()))
     }
 
-    fn changed_paths(&self, base: &str) -> anyhow::Result<Vec<String>> {
+    fn changed_paths(&self, base: &str, head: &str) -> anyhow::Result<Vec<String>> {
         let root = repo_root()?;
         // Three-dot: the changes THIS branch made, never main's own drift.
+        // #7282: `head` is the `--head` branch when one was named, so the labels
+        // describe the branch being opened rather than the checkout's HEAD.
         let out = std::process::Command::new("git")
-            .args(["diff", "--name-only", &format!("origin/{base}...HEAD")])
+            .args(["diff", "--name-only", &format!("origin/{base}...{head}")])
             .current_dir(&root)
             .output()
             .context("cannot run `git diff --name-only`")?;
         anyhow::ensure!(
             out.status.success(),
-            "`git diff --name-only origin/{base}...HEAD` failed: {}",
+            "`git diff --name-only origin/{base}...{head}` failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()
         );
         Ok(String::from_utf8_lossy(&out.stdout)
@@ -157,6 +162,33 @@ impl Preflight for RealPreflight {
     fn ownership(&self) -> CrateOwnership {
         CrateOwnership::resolve(std::env::current_dir().ok().as_deref())
     }
+}
+
+/// The `--head` branch, when the caller named a non-blank one.
+///
+/// Why: a blank `--head ""` must read as "not supplied" rather than reaching
+/// `gh` as an empty head, which it rejects with a message about the current
+/// branch — the exact confusion #7282 was.
+/// What: trims, and drops the empty result.
+/// Test: `open_head_is_ignored_when_blank`.
+fn head_branch(args: &PrOpenArgs) -> Option<&str> {
+    args.head
+        .as_deref()
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+}
+
+/// The revision the pre-flight diffs against `origin/<base>`.
+///
+/// Why (#7282): the changelog gate and the component-label diff both asked
+/// about `HEAD`, which is the checkout's current branch — not the branch a
+/// `--head` caller is opening. Reading main's own state there answers "no
+/// changes" for every such PR, so the gate passes vacuously and the PR gets no
+/// component labels.
+/// What: the `--head` branch when one was named, else `HEAD`.
+/// Test: `open_head_drives_the_preflight_diff_revision`.
+fn diff_head(args: &PrOpenArgs) -> &str {
+    head_branch(args).unwrap_or("HEAD")
 }
 
 /// The repository root of the current working directory.
@@ -271,6 +303,12 @@ pub(crate) fn plan(
     }
     gh_argv.push("--base".to_string());
     gh_argv.push(args.base.clone());
+    // #7282: `gh` otherwise reads the head from the checkout's current branch,
+    // which is wrong for any caller whose branch is not checked out.
+    if let Some(head) = head_branch(args) {
+        gh_argv.push("--head".to_string());
+        gh_argv.push(head.to_string());
+    }
     gh_argv.push("--title".to_string());
     gh_argv.push(args.title.clone());
     gh_argv.push("--body".to_string());
@@ -397,7 +435,7 @@ fn apply_metadata<R: GhRunner, P: Preflight>(
 ) {
     // #7274 round 2: a failed read reaches `plan` as its own state, so the note
     // it prints names the failure rather than blaming an empty answer.
-    let read = pre.changed_paths(&args.base);
+    let read = pre.changed_paths(&args.base, diff_head(args));
     let changed = match &read {
         Ok(paths) => ChangedPaths::Read(&paths[..]),
         Err(e) => {

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
@@ -86,6 +86,8 @@ struct FakePreflight {
     /// #7275: a scratch registry, so no test writes a live cleanup entry that
     /// would arm the daemon's branch-deleting sweep against an invented repo.
     registry_dir: tempfile::TempDir,
+    /// #7282: every revision `changed_paths` was asked to diff against.
+    diff_heads: std::cell::RefCell<Vec<String>>,
 }
 
 impl FakePreflight {
@@ -97,6 +99,7 @@ impl FakePreflight {
             ownership: CrateOwnership::default(),
             diff_fails: false,
             registry_dir: tempfile::tempdir().expect("registry tempdir"),
+            diff_heads: std::cell::RefCell::new(Vec::new()),
         }
     }
 
@@ -122,8 +125,9 @@ impl Preflight for FakePreflight {
     fn changelog_gate(&self, _base: &str) -> anyhow::Result<ChangelogVerdict> {
         Ok(self.changelog.clone())
     }
-    fn changed_paths(&self, _base: &str) -> anyhow::Result<Vec<String>> {
+    fn changed_paths(&self, _base: &str, head: &str) -> anyhow::Result<Vec<String>> {
         anyhow::ensure!(!self.diff_fails, "git diff exploded");
+        self.diff_heads.borrow_mut().push(head.to_string());
         Ok(self.changed.clone())
     }
     fn ownership(&self) -> CrateOwnership {
@@ -180,6 +184,7 @@ fn open_args(body_file: &str) -> PrOpenArgs {
         closes: false,
         rung: None,
         base: "main".to_string(),
+        head: None,
         docs_only: false,
         session: None,
         repo: None,
@@ -544,6 +549,110 @@ fn open_docs_only_skips_the_changelog_gate() {
     )
     .expect("docs-only plans without the gate");
     assert!(plan.argv.join(" ").contains("pr create"));
+}
+
+// ── open: the explicit head branch (#7282) ───────────────────────────────
+
+/// The value `flag` was given in `argv`, or `None` when the flag is absent.
+fn flag_value<'a>(argv: &'a [String], flag: &str) -> Option<&'a str> {
+    let at = argv.iter().position(|a| a == flag)?;
+    argv.get(at + 1).map(String::as_str)
+}
+
+/// Why: `gh pr create` reads the head from the checkout's CURRENT branch. The
+/// session-pause publisher builds its branch with git plumbing and never checks
+/// it out, so `gh` read `main`, found nothing to open, and aborted with
+/// "you must first push the current branch to a remote, or use the --head
+/// flag" (#7282 round 4). Naming the head is what makes the caller's checkout
+/// state irrelevant.
+/// Test target: `plan`'s argv assembly.
+#[test]
+fn open_argv_carries_the_explicit_head_branch() {
+    let mut args = open_args("/dev/null");
+    args.head = Some("chore/sessions-abc-20260909-233853".to_string());
+    let plan = open::plan(
+        &args,
+        &full_body(),
+        Some("s"),
+        ChangelogVerdict::Pass,
+        &ResolvedTicketing::default(),
+    )
+    .expect("a named head plans");
+
+    assert_eq!(
+        flag_value(&plan.argv, "--head"),
+        Some("chore/sessions-abc-20260909-233853"),
+        "{:?}",
+        plan.argv
+    );
+    // The base is still named too, so neither end of the PR is inferred.
+    assert_eq!(flag_value(&plan.argv, "--base"), Some("main"));
+}
+
+/// Why: no `--head` must leave `gh` inferring the head exactly as before, so
+/// every existing caller keeps its behavior.
+#[test]
+fn open_argv_omits_head_when_none_is_named() {
+    let args = open_args("/dev/null");
+    let plan = open::plan(
+        &args,
+        &full_body(),
+        Some("s"),
+        ChangelogVerdict::Pass,
+        &ResolvedTicketing::default(),
+    )
+    .expect("plans without a head");
+    assert!(!plan.argv.iter().any(|a| a == "--head"), "{:?}", plan.argv);
+}
+
+/// Why: `--head ""` reaching `gh` as an empty head produces the same confusing
+/// current-branch message this fix exists to end, so a blank reads as absent.
+#[test]
+fn open_head_is_ignored_when_blank() {
+    let mut args = open_args("/dev/null");
+    args.head = Some("   ".to_string());
+    let plan = open::plan(
+        &args,
+        &full_body(),
+        Some("s"),
+        ChangelogVerdict::Pass,
+        &ResolvedTicketing::default(),
+    )
+    .expect("a blank head plans");
+    assert!(!plan.argv.iter().any(|a| a == "--head"), "{:?}", plan.argv);
+}
+
+/// Why: the component labels come from `origin/<base>...<rev>`. Asking about
+/// `HEAD` when the PR opens from another branch describes the checkout, not the
+/// PR — an empty diff and no labels for every `--head` caller.
+/// Test target: `diff_head`, through `run`.
+#[test]
+fn open_head_drives_the_preflight_diff_revision() {
+    let (_d, path) = scratch_body(&full_body());
+    let mut args = open_args(&path.to_string_lossy());
+    args.head = Some("chore/sessions-abc".to_string());
+    let gh = FakeGh::new()
+        .on("pr create", "https://github.com/o/r/pull/4242\n")
+        .on("pr edit", "");
+    let pre = FakePreflight::ok().with_diff(&["crates/trusty-mpm/src/lib.rs"]);
+    open::run(&gh, &args, &pre).expect("create succeeds");
+    assert_eq!(
+        pre.diff_heads.borrow().as_slice(),
+        ["chore/sessions-abc".to_string()]
+    );
+}
+
+/// Why: without `--head` the diff must still be the checkout's `HEAD`.
+#[test]
+fn open_without_head_diffs_the_checkouts_head() {
+    let (_d, path) = scratch_body(&full_body());
+    let args = open_args(&path.to_string_lossy());
+    let gh = FakeGh::new()
+        .on("pr create", "https://github.com/o/r/pull/4242\n")
+        .on("pr edit", "");
+    let pre = FakePreflight::ok().with_diff(&["crates/trusty-mpm/src/lib.rs"]);
+    open::run(&gh, &args, &pre).expect("create succeeds");
+    assert_eq!(pre.diff_heads.borrow().as_slice(), ["HEAD".to_string()]);
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
@@ -570,11 +570,13 @@ fn flag_value<'a>(argv: &'a [String], flag: &str) -> Option<&'a str> {
 fn open_argv_carries_the_explicit_head_branch() {
     let mut args = open_args("/dev/null");
     args.head = Some("chore/sessions-abc-20260909-233853".to_string());
+    // #7282 round 5: `--head` only plans when paired with `--docs-only`.
+    args.docs_only = true;
     let plan = open::plan(
         &args,
         &full_body(),
         Some("s"),
-        ChangelogVerdict::Pass,
+        ChangelogVerdict::Skipped,
         &ResolvedTicketing::default(),
     )
     .expect("a named head plans");
@@ -631,6 +633,8 @@ fn open_head_drives_the_preflight_diff_revision() {
     let (_d, path) = scratch_body(&full_body());
     let mut args = open_args(&path.to_string_lossy());
     args.head = Some("chore/sessions-abc".to_string());
+    // #7282 round 5: `--head` only reaches `gh` alongside `--docs-only`.
+    args.docs_only = true;
     let gh = FakeGh::new()
         .on("pr create", "https://github.com/o/r/pull/4242\n")
         .on("pr edit", "");
@@ -640,6 +644,80 @@ fn open_head_drives_the_preflight_diff_revision() {
         pre.diff_heads.borrow().as_slice(),
         ["chore/sessions-abc".to_string()]
     );
+}
+
+/// Why: `scripts/check_changelog_fragment.sh` accepts only `--base`, `--staged`
+/// and `--file`, so the gate `tm pr open` runs can diff nothing but
+/// `origin/<base>...HEAD`. A `--head` caller standing on another branch would
+/// have that gate judge the checkout instead of the PR, and a source PR with no
+/// fragment would pass it — the changelog gate silently evaluating the wrong
+/// ref (#7282 round 5, code-critic HIGH). The refusal has to name the
+/// obligation, because the caller's next move is either `--docs-only` or a real
+/// checkout of the head.
+/// Test target: `head_docs_only_conflict`, through `plan`.
+#[test]
+fn open_head_without_docs_only_is_refused() {
+    let mut args = open_args("/dev/null");
+    args.head = Some("chore/sessions-abc".to_string());
+    let failures = open::plan(
+        &args,
+        &full_body(),
+        Some("s"),
+        ChangelogVerdict::Pass,
+        &ResolvedTicketing::default(),
+    )
+    .expect_err("--head without --docs-only must not plan");
+
+    assert_eq!(failures.len(), 1, "{failures:?}");
+    assert!(
+        failures[0].contains("--head requires --docs-only"),
+        "{failures:?}"
+    );
+    assert!(
+        failures[0].contains("check_changelog_fragment.sh"),
+        "the refusal must name what cannot be checked: {failures:?}"
+    );
+    assert!(
+        failures[0].contains("chore/sessions-abc"),
+        "the refusal must name the head it is about: {failures:?}"
+    );
+}
+
+/// Why: the refusal is worth nothing if the PR opens anyway — `gh` must never
+/// be spawned, and the exit code must be the check-failed one every other
+/// pre-flight failure uses.
+/// Test target: `run`'s failure path with a `--head` and no `--docs-only`.
+#[test]
+fn open_head_without_docs_only_never_calls_gh() {
+    let (_d, path) = scratch_body(&full_body());
+    let mut args = open_args(&path.to_string_lossy());
+    args.head = Some("chore/sessions-abc".to_string());
+    let gh = FakeGh::new();
+    let code = open::run(&gh, &args, &FakePreflight::ok()).expect("a failed check is not an error");
+
+    assert_eq!(code, 2);
+    assert!(gh.calls().is_empty(), "{:?}", gh.calls());
+}
+
+/// Why: `--docs-only` is the one case where the gate's verdict cannot be wrong,
+/// because it is skipped — so the pair must still plan. This is the pause
+/// publisher's own invocation, and refusing it would break every pause.
+/// Test target: `head_docs_only_conflict`, permitting arm.
+#[test]
+fn open_head_with_docs_only_plans() {
+    let mut args = open_args("/dev/null");
+    args.head = Some("chore/sessions-abc".to_string());
+    args.docs_only = true;
+    let plan = open::plan(
+        &args,
+        &full_body(),
+        Some("s"),
+        ChangelogVerdict::Skipped,
+        &ResolvedTicketing::default(),
+    )
+    .expect("--head with --docs-only plans");
+
+    assert_eq!(flag_value(&plan.argv, "--head"), Some("chore/sessions-abc"));
 }
 
 /// Why: without `--head` the diff must still be the checkout's `HEAD`.

--- a/crates/trusty-mpm/src/core/session_pause_pr.rs
+++ b/crates/trusty-mpm/src/core/session_pause_pr.rs
@@ -18,7 +18,10 @@
 //! on a fresh `chore/sessions-<slug>-<ts>` branch off the project's default
 //! branch, is pushed, and the PR is opened and armed through the existing
 //! `tm pr open` / `tm pr merge --auto` path — this module spells no
-//! `gh pr create` of its own.
+//! `gh pr create` of its own. Both ends of that PR are named explicitly
+//! (`--head <chore branch> --base <default>`), because the chore branch is
+//! never checked out and `gh` would otherwise open from whatever branch the
+//! checkout happens to be on (#7282).
 //! Test: `session_pause_pr_tests.rs`.
 
 use std::path::{Path, PathBuf};
@@ -214,10 +217,14 @@ fn commit_note(branch: Option<&str>, commit: Option<&str>) -> String {
 /// `GIT_INDEX_FILE` in a per-call [`tempfile::TempDir`], commits with
 /// `commit-tree` parented on `origin/<default>`, points a fresh
 /// `chore/sessions-<slug>-<ts>` branch at it, pushes that ref, and hands the PR
-/// to `tm pr open` and `tm pr merge --auto`. Nothing here runs `git add`,
-/// `git stash`, or `git checkout`, so the working tree, HEAD, and the shared
-/// index are untouched.
+/// to `tm pr open` — naming that branch as `--head` — and `tm pr merge --auto`.
+/// Nothing here runs `git add`, `git stash`, or `git checkout`, so the working
+/// tree, HEAD, and the shared index are untouched.
 /// Test: `publish_commits_only_the_allowlisted_paths`,
+/// `pr_open_names_the_chore_branch_as_the_head`,
+/// `the_pushed_branch_is_the_head_the_pr_opens_from`,
+/// `a_dirty_checkout_is_never_read_staged_or_switched`,
+/// `a_detached_checkout_is_refused_by_name`,
 /// `publish_branch_name_carries_session_and_timestamp`,
 /// `publish_refuses_when_not_on_the_default_branch`,
 /// `publish_uses_the_configured_default_branch`,
@@ -393,6 +400,11 @@ pub fn publish_pause_snapshot<V: PauseVcs>(
                 &body_path.to_string_lossy(),
                 "--base",
                 &default,
+                // #7282: the commit was built with plumbing, so this branch is
+                // never the checkout's current one — name it or `gh` reads the
+                // checkout's branch and aborts.
+                "--head",
+                &branch,
                 "--docs-only",
                 "--rung",
                 "1",

--- a/crates/trusty-mpm/src/core/session_pause_pr.rs
+++ b/crates/trusty-mpm/src/core/session_pause_pr.rs
@@ -41,6 +41,9 @@ pub const SESSIONS_PREFIX: &str = ".trusty-mpm/sessions/";
 /// resort in [`resolve_default_branch`], never an override (#7282 review).
 pub const FALLBACK_BRANCH: &str = "main";
 
+/// What `git rev-parse --abbrev-ref HEAD` prints for a detached checkout.
+const DETACHED_HEAD: &str = "HEAD";
+
 /// Blob mode for a regular non-executable file, as `update-index` spells it.
 const BLOB_MODE: &str = "100644";
 
@@ -154,10 +157,10 @@ pub struct PublishOutcome {
 /// Why: "this project does not track its sessions" is a legitimate no-op, while
 /// "the push failed after the commit was made" leaves a local commit a person
 /// must deal with. Collapsing the two into one string would hide the second.
-/// What: `NotTracked` is the no-op; `NotOnDefaultBranch` refuses before
-/// anything is created and names the branch it expected; `Step` names the
-/// failed step and carries the branch and commit when they already exist.
-/// Test: `publish_refuses_when_not_on_the_default_branch`,
+/// What: `NotTracked` is the no-op; `NotOnDefaultBranch` refuses a detached
+/// checkout before anything is created; `Step` names the failed step and
+/// carries the branch and commit when they already exist.
+/// Test: `a_detached_checkout_is_refused_by_name`,
 /// `push_failure_leaves_the_commit_and_names_it`,
 /// `publish_skips_a_directory_that_is_not_a_git_repo`.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -169,15 +172,21 @@ pub enum PublishError {
     /// The project directory is not a git checkout at all.
     #[error("`{0}` is not a git repository; there is nothing to publish a snapshot into")]
     NotAGitRepo(String),
-    /// The checkout is on some branch other than the project's default.
+    /// The checkout has no branch checked out at all.
+    ///
+    /// The name is historical: this refused every non-default branch until the
+    /// owner ruled that a pause publishes from any checkout (#7282). A detached
+    /// HEAD is all that is left, because `rev-parse --abbrev-ref HEAD` answers
+    /// the literal `HEAD` there rather than a branch name.
     #[error(
-        "pause snapshots publish only from `{expected}`; this checkout is on `{actual}`. \
+        "pause snapshots cannot publish from a detached checkout: HEAD names no branch, \
+         and this project's default is `{expected}` (git reported `{actual}`). \
          The snapshot file was written; commit and open its PR by hand."
     )]
     NotOnDefaultBranch {
         /// The project's default branch, as resolved for this checkout.
         expected: String,
-        /// The branch the checkout is actually on.
+        /// What `rev-parse --abbrev-ref HEAD` reported — the literal `HEAD`.
         actual: String,
     },
     /// A step failed. `commit` is `Some` once the commit exists locally.
@@ -211,8 +220,8 @@ fn commit_note(branch: Option<&str>, commit: Option<&str>) -> String {
 ///
 /// Why: see the module doc — a pause must reach `origin/main`, and it must do
 /// so without disturbing a checkout other sessions are working in.
-/// What: refuses unless the checkout is on the project's default branch and the
-/// paths are tracked regular files, then builds the tree with `hash-object` /
+/// What: refuses a detached checkout and any path that is not a tracked regular
+/// file, then builds the tree with `hash-object` /
 /// `read-tree` / `update-index` / `write-tree` against a scratch
 /// `GIT_INDEX_FILE` in a per-call [`tempfile::TempDir`], commits with
 /// `commit-tree` parented on `origin/<default>`, points a fresh
@@ -225,8 +234,8 @@ fn commit_note(branch: Option<&str>, commit: Option<&str>) -> String {
 /// `the_pushed_branch_is_the_head_the_pr_opens_from`,
 /// `a_dirty_checkout_is_never_read_staged_or_switched`,
 /// `a_detached_checkout_is_refused_by_name`,
+/// `a_feature_branch_checkout_still_publishes`,
 /// `publish_branch_name_carries_session_and_timestamp`,
-/// `publish_refuses_when_not_on_the_default_branch`,
 /// `publish_uses_the_configured_default_branch`,
 /// `concurrent_publishes_never_share_a_scratch_index`,
 /// `push_failure_leaves_the_commit_and_names_it`,
@@ -253,7 +262,14 @@ pub fn publish_pause_snapshot<V: PauseVcs>(
     }
     let current = branch_out.out().to_string();
     let default = resolve_default_branch(vcs, req);
-    if current != default {
+    // #7282 (owner ruling): a pause is live state and must publish as its own
+    // PR, so which branch the checkout sits on no longer decides whether it
+    // can. Every step below is plumbing against `origin/<default>` and the PR
+    // names its pushed branch as `--head`, so HEAD is never read or moved.
+    // What still cannot work is a checkout with no branch at all: `rev-parse
+    // --abbrev-ref HEAD` answers the literal `HEAD` there, which is not a
+    // branch name and gives a person nothing to act on.
+    if current == DETACHED_HEAD {
         return Err(PublishError::NotOnDefaultBranch {
             expected: default,
             actual: current,
@@ -541,13 +557,13 @@ fn walk_is_unredirected(repo: &Path, p: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// The branch this project publishes pauses from.
+/// The branch a pause PR is based on, and the ref its commit is parented on.
 ///
 /// Why: `session_context_pause` serves every managed project, so a literal
-/// `main` made a pause on a `master` or `develop` project always error
-/// (#7282 review). The operator's declared answer wins; `origin/HEAD` is what
-/// the checkout itself says; [`FALLBACK_BRANCH`] is the last resort, consulted
-/// only when neither answered.
+/// `main` sent a `master` or `develop` project's pause at a ref that does not
+/// exist (#7282 review). The operator's declared answer wins; `origin/HEAD` is
+/// what the checkout itself says; [`FALLBACK_BRANCH`] is the last resort,
+/// consulted only when neither answered.
 /// What: configured branch, else `git rev-parse --abbrev-ref origin/HEAD` with
 /// its `origin/` prefix stripped, else `main`.
 /// Test: `publish_uses_the_configured_default_branch`,

--- a/crates/trusty-mpm/src/core/session_pause_pr_tests.rs
+++ b/crates/trusty-mpm/src/core/session_pause_pr_tests.rs
@@ -570,6 +570,133 @@ fn publish_opens_the_pr_through_tm_pr_open() {
     );
 }
 
+// ── the explicit head branch (#7282 round 4) ─────────────────────────────
+
+/// REGRESSION (#7282 round 4): the publish reached `pr-open` and `gh pr create`
+/// aborted with "you must first push the current branch to a remote, or use the
+/// --head flag". The branch WAS pushed; what was missing is that `gh` reads the
+/// head from the checkout's current branch, which is the default branch here
+/// and never the plumbing-built chore branch. Naming both ends of the PR is the
+/// fix.
+/// Test target: the `tm pr open` argv.
+#[test]
+fn pr_open_names_the_chore_branch_as_the_head() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let vcs = happy();
+    let out = publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths()))
+        .unwrap()
+        .expect("the happy path publishes");
+
+    let open = tm_call(&vcs, 0);
+    assert_eq!(
+        flag_value(&open, "--head").as_deref(),
+        Some(out.branch.as_str()),
+        "{open:?}"
+    );
+    assert_eq!(
+        flag_value(&open, "--base").as_deref(),
+        Some("main"),
+        "{open:?}"
+    );
+}
+
+/// Why: the head must be the branch that was pushed, not a name derived a
+/// second time — a `--head` naming a ref the push never created opens nothing.
+/// Test target: push refspec and `--head`, read from the same run.
+#[test]
+fn the_pushed_branch_is_the_head_the_pr_opens_from() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let vcs = happy();
+    let out = publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths()))
+        .unwrap()
+        .expect("the happy path publishes");
+
+    let branch = &out.branch;
+    let calls = vcs.calls();
+    let push_at = calls
+        .iter()
+        .position(|c| {
+            c.program == "git"
+                && c.args.first().map(String::as_str) == Some("push")
+                && c.args
+                    .contains(&format!("refs/heads/{branch}:refs/heads/{branch}"))
+        })
+        .expect("the exact branch must be pushed");
+    let open_at = calls
+        .iter()
+        .position(|c| c.program == "tm" && c.args.first().map(String::as_str) == Some("pr"))
+        .expect("the PR must be opened");
+    assert!(
+        push_at < open_at,
+        "the push must precede pr-open: {calls:?}"
+    );
+    assert_eq!(calls[push_at].args[1], "origin", "{:?}", calls[push_at]);
+}
+
+/// Why: the live failure came from a checkout carrying 89 uncommitted changes,
+/// which `gh` warned about. The publish must not read, stage, stash, or switch
+/// anything in that checkout — its state is the caller's, and the commit is
+/// built from the allowlisted files alone.
+/// Test target: the whole command set the publish runs.
+#[test]
+fn a_dirty_checkout_is_never_read_staged_or_switched() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let vcs = happy();
+    publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths())).unwrap();
+
+    for argv in vcs.git_argv() {
+        let verb = argv.split(' ').next().unwrap_or_default();
+        assert!(
+            !matches!(
+                verb,
+                "add" | "stash" | "checkout" | "switch" | "status" | "commit"
+            ),
+            "the publish must not touch the checkout: `git {argv}`"
+        );
+    }
+}
+
+/// Why: a detached checkout has no branch name, so `rev-parse --abbrev-ref
+/// HEAD` answers the literal `HEAD`. That must produce the named refusal that
+/// tells a person what to do — never a publish onto a `HEAD` branch, and never
+/// a panic.
+/// Test target: the default-branch guard, detached arm.
+#[test]
+fn a_detached_checkout_is_refused_by_name() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let vcs = happy().ok(&["rev-parse", "--abbrev-ref", "HEAD"], "HEAD\n");
+    let err = publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths())).unwrap_err();
+
+    assert_eq!(
+        err,
+        PublishError::NotOnDefaultBranch {
+            expected: "main".to_string(),
+            actual: "HEAD".to_string(),
+        }
+    );
+    assert!(
+        !vcs.calls().iter().any(|c| c.program == "tm"),
+        "no PR may be opened from a detached checkout: {:?}",
+        vcs.calls()
+    );
+}
+
+/// The argv of the `n`th recorded `tm` call.
+fn tm_call(vcs: &FakeVcs, n: usize) -> Vec<String> {
+    vcs.calls()
+        .into_iter()
+        .filter(|c| c.program == "tm")
+        .map(|c| c.args)
+        .nth(n)
+        .unwrap_or_else(|| panic!("no tm call #{n}"))
+}
+
+/// The value `flag` was given in `argv`, or `None` when the flag is absent.
+fn flag_value(argv: &[String], flag: &str) -> Option<String> {
+    let at = argv.iter().position(|a| a == flag)?;
+    argv.get(at + 1).cloned()
+}
+
 /// Why: `tm pr merge --auto` refuses for reasons a person must act on — a
 /// missing label, auto-merge disabled on the repo, a permissions gap. Dropping
 /// its stderr left `auto_merge_armed: false` as the entire report, so the PR

--- a/crates/trusty-mpm/src/core/session_pause_pr_tests.rs
+++ b/crates/trusty-mpm/src/core/session_pause_pr_tests.rs
@@ -325,40 +325,45 @@ fn publish_rejects_a_path_outside_the_sessions_tree() {
     );
 }
 
-/// Why: publishing off a feature branch would put unrelated commits in the PR.
-/// The refusal must be an error, not a warning — the snapshot file is already
-/// written, and a silent skip is how the old behaviour went unnoticed.
-/// Test target: the default-branch guard.
+/// Why (owner ruling, #7282 round 5): a pause is live state and publishes as
+/// its own PR, so a checkout parked on a feature branch must still produce one.
+/// The commit is built with plumbing against `origin/<default>` and the PR
+/// names its own `--head`, so the checkout's branch cannot leak into either —
+/// which is what makes refusing it unnecessary. Nothing about the feature
+/// branch may appear in the commit, the push, or the PR.
+/// Test target: the detached-HEAD guard, permitting arm.
 #[test]
-fn publish_refuses_when_not_on_the_default_branch() {
+fn a_feature_branch_checkout_still_publishes() {
     let dir = tempfile::TempDir::new().unwrap();
-    let vcs = FakeVcs::new()
-        .ok(
-            &["rev-parse", "--abbrev-ref", "HEAD"],
-            "fix/7282-something\n",
-        )
-        .ok(
-            &["rev-parse", "--abbrev-ref", "origin/HEAD"],
-            "origin/main\n",
-        );
-    let err = publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths())).unwrap_err();
+    let vcs = happy().ok(
+        &["rev-parse", "--abbrev-ref", "HEAD"],
+        "fix/7282-something\n",
+    );
+    let out = publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths()))
+        .unwrap()
+        .expect("a feature-branch checkout publishes");
 
+    assert_eq!(out.branch, "chore/sessions-trusty-tools-95-20260909-183015");
+    assert_eq!(out.commit, "c0ffee1");
+
+    let argv = vcs.git_argv();
+    // Parented on `origin/main`, never on the checkout's branch.
+    assert!(
+        argv.iter()
+            .any(|a| a.starts_with("commit-tree newtree9 -p base000")),
+        "{argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|a| a.contains("fix/7282-something")),
+        "the checkout's branch may not reach any git step: {argv:?}"
+    );
+    // The PR opens from the chore branch, against the default branch.
+    let tm = tm_call(&vcs, 0);
     assert_eq!(
-        err,
-        PublishError::NotOnDefaultBranch {
-            expected: "main".to_string(),
-            actual: "fix/7282-something".to_string(),
-        }
+        flag_value(&tm, "--head").as_deref(),
+        Some(out.branch.as_str())
     );
-    assert!(
-        err.to_string().contains("The snapshot file was written"),
-        "{err}"
-    );
-    assert!(
-        !vcs.git_argv().iter().any(|a| a.starts_with("fetch")),
-        "nothing beyond the two branch probes may run: {:?}",
-        vcs.calls()
-    );
+    assert_eq!(flag_value(&tm, "--base").as_deref(), Some("main"));
 }
 
 /// Why: `session_context_pause` serves every managed project, so a `develop`
@@ -430,28 +435,34 @@ fn publish_falls_back_to_origin_head_for_the_default_branch() {
     );
 }
 
-/// Why: `main` stays the answer when nothing else names one, and the refusal
-/// has to say which branch it expected so the operator can fix the config.
+/// Why: `main` stays the answer when nothing else names one, and it has to
+/// reach the fetch, the parent commit and the PR base — a checkout sitting on
+/// some other branch must not become the answer by default.
 /// Test target: `resolve_default_branch`, `FALLBACK_BRANCH` arm.
 #[test]
 fn publish_falls_back_to_main_when_nothing_names_a_branch() {
     let dir = tempfile::TempDir::new().unwrap();
-    let vcs = FakeVcs::new()
+    let vcs = happy()
         .ok(&["rev-parse", "--abbrev-ref", "HEAD"], "master\n")
         .fail(
             &["rev-parse", "--abbrev-ref", "origin/HEAD"],
             "fatal: ambiguous argument 'origin/HEAD'",
         );
-    let err = publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths())).unwrap_err();
+    let out = publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths()))
+        .unwrap()
+        .expect("a changed tree publishes");
 
-    assert_eq!(
-        err,
-        PublishError::NotOnDefaultBranch {
-            expected: "main".to_string(),
-            actual: "master".to_string(),
-        }
+    assert_eq!(out.commit, "c0ffee1");
+    let argv = vcs.git_argv();
+    assert!(argv.contains(&"fetch origin main".to_string()), "{argv:?}");
+    assert!(
+        !argv.iter().any(|a| a.contains("master")),
+        "the checkout's branch is not a default-branch answer: {argv:?}"
     );
-    assert!(err.to_string().contains("only from `main`"), "{err}");
+    assert_eq!(
+        flag_value(&tm_call(&vcs, 0), "--base").as_deref(),
+        Some("main")
+    );
 }
 
 /// Why: when the push fails the commit already exists locally, and a person
@@ -636,12 +647,14 @@ fn the_pushed_branch_is_the_head_the_pr_opens_from() {
 /// Why: the live failure came from a checkout carrying 89 uncommitted changes,
 /// which `gh` warned about. The publish must not read, stage, stash, or switch
 /// anything in that checkout — its state is the caller's, and the commit is
-/// built from the allowlisted files alone.
+/// built from the allowlisted files alone. The fixture sits on a feature
+/// branch, because that is now a checkout the publish accepts (#7282 round 5)
+/// and the one where a stray `checkout` or `switch` would do the most damage.
 /// Test target: the whole command set the publish runs.
 #[test]
 fn a_dirty_checkout_is_never_read_staged_or_switched() {
     let dir = tempfile::TempDir::new().unwrap();
-    let vcs = happy();
+    let vcs = happy().ok(&["rev-parse", "--abbrev-ref", "HEAD"], "fix/some-work\n");
     publish_pause_snapshot(&vcs, &request(dir.path(), snapshot_paths())).unwrap();
 
     for argv in vcs.git_argv() {
@@ -659,8 +672,9 @@ fn a_dirty_checkout_is_never_read_staged_or_switched() {
 /// Why: a detached checkout has no branch name, so `rev-parse --abbrev-ref
 /// HEAD` answers the literal `HEAD`. That must produce the named refusal that
 /// tells a person what to do — never a publish onto a `HEAD` branch, and never
-/// a panic.
-/// Test target: the default-branch guard, detached arm.
+/// a panic. This is the one checkout state the publish still refuses (#7282
+/// round 5); a feature branch is not.
+/// Test target: the detached-HEAD guard, refusing arm.
 #[test]
 fn a_detached_checkout_is_refused_by_name() {
     let dir = tempfile::TempDir::new().unwrap();
@@ -673,6 +687,11 @@ fn a_detached_checkout_is_refused_by_name() {
             expected: "main".to_string(),
             actual: "HEAD".to_string(),
         }
+    );
+    assert!(err.to_string().contains("detached checkout"), "{err}");
+    assert!(
+        err.to_string().contains("The snapshot file was written"),
+        "{err}"
     );
     assert!(
         !vcs.calls().iter().any(|c| c.program == "tm"),


### PR DESCRIPTION
## Outcome

Refs bobmatnyc/trusty-tools#7282

## Changes

1. `tm pr open --head` without `--docs-only` is now refused before `gh` is
   spawned. `check_changelog_fragment.sh` takes only `--base`, so it would
   judge the wrong checkout when the caller passes `--head` — the guard stops
   that call instead of silently gating on the wrong tree.
2. The session-pause publisher's guard narrows from "not on the default
   branch" to "detached HEAD", per the owner's ruling that a session is live
   state and pause must publish from any checkout — including a feature
   branch — not just non-main.

Out of scope: no change to the pause commit/push mechanics themselves, only
the guard condition that decides whether to run them.

## Risk

Low. Both changes narrow an existing guard's condition; neither adds a new
code path. `tm pr open --head` gains a stop it did not have before, and the
pause publisher gains a permission it did not have before, per the owner's
ruling.

## Tests

Rung 3.

- `cargo test -p trusty-mpm --no-fail-fast`: 56 targets ok — lib 6559 passed,
  `tm` bin 2449 passed, 8+1 ignored.
- `cargo fmt --check`, `cargo check -p trusty-mpm`,
  `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: exit 0.
- Line-cap, test-pointers, changelog-fragment, and rustdoc gates: exit 0.
- Three regression tests proven failing on `f996e91f4` with the fix reverted:
  `a_feature_branch_checkout_still_publishes`,
  `open_head_without_docs_only_is_refused`,
  `open_head_without_docs_only_never_calls_gh`.

## Baseline

No pre-existing red on this crate at this head.

## Docs

Changelog fragment added under `crates/trusty-mpm/changelog.d/`.

## Review

Prior review: code-critic returned WARN on r4; addressed in this revision (r5).

Refs #7282

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
