### PR TITLE
docs(trusty-mpm): ban prose that tells a dispatched agent to create its own worktree (Refs #5649)

### DIFF
--- a/crates/trusty-mpm/changelog.d/5649-worktree-isolation-one-mechanism.md
+++ b/crates/trusty-mpm/changelog.d/5649-worktree-isolation-one-mechanism.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `tm-workflow` and `tm-delegation-patterns` now ban telling a dispatched agent to hand-roll its own worktree in ANY wording, not only a literal `git worktree add` — the prose form ("work in a worktree of your own") recurred in a different project after the literal-command form was fixed, because `tm hook --pm-guard` cannot see either phrasing in a dispatch prompt (#5649).

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -300,10 +300,14 @@ sequential agents, read-only research, or separate file trees. Use
 `run_in_background: true` for fire-and-forget parallel work.
 
 🔴 **`isolation: "worktree"` is the only sanctioned mechanism, and the PM never
-authors a `git worktree add` into a dispatch prompt (#5649).**
+tells a dispatched agent to hand-roll one — not a literal `git worktree add`,
+and not prose like "work in a worktree of your own" (#5649).**
 `tm hook --pm-guard` reads the declared parameter and never the prompt, so a
 hand-rolled worktree leaves the agent counted against the shared HEAD and gets
-the next file-mutating dispatch denied for a collision that does not exist.
+the next file-mutating dispatch denied for a collision that does not exist. The
+prose form recurred on 2026-09-09 in a different project after the literal-command
+form was fixed here — the guard cannot see either phrasing, so both are banned,
+regardless of wording.
 
 **When `isolation` is unavailable, serialize** — one file-mutating agent at a
 time, each waited for before the next. Serializing always works. Hand-rolling to

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -321,12 +321,16 @@ and keeps bundled in that same worktree and PR.
 worktree only once its result is accepted for implementation.
 
 🔴 **A file-mutating subagent dispatch declares `isolation: "worktree"`. That is
-the only sanctioned mechanism, and the PM never authors a `git worktree add` into
-a dispatch prompt (#5649).** The harness provisions the tree and puts the agent
-in it. A hand-rolled worktree is invisible to `tm hook --pm-guard`, which reads
-the declared `isolation` parameter and never the prompt — so an agent that made
-its own tree still counts as occupying the shared HEAD, and the next
-file-mutating dispatch is denied for a collision that does not exist.
+the only sanctioned mechanism, and the PM never tells the agent to hand-roll one
+— not a literal `git worktree add`, and not prose like "work in a worktree of
+your own" (#5649).** The harness provisions the tree and puts the agent in it. A
+hand-rolled worktree is invisible to `tm hook --pm-guard`, which reads the
+declared `isolation` parameter and never the prompt — so an agent that made its
+own tree still counts as occupying the shared HEAD, and the next file-mutating
+dispatch is denied for a collision that does not exist. The prose form recurred
+in a different project on 2026-09-09, after the literal-command form was fixed
+here — the guard cannot see either phrasing, so both are banned, regardless of
+wording.
 
 **When `isolation` is unavailable, the PM serializes.** Dispatch one
 file-mutating agent, wait for it, dispatch the next. Serializing is always


### PR DESCRIPTION
Refs #5649

PR #5654 fixed the original conflict, but the rule banned only the literal `git worktree add` in a dispatch brief. The 2026-09-09 recurrence used prose ("work in a worktree of your own") and slipped through. `tm-delegation-patterns.md` and `tm-workflow.md` now ban any wording that tells a dispatched agent to create its own worktree; `isolation: "worktree"` is the one mechanism (ADR-0048).

Test ladder: rung 1 (skill-asset prose) + asset-pinning suite.
- `bash scripts/check_sld.sh` — 0 errors
- `bash scripts/check_doc_paths.sh` — 62 files, all resolve
- `bash scripts/check_line_cap.sh` — 0 violations
- `bash scripts/check_changelog_fragment.sh --staged` — fragment present
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — all ok
Credential scan of `origin/main...HEAD`: PASS.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0194bkFi1G1Wv3kh1bVbMw4q
