### PR TITLE
fix(trusty-mpm): tm doctor --fix repoints build-tree hook commands machine-wide; catch the bare claude-hook shim (Refs #7262)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7262-foreign-shim-and-legacy-remedy.md
+++ b/crates/trusty-mpm/changelog.d/7262-foreign-shim-and-legacy-remedy.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `hooks_foreign_conflict` reported CLEAN while claude-mpm's `claude-hook` shim
+  raced tm's `PreToolUse` rewrite in a real project. The check asked whether the
+  command string spelled `claude-mpm` anywhere, and the shim is registered by
+  bare name off `PATH`, so nothing in it named the owning harness. It now
+  resolves what the command actually invokes and classifies by the executable's
+  file name as well. `legacy_overrides` has no `--fix` arm — repairing it means
+  deleting a tracked file, which needs an owner ruling — so its failure text now
+  prints the exact `git rm` command over the files it found instead of leaving
+  the operator to assemble one (#7262).

--- a/crates/trusty-mpm/changelog.d/7262-settings-corruption-repair.md
+++ b/crates/trusty-mpm/changelog.d/7262-settings-corruption-repair.md
@@ -1,0 +1,16 @@
+Added
+
+- `tm doctor --fix` now repairs `hooks_build_tree_binary` instead of only
+  reporting it. Every hook and `statusLine.command` whose executable lives in a
+  Cargo build tree is REPOINTED at the installed `tm` binary, keeping its argv,
+  so a corrupted `--pm-guard` entry comes back as a working `--pm-guard` entry
+  rather than being removed and leaving PM enforcement offline until the next
+  managed launch. The pass snapshots each file to
+  `<name>.<YYYYMMDDTHHMMSSZ>.bak` before writing, is fail-closed on an
+  unreadable, unparseable, or non-object settings file — reported, never backed
+  up and never rewritten — and is idempotent: a repointed command names an
+  installed binary, which the classifier rejects, so a second run writes
+  nothing. It is the one repair that sweeps every settings file on the machine
+  rather than the current project: the eight projects corrupted on 2026-09-09
+  were none of them the cwd of the operator who ran `tm doctor`, which is why
+  that repair had to be done by hand with `sed` (#7262).

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -1584,9 +1584,14 @@ pub struct DoctorFlags {
     /// carrying tm hook entries, a repairable skill drift — all `Warn`,
     /// none actionable without a separate command the operator had to know
     /// existed. This runs the repairs whose target is something tm itself
-    /// wrote: the skill redeploy (`skill_staleness`), the project hook
+    /// wrote: the skill redeploy (`skill_staleness`), the build-tree
+    /// repoint (`hooks_build_tree_binary`, #7262), the project hook
     /// cleanup (`hooks_contamination`), and the push-guard retrofit
     /// (`push_guard`).
+    /// The repoint is the one repair that is MACHINE-WIDE rather than
+    /// scoped to this project: the corruption is written by whichever
+    /// build tree ran last, wherever that session was pointed, so a
+    /// cwd-scoped pass leaves the other projects broken (#7262).
     /// What: on its own it CHANGES NOTHING — it prints, per item and with
     /// the path, exactly what it would do. `--yes` performs the writes.
     /// It never deletes: `legacy_sources` findings under `~/.claude` are

--- a/crates/trusty-mpm/src/bin/tm/commands/doctor_repair.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/doctor_repair.rs
@@ -18,8 +18,8 @@
 
 use colored::Colorize;
 use trusty_mpm::core::doctor_repair::{
-    RepairMode, RepairStep, StepStatus, refuse_legacy_sources, repair_hooks_contamination,
-    repair_output_style, repair_push_guard,
+    RepairMode, RepairStep, StepStatus, refuse_legacy_sources, repair_build_tree_binary,
+    repair_hooks_contamination, repair_output_style, repair_push_guard,
 };
 use trusty_mpm::core::skill_repair::RepairAction;
 use trusty_mpm::core::stray_mcp::{quarantine_explicit, quarantine_strays};
@@ -116,8 +116,10 @@ const FIX_APPLY_HINT: &str = "tm doctor --fix --yes";
 /// Why: see the module doc. The default is a preview because these repairs
 /// rewrite files the operator can see and care about; `--yes` is the second
 /// deliberate act that lets one write.
-/// What: runs, in order, the skill redeploy (`skill_staleness`), the project
-/// hook cleanup (`hooks_contamination`), the push-guard retrofit
+/// What: runs, in order, the skill redeploy (`skill_staleness`), the
+/// machine-wide build-tree repoint (`hooks_build_tree_binary`, #7262 — first,
+/// so the strip below cannot delete a PM guard the repoint would have fixed),
+/// the project hook cleanup (`hooks_contamination`), the push-guard retrofit
 /// (`push_guard`), the output-style redeploy (`output_style_staleness`, #5866),
 /// the `legacy_sources` refusals, and the stray-`.mcp.json`
 /// sweep (`stray_mcp_json`) — printing each item's path, what would change,
@@ -140,6 +142,13 @@ pub(crate) fn run_repairs(apply: bool, include_frozen: bool) {
     let mut steps = skill_steps(include_frozen, mode);
 
     let project_dir = std::env::current_dir().ok();
+    // #7262: the repoint runs BEFORE the contamination strip. A build-tree
+    // command is tm-owned by `is_mpm_hook_command`, so a strip that ran first
+    // would delete the PM guard this pass repairs in place.
+    steps.extend(repair_build_tree_binary(
+        &machine_wide_settings_files(project_dir.as_deref()),
+        mode,
+    ));
     if let Some(project) = &project_dir {
         steps.extend(repair_hooks_contamination(project, mode));
         steps.extend(repair_push_guard(project, mode));
@@ -168,6 +177,45 @@ pub(crate) fn run_repairs(apply: bool, include_frozen: bool) {
     }
 
     print_steps(&steps, apply, FIX_APPLY_HINT);
+}
+
+/// Every `.claude/settings*.json` the build-tree repoint should reach (#7262).
+///
+/// Why: the corruption is written by whichever build tree ran last, into
+/// whichever project that session was pointed at — on 2026-09-10 that was eight
+/// projects, none of them the cwd of the operator who ran `tm doctor`. A
+/// cwd-scoped repair leaves seven of them broken and reports success, which is
+/// why the fix had to be done by hand with `sed`. The sweep therefore uses the
+/// same `$HOME`-wide discovery `tm hooks clean` (no `--path`) already owns
+/// rather than a second enumerator, plus the cwd, which a `$HOME` walk misses
+/// when the project lives outside the home directory.
+/// What: the deduplicated union of `<cwd>/.claude/{settings.json,
+/// settings.local.json}` and
+/// [`trusty_common::claude_config::discover_claude_settings`] under the resolved
+/// home. Existence is not checked here — [`repair_build_tree_binary`] treats a
+/// missing file as nothing to do. An unresolvable home contributes nothing
+/// rather than aborting the repair.
+///
+/// This walk is the reason it belongs to `--fix` and not to `tm doctor` itself:
+/// the diagnostic must stay fast, so its `hooks_build_tree_binary` probe stays
+/// scoped to the projects the daemon tracks (see
+/// `daemon::doctor_hooks_hygiene::candidate_settings_files`), while the repair
+/// the operator explicitly asked for pays the cost once.
+/// Test: `machine_wide_settings_files_includes_the_cwd_project`.
+fn machine_wide_settings_files(project_dir: Option<&std::path::Path>) -> Vec<std::path::PathBuf> {
+    let mut set: std::collections::BTreeSet<std::path::PathBuf> = std::collections::BTreeSet::new();
+    if let Some(dir) = project_dir {
+        for name in ["settings.json", "settings.local.json"] {
+            set.insert(dir.join(".claude").join(name));
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        set.extend(trusty_common::claude_config::discover_claude_settings(
+            &home,
+            trusty_common::claude_config::default_settings_max_depth(),
+        ));
+    }
+    set.into_iter().collect()
 }
 
 /// Print one repair's worth of steps, with the per-outcome tallies.
@@ -352,5 +400,27 @@ mod tests {
     fn fix_hint_names_the_fix_command() {
         assert_eq!(FIX_APPLY_HINT, "tm doctor --fix --yes");
         assert!(!FIX_APPLY_HINT.contains("--quarantine-mcp"));
+    }
+
+    /// #7262: the eight projects corrupted on 2026-09-09 were not the cwd of the
+    /// operator who ran `tm doctor`, so the sweep must reach past it. A project
+    /// checked out OUTSIDE `$HOME` is only reachable through the cwd entry,
+    /// which is why both sources are unioned rather than one replacing the
+    /// other.
+    #[test]
+    fn machine_wide_settings_files_includes_the_cwd_project() {
+        let project = std::path::Path::new("/srv/projects/acme");
+        let files = machine_wide_settings_files(Some(project));
+
+        for name in ["settings.json", "settings.local.json"] {
+            let expected = project.join(".claude").join(name);
+            assert!(files.contains(&expected), "{expected:?} missing: {files:?}");
+        }
+        // Deduplicated and ordered, so one project can never be repaired twice
+        // in one run.
+        let mut sorted = files.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted, files, "the list must be sorted and deduplicated");
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
+++ b/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
@@ -164,7 +164,7 @@ pub(crate) const DOCTOR_CHECKS: &[(&str, &str)] = &[
     ),
     (
         "hooks_build_tree_binary",
-        "Warns when a hook or `statusLine` command in a project's `.claude/settings*.json` runs a binary that lives in a Cargo build tree, naming the file and each offending command. Such a command stops working the moment the artifact is rebuilt away, which silently disables PM-guard enforcement; the hook entries are removed by `tm doctor --fix --yes` / `tm hooks clean` and re-rendered from the installed binary on the next managed launch (issue #7262).",
+        "Warns when a hook or `statusLine` command in a project's `.claude/settings*.json` runs a binary that lives in a Cargo build tree, naming the file and each offending command. Such a command stops working the moment the artifact is rebuilt away, which silently disables PM-guard enforcement. `tm doctor --fix` previews repointing every one of them at the installed `tm` binary — machine-wide, not just this project — and `--yes` applies it, taking a timestamped snapshot of each file first; `statusLine.command` is repaired by the same pass (issue #7262).",
     ),
     (
         "tcc_taint",

--- a/crates/trusty-mpm/src/core/doctor_repair.rs
+++ b/crates/trusty-mpm/src/core/doctor_repair.rs
@@ -33,8 +33,9 @@
 //!    than silent: `legacy_sources` findings are REPORTED with their paths and
 //!    a reason, never acted on. See #4409.
 //!
-//! What: [`RepairMode`], the [`RepairStep`] outcome model, and the four
-//! repairs `--fix` drives — [`repair_hooks_contamination`],
+//! What: [`RepairMode`], the [`RepairStep`] outcome model, and the repairs
+//! `--fix` drives — [`repair_build_tree_binary`] (#7262, the repoint that runs
+//! first), [`repair_hooks_contamination`],
 //! [`repair_push_guard`], [`repair_output_style`] (#5866 — the one check whose
 //! remedy string named a command with no such step), and (via
 //! [`crate::core::skill_repair`]) the skill redeploy — plus
@@ -47,6 +48,8 @@ use crate::core::push_guard::{
     GuardState, HookInstall, inspect_pre_push_guard, install_pre_push_guard,
 };
 use crate::core::standalone::hooks::cleanup::clean_settings_file;
+use crate::core::standalone::hooks::repoint::{build_tree_commands_in, repoint_settings_file};
+use crate::core::standalone::hooks::{StableHookExeError, resolve_stable_hook_exe};
 
 /// Whether a repair may write, or is only describing what it would write.
 ///
@@ -212,6 +215,141 @@ pub fn repair_hooks_contamination(project_dir: &Path, mode: RepairMode) -> Vec<R
         }
     }
     steps
+}
+
+/// The `tm doctor` check [`repair_build_tree_binary`] answers.
+///
+/// Why: named once so the repair, its tests, and the driver's ordering comment
+/// cannot drift onto a check name the report does not emit.
+/// What: the string `hooks_build_tree_binary`, as
+/// `daemon::doctor_hooks_hygiene` publishes it.
+/// Test: `build_tree_repair_repoints_at_the_installed_binary`.
+const BUILD_TREE_CHECK: &str = "hooks_build_tree_binary";
+
+/// Repoint every build-tree hook and `statusLine` command at the installed
+/// binary (issue #7262, reopened).
+///
+/// Why: #7286 made `hooks_build_tree_binary` visible and left it unrepairable —
+/// `--fix` planned zero repairs for it, and on 2026-09-10 eight projects were
+/// fixed by hand with `sed`. [`repair_hooks_contamination`] is not that repair:
+/// it REMOVES the entry, which takes PM enforcement offline until the project's
+/// next managed launch and cannot touch `statusLine.command` at all. Repointing
+/// keeps the entry and fixes the one thing wrong with it.
+///
+/// This runs BEFORE [`repair_hooks_contamination`] in the driver, deliberately.
+/// [`crate::core::standalone::hooks::is_mpm_hook_command`] claims a build-tree
+/// command, so a contamination pass that ran first would delete the PM guard
+/// this pass would have restored.
+/// What: one step per file that carried at least one such command, naming the
+/// count and the first command in full. Scope is the caller's — the driver
+/// passes every settings file on the machine, not just this project's, because
+/// the damage is written by whichever build tree ran last and lands wherever
+/// that session was pointed. Applying takes a timestamped snapshot before it
+/// writes; see [`repoint_settings_file`], which is fail-closed on an
+/// unreadable, unparseable, or non-object file.
+///
+/// When no installed `tm`/`trusty-mpm` binary resolves there is nothing to
+/// repoint to, so every affected file gets a [`StepStatus::Refused`] naming the
+/// reason — a clean file stays silent, because a machine with no tm on `PATH`
+/// must not grow a refusal line per project.
+/// Test: `build_tree_repair_repoints_at_the_installed_binary`,
+/// `build_tree_repair_dry_run_changes_nothing`,
+/// `build_tree_repair_is_idempotent`,
+/// `build_tree_repair_fails_closed_on_unparseable_json`,
+/// `build_tree_repair_refuses_when_no_installed_binary_resolves`,
+/// `build_tree_repair_is_silent_for_a_clean_file`.
+pub fn repair_build_tree_binary(settings_files: &[PathBuf], mode: RepairMode) -> Vec<RepairStep> {
+    repair_build_tree_binary_with(settings_files, resolve_stable_hook_exe(None), mode)
+}
+
+/// [`repair_build_tree_binary`] with the installed-binary resolution supplied.
+///
+/// Why: [`resolve_stable_hook_exe`] reads `current_exe()` and `PATH`, so a test
+/// running inside a `cargo test` harness would get a different answer on a
+/// machine that has `tm` installed than on one that does not — and the refusal
+/// arm is the half worth pinning. Injecting the result makes both arms
+/// deterministic without a second resolver.
+/// What: as [`repair_build_tree_binary`]; `installed` is what that function
+/// resolves in production.
+/// Test: see [`repair_build_tree_binary`].
+fn repair_build_tree_binary_with(
+    settings_files: &[PathBuf],
+    installed: Result<PathBuf, StableHookExeError>,
+    mode: RepairMode,
+) -> Vec<RepairStep> {
+    settings_files
+        .iter()
+        .filter_map(|path| build_tree_step(path, installed.as_deref(), mode))
+        .collect()
+}
+
+/// One file's worth of [`repair_build_tree_binary`].
+///
+/// Why: three outcomes (nothing to do, repointed, refused/failed) read far
+/// better as one function than as three arms nested inside a loop.
+/// What: `None` when the file carries no build-tree command. Otherwise the step
+/// — `Refused` when `installed` is an error, `Failed` when the rewrite itself
+/// failed, else `Planned`/`Applied`.
+/// Test: see [`repair_build_tree_binary`].
+fn build_tree_step(
+    path: &Path,
+    installed: Result<&Path, &StableHookExeError>,
+    mode: RepairMode,
+) -> Option<RepairStep> {
+    let installed = match installed {
+        Ok(bin) => bin,
+        Err(e) => {
+            // Speak up only for a file that actually carries the damage.
+            if build_tree_commands_in(path).is_empty() {
+                return None;
+            }
+            return Some(RepairStep {
+                check: BUILD_TREE_CHECK,
+                path: path.to_path_buf(),
+                what: "repoint build-tree hook commands at the installed tm binary".to_string(),
+                status: StepStatus::Refused(e.to_string()),
+            });
+        }
+    };
+
+    match repoint_settings_file(path, installed, mode == RepairMode::Apply) {
+        Ok(None) => None,
+        Ok(Some(outcome)) => {
+            let (first, _) = outcome
+                .hooks
+                .first()
+                .or(outcome.statusline.as_ref())
+                .expect("an outcome exists only when at least one command was rewritten");
+            let what = format!(
+                "repoint {} command{} at {} (first: `{first}`)",
+                outcome.command_count(),
+                if outcome.command_count() == 1 {
+                    ""
+                } else {
+                    "s"
+                },
+                installed.display(),
+            );
+            let status = match mode {
+                RepairMode::DryRun => StepStatus::Planned,
+                RepairMode::Apply => StepStatus::Applied {
+                    backup: outcome.backup_path,
+                },
+            };
+            Some(RepairStep {
+                check: BUILD_TREE_CHECK,
+                path: outcome.path,
+                what,
+                status,
+            })
+        }
+        Err(e) => Some(RepairStep {
+            check: BUILD_TREE_CHECK,
+            path: path.to_path_buf(),
+            what: "repoint build-tree hook commands at the installed tm binary".to_string(),
+            status: StepStatus::Failed(e.to_string()),
+        }),
+    }
 }
 
 /// Install the #2867 cross-branch `pre-push` guard on this clone.

--- a/crates/trusty-mpm/src/core/doctor_repair_tests.rs
+++ b/crates/trusty-mpm/src/core/doctor_repair_tests.rs
@@ -192,6 +192,185 @@ fn hooks_repair_omits_the_pm_guard_clause_for_other_entries() {
     );
 }
 
+/// The installed binary the #7262 repoint tests write.
+///
+/// Why: [`resolve_stable_hook_exe`] reads the host's `PATH`, which would make
+/// these assertions depend on whether the machine has `tm` installed. Every test
+/// here injects this instead.
+const INSTALLED_BIN: &str = "/usr/local/bin/tm";
+
+/// Seed `<project>/.claude/settings.json` with the #7244 incident shape.
+///
+/// Why (#7262): the ONE fixture the classifier, the cleanup, the doctor probe
+/// and now the repair all share — see
+/// `core::standalone::hooks::build_tree::tests::incident_settings`.
+fn write_build_tree_settings(project: &Path) -> PathBuf {
+    let claude = project.join(".claude");
+    fs::create_dir_all(&claude).unwrap();
+    let path = claude.join("settings.json");
+    fs::write(
+        &path,
+        crate::core::standalone::hooks::build_tree::tests::incident_settings().to_string(),
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn build_tree_repair_repoints_at_the_installed_binary() {
+    // #7262 reopened: `hooks_build_tree_binary` had no `--fix` arm at all, so
+    // this is the whole point of the change.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_build_tree_settings(tmp.path());
+
+    let steps = repair_build_tree_binary_with(
+        std::slice::from_ref(&path),
+        Ok(PathBuf::from(INSTALLED_BIN)),
+        RepairMode::Apply,
+    );
+
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert_eq!(steps[0].check, "hooks_build_tree_binary");
+    assert_eq!(steps[0].path, path);
+    assert!(steps[0].changed(), "{:?}", steps[0]);
+    assert!(
+        steps[0]
+            .what
+            .contains("repoint 8 commands at /usr/local/bin/tm"),
+        "{}",
+        steps[0].what
+    );
+    match &steps[0].status {
+        StepStatus::Applied { backup } => {
+            let backup = backup.as_ref().expect("apply snapshots the file first");
+            assert!(backup.exists(), "{}", backup.display());
+        }
+        other => panic!("expected Applied, got {other:?}"),
+    }
+
+    // Detect → repair → clean.
+    let after: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert!(
+        crate::core::standalone::hooks::cleanup::build_tree_hook_commands(&after).is_empty(),
+        "{after}"
+    );
+    assert!(
+        crate::core::standalone::hooks::cleanup::build_tree_statusline_command(&after).is_none(),
+        "{after}"
+    );
+}
+
+#[test]
+fn build_tree_repair_dry_run_changes_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_build_tree_settings(tmp.path());
+    let raw = fs::read_to_string(&path).unwrap();
+
+    let steps = repair_build_tree_binary_with(
+        std::slice::from_ref(&path),
+        Ok(PathBuf::from(INSTALLED_BIN)),
+        RepairMode::DryRun,
+    );
+
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert_eq!(steps[0].status, StepStatus::Planned);
+    assert!(!steps[0].changed());
+    assert_eq!(fs::read_to_string(&path).unwrap(), raw);
+}
+
+#[test]
+fn build_tree_repair_is_idempotent() {
+    // A second `--fix --yes` must plan nothing and rewrite nothing.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_build_tree_settings(tmp.path());
+    let files = [path.clone()];
+
+    repair_build_tree_binary_with(&files, Ok(PathBuf::from(INSTALLED_BIN)), RepairMode::Apply);
+    let after_first = fs::read_to_string(&path).unwrap();
+
+    let second =
+        repair_build_tree_binary_with(&files, Ok(PathBuf::from(INSTALLED_BIN)), RepairMode::Apply);
+
+    assert!(second.is_empty(), "{second:?}");
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        after_first,
+        "the second pass must be byte-identical"
+    );
+}
+
+#[test]
+fn build_tree_repair_fails_closed_on_unparseable_json() {
+    // The error arm: an unparseable file is REPORTED as a failed step, never
+    // skipped silently and never rewritten.
+    let tmp = tempfile::tempdir().unwrap();
+    let claude = tmp.path().join(".claude");
+    fs::create_dir_all(&claude).unwrap();
+    let path = claude.join("settings.json");
+    fs::write(&path, "{ \"hooks\": ").unwrap();
+
+    let steps = repair_build_tree_binary_with(
+        std::slice::from_ref(&path),
+        Ok(PathBuf::from(INSTALLED_BIN)),
+        RepairMode::Apply,
+    );
+
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    assert_eq!(steps[0].check, "hooks_build_tree_binary");
+    match &steps[0].status {
+        StepStatus::Failed(msg) => assert!(msg.contains("is not valid JSON"), "{msg}"),
+        other => panic!("expected Failed, got {other:?}"),
+    }
+    assert_eq!(fs::read_to_string(&path).unwrap(), "{ \"hooks\": ");
+}
+
+#[test]
+fn build_tree_repair_refuses_when_no_installed_binary_resolves() {
+    // Nothing to repoint TO is a refusal with a reason, not a silent pass.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_build_tree_settings(tmp.path());
+    let raw = fs::read_to_string(&path).unwrap();
+
+    let steps = repair_build_tree_binary_with(
+        std::slice::from_ref(&path),
+        Err(crate::core::standalone::hooks::StableHookExeError::Unresolved),
+        RepairMode::Apply,
+    );
+
+    assert_eq!(steps.len(), 1, "{steps:?}");
+    match &steps[0].status {
+        StepStatus::Refused(reason) => {
+            assert!(
+                reason.contains("no installed tm/trusty-mpm binary"),
+                "{reason}"
+            );
+        }
+        other => panic!("expected Refused, got {other:?}"),
+    }
+    assert_eq!(fs::read_to_string(&path).unwrap(), raw);
+}
+
+#[test]
+fn build_tree_repair_is_silent_for_a_clean_file() {
+    // A machine with no tm on PATH must not grow one refusal line per project.
+    let tmp = tempfile::tempdir().unwrap();
+    let path = write_mixed_settings(tmp.path());
+
+    for installed in [
+        Ok(PathBuf::from(INSTALLED_BIN)),
+        Err(crate::core::standalone::hooks::StableHookExeError::Unresolved),
+    ] {
+        let steps = repair_build_tree_binary_with(
+            std::slice::from_ref(&path),
+            installed,
+            RepairMode::Apply,
+        );
+        assert!(steps.is_empty(), "{steps:?}");
+    }
+    assert!(!tmp.path().join(".claude/settings.json.bak").exists());
+}
+
 #[test]
 fn push_guard_repair_installs_when_missing() {
     let Some((_dir, repo)) = temp_repo() else {

--- a/crates/trusty-mpm/src/core/standalone/hooks/build_tree.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/build_tree.rs
@@ -26,8 +26,16 @@
 //! REPAIR half (#7262, reopened): they hand back the same command with its
 //! executable replaced by the installed binary and its argv untouched, which is
 //! what [`super::repoint`] writes back. Detection and repair share one split
-//! ([`split_build_tree_command`]), so a command the probe names is exactly a
-//! command the repair rewrites.
+//! ([`split_build_tree_command`]), so the repair can never rewrite a command the
+//! probe would not name.
+//!
+//! **Repair is narrower than detection, deliberately.** Naming a dead artifact
+//! costs a report line; rewriting one makes tm run on an event tm may never have
+//! registered. So the repair asks a second question the probe does not — is this
+//! executable one tm's OWN writer could have persisted ([`is_tm_writable_exe`])
+//! — and declines a foreign stem such as `<build-tree>/mytool`. What it still
+//! repairs is what #7244 actually wrote: a tm stem, or the hash-suffixed
+//! `deps/` artifact `current_exe()` yields for a Cargo binary.
 //!
 //! **Where the line is drawn.** A build-tree path ALONE is not enough: a
 //! project may legitimately register its own hook that happens to live under
@@ -143,13 +151,15 @@ pub fn is_build_tree_statusline_command(cmd: &str) -> bool {
 /// fixes the one thing wrong with it — the dead path. The argv is preserved
 /// verbatim, so `--pm-guard` stays `--pm-guard`.
 /// What: `Some(<installed><tail>)` when [`is_build_tree_hook_command`] claims
-/// `cmd`, where `<tail>` is the matched entry of [`TM_HOOK_ARGV_TAILS`];
-/// `None` for every command that predicate rejects, and for an `installed`
-/// path that is not valid UTF-8. It never inspects `installed` further — the
-/// caller ([`super::repoint::repoint_settings_file`]) validates it once, so a
-/// refusal is reported rather than silently collapsing into "nothing to do".
+/// `cmd` AND [`is_tm_writable_exe`] claims its executable, where `<tail>` is the
+/// matched entry of [`TM_HOOK_ARGV_TAILS`]; `None` for every command either
+/// rejects, and for an `installed` path that is not valid UTF-8. It never
+/// inspects `installed` further — the caller
+/// ([`super::repoint::repoint_settings_file`]) validates it once, so a refusal
+/// is reported rather than silently collapsing into "nothing to do".
 /// Test: `repointed_hook_command_rewrites_every_argv_shape`,
-/// `repointed_hook_command_declines_an_installed_binary`.
+/// `repointed_hook_command_declines_an_installed_binary`,
+/// `repointed_hook_command_declines_a_foreign_build_tree_stem`.
 pub fn repointed_hook_command(cmd: &str, installed: &Path) -> Option<String> {
     repointed(cmd, TM_HOOK_ARGV_TAILS, installed)
 }
@@ -179,14 +189,49 @@ fn exe_in_build_tree(cmd: &str, tails: &[&str]) -> bool {
 /// Shared rule behind both repointers above.
 ///
 /// Why (#7262): a repoint that used its own notion of "is this the damage" could
-/// rewrite a command the detector never flagged, or skip one it did. Deriving
-/// the rewrite from the SAME split the predicate answers with makes the two
-/// unable to disagree.
+/// rewrite a command the detector never flagged. Deriving the rewrite from the
+/// SAME split the predicate answers with makes the two unable to disagree about
+/// which commands are candidates. Repair then asks ONE more question detection
+/// does not — see [`is_tm_writable_exe`] — so the set it rewrites is a subset of
+/// the set the probe names, never a different set.
 /// What: `Some(<installed><tail>)` when [`split_build_tree_command`] claims
-/// `cmd`; `None` otherwise, or when `installed` is not valid UTF-8.
+/// `cmd` AND [`is_tm_writable_exe`] claims the executable half; `None`
+/// otherwise, or when `installed` is not valid UTF-8.
 fn repointed(cmd: &str, tails: &[&str], installed: &Path) -> Option<String> {
-    let (_, tail) = split_build_tree_command(cmd, tails)?;
+    let (exe, tail) = split_build_tree_command(cmd, tails)?;
+    if !is_tm_writable_exe(Path::new(exe)) {
+        return None;
+    }
     Some(format!("{}{tail}", installed.to_str()?))
+}
+
+/// Could tm's own writer have persisted `exe` as a hook command's executable?
+///
+/// Why (#7262 round 2): repair and detection are not the same question.
+/// Detection names a dead build artifact whoever owns it, which costs the
+/// operator a report line. Repair rewrites the command into `<installed tm>
+/// …`, which starts invoking tm on an event tm may never have registered — a
+/// project that builds its own `target/debug/mytool` and wires it with tm's
+/// argv would come back pointing at tm. That is a worse outcome than the dead
+/// path it replaces, so the rewrite requires the executable to be one tm's
+/// writer could actually have produced.
+/// What: `true` when the file name is a shipped tm stem
+/// ([`super::is_mpm_bin_stem_path`], a Cargo `-<hexhash>` suffix tolerated), or
+/// when the path is a hash-suffixed artifact under a `deps/` directory. That
+/// second arm is what #7244 wrote: the pre-fix writer persisted `current_exe()`
+/// of whatever harness was running, and Cargo places every such artifact at
+/// `…/deps/<stem>-<hexhash>`. A hand-named binary sitting directly in a build
+/// tree matches neither arm.
+/// Test: `repointed_hook_command_declines_a_foreign_build_tree_stem`,
+/// `repointed_hook_command_still_claims_what_tm_wrote`.
+fn is_tm_writable_exe(exe: &Path) -> bool {
+    if super::is_mpm_bin_stem_path(exe) {
+        return true;
+    }
+    let Some(name) = exe.file_name().and_then(|f| f.to_str()) else {
+        return false;
+    };
+    super::hash_stripped_stem(name) != name && exe.components().any(|c| c.as_os_str() == "deps")
 }
 
 /// Split `cmd` into its build-tree executable and the tm argv tail after it.

--- a/crates/trusty-mpm/src/core/standalone/hooks/build_tree.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/build_tree.rs
@@ -22,6 +22,13 @@
 //! clean`, and both writers' replace-by-identity strips — sees this shape
 //! without a second predicate to keep in sync.
 //!
+//! [`repointed_hook_command`] and [`repointed_statusline_command`] are the
+//! REPAIR half (#7262, reopened): they hand back the same command with its
+//! executable replaced by the installed binary and its argv untouched, which is
+//! what [`super::repoint`] writes back. Detection and repair share one split
+//! ([`split_build_tree_command`]), so a command the probe names is exactly a
+//! command the repair rewrites.
+//!
 //! **Where the line is drawn.** A build-tree path ALONE is not enough: a
 //! project may legitimately register its own hook that happens to live under
 //! `target/debug`, and tm must not delete another owner's entry. Both halves
@@ -127,6 +134,38 @@ pub fn is_build_tree_statusline_command(cmd: &str) -> bool {
     exe_in_build_tree(cmd, &[STATUSLINE_ARGV_TAIL])
 }
 
+/// The same hook command with its executable half replaced by `installed`
+/// (issue #7262).
+///
+/// Why: removing a corrupted hook entry and repointing it are different
+/// outcomes. Removal takes PM enforcement offline until the project's next
+/// managed launch; repointing keeps the entry the operator already has and
+/// fixes the one thing wrong with it — the dead path. The argv is preserved
+/// verbatim, so `--pm-guard` stays `--pm-guard`.
+/// What: `Some(<installed><tail>)` when [`is_build_tree_hook_command`] claims
+/// `cmd`, where `<tail>` is the matched entry of [`TM_HOOK_ARGV_TAILS`];
+/// `None` for every command that predicate rejects, and for an `installed`
+/// path that is not valid UTF-8. It never inspects `installed` further — the
+/// caller ([`super::repoint::repoint_settings_file`]) validates it once, so a
+/// refusal is reported rather than silently collapsing into "nothing to do".
+/// Test: `repointed_hook_command_rewrites_every_argv_shape`,
+/// `repointed_hook_command_declines_an_installed_binary`.
+pub fn repointed_hook_command(cmd: &str, installed: &Path) -> Option<String> {
+    repointed(cmd, TM_HOOK_ARGV_TAILS, installed)
+}
+
+/// The `statusLine.command` counterpart of [`repointed_hook_command`] (#7262).
+///
+/// Why: #7286 could only REPORT a build-tree `statusLine.command`, because the
+/// hooks writer does not own that key and stripping it would leave the operator
+/// with no statusline at all. Repointing has neither problem: the key keeps its
+/// value and gains a working path.
+/// What: as [`repointed_hook_command`], against [`STATUSLINE_ARGV_TAIL`].
+/// Test: `repointed_statusline_command_rewrites_the_incident_shape`.
+pub fn repointed_statusline_command(cmd: &str, installed: &Path) -> Option<String> {
+    repointed(cmd, &[STATUSLINE_ARGV_TAIL], installed)
+}
+
 /// Shared rule behind both predicates above.
 ///
 /// Why: the two differ only in which argv tails they accept; the path test is
@@ -134,11 +173,39 @@ pub fn is_build_tree_statusline_command(cmd: &str) -> bool {
 /// What: finds the first `tails` entry that is a suffix of `cmd`, then returns
 /// whether the remaining prefix is an absolute build-tree path.
 fn exe_in_build_tree(cmd: &str, tails: &[&str]) -> bool {
-    let Some(exe) = tails.iter().find_map(|tail| cmd.strip_suffix(tail)) else {
-        return false;
-    };
+    split_build_tree_command(cmd, tails).is_some()
+}
+
+/// Shared rule behind both repointers above.
+///
+/// Why (#7262): a repoint that used its own notion of "is this the damage" could
+/// rewrite a command the detector never flagged, or skip one it did. Deriving
+/// the rewrite from the SAME split the predicate answers with makes the two
+/// unable to disagree.
+/// What: `Some(<installed><tail>)` when [`split_build_tree_command`] claims
+/// `cmd`; `None` otherwise, or when `installed` is not valid UTF-8.
+fn repointed(cmd: &str, tails: &[&str], installed: &Path) -> Option<String> {
+    let (_, tail) = split_build_tree_command(cmd, tails)?;
+    Some(format!("{}{tail}", installed.to_str()?))
+}
+
+/// Split `cmd` into its build-tree executable and the tm argv tail after it.
+///
+/// Why: the predicate and the repointer ask the same question — is this
+/// executable a dead build artifact invoked with one of tm's own argv shapes —
+/// and only differ in what they do with the answer. One split, two consumers.
+/// What: `Some((exe, tail))` for the first `tails` entry that is a suffix of
+/// `cmd` whose remaining prefix is an ABSOLUTE path
+/// [`trusty_common::bin_resolve::is_ephemeral_build_path`] claims. A relative
+/// prefix is never matched: tm always persists an absolute path, so a bare
+/// `tm hook` belongs to the exact-name branch, not this one.
+fn split_build_tree_command<'a>(cmd: &'a str, tails: &[&'a str]) -> Option<(&'a str, &'a str)> {
+    let (exe, tail) = tails
+        .iter()
+        .find_map(|tail| cmd.strip_suffix(tail).map(|exe| (exe, *tail)))?;
     let path = Path::new(exe);
-    path.is_absolute() && trusty_common::bin_resolve::is_ephemeral_build_path(path)
+    (path.is_absolute() && trusty_common::bin_resolve::is_ephemeral_build_path(path))
+        .then_some((exe, tail))
 }
 
 // `pub(crate)` so the #7244 incident fixture below is written ONCE and shared

--- a/crates/trusty-mpm/src/core/standalone/hooks/build_tree_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/build_tree_tests.rs
@@ -144,6 +144,49 @@ fn build_tree_statusline_command_ignores_an_installed_binary() {
 }
 
 #[test]
+fn repointed_hook_command_rewrites_every_argv_shape() {
+    // #7262 (reopened): the repair keeps the argv and replaces only the path,
+    // so a `--pm-guard` entry comes back as a `--pm-guard` entry.
+    let installed = std::path::Path::new("/usr/local/bin/tm");
+    for tail in TM_HOOK_ARGV_TAILS {
+        assert_eq!(
+            repointed_hook_command(&format!("{INCIDENT_EXE}{tail}"), installed).as_deref(),
+            Some(format!("/usr/local/bin/tm{tail}").as_str()),
+            "tail {tail:?} was not repointed"
+        );
+    }
+}
+
+#[test]
+fn repointed_hook_command_declines_an_installed_binary() {
+    // Detection and repair share one split, so anything the predicate rejects
+    // the repointer must decline — that is what makes a second pass a no-op.
+    let installed = std::path::Path::new("/usr/local/bin/tm");
+    for cmd in [
+        "/usr/local/bin/tm hook",
+        "/usr/local/bin/tm hook --pm-guard",
+        "tm hook",
+        &format!("{INCIDENT_EXE} lint --fix"),
+    ] {
+        assert!(
+            repointed_hook_command(cmd, installed).is_none(),
+            "{cmd} should not be repointed"
+        );
+    }
+}
+
+#[test]
+fn repointed_statusline_command_rewrites_the_incident_shape() {
+    let installed = std::path::Path::new("/usr/local/bin/tm");
+    assert_eq!(
+        repointed_statusline_command(&format!("{INCIDENT_EXE} statusline"), installed).as_deref(),
+        Some("/usr/local/bin/tm statusline")
+    );
+    assert!(repointed_statusline_command(&format!("{INCIDENT_EXE} hook"), installed).is_none());
+    assert!(repointed_statusline_command("/usr/local/bin/tm statusline", installed).is_none());
+}
+
+#[test]
 fn statusline_tail_is_not_a_hook_tail() {
     // The two lists must stay disjoint: a strip driven by the hook predicate
     // must never claim a `statusLine` command it does not put back.

--- a/crates/trusty-mpm/src/core/standalone/hooks/build_tree_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/build_tree_tests.rs
@@ -195,3 +195,50 @@ fn statusline_tail_is_not_a_hook_tail() {
     )));
     assert!(!TM_HOOK_ARGV_TAILS.contains(&STATUSLINE_ARGV_TAIL));
 }
+
+/// #7262 round 2: detection is wide on purpose, but the REWRITE must not adopt
+/// another owner's entry. A project that builds its own `target/debug/mytool`
+/// and registers it with tm's argv would otherwise come back invoking tm.
+#[test]
+fn repointed_hook_command_declines_a_foreign_build_tree_stem() {
+    let installed = std::path::Path::new("/usr/local/bin/tm");
+    for exe in [
+        "/repo/target/debug/mytool",
+        "/repo/target/release/some_bin",
+        "/repo/target-7224/debug/deps/mytool",
+    ] {
+        let cmd = format!("{exe} hook");
+        assert!(
+            is_build_tree_hook_command(&cmd),
+            "{exe} is still named as a dead build artifact"
+        );
+        assert!(
+            repointed_hook_command(&cmd, installed).is_none(),
+            "{exe} must not be repointed"
+        );
+        assert!(
+            repointed_statusline_command(&format!("{exe} statusline"), installed).is_none(),
+            "{exe} statusline must not be repointed"
+        );
+    }
+}
+
+/// The other half of that rule: every shape tm's OWN writer produced before
+/// #7244 is still repaired — a tm stem anywhere in a build tree, and the
+/// hash-suffixed `deps/` artifact `current_exe()` yields for a Cargo binary.
+#[test]
+fn repointed_hook_command_still_claims_what_tm_wrote() {
+    let installed = std::path::Path::new("/usr/local/bin/tm");
+    for exe in [
+        "/repo/target/debug/tm",
+        "/repo/target-7224/debug/trusty-mpm",
+        "/repo/target/debug/deps/trusty_mpm-1a2b3c4d5e6f7a8b",
+        INCIDENT_EXE,
+    ] {
+        assert_eq!(
+            repointed_hook_command(&format!("{exe} hook"), installed).as_deref(),
+            Some("/usr/local/bin/tm hook"),
+            "{exe} must still be repaired"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -42,6 +42,7 @@ mod tests;
 pub(crate) mod backup;
 pub mod build_tree;
 pub mod cleanup;
+pub mod repoint;
 
 pub use build_tree::{is_build_tree_hook_command, is_build_tree_statusline_command};
 
@@ -126,7 +127,12 @@ pub fn mpm_hook_command(exe_override: Option<&Path>) -> Result<String, StableHoo
 /// Test: covered by `test_hook_command_uses_absolute_path`,
 /// `test_hook_command_rejects_ephemeral_exe_override`,
 /// `test_hook_command_rejects_system_temp_exe_override`.
-fn resolve_stable_hook_exe(exe_override: Option<&Path>) -> Result<PathBuf, StableHookExeError> {
+///
+/// `pub` since #7262 (reopened): [`crate::core::doctor_repair`] repoints a
+/// corrupted hook command at the installed binary, and the binary it repoints
+/// to must be resolved by the SAME rule the writers persist — a second resolver
+/// could hand the repair a path the writer would have refused.
+pub fn resolve_stable_hook_exe(exe_override: Option<&Path>) -> Result<PathBuf, StableHookExeError> {
     let running = exe_override
         .map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()))
         .or_else(|| {
@@ -530,17 +536,48 @@ pub fn is_mpm_hook_command(cmd: &str) -> bool {
 /// — checked here defensively so a command is NEVER double-classified.
 /// What: returns `true` when `cmd` contains the substring `claude-mpm` or
 /// `claude_mpm` (case-insensitive, covering both the installed CLI and a
-/// `.claude-mpm/`-rooted script path) AND [`is_mpm_hook_command`] does not
-/// already claim it.
+/// `.claude-mpm/`-rooted script path) OR its executable's file name is one of
+/// [`CLAUDE_MPM_HOOK_BIN_NAMES`], AND [`is_mpm_hook_command`] does not already
+/// claim it.
+///
+/// #7262 (reopened): the substring test alone reported CLEAN while claude-mpm's
+/// `claude-hook` shim raced tm's `PreToolUse` rewrite in a real project. The
+/// shim is invoked by BARE NAME off `PATH`, so no part of the command string
+/// names the harness — the check has to resolve what the command actually
+/// invokes, not look for a spelling of the owner's name inside it.
 /// Test: `test_is_claude_mpm_hook_command_recognises_foreign_signatures`,
-/// `test_is_claude_mpm_hook_command_never_overlaps_tm`.
+/// `test_is_claude_mpm_hook_command_never_overlaps_tm`,
+/// `is_claude_mpm_hook_command_recognises_the_bare_claude_hook_shim`.
 pub fn is_claude_mpm_hook_command(cmd: &str) -> bool {
     if is_mpm_hook_command(cmd) {
         return false;
     }
     let lower = cmd.to_ascii_lowercase();
-    lower.contains("claude-mpm") || lower.contains("claude_mpm")
+    if lower.contains("claude-mpm") || lower.contains("claude_mpm") {
+        return true;
+    }
+    // #7262: classify by the executable the command runs, not by a substring.
+    lower
+        .split_whitespace()
+        .next()
+        .map(Path::new)
+        .and_then(Path::file_name)
+        .and_then(|f| f.to_str())
+        .is_some_and(|stem| CLAUDE_MPM_HOOK_BIN_NAMES.contains(&stem))
 }
+
+/// Executable names that belong to the foreign claude-mpm harness (#7262).
+///
+/// Why: `claude-hook` is the shim the Python claude-mpm installs (observed at
+/// `~/.local/share/uv/tools/claude-mpm/`), and it is registered by bare name.
+/// Nothing in `claude-hook <args>` spells `claude-mpm`, so the substring test
+/// in [`is_claude_mpm_hook_command`] answered "not foreign" and
+/// `hooks_foreign_conflict` reported clean while both harnesses' `PreToolUse`
+/// hooks fired.
+/// What: file names, compared lower-cased against the command's first word.
+/// tm ships none of them, so this can never overlap [`is_mpm_hook_command`].
+/// Test: `is_claude_mpm_hook_command_recognises_the_bare_claude_hook_shim`.
+const CLAUDE_MPM_HOOK_BIN_NAMES: &[&str] = &["claude-hook", "claude_hook"];
 
 /// The two GLOBAL Claude settings files under `home`.
 ///

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -545,9 +545,12 @@ pub fn is_mpm_hook_command(cmd: &str) -> bool {
 /// shim is invoked by BARE NAME off `PATH`, so no part of the command string
 /// names the harness — the check has to resolve what the command actually
 /// invokes, not look for a spelling of the owner's name inside it.
+/// [`command_exe_is_named`] does that resolution, and reads an executable whose
+/// path contains a space.
 /// Test: `test_is_claude_mpm_hook_command_recognises_foreign_signatures`,
 /// `test_is_claude_mpm_hook_command_never_overlaps_tm`,
-/// `is_claude_mpm_hook_command_recognises_the_bare_claude_hook_shim`.
+/// `is_claude_mpm_hook_command_recognises_the_bare_claude_hook_shim`,
+/// `is_claude_mpm_hook_command_finds_the_shim_behind_a_spaced_path`.
 pub fn is_claude_mpm_hook_command(cmd: &str) -> bool {
     if is_mpm_hook_command(cmd) {
         return false;
@@ -557,13 +560,58 @@ pub fn is_claude_mpm_hook_command(cmd: &str) -> bool {
         return true;
     }
     // #7262: classify by the executable the command runs, not by a substring.
-    lower
-        .split_whitespace()
-        .next()
-        .map(Path::new)
-        .and_then(Path::file_name)
-        .and_then(|f| f.to_str())
-        .is_some_and(|stem| CLAUDE_MPM_HOOK_BIN_NAMES.contains(&stem))
+    command_exe_is_named(&lower, CLAUDE_MPM_HOOK_BIN_NAMES)
+}
+
+/// Does the executable `cmd` invokes have a file name in `names`?
+///
+/// Why (#7262 round 2): reading the executable as `split_whitespace().next()`
+/// stops at the first space, so
+/// `/Users/Some Name/.local/bin/claude-hook PreToolUse` resolved to
+/// `/Users/Some` and the shim went unseen. A space in a home directory or in
+/// `~/Library/Application Support/…` is ordinary on macOS.
+/// [`build_tree::is_build_tree_hook_command`] does not have the bug because it
+/// splits on a KNOWN argv tail and keeps the whole prefix; nothing here knows
+/// the foreign harness's argv, so the executable is found by growing the
+/// candidate instead of by cutting the tail off.
+/// What: tests the file name of each prefix of `cmd` that ends at a whitespace
+/// boundary, growing the candidate only while the next token continues a path —
+/// it contains a separator and starts with neither `/` nor `-`. That bound is
+/// what keeps `/usr/bin/env claude-hook` reading as `env` with an argument, and
+/// `foo --config /opt/claude-hook` as `foo` with a flag.
+/// Test: `is_claude_mpm_hook_command_finds_the_shim_behind_a_spaced_path`,
+/// `is_claude_mpm_hook_command_recognises_the_bare_claude_hook_shim`.
+fn command_exe_is_named(cmd: &str, names: &[&str]) -> bool {
+    let bytes = cmd.as_bytes();
+    let mut idx = 0;
+    let mut first = true;
+    while idx < bytes.len() {
+        while idx < bytes.len() && bytes[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+        let start = idx;
+        while idx < bytes.len() && !bytes[idx].is_ascii_whitespace() {
+            idx += 1;
+        }
+        if start == idx {
+            break;
+        }
+        let token = &cmd[start..idx];
+        let continues_path =
+            token.contains('/') && !token.starts_with('/') && !token.starts_with('-');
+        if !first && !continues_path {
+            break;
+        }
+        first = false;
+        if Path::new(&cmd[..idx])
+            .file_name()
+            .and_then(|f| f.to_str())
+            .is_some_and(|name| names.contains(&name))
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Executable names that belong to the foreign claude-mpm harness (#7262).
@@ -574,7 +622,8 @@ pub fn is_claude_mpm_hook_command(cmd: &str) -> bool {
 /// in [`is_claude_mpm_hook_command`] answered "not foreign" and
 /// `hooks_foreign_conflict` reported clean while both harnesses' `PreToolUse`
 /// hooks fired.
-/// What: file names, compared lower-cased against the command's first word.
+/// What: file names, compared lower-cased against the executable
+/// [`command_exe_is_named`] reads out of the command.
 /// tm ships none of them, so this can never overlap [`is_mpm_hook_command`].
 /// Test: `is_claude_mpm_hook_command_recognises_the_bare_claude_hook_shim`.
 const CLAUDE_MPM_HOOK_BIN_NAMES: &[&str] = &["claude-hook", "claude_hook"];

--- a/crates/trusty-mpm/src/core/standalone/hooks/repoint.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/repoint.rs
@@ -105,7 +105,11 @@ pub fn build_tree_commands_in(path: &Path) -> Vec<String> {
 /// Repoint every build-tree command in one settings file at `installed`.
 ///
 /// Why: see the module doc — this is the `--fix` arm `hooks_build_tree_binary`
-/// lacked, and the reason the 2026-09-10 repair had to be done by hand.
+/// lacked, and the reason the 2026-09-10 repair had to be done by hand. The
+/// read-modify-write below takes no cross-process lock, so a settings file
+/// written concurrently by another process loses one side's edit; that limit is
+/// shared with every other writer of a `.claude/settings.json` in this crate —
+/// [`super::write_project_hooks`] and [`super::cleanup::clean_settings_file`].
 /// What: reads `path` (missing → `Ok(None)`), parses it, and rewrites every
 /// command [`repointed_hook_command`] / [`repointed_statusline_command`]
 /// claims. Returns `Ok(None)` when nothing matched, which is also what a second

--- a/crates/trusty-mpm/src/core/standalone/hooks/repoint.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/repoint.rs
@@ -1,0 +1,243 @@
+//! Repair a persisted hook or `statusLine` command that points into a Cargo
+//! build tree, by repointing it at the installed binary (issue #7262).
+//!
+//! Why: #7286 taught `tm doctor` to SEE this corruption and stopped there.
+//! `tm doctor --fix` planned zero repairs for `hooks_build_tree_binary`, and on
+//! 2026-09-10 eight projects were repaired by hand with `sed`. The removal path
+//! that already exists is the wrong remedy here twice over: it takes PM
+//! enforcement offline until the project's next managed launch, and it cannot
+//! touch `statusLine.command` at all, because the hooks writer does not own that
+//! key and a strip would leave the operator with no statusline rather than a
+//! working one. Repointing has neither problem — the entry the operator already
+//! has keeps its argv and gains a path that exists.
+//!
+//! What: [`repoint_settings_file`] rewrites every command
+//! [`super::build_tree`] claims in one `.claude/settings*.json`, taking a
+//! timestamped snapshot ([`super::backup::snapshot_then_prune`], the same
+//! convention #7244's writer fix uses) before it writes, and writing atomically.
+//! [`build_tree_commands_in`] is the read-only probe the repair driver uses to
+//! decide whether a file is worth reporting when no installed binary could be
+//! resolved.
+//!
+//! **Fail-closed, everywhere.** A settings file that cannot be read, cannot be
+//! parsed, is not a JSON object, or cannot be snapshotted returns `Err` and is
+//! NOT rewritten — no backup is taken for an unparseable file, because there is
+//! nothing this module could write back that would preserve its contents. That
+//! is the opposite of [`super::cleanup::clean_settings_file`], which answers
+//! `Ok(None)` for a malformed file: `clean` is also the doctor probe's scanner
+//! and must tolerate a file it does not own, whereas this is a repair the
+//! operator asked for and a silent skip would read as "nothing was wrong".
+//!
+//! **Idempotent by construction.** A repointed command names an installed
+//! binary, which [`super::build_tree::is_build_tree_hook_command`] rejects, so a
+//! second pass finds nothing, returns `Ok(None)`, and writes nothing at all —
+//! not even a snapshot.
+//!
+//! Test: `repoint_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::backup::{HOOK_SETTINGS_SNAPSHOTS_KEPT, snapshot_then_prune};
+use super::build_tree::{repointed_hook_command, repointed_statusline_command};
+use super::cleanup::{build_tree_hook_commands, build_tree_statusline_command};
+
+/// What one [`repoint_settings_file`] pass found — or changed — in one file.
+///
+/// Why: the repair driver prints one line per file and must name the exact
+/// commands, because the operator's decision ("is that really tm's entry?")
+/// depends on the string and not on a count. Reporting the before/after pair
+/// rather than only the new value is what lets a dry run be read as a diff.
+/// What: the file, every `(old, new)` hook-command pair, the `statusLine` pair
+/// when that key was affected, and — only when `force` was set — the snapshot
+/// taken before the rewrite.
+/// Test: `repoint_settings_file_dry_run_changes_nothing`,
+/// `repoint_settings_file_applies_and_snapshots`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepointOutcome {
+    /// The settings file that was scanned.
+    pub path: PathBuf,
+    /// Every `hooks.<event>[*].hooks[*].command` rewritten, as `(old, new)`.
+    pub hooks: Vec<(String, String)>,
+    /// The `statusLine.command` rewrite, as `(old, new)`, when there was one.
+    pub statusline: Option<(String, String)>,
+    /// The snapshot written before mutating `path`, when `force` was set.
+    pub backup_path: Option<PathBuf>,
+}
+
+impl RepointOutcome {
+    /// How many commands this pass rewrote.
+    ///
+    /// Why: the driver's one-line summary counts commands, not files.
+    /// What: the hook rewrites plus the `statusLine` one.
+    /// Test: `repoint_settings_file_applies_and_snapshots`.
+    pub fn command_count(&self) -> usize {
+        self.hooks.len() + usize::from(self.statusline.is_some())
+    }
+}
+
+/// Every build-tree command in `path`, hooks and `statusLine` alike (#7262).
+///
+/// Why: when no installed binary can be resolved there is nothing to repoint
+/// to, and the driver must still say WHICH files carry the damage rather than
+/// falling silent. Answering that from the same classifiers the repair uses
+/// keeps the refusal and the repair talking about the same set.
+/// What: the hook commands then the `statusLine` command, in that order. Empty
+/// for a file that is missing, unreadable, unparseable, or clean — this is a
+/// "should I speak up" probe, and every one of those answers is "no". The
+/// repair itself reports a read or parse failure; see [`repoint_settings_file`].
+/// Test: `build_tree_commands_in_lists_the_incident_commands`,
+/// `build_tree_commands_in_is_empty_for_an_unparseable_file`.
+pub fn build_tree_commands_in(path: &Path) -> Vec<String> {
+    let Some(val) = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str::<Value>(&text).ok())
+        .filter(Value::is_object)
+    else {
+        return Vec::new();
+    };
+    let mut found = build_tree_hook_commands(&val);
+    found.extend(build_tree_statusline_command(&val));
+    found
+}
+
+/// Repoint every build-tree command in one settings file at `installed`.
+///
+/// Why: see the module doc — this is the `--fix` arm `hooks_build_tree_binary`
+/// lacked, and the reason the 2026-09-10 repair had to be done by hand.
+/// What: reads `path` (missing → `Ok(None)`), parses it, and rewrites every
+/// command [`repointed_hook_command`] / [`repointed_statusline_command`]
+/// claims. Returns `Ok(None)` when nothing matched, which is also what a second
+/// pass over an already-repaired file returns. With `force`, snapshots `path`
+/// to `<name>.<YYYYMMDDTHHMMSSZ>.bak` FIRST and then writes atomically via
+/// [`trusty_common::claude_config::write_json_atomic`]; in dry run the file is
+/// never opened for writing and `backup_path` is `None`.
+///
+/// Fail-closed on every failure it can reach: a read error other than
+/// `NotFound`, unparseable JSON, a non-object document, or a snapshot that
+/// could not be taken each return `Err` with nothing written and no backup
+/// left behind. `installed` is validated once, up front — an `installed` that
+/// is itself an ephemeral build path is refused rather than written, so this
+/// repair can never persist the corruption it exists to remove.
+/// Test: `repoint_settings_file_applies_and_snapshots`,
+/// `repoint_settings_file_dry_run_changes_nothing`,
+/// `repoint_settings_file_is_idempotent`,
+/// `repoint_settings_file_refuses_unparseable_json`,
+/// `repoint_settings_file_refuses_a_non_object_document`,
+/// `repoint_settings_file_refuses_an_ephemeral_installed_binary`,
+/// `repoint_settings_file_leaves_foreign_entries_alone`.
+pub fn repoint_settings_file(
+    path: &Path,
+    installed: &Path,
+    force: bool,
+) -> anyhow::Result<Option<RepointOutcome>> {
+    // #7262: writing a build-tree path back would recreate the exact damage.
+    if !installed.is_absolute() || trusty_common::bin_resolve::is_ephemeral_build_path(installed) {
+        anyhow::bail!(
+            "refusing to repoint at {} — it is not an installed absolute binary path",
+            installed.display()
+        );
+    }
+
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => anyhow::bail!("read {}: {e}", path.display()),
+    };
+    // Fail-closed: an unparseable file is reported, never rewritten and never
+    // backed up — a snapshot of a file we cannot restore buys nothing.
+    let mut val: Value = serde_json::from_str(&text).map_err(|e| {
+        anyhow::anyhow!(
+            "{} is not valid JSON ({e}) — refusing to rewrite it; no backup was taken",
+            path.display()
+        )
+    })?;
+    if !val.is_object() {
+        anyhow::bail!(
+            "{} is valid JSON but not an object — refusing to rewrite it",
+            path.display()
+        );
+    }
+
+    let hooks = rewrite_hook_commands(&mut val, installed);
+    let statusline = rewrite_statusline_command(&mut val, installed);
+    if hooks.is_empty() && statusline.is_none() {
+        return Ok(None);
+    }
+
+    let mut backup_path = None;
+    if force {
+        backup_path = snapshot_then_prune(path, HOOK_SETTINGS_SNAPSHOTS_KEPT)
+            .map_err(|e| anyhow::anyhow!("snapshot {}: {e}", path.display()))?;
+        trusty_common::claude_config::write_json_atomic(path, &val)
+            .map_err(|e| anyhow::anyhow!("write {}: {e}", path.display()))?;
+    }
+
+    Ok(Some(RepointOutcome {
+        path: path.to_path_buf(),
+        hooks,
+        statusline,
+        backup_path,
+    }))
+}
+
+/// Rewrite every build-tree `hooks.<event>[*].hooks[*].command` in place.
+///
+/// Why: the read-side walker in [`super::cleanup`] hands out `&str`, which
+/// cannot be assigned through. This is the same four-level traversal with
+/// mutable access, kept beside the only mutation that needs it rather than
+/// widening the shared walker to a shape one of its two callers cannot use.
+/// What: replaces each claimed command with its repointed form and returns the
+/// `(old, new)` pairs in document order. A level whose JSON shape is not the
+/// expected object/array is skipped, exactly as the read-side walker skips it.
+/// Test: `repoint_settings_file_applies_and_snapshots`,
+/// `repoint_settings_file_leaves_foreign_entries_alone`.
+fn rewrite_hook_commands(val: &mut Value, installed: &Path) -> Vec<(String, String)> {
+    let mut changed = Vec::new();
+    let Some(events) = val.get_mut("hooks").and_then(Value::as_object_mut) else {
+        return changed;
+    };
+    for groups in events.values_mut() {
+        let Some(groups) = groups.as_array_mut() else {
+            continue;
+        };
+        for group in groups {
+            let Some(entries) = group.get_mut("hooks").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            for entry in entries {
+                let Some(cmd) = entry.get("command").and_then(Value::as_str) else {
+                    continue;
+                };
+                let Some(new) = repointed_hook_command(cmd, installed) else {
+                    continue;
+                };
+                changed.push((cmd.to_string(), new.clone()));
+                entry["command"] = Value::String(new);
+            }
+        }
+    }
+    changed
+}
+
+/// Rewrite a build-tree `statusLine.command` in place (#7262, #4492).
+///
+/// Why: the corruption reaches this key too, and #7286 could only name it. The
+/// key is a single string rather than a nested array, so it gets its own
+/// two-line rewrite instead of a branch inside [`rewrite_hook_commands`].
+/// What: `Some((old, new))` when [`repointed_statusline_command`] claims the
+/// current value; `None` for any other shape or a missing key.
+/// Test: `repoint_settings_file_applies_and_snapshots`,
+/// `repoint_settings_file_ignores_an_installed_statusline`.
+fn rewrite_statusline_command(val: &mut Value, installed: &Path) -> Option<(String, String)> {
+    let cmd = val.get("statusLine")?.get("command")?.as_str()?;
+    let new = repointed_statusline_command(cmd, installed)?;
+    let old = cmd.to_string();
+    val["statusLine"]["command"] = Value::String(new.clone());
+    Some((old, new))
+}
+
+#[cfg(test)]
+#[path = "repoint_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/standalone/hooks/repoint_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/repoint_tests.rs
@@ -1,0 +1,277 @@
+//! Unit tests for [`super`] (the #7262 build-tree repoint repair).
+//!
+//! Why: split out of `repoint.rs` to keep the production file focused, mirroring
+//! the `{build_tree,cleanup}.rs` / `*_tests.rs` split already used here.
+//! What: one fixture per corruption shape the issue enumerates — a build-tree
+//! hook command, a build-tree `--pm-guard` command, a build-tree
+//! `statusLine.command` — each asserted detect → repair → clean, plus the
+//! idempotence pass, the unparseable-JSON refusal, and the refusal to repoint at
+//! an ephemeral binary.
+//! Test: this module IS the test suite for `super`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::super::build_tree::tests::{INCIDENT_EXE, incident_settings};
+use super::super::cleanup::{build_tree_hook_commands, build_tree_statusline_command};
+use super::*;
+
+/// An installed binary path the repoint may write.
+///
+/// Why: [`repoint_settings_file`] refuses a relative or ephemeral target, so
+/// every positive test needs one absolute path that no build-tree rule claims.
+/// Resolving the real `tm` would make the assertions depend on the host.
+/// What: a fixed absolute path outside any Cargo layout.
+const INSTALLED: &str = "/usr/local/bin/tm";
+
+/// Write `incident_settings()` into a fresh temp dir and hand back the path.
+fn seed_incident() -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("settings.json");
+    fs::write(&path, incident_settings().to_string()).expect("seed");
+    (tmp, path)
+}
+
+/// The parsed contents of `path`.
+fn read(path: &Path) -> serde_json::Value {
+    serde_json::from_str(&fs::read_to_string(path).expect("read")).expect("parse")
+}
+
+/// How many snapshot siblings of `path` exist.
+fn snapshot_count(path: &Path) -> usize {
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("a named file");
+    fs::read_dir(path.parent().expect("a parent"))
+        .expect("read_dir")
+        .flatten()
+        .filter(|e| {
+            let entry = e.file_name();
+            let entry = entry.to_string_lossy();
+            entry != name && entry.starts_with(name) && entry.ends_with(".bak")
+        })
+        .count()
+}
+
+#[test]
+fn repoint_settings_file_applies_and_snapshots() {
+    // The three corruption shapes at once: six lifecycle ` hook` commands, one
+    // ` hook --pm-guard`, and the `statusLine.command`.
+    let (_tmp, path) = seed_incident();
+    let before = read(&path);
+    assert_eq!(build_tree_hook_commands(&before).len(), 2, "two distinct");
+    assert!(build_tree_statusline_command(&before).is_some());
+
+    let outcome = repoint_settings_file(&path, Path::new(INSTALLED), true)
+        .expect("repoint")
+        .expect("the incident file carries build-tree commands");
+
+    // Seven hook entries carry the damage (six lifecycle + the guard).
+    assert_eq!(outcome.hooks.len(), 7, "{:?}", outcome.hooks);
+    assert_eq!(outcome.command_count(), 8, "plus the statusLine");
+    assert!(
+        outcome
+            .statusline
+            .as_ref()
+            .is_some_and(|(_, new)| new == "/usr/local/bin/tm statusline"),
+        "{:?}",
+        outcome.statusline
+    );
+    let backup = outcome.backup_path.expect("apply takes a snapshot");
+    assert_eq!(
+        fs::read_to_string(&backup).expect("backup readable"),
+        before.to_string(),
+        "the snapshot must be the file as it was"
+    );
+
+    // Detect-then-repair-then-clean: nothing left for the classifiers to name.
+    let after = read(&path);
+    assert!(build_tree_hook_commands(&after).is_empty(), "{after}");
+    assert!(build_tree_statusline_command(&after).is_none(), "{after}");
+    assert_eq!(
+        after["hooks"]["PreToolUse"][1]["hooks"][0]["command"],
+        serde_json::json!("/usr/local/bin/tm hook --pm-guard"),
+        "the guard keeps its argv and gains a working path"
+    );
+    // Every other key survives untouched.
+    assert_eq!(after["outputStyle"], serde_json::json!("trusty-mpm"));
+    assert_eq!(
+        after["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
+        serde_json::json!("trusty-memory prompt-context"),
+    );
+}
+
+#[test]
+fn repoint_settings_file_dry_run_changes_nothing() {
+    let (_tmp, path) = seed_incident();
+    let raw = fs::read_to_string(&path).expect("read");
+
+    let outcome = repoint_settings_file(&path, Path::new(INSTALLED), false)
+        .expect("repoint")
+        .expect("the damage is reported in dry run too");
+
+    assert_eq!(outcome.command_count(), 8);
+    assert!(outcome.backup_path.is_none(), "dry run snapshots nothing");
+    assert_eq!(fs::read_to_string(&path).expect("read"), raw);
+    assert_eq!(snapshot_count(&path), 0);
+}
+
+#[test]
+fn repoint_settings_file_is_idempotent() {
+    // #7262: the second pass must be a no-op — no rewrite, no snapshot, and a
+    // byte-identical file.
+    let (_tmp, path) = seed_incident();
+    repoint_settings_file(&path, Path::new(INSTALLED), true).expect("first pass");
+    let after_first = fs::read_to_string(&path).expect("read");
+    let snapshots_after_first = snapshot_count(&path);
+
+    let second = repoint_settings_file(&path, Path::new(INSTALLED), true).expect("second pass");
+
+    assert!(second.is_none(), "nothing left to repoint: {second:?}");
+    assert_eq!(
+        fs::read_to_string(&path).expect("read"),
+        after_first,
+        "the second pass must not rewrite the file"
+    );
+    assert_eq!(
+        snapshot_count(&path),
+        snapshots_after_first,
+        "the second pass must not take a snapshot either"
+    );
+}
+
+#[test]
+fn repoint_settings_file_refuses_unparseable_json() {
+    // Fail-closed: report, back up nothing, rewrite nothing.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("settings.json");
+    let raw = "{ \"hooks\": { \"PreToolUse\": [ ,,, ";
+    fs::write(&path, raw).expect("seed");
+
+    let err = repoint_settings_file(&path, Path::new(INSTALLED), true)
+        .expect_err("unparseable JSON must be an error, never a silent skip");
+
+    assert!(
+        err.to_string().contains("is not valid JSON"),
+        "the message must name the reason: {err}"
+    );
+    assert_eq!(fs::read_to_string(&path).expect("read"), raw);
+    assert_eq!(
+        snapshot_count(&path),
+        0,
+        "no backup of a file we cannot fix"
+    );
+}
+
+#[test]
+fn repoint_settings_file_refuses_a_non_object_document() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("settings.json");
+    fs::write(&path, "[1, 2, 3]").expect("seed");
+
+    let err = repoint_settings_file(&path, Path::new(INSTALLED), true)
+        .expect_err("a non-object settings document is not repairable");
+
+    assert!(err.to_string().contains("not an object"), "{err}");
+    assert_eq!(fs::read_to_string(&path).expect("read"), "[1, 2, 3]");
+}
+
+#[test]
+fn repoint_settings_file_refuses_an_ephemeral_installed_binary() {
+    // The repair must never write the class of path it exists to remove.
+    let (_tmp, path) = seed_incident();
+    let raw = fs::read_to_string(&path).expect("read");
+
+    let err = repoint_settings_file(&path, Path::new(INCIDENT_EXE), true)
+        .expect_err("an ephemeral target is refused");
+
+    assert!(err.to_string().contains("not an installed"), "{err}");
+    assert_eq!(fs::read_to_string(&path).expect("read"), raw);
+}
+
+#[test]
+fn repoint_settings_file_refuses_a_relative_installed_binary() {
+    let (_tmp, path) = seed_incident();
+    let err = repoint_settings_file(&path, Path::new("tm"), true)
+        .expect_err("a bare name is not an absolute installed path");
+    assert!(err.to_string().contains("not an installed"), "{err}");
+}
+
+#[test]
+fn repoint_settings_file_missing_file_is_noop() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("settings.json");
+    assert!(
+        repoint_settings_file(&missing, Path::new(INSTALLED), true)
+            .expect("a missing file is not an error")
+            .is_none()
+    );
+}
+
+#[test]
+fn repoint_settings_file_leaves_foreign_entries_alone() {
+    // A build-tree path alone is not enough — the argv must be one tm writes.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("settings.json");
+    let body = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "*",
+                "hooks": [
+                    { "type": "command", "command": format!("{INCIDENT_EXE} lint --fix") },
+                    { "type": "command", "command": "claude-hook pre" },
+                ]
+            }]
+        }
+    })
+    .to_string();
+    fs::write(&path, &body).expect("seed");
+
+    assert!(
+        repoint_settings_file(&path, Path::new(INSTALLED), true)
+            .expect("repoint")
+            .is_none()
+    );
+    assert_eq!(fs::read_to_string(&path).expect("read"), body);
+}
+
+#[test]
+fn repoint_settings_file_ignores_an_installed_statusline() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("settings.json");
+    let body = serde_json::json!({
+        "statusLine": { "type": "command", "command": "/usr/local/bin/tm statusline" }
+    })
+    .to_string();
+    fs::write(&path, &body).expect("seed");
+
+    assert!(
+        repoint_settings_file(&path, Path::new(INSTALLED), true)
+            .expect("repoint")
+            .is_none()
+    );
+    assert_eq!(fs::read_to_string(&path).expect("read"), body);
+}
+
+#[test]
+fn build_tree_commands_in_lists_the_incident_commands() {
+    let (_tmp, path) = seed_incident();
+    let found = build_tree_commands_in(&path);
+    assert_eq!(found.len(), 3, "two distinct hooks plus the statusLine");
+    assert!(
+        found.iter().all(|c| c.starts_with(INCIDENT_EXE)),
+        "{found:?}"
+    );
+}
+
+#[test]
+fn build_tree_commands_in_is_empty_for_an_unparseable_file() {
+    // The probe answers "should I speak up", and an unparseable file is the
+    // repair's error to report, not the probe's.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("settings.json");
+    fs::write(&path, "not json").expect("seed");
+    assert!(build_tree_commands_in(&path).is_empty());
+    assert!(build_tree_commands_in(&tmp.path().join("absent.json")).is_empty());
+}

--- a/crates/trusty-mpm/src/core/standalone/hooks/repoint_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/repoint_tests.rs
@@ -237,6 +237,39 @@ fn repoint_settings_file_leaves_foreign_entries_alone() {
 }
 
 #[test]
+fn repoint_settings_file_leaves_a_foreign_build_tree_binary_alone() {
+    // #7262 round 2: a build-tree path plus tm's argv does not prove the entry
+    // is tm's. Rewriting another owner's hook would start invoking tm on an
+    // event tm never registered — worse than the dead path it replaces.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let foreign = tmp.path().join("target").join("debug").join("mytool");
+    let path = tmp.path().join("settings.json");
+    let body = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "*",
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("{} hook", foreign.display()),
+                }]
+            }]
+        }
+    })
+    .to_string();
+    fs::write(&path, &body).expect("seed");
+
+    // The probe still NAMES it — a dead build artifact is worth reporting.
+    assert_eq!(build_tree_commands_in(&path).len(), 1);
+    assert!(
+        repoint_settings_file(&path, Path::new(INSTALLED), true)
+            .expect("repoint")
+            .is_none(),
+        "a foreign stem must not be repointed"
+    );
+    assert_eq!(fs::read_to_string(&path).expect("read"), body);
+}
+
+#[test]
 fn repoint_settings_file_ignores_an_installed_statusline() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let path = tmp.path().join("settings.json");

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -814,6 +814,27 @@ fn test_is_claude_mpm_hook_command_recognises_foreign_signatures() {
     assert!(!is_claude_mpm_hook_command("some-other-tool run"));
 }
 
+/// #7262 (reopened): `hooks_foreign_conflict` reported CLEAN while claude-mpm's
+/// `claude-hook` shim raced tm's `PreToolUse` rewrite in a real project. The
+/// shim is registered by BARE NAME, so no part of the command string spells the
+/// owning harness and the substring test could never see it.
+#[test]
+fn is_claude_mpm_hook_command_recognises_the_bare_claude_hook_shim() {
+    assert!(is_claude_mpm_hook_command("claude-hook"));
+    assert!(is_claude_mpm_hook_command("claude-hook PreToolUse"));
+    assert!(is_claude_mpm_hook_command("claude_hook Stop"));
+    // The observed install location resolves through the file NAME, not the
+    // `claude-mpm` directory it happens to sit under.
+    assert!(is_claude_mpm_hook_command(
+        "/Users/x/.local/share/uv/tools/claude-mpm/bin/claude-hook PreToolUse"
+    ));
+    // Only the executable word decides — an argument that happens to say it
+    // does not make a foreign hook.
+    assert!(!is_claude_mpm_hook_command("/usr/bin/env claude-hook"));
+    assert!(!is_claude_mpm_hook_command("some-tool claude-hook"));
+    assert!(!is_claude_mpm_hook_command("claude-hooks-lint run"));
+}
+
 /// Why (issue #2940): the two predicates gate mutually exclusive actions
 /// (strip vs. warn-only) — if they ever overlapped, `tm hooks clean` could
 /// delete a foreign harness's hooks, which is strictly the operator's call.

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -835,6 +835,28 @@ fn is_claude_mpm_hook_command_recognises_the_bare_claude_hook_shim() {
     assert!(!is_claude_mpm_hook_command("claude-hooks-lint run"));
 }
 
+/// #7262 round 2: taking the first whitespace token as the executable reads
+/// `/Users/Some Name/.local/bin/claude-hook PreToolUse` as `/Users/Some`, so
+/// the shim went unseen on any account whose home or `Application Support`
+/// path carries a space.
+#[test]
+fn is_claude_mpm_hook_command_finds_the_shim_behind_a_spaced_path() {
+    assert!(is_claude_mpm_hook_command(
+        "/Users/Some Name/.local/bin/claude-hook PreToolUse"
+    ));
+    assert!(is_claude_mpm_hook_command(
+        "/Users/x/Library/Application Support/foo/claude_hook Stop"
+    ));
+    // A flag ends the path, so an argument that names the shim still does not
+    // make the command foreign.
+    assert!(!is_claude_mpm_hook_command(
+        "/usr/bin/foo --config /opt/claude-hook"
+    ));
+    assert!(!is_claude_mpm_hook_command(
+        "/Users/Some Name/bin/other PreToolUse"
+    ));
+}
+
 /// Why (issue #2940): the two predicates gate mutually exclusive actions
 /// (strip vs. warn-only) — if they ever overlapped, `tm hooks clean` could
 /// delete a foreign harness's hooks, which is strictly the operator's call.

--- a/crates/trusty-mpm/src/daemon/doctor_hooks_hygiene.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_hooks_hygiene.rs
@@ -195,9 +195,12 @@ pub(super) fn check_hooks_hygiene(
 /// string — is readable on its own and the scan loop stays a scan loop.
 /// What: `Ok` when `offenders` is empty. Otherwise `Warn`, listing up to 5
 /// `<path>: <command>` pairs plus an overflow count, and naming
-/// `tm doctor --fix` / `tm hooks clean` as the repair. A `statusLine` command is
-/// listed too but not repaired by either — the message says so, because
-/// silently under-delivering on a named remedy is how #4948 happened.
+/// `tm doctor --fix` as the repair. #7262 (reopened): that repair now REPOINTS
+/// each command at the installed binary rather than removing it, `statusLine`
+/// included, and sweeps every settings file on the machine — the message says
+/// both, because silently under-delivering on a named remedy is how #4948
+/// happened and naming a project-scoped remedy for machine-wide damage is how
+/// this one came back.
 /// Test: `check_hooks_hygiene_reports_the_build_tree_incident_shape`,
 /// `check_hooks_hygiene_reports_a_build_tree_statusline`,
 /// `check_hooks_hygiene_build_tree_check_is_ok_for_an_installed_binary`.
@@ -224,11 +227,10 @@ fn build_tree_check(offenders: &[(PathBuf, String)]) -> DoctorCheck {
         CheckStatus::Warn,
         format!(
             "{} command{} point into a Cargo build tree and stop working the moment that \
-             artifact is rebuilt away — `tm doctor --fix` previews the removal of the hook \
-             entries for this project and `--yes` applies it, `tm hooks clean` sweeps every \
-             project under $HOME, and the correct command is re-rendered from the installed \
-             binary on the next managed launch. A `statusLine` command is reported here but \
-             repaired only by that relaunch. {}{}",
+             artifact is rebuilt away — `tm doctor --fix` previews repointing every one of \
+             them at the installed tm binary and `--yes` applies it, snapshotting each file \
+             first. That repair sweeps every settings file on the machine, not just this \
+             project, and repairs a `statusLine` command the same way (#7262). {}{}",
             offenders.len(),
             if offenders.len() == 1 { "" } else { "s" },
             shown.join("; "),

--- a/crates/trusty-mpm/src/daemon/doctor_legacy_overrides.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_legacy_overrides.rs
@@ -61,10 +61,29 @@ pub(super) fn check_legacy_overrides(project_dir: Option<&Path>) -> DoctorCheck 
         CheckStatus::Fail,
         format!(
             "{} retired override file(s) are NO LONGER READ and their contents do not \
-             reach the PM prompt: {} — {LEGACY_MIGRATION_HINT}",
+             reach the PM prompt: {} — {LEGACY_MIGRATION_HINT} {}",
             names.len(),
-            names.join(", ")
+            names.join(", "),
+            removal_command(&names),
         ),
+    )
+}
+
+/// The exact command that removes the retired files, for the failure text.
+///
+/// Why (#7262): this check has no `--fix` arm and must not grow one without an
+/// owner ruling — the files are TRACKED, so repairing them means deleting a
+/// file the project committed, which is not a call `tm doctor` may make on its
+/// own. What it can do is stop making the operator assemble the command: the
+/// finding names paths, and the remedy is one `git rm` over exactly those
+/// paths.
+/// What: `Run this once the sections are migrated: git rm <paths>`, space
+/// separated in the order [`detect_legacy_overrides`] found them.
+/// Test: `legacy_overrides_prints_the_exact_git_rm_command`.
+fn removal_command(names: &[String]) -> String {
+    format!(
+        "Once those sections are migrated, remove the files with: git rm {}",
+        names.join(" ")
     )
 }
 
@@ -103,6 +122,32 @@ mod tests {
 
         let check = check_legacy_overrides(Some(tmp.path()));
         assert_eq!(check.status, CheckStatus::Ok);
+    }
+
+    /// #7262: this check has no `--fix` arm — repairing it means deleting a
+    /// TRACKED file, which needs an owner ruling — so the failure text must at
+    /// least hand the operator the exact command instead of the shape of one.
+    #[test]
+    fn legacy_overrides_prints_the_exact_git_rm_command() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_legacy(tmp.path(), FILE_INSTRUCTIONS);
+        let expected = tmp.path().join(OVERRIDE_DIR_NAME).join(FILE_INSTRUCTIONS);
+
+        let check = check_legacy_overrides(Some(tmp.path()));
+
+        assert_eq!(
+            check.message.matches("git rm ").count(),
+            1,
+            "one command, not a hint: {}",
+            check.message
+        );
+        assert!(
+            check
+                .message
+                .contains(&format!("git rm {}", expected.display())),
+            "the command must name the file that was found: {}",
+            check.message
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Outcome
Refs #7262. `tm doctor --fix` now REPAIRS the hooks_build_tree_binary corruption #7286 only detected: each hook or statusLine command whose executable is a dead Cargo build-tree artifact tm's own writer could have persisted is repointed to the installed tm, keeping its argv. The sweep covers every `.claude/settings*.json` under `$HOME`, as the reopen asked. Two detection gaps closed: `hooks_foreign_conflict` now recognises the bare `claude-hook` shim (by executable name, including behind a spaced path), and `legacy_overrides` prints the exact `git rm` remedy.

## Changes
- `crates/trusty-mpm/src/core/standalone/hooks/repoint.rs` (new): `repoint_settings_file`, `build_tree_commands_in`.
- `hooks/build_tree.rs`: `repointed_hook_command` / `repointed_statusline_command` over the shared `split_build_tree_command`; `is_tm_writable_exe` gate (critic HIGH: a foreign build-tree binary is reported, never repointed).
- `core/doctor_repair.rs`, `bin/tm/commands/doctor_repair.rs`: `repair_build_tree_binary` runs before `repair_hooks_contamination`, over `machine_wide_settings_files`.
- `hooks/mod.rs`: `is_claude_mpm_hook_command` classifies by executable file name; `command_exe_is_named` handles a space in the path (critic MEDIUM).
- `daemon/doctor_legacy_overrides.rs`: exact `git rm` remedy text.
- Fragments: `changelog.d/7262-settings-corruption-repair.md` (Added), `changelog.d/7262-foreign-shim-and-legacy-remedy.md` (Fixed).

## Risk
High: persisted config rewritten across every project on the machine. Bounded by dry-run default, a timestamped snapshot per file before any write, tmp-then-rename writes, idempotence, and fail-closed on unparseable or non-object JSON. Known limit, pre-existing and shared with every settings.json writer in the crate: no cross-process lock, so a concurrent harness write to the same file can be lost (named in the Why doc of `repoint_settings_file`).

## Tests
Rung 3, `-p trusty-mpm`: fmt --check, clippy --all-targets -D warnings, `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — 56 targets, 11985 passed, 0 failed, 18 ignored. New: 10 `repoint::tests` (one per corruption shape detect→repair→clean, idempotence, unparseable JSON, non-object, ephemeral/relative target refusals, foreign-entry negative), 6 `build_tree_repair_*`, 3 `build_tree::tests`, the two detection tests, and the three critic-fold tests. Fails-before shown on 7886f486c and origin/main.

## Baseline
origin/main 132f557da, green.

## Docs
Why/What/Test on every new public item; `// #7262:` at change sites. Doc gates: check_line_cap, check_changelog_fragment (staged + post-commit), check_test_pointers, check_sld, check_doc_paths — all OK.

## Review
code-critic WARN (one HIGH, two MEDIUM); HIGH and one MEDIUM folded in 855ed18bd, the lock MEDIUM documented as a shared pre-existing limit. Credential scan of `origin/main...HEAD`: PASS.

https://claude.ai/code/session_0194bkFi1G1Wv3kh1bVbMw4q

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
