### PR TITLE
fix(trusty-common,trusty-code): refuse to take over a non-socket on the UDS path; bound the bind-failure test (Refs #7312 #7219)

### DIFF
--- a/crates/trusty-code/changelog.d/7312-uds-bind-failure-test-hang.md
+++ b/crates/trusty-code/changelog.d/7312-uds-bind-failure-test-hang.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `run_uds_socket_bind_failure_is_fatal` now bounds the daemon future it awaits
+  at ten seconds. Its shutdown signal is `std::future::pending()`, so a daemon
+  that manages to bind serves forever — which is what happened on Linux, where
+  `bind_singleton_hardened` read the test's occupying regular file as a dead
+  socket and bound over it. The test consumed the whole `Rust tests
+  (pre-publish gate)` shard 6 until the job's 45-minute cancel, on every push to
+  main, and the shard's other targets never reported. A regression now fails in
+  seconds naming the cause ([#7312](https://github.com/bobmatnyc/trusty-tools/issues/7312),
+  [#7219](https://github.com/bobmatnyc/trusty-tools/pull/7219))

--- a/crates/trusty-code/src/serve/uds_tests.rs
+++ b/crates/trusty-code/src/serve/uds_tests.rs
@@ -137,6 +137,18 @@ async fn open_stream(
     send_framed_stream_request(socket, &request, CALL_TIMEOUT).await
 }
 
+/// How long a daemon future given a shutdown signal that never fires may run
+/// before the test calls it a regression.
+///
+/// Why a bound at all (#7312): this test's shutdown signal is
+/// `std::future::pending()`, so a daemon that manages to bind serves forever.
+/// On Linux `bind_singleton_hardened` did exactly that — it read the regular
+/// file below as a dead socket, unlinked it, and bound — and the test consumed
+/// its whole CI shard until the job's 45-minute cancel, with the shard's other
+/// tests never reported. A regression must fail in seconds and say what
+/// happened.
+const BIND_FAILURE_BUDGET: Duration = Duration::from_secs(10);
+
 /// A socket path already occupied by something that is not a dead socket must
 /// stop the daemon outright — never a silent degrade to HTTP only, which would
 /// leave every socket client reporting "no daemon" against a live process.
@@ -146,27 +158,36 @@ async fn run_uds_socket_bind_failure_is_fatal() {
     let data = tempfile::tempdir().expect("data tempdir");
     let project = tempfile::tempdir().expect("project tempdir");
     let socket = dir.path().join("tcode.sock");
-    // A regular file, not a stale socket: `bind_singleton_hardened` only
-    // unlinks a path the kernel proved is not serving, and a regular file is
-    // never that, so the bind below genuinely fails.
+    // A regular file, not a stale socket: `bind_singleton_hardened` refuses a
+    // path holding anything that is not a socket and never unlinks it, so the
+    // bind below genuinely fails. #7312: that file-type check is what makes
+    // this true on Linux as well as macOS.
     std::fs::write(&socket, b"not a socket").expect("occupy the socket path");
 
     let binding =
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind");
-    let err = run_daemon_on(
-        binding,
-        &socket,
-        Some(data.path()),
-        // A port is offered and must NOT be bound: the socket failed first.
-        Some(0),
-        std::future::pending(),
+    let err = timeout(
+        BIND_FAILURE_BUDGET,
+        run_daemon_on(
+            binding,
+            &socket,
+            Some(data.path()),
+            // A port is offered and must NOT be bound: the socket failed first.
+            Some(0),
+            std::future::pending(),
+        ),
     )
     .await
+    .expect("the daemon began serving instead of failing the bind — see #7312")
     .expect_err("an unbindable socket must stop the daemon");
     let rendered = format!("{err:#}");
     assert!(
         rendered.contains("bind the daemon socket"),
         "the failure must name the bind, got: {rendered}"
+    );
+    assert!(
+        socket.is_file(),
+        "the occupying file must survive the refused bind"
     );
 }
 

--- a/crates/trusty-common/changelog.d/7312-uds-probe-enotsock.md
+++ b/crates/trusty-common/changelog.d/7312-uds-probe-enotsock.md
@@ -1,0 +1,15 @@
+Fixed
+
+- `uds::bind_singleton_hardened` refuses a socket path holding anything that is
+  not a socket, instead of unlinking it and binding over it. The takeover
+  decision used to rest on the connect probe alone, and the two platforms
+  disagree about which errno a connect to a non-socket returns: macOS/BSD
+  answers `ENOTSOCK`, which classified as `Inconclusive` and refused, while
+  Linux's `unix_find_other` sets `-ECONNREFUSED` before its `S_ISSOCK` test,
+  which classified as `NotServing` and licensed the unlink. So on Linux a daemon
+  pointed at a path holding an ordinary file deleted that file and came up
+  serving. The file type is now read with `lstat` and outranks the probe, and
+  the refusal is its own `UdsSecurityError::NotASocketFile` naming what is
+  actually there rather than the borrowed `AlreadyServing`
+  ([#7312](https://github.com/bobmatnyc/trusty-tools/issues/7312),
+  [#7219](https://github.com/bobmatnyc/trusty-tools/pull/7219))

--- a/crates/trusty-common/src/uds/mod.rs
+++ b/crates/trusty-common/src/uds/mod.rs
@@ -257,6 +257,22 @@ pub enum UdsSecurityError {
         path: PathBuf,
     },
 
+    /// The socket path exists but holds something that is not a socket, so a
+    /// singleton bind refused it instead of unlinking it.
+    ///
+    /// Why its own variant rather than [`UdsSecurityError::AlreadyServing`]:
+    /// the two say different things to an operator — one means "another daemon
+    /// has this path", the other "something unrelated is sitting on it" — and
+    /// on macOS the second used to arrive dressed as the first, by accident of
+    /// which errno a connect to a regular file returns. See #7312.
+    #[error("socket path {path} is a {found}, not a socket; refusing to remove it")]
+    NotASocketFile {
+        /// The offending path.
+        path: PathBuf,
+        /// What `lstat` actually found there.
+        found: String,
+    },
+
     /// `UnixListener::bind` failed.
     #[error("bind unix socket at {path}: {source}")]
     Bind {

--- a/crates/trusty-common/src/uds/singleton.rs
+++ b/crates/trusty-common/src/uds/singleton.rs
@@ -15,11 +15,23 @@
 //! exactly as a first bind would be.
 //!
 //! 🔴 The takeover fires ONLY on [`SocketVerdict::NotServing`], the verdict the
-//! kernel actually proves (ENOENT / ECONNREFUSED). An ambiguous probe —
+//! kernel actually proves (ENOENT / ECONNREFUSED), **and only when the path is
+//! a socket to begin with**. An ambiguous probe —
 //! [`SocketVerdict::Inconclusive`] — is treated as a live owner and refused.
 //! The asymmetry is the point: refusing a dead socket costs one failed start
 //! that a retry fixes, while unlinking a live one strands its owner on an
 //! inode nothing can reach.
+//!
+//! 🔴 The file-type half of that rule is load-bearing and was missing until
+//! #7312. Linux and macOS disagree about which errno a connect to a NON-socket
+//! returns: macOS/BSD `unp_connect` answers `ENOTSOCK`, which classifies as
+//! `Inconclusive` and refuses, while Linux's `unix_find_other` sets
+//! `-ECONNREFUSED` before its `S_ISSOCK` test, which classifies as
+//! `NotServing` and licensed an unlink. So on Linux a daemon pointed at a path
+//! holding an ordinary file deleted that file and bound over it. The probe
+//! cannot be made to answer this — `lstat` can, and does, first.
+//! [`super::verify_socket_for_connect`] has always applied that rule on the
+//! dialing side; this is its missing half on the binding side.
 //!
 //! The probe is a bare `connect`, not [`super::connect_hardened`], and that is
 //! deliberate. The question here is only "is a process serving this path", and
@@ -31,7 +43,7 @@
 //! its own copy; migrating it is a separate change, not a side effect of one
 //! that adds two new bind sites.
 //!
-//! Test: `tests.rs` — `bind_singleton_*`.
+//! Test: `tests.rs` — `bind_singleton_*` and `takeover_verdict_*`.
 
 use std::path::Path;
 use std::time::Duration;
@@ -52,6 +64,51 @@ use super::{UdsSecurityError, bind_hardened};
 /// wrong.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// What [`bind_singleton_hardened`] must do about a path that already exists.
+///
+/// Why a named decision rather than an inline `match`: the two refusal arms are
+/// awkward to reach through real syscalls — `Inconclusive` needs a socket whose
+/// connect neither completes nor is refused, and `NotASocket` needs a kernel
+/// that reports the file type through the errno, which macOS does and Linux
+/// does not. Separating the decision from the syscalls makes every arm testable
+/// unprivileged on either platform, the same reason
+/// [`super::dir::DirVerdict`] exists.
+///
+/// Test: the `takeover_verdict_*` tests in `tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TakeoverVerdict {
+    /// A socket corpse: unlink it and rebind.
+    TakeOver,
+    /// A socket that is, or may be, serving: refuse and leave it alone.
+    Occupied,
+    /// Not a socket at all: refuse, and never unlink it.
+    NotASocket,
+}
+
+/// Decide whether an existing path may be unlinked and rebound.
+///
+/// Why: see [`TakeoverVerdict`]. The file type is checked FIRST and outranks
+/// the probe, because on Linux the probe's answer for a non-socket is
+/// indistinguishable from its answer for a dead socket (#7312).
+/// What: `NotASocket` whenever `is_socket` is false, whatever the probe said;
+/// otherwise `TakeOver` on the one verdict the kernel proved, `Occupied` on
+/// every other.
+/// Test: `takeover_verdict_refuses_a_non_socket_even_when_the_probe_says_dead`,
+/// `takeover_verdict_takes_over_a_dead_socket`,
+/// `takeover_verdict_refuses_a_served_socket`,
+/// `takeover_verdict_refuses_an_inconclusive_probe`.
+pub(crate) fn classify_takeover(is_socket: bool, verdict: SocketVerdict) -> TakeoverVerdict {
+    // #7312: bind-failure test hung the CI shard — a Linux connect to a regular
+    // file answers ECONNREFUSED, so the probe alone reads it as a dead socket.
+    if !is_socket {
+        return TakeoverVerdict::NotASocket;
+    }
+    match verdict {
+        SocketVerdict::NotServing => TakeoverVerdict::TakeOver,
+        _ => TakeoverVerdict::Occupied,
+    }
+}
+
 /// Bind `path`, taking over a socket file no process is serving.
 ///
 /// # Errors
@@ -59,25 +116,49 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 /// [`UdsSecurityError::AlreadyServing`] when another process answers the path,
 /// or when the probe cannot settle the question — a caller must not proceed,
 /// because two listeners on one socket means every delivery goes to whichever
-/// the kernel picks. Otherwise any [`super::bind_hardened`] error.
+/// the kernel picks. [`UdsSecurityError::NotASocketFile`] when the path holds
+/// something that is not a socket, which this function refuses rather than
+/// deletes (#7312). Otherwise any [`super::bind_hardened`] error.
 ///
 /// Test: `bind_singleton_takes_over_a_stale_socket_file`,
 /// `bind_singleton_refuses_a_socket_someone_is_serving`,
+/// `bind_singleton_refuses_a_regular_file_and_leaves_it_on_disk`,
 /// `bind_singleton_binds_a_fresh_path`.
 pub async fn bind_singleton_hardened(path: &Path) -> Result<UnixListener, UdsSecurityError> {
-    if path.exists() {
+    // #7312: `lstat`, not `Path::exists` — the latter follows a symlink and
+    // answers only "is something there", which is one of the two inputs the
+    // decision below needs. A stat that fails for any other reason is left to
+    // `bind_hardened` to report, exactly as `exists()` returning false was.
+    if let Ok(meta) = std::fs::symlink_metadata(path) {
+        let file_type = meta.file_type();
         // #5182 review: three-state, not `is_ok()`. On macOS a live listener
         // with a saturated accept queue answers ECONNREFUSED, and a probe that
         // simply times out proves nothing — see `uds::probe::SocketVerdict`.
         // Only a verdict the kernel proved licenses an unlink.
-        match probe_socket_verdict(path, PROBE_TIMEOUT).await {
-            SocketVerdict::NotServing => {
+        let verdict = probe_socket_verdict(path, PROBE_TIMEOUT).await;
+        match classify_takeover(
+            std::os::unix::fs::FileTypeExt::is_socket(&file_type),
+            verdict,
+        ) {
+            TakeoverVerdict::TakeOver => {
                 // A corpse from a child that died without cleaning up. Removing
                 // it is the whole point of this function; a failure to remove it
                 // is reported by the bind that follows.
                 let _ = std::fs::remove_file(path);
             }
-            verdict => {
+            TakeoverVerdict::NotASocket => {
+                let found = super::dir::describe_file_type(&file_type);
+                tracing::debug!(
+                    socket = %path.display(),
+                    found,
+                    "refusing to remove a non-socket sitting on the socket path"
+                );
+                return Err(UdsSecurityError::NotASocketFile {
+                    path: path.to_path_buf(),
+                    found: found.to_string(),
+                });
+            }
+            TakeoverVerdict::Occupied => {
                 tracing::debug!(
                     socket = %path.display(),
                     ?verdict,

--- a/crates/trusty-common/src/uds/singleton.rs
+++ b/crates/trusty-common/src/uds/singleton.rs
@@ -92,19 +92,25 @@ pub(crate) enum TakeoverVerdict {
 /// indistinguishable from its answer for a dead socket (#7312).
 /// What: `NotASocket` whenever `is_socket` is false, whatever the probe said;
 /// otherwise `TakeOver` on the one verdict the kernel proved, `Occupied` on
-/// every other.
+/// every other. `verdict` is `None` when the caller skipped the probe because
+/// the path is not a socket — a non-socket occupant costs no `connect`, since
+/// the errno one would return is the very thing that misread it.
 /// Test: `takeover_verdict_refuses_a_non_socket_even_when_the_probe_says_dead`,
+/// `takeover_verdict_refuses_a_non_socket_that_was_never_probed`,
 /// `takeover_verdict_takes_over_a_dead_socket`,
 /// `takeover_verdict_refuses_a_served_socket`,
 /// `takeover_verdict_refuses_an_inconclusive_probe`.
-pub(crate) fn classify_takeover(is_socket: bool, verdict: SocketVerdict) -> TakeoverVerdict {
+pub(crate) fn classify_takeover(
+    is_socket: bool,
+    verdict: Option<SocketVerdict>,
+) -> TakeoverVerdict {
     // #7312: bind-failure test hung the CI shard — a Linux connect to a regular
     // file answers ECONNREFUSED, so the probe alone reads it as a dead socket.
     if !is_socket {
         return TakeoverVerdict::NotASocket;
     }
     match verdict {
-        SocketVerdict::NotServing => TakeoverVerdict::TakeOver,
+        Some(SocketVerdict::NotServing) => TakeoverVerdict::TakeOver,
         _ => TakeoverVerdict::Occupied,
     }
 }
@@ -123,6 +129,8 @@ pub(crate) fn classify_takeover(is_socket: bool, verdict: SocketVerdict) -> Take
 /// Test: `bind_singleton_takes_over_a_stale_socket_file`,
 /// `bind_singleton_refuses_a_socket_someone_is_serving`,
 /// `bind_singleton_refuses_a_regular_file_and_leaves_it_on_disk`,
+/// `bind_singleton_hardened_refuses_a_symlink_to_a_dead_socket`,
+/// `bind_singleton_hardened_refuses_a_symlink_to_a_live_socket`,
 /// `bind_singleton_binds_a_fresh_path`.
 pub async fn bind_singleton_hardened(path: &Path) -> Result<UnixListener, UdsSecurityError> {
     // #7312: `lstat`, not `Path::exists` — the latter follows a symlink and
@@ -131,15 +139,22 @@ pub async fn bind_singleton_hardened(path: &Path) -> Result<UnixListener, UdsSec
     // `bind_hardened` to report, exactly as `exists()` returning false was.
     if let Ok(meta) = std::fs::symlink_metadata(path) {
         let file_type = meta.file_type();
+        let is_socket = std::os::unix::fs::FileTypeExt::is_socket(&file_type);
         // #5182 review: three-state, not `is_ok()`. On macOS a live listener
         // with a saturated accept queue answers ECONNREFUSED, and a probe that
         // simply times out proves nothing — see `uds::probe::SocketVerdict`.
         // Only a verdict the kernel proved licenses an unlink.
-        let verdict = probe_socket_verdict(path, PROBE_TIMEOUT).await;
-        match classify_takeover(
-            std::os::unix::fs::FileTypeExt::is_socket(&file_type),
-            verdict,
-        ) {
+        //
+        // #7312: a non-socket occupant is refused on its type alone, so it
+        // never reaches this connect. The decision below still refuses it on
+        // `is_socket` whatever a verdict says, so skipping the probe is a cost
+        // saving, not the rule.
+        let verdict = if is_socket {
+            Some(probe_socket_verdict(path, PROBE_TIMEOUT).await)
+        } else {
+            None
+        };
+        match classify_takeover(is_socket, verdict) {
             TakeoverVerdict::TakeOver => {
                 // A corpse from a child that died without cleaning up. Removing
                 // it is the whole point of this function; a failure to remove it

--- a/crates/trusty-common/src/uds/tests.rs
+++ b/crates/trusty-common/src/uds/tests.rs
@@ -610,20 +610,8 @@ async fn bind_singleton_takes_over_a_stale_socket_file() {
     drop(dead); // tokio does not unlink on drop, so the file survives.
     assert!(sock.exists(), "the corpse must still be on disk");
 
-    // Dropping the listener closes the fd; the kernel finishes tearing the
-    // socket down afterwards, and on macOS under a loaded test binary a connect
-    // lands in that window and succeeds. Waiting for the corpse to actually
-    // read dead establishes the precondition this test assumes — the subject is
-    // the takeover, not how fast the kernel reclaims a socket.
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    while probe_socket_verdict(&sock, Duration::from_millis(50)).await != SocketVerdict::NotServing
-    {
-        assert!(
-            std::time::Instant::now() < deadline,
-            "the dropped listener never stopped answering connects"
-        );
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
+    // The subject is the takeover, not how fast the kernel reclaims a socket.
+    wait_until_corpse(&sock).await;
 
     let listener = bind_singleton_hardened(&sock)
         .await
@@ -666,7 +654,7 @@ fn takeover_verdict_refuses_a_non_socket_even_when_the_probe_says_dead() {
     // hands the decision for a regular file on the socket path. Before #7312 it
     // unlinked the file and bound over it.
     assert_eq!(
-        classify_takeover(false, SocketVerdict::NotServing),
+        classify_takeover(false, Some(SocketVerdict::NotServing)),
         TakeoverVerdict::NotASocket
     );
 }
@@ -679,7 +667,7 @@ fn takeover_verdict_refuses_a_non_socket_on_every_probe_answer() {
         SocketVerdict::Inconclusive,
     ] {
         assert_eq!(
-            classify_takeover(false, verdict),
+            classify_takeover(false, Some(verdict)),
             TakeoverVerdict::NotASocket,
             "the file type outranks the probe, got {verdict:?}"
         );
@@ -687,10 +675,28 @@ fn takeover_verdict_refuses_a_non_socket_on_every_probe_answer() {
 }
 
 #[test]
+fn takeover_verdict_refuses_a_non_socket_that_was_never_probed() {
+    // What `bind_singleton_hardened` actually passes for a non-socket: no
+    // verdict, because it does not spend a connect on one.
+    assert_eq!(
+        classify_takeover(false, None),
+        TakeoverVerdict::NotASocket,
+        "an unprobed non-socket is still refused"
+    );
+}
+
+#[test]
+fn takeover_verdict_refuses_an_unprobed_socket() {
+    // A missing verdict is never grounds to unlink. Only the one the kernel
+    // proved is.
+    assert_eq!(classify_takeover(true, None), TakeoverVerdict::Occupied);
+}
+
+#[test]
 fn takeover_verdict_takes_over_a_dead_socket() {
     // The one arm that unlinks anything, unchanged by #7312.
     assert_eq!(
-        classify_takeover(true, SocketVerdict::NotServing),
+        classify_takeover(true, Some(SocketVerdict::NotServing)),
         TakeoverVerdict::TakeOver
     );
 }
@@ -698,7 +704,7 @@ fn takeover_verdict_takes_over_a_dead_socket() {
 #[test]
 fn takeover_verdict_refuses_a_served_socket() {
     assert_eq!(
-        classify_takeover(true, SocketVerdict::Serving),
+        classify_takeover(true, Some(SocketVerdict::Serving)),
         TakeoverVerdict::Occupied
     );
 }
@@ -708,7 +714,7 @@ fn takeover_verdict_refuses_an_inconclusive_probe() {
     // The fail-open check: `Inconclusive` must never reach the unlink. A probe
     // that could not settle the question is treated as a live owner.
     assert_eq!(
-        classify_takeover(true, SocketVerdict::Inconclusive),
+        classify_takeover(true, Some(SocketVerdict::Inconclusive)),
         TakeoverVerdict::Occupied
     );
 }
@@ -745,6 +751,94 @@ async fn bind_singleton_refuses_a_regular_file_and_leaves_it_on_disk() {
         std::fs::read(&sock).expect("read the file back"),
         b"not a socket",
         "the file's contents must be untouched"
+    );
+}
+
+/// Wait for a dropped listener's socket to actually read dead.
+///
+/// Why: dropping the listener closes the fd, and the kernel finishes tearing
+/// the socket down afterwards; on macOS under a loaded test binary a connect
+/// lands in that window and succeeds. Two tests establish the same
+/// precondition, so the loop is written once.
+async fn wait_until_corpse(sock: &Path) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while probe_socket_verdict(sock, Duration::from_millis(50)).await != SocketVerdict::NotServing {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the dropped listener never stopped answering connects"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn bind_singleton_hardened_refuses_a_symlink_to_a_dead_socket() {
+    // #7312: a symlink is refused on its own type, and the dead socket it
+    // points at is NOT the corpse this function may reclaim — reclaiming
+    // through a link would unlink the link and bind a fresh socket at a path
+    // whose name still promises indirection. `verify_socket_for_connect`
+    // refuses a symlinked socket on the dialing side for the same reason.
+    //
+    // Note the target here is genuinely dead, so the probe would answer
+    // `NotServing` on BOTH platforms. Only the file-type check stops the
+    // takeover, which makes this the arm with no platform escape hatch.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    let target = dir.join("dead.sock");
+    let dead = bind_hardened(&target).expect("bind the soon-to-be corpse");
+    drop(dead); // tokio does not unlink on drop, so the file survives.
+    wait_until_corpse(&target).await;
+
+    let link = dir.join("link.sock");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink onto the corpse");
+
+    let err = bind_singleton_hardened(&link)
+        .await
+        .expect_err("a symlinked socket path must stop the bind");
+
+    assert!(
+        matches!(err, UdsSecurityError::NotASocketFile { ref found, .. } if found == "symlink"),
+        "expected NotASocketFile naming a symlink, got {err:?}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&link).is_ok(),
+        "the symlink itself must survive"
+    );
+    assert!(
+        std::fs::symlink_metadata(&target).is_ok(),
+        "the symlink's target must survive"
+    );
+}
+
+#[tokio::test]
+async fn bind_singleton_hardened_refuses_a_symlink_to_a_live_socket() {
+    // The same refusal with an owner behind it: unlinking here would strand a
+    // live listener, which is what `AlreadyServing` exists to prevent — but the
+    // symlink is refused before the probe ever runs, so the refusal does not
+    // depend on catching the owner in the act.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    let target = dir.join("live.sock");
+    let _live = bind_hardened(&target).expect("bind the live owner");
+
+    let link = dir.join("link.sock");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink onto the live socket");
+
+    let err = bind_singleton_hardened(&link)
+        .await
+        .expect_err("a symlinked socket path must stop the bind");
+
+    assert!(
+        matches!(err, UdsSecurityError::NotASocketFile { ref found, .. } if found == "symlink"),
+        "expected NotASocketFile naming a symlink, got {err:?}"
+    );
+    assert!(
+        std::fs::symlink_metadata(&link).is_ok(),
+        "the symlink itself must survive"
+    );
+    assert!(
+        socket_is_serving(&target, Duration::from_millis(500)).await,
+        "the live owner must still be answering on its own path"
     );
 }
 

--- a/crates/trusty-common/src/uds/tests.rs
+++ b/crates/trusty-common/src/uds/tests.rs
@@ -13,6 +13,7 @@
 
 use super::dir::{DirVerdict, classify_existing_dir};
 use super::peer::peer_uid_verdict;
+use super::singleton::{TakeoverVerdict, classify_takeover};
 use super::*;
 
 use std::os::unix::fs::PermissionsExt;
@@ -649,6 +650,123 @@ async fn bind_singleton_refuses_a_socket_someone_is_serving() {
         "expected AlreadyServing, got {err:?}"
     );
     assert!(sock.exists(), "the live owner's socket must survive");
+}
+
+// ── the takeover decision (#7312) ───────────────────────────────────────────
+//
+// Every arm below is asserted against `classify_takeover` directly, because two
+// of the four cannot be reached through real syscalls on this machine: Linux
+// reports a non-socket as ECONNREFUSED and macOS as ENOTSOCK, and neither
+// platform lets an unprivileged test manufacture an `Inconclusive` probe of a
+// real socket.
+
+#[test]
+fn takeover_verdict_refuses_a_non_socket_even_when_the_probe_says_dead() {
+    // This pair — not a socket, probe says NotServing — is exactly what Linux
+    // hands the decision for a regular file on the socket path. Before #7312 it
+    // unlinked the file and bound over it.
+    assert_eq!(
+        classify_takeover(false, SocketVerdict::NotServing),
+        TakeoverVerdict::NotASocket
+    );
+}
+
+#[test]
+fn takeover_verdict_refuses_a_non_socket_on_every_probe_answer() {
+    for verdict in [
+        SocketVerdict::Serving,
+        SocketVerdict::NotServing,
+        SocketVerdict::Inconclusive,
+    ] {
+        assert_eq!(
+            classify_takeover(false, verdict),
+            TakeoverVerdict::NotASocket,
+            "the file type outranks the probe, got {verdict:?}"
+        );
+    }
+}
+
+#[test]
+fn takeover_verdict_takes_over_a_dead_socket() {
+    // The one arm that unlinks anything, unchanged by #7312.
+    assert_eq!(
+        classify_takeover(true, SocketVerdict::NotServing),
+        TakeoverVerdict::TakeOver
+    );
+}
+
+#[test]
+fn takeover_verdict_refuses_a_served_socket() {
+    assert_eq!(
+        classify_takeover(true, SocketVerdict::Serving),
+        TakeoverVerdict::Occupied
+    );
+}
+
+#[test]
+fn takeover_verdict_refuses_an_inconclusive_probe() {
+    // The fail-open check: `Inconclusive` must never reach the unlink. A probe
+    // that could not settle the question is treated as a live owner.
+    assert_eq!(
+        classify_takeover(true, SocketVerdict::Inconclusive),
+        TakeoverVerdict::Occupied
+    );
+}
+
+#[tokio::test]
+async fn bind_singleton_refuses_a_regular_file_and_leaves_it_on_disk() {
+    // #7312: the takeover exists for a socket corpse. A regular file on the
+    // socket path is not one, and deleting it is data loss in whatever owns it.
+    //
+    // This is the platform split, in one test. macOS answers a connect to a
+    // regular file with ENOTSOCK, which reads `Inconclusive` and refused — by
+    // accident, and under the wrong error. Linux answers ECONNREFUSED, which
+    // read `NotServing`: the file was unlinked, the bind succeeded, and
+    // `trusty-code`'s `run_uds_socket_bind_failure_is_fatal` then served
+    // forever instead of failing, hanging a CI shard until its 45-minute
+    // cancel. Both platforms must now refuse for the stated reason.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    std::fs::create_dir_all(&dir).expect("socket dir");
+    let sock = dir.join("occupied.sock");
+    std::fs::write(&sock, b"not a socket").expect("occupy the socket path");
+
+    let err = bind_singleton_hardened(&sock)
+        .await
+        .expect_err("a regular file on the socket path must stop the bind");
+
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("is a regular file, not a socket"),
+        "the refusal must name what is actually there, got: {rendered}"
+    );
+    assert!(sock.exists(), "the file must not have been unlinked");
+    assert_eq!(
+        std::fs::read(&sock).expect("read the file back"),
+        b"not a socket",
+        "the file's contents must be untouched"
+    );
+}
+
+#[tokio::test]
+async fn bind_singleton_refuses_a_directory_on_the_socket_path() {
+    // The other shape the same rule covers: a directory is not a corpse either,
+    // and `remove_file` on one would have failed silently, leaving the bind to
+    // report an unrelated EADDRINUSE.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("sockets");
+    let sock = dir.join("occupied.sock");
+    std::fs::create_dir_all(&sock).expect("occupy the socket path with a directory");
+
+    let err = bind_singleton_hardened(&sock)
+        .await
+        .expect_err("a directory on the socket path must stop the bind");
+
+    assert!(
+        matches!(err, UdsSecurityError::NotASocketFile { ref found, .. } if found == "directory"),
+        "expected NotASocketFile naming a directory, got {err:?}"
+    );
+    assert!(sock.is_dir(), "the directory must survive");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Refs #7312
Refs #7219

trusty-code's UDS bind-failure test hung forever on Linux because
`ECONNREFUSED` on a connect-to-a-regular-file was read as evidence of a dead
socket, so the code then unlinked and rebound over it and served forever.

## Changes

- `bind_singleton_hardened` lstat-checks the occupant before any takeover. A
  non-socket occupant (regular file, directory, symlink to a live socket, or
  symlink to a dead socket) is refused with `UdsSecurityError::NotASocketFile`
  and left on disk.
- The liveness probe (`connect()`) runs only when the occupant is confirmed
  to be a socket.
- `classify_takeover` now takes `Option<SocketVerdict>` and never unlinks on
  a missing verdict.
- The bind-failure test gains a 10s bound so a regression hangs the test
  instead of the whole suite.

Out of scope: no change to the socket protocol or the daemon's client-facing
API; this only changes what happens when the socket path is occupied by
something that is not a socket.

## Risk

Rung 4 — cross-crate change to a shared library (`trusty-common`'s UDS
takeover path) with `trusty-code` and `trusty-mpm` as direct consumers via
`daemon/socket.rs`. Behavior change is a narrowing (refuse takeover of a
non-socket instead of unlinking it), so the risk is a false refusal on a path
that used to succeed; covered by the added symlink and non-socket test cases.

## Tests

- `cargo check --workspace` (four Tauri UI crates excluded, matching
  `ci.yml`): exit 0
- `cargo test -p trusty-common --features uds --no-fail-fast`: 689 passed, 0
  failed
- `cargo test -p trusty-code --no-fail-fast` under `timeout 1200`: 1824
  passed, 0 failed; bind-failure test completes instead of hanging
- `cargo test -p trusty-mpm --no-fail-fast` (direct consumer via
  `daemon/socket.rs`): 6555 passed, 0 failed
- `fmt --check` / `clippy --all-targets -- -D warnings`: exit 0

## Baseline

No pre-existing red on this branch's gates.

## Docs

Two changelog fragments added (trusty-common, trusty-code). line-cap,
test-pointers, and changelog-fragment gates: exit 0.

## Review

code-critic APPROVE on 5334a6b42; its two findings (symlink coverage, no
`connect()` on a non-socket) are implemented in this PR's head.

Green main from this fix also clears #7226, #7028's tracker, and #7288.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
