### PR TITLE
chore(trusty-mpm): bump to 1.5.24 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11919,7 +11919,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.23"
+version = "1.5.24"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -37,7 +37,7 @@ name = "trusty-mpm"
 # 1.5.23 (owner-authorized reinstall, refs #7311 #7314): patch,
 # version-only — 1.5.22 is already published and this bump exists solely so
 # `tm --version` identifies the reinstalled build (rtk pipe-mode fix).
-version = "1.5.23"
+version = "1.5.24"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -37,6 +37,10 @@ name = "trusty-mpm"
 # 1.5.23 (owner-authorized reinstall, refs #7311 #7314): patch,
 # version-only — 1.5.22 is already published and this bump exists solely so
 # `tm --version` identifies the reinstalled build (rtk pipe-mode fix).
+# 1.5.24 (owner-authorized reinstall, refs #7311 #7313 #7312 #7278 #7282
+# #7275 #7237 #7325 #7319): patch, version-only — 1.5.23 is already
+# published and this bump exists solely so `tm --version` identifies the
+# reinstalled build (statusline savings percentage format).
 version = "1.5.24"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Outcome

Version-only patch bump so `tm --version` identifies the reinstalled build (owner ruling: every reinstall carries a patch bump). Carries, since the installed 1.5.23:

- #7275 (PR #7339) — `tm pr cleanup` base fetch and removal re-probe
- #7237 (PR #7340) — search-index create confirmed by registry poll
- #7325 (PR #7341) — rtk resolver seam
- #7319 — 💸`<session>%`/`<avg>%` statusline format

Refs #7275 #7237 #7325 #7319

## Changes

`crates/trusty-mpm/Cargo.toml` version bumped 1.5.23 -> 1.5.24, with the version-history comment updated. Matching `Cargo.lock` entry. No source change, so no changelog fragment is owed — `check-pr-version-bump.sh` reports 2 paths examined, none under `src`.

## Risk

Low, rung 1 (metadata only).

## Tests

- `cargo check -p trusty-mpm`: exit 0
- `scripts/check-pr-version-bump.sh`: OK, run post-commit
- `scripts/check_workspace_dep_versions.sh`: exit 0 — the workspace row is a loose `1.0.0` requirement, no widen needed for a patch bump

## Baseline

`main` green at 5077d98ca.

## Docs

None.

## Review

None needed — version-only change.

https://claude.ai/code/session_0194bkFi1G1Wv3kh1bVbMw4q

Refs #7275

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
