### PR TITLE
fix(trusty-mpm): emit the retired-override ERROR once per launch, not twice (Refs #7326)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7326-retired-override-single-signal.md
+++ b/crates/trusty-mpm/changelog.d/7326-retired-override-single-signal.md
@@ -1,0 +1,3 @@
+Fixed
+
+- A launch with a leftover retired `.trusty-mpm/` override file logged the "RETIRED override file is NO LONGER READ" ERROR twice, because one launch resolves the PM prompt twice — once for the `prepare_session` stash and once for the launch itself. The emitter now reports each file at most once per process, keyed by path so a second project still reports its own leftover (#7326).

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -20,8 +20,9 @@
 //! is reported by `warn_unapplied` rather than dropped in silence.
 //!
 //! [`detect_legacy_overrides`] reports leftover retired files;
-//! [`warn_legacy_overrides`] logs them on every resolution, and the
-//! `legacy_overrides` `tm doctor` check fails on them.
+//! [`warn_legacy_overrides`] logs them once per file per process (#7326 — one
+//! launch resolves the prompt twice), and the `legacy_overrides` `tm doctor`
+//! check fails on them.
 //!
 //! Naming note: `base_pm()` and the `# Framework Instructions` heading are
 //! historical labels. `BASE_PM.md` the FILE was deleted by #4183 and
@@ -127,16 +128,65 @@ pub fn detect_legacy_overrides(project_dir: &Path) -> Vec<std::path::PathBuf> {
 /// rather than `warn!` deliberately: the project's instructions are no longer
 /// reaching the PM, which is a broken configuration, not a style note.
 /// What: one `tracing::error!` per leftover file, naming the path and
-/// [`LEGACY_MIGRATION_HINT`]. Silent when the project is clean.
-/// Test: `legacy_file_signal_names_the_migration`.
+/// [`LEGACY_MIGRATION_HINT`], and at most one per file for the life of the
+/// process — see [`claim_legacy_warning`]. Silent when the project is clean.
+/// Test: `legacy_file_signal_names_the_migration`,
+/// `the_retired_override_signal_is_emitted_once_per_launch`.
 fn warn_legacy_overrides(project_dir: &Path) {
     for path in detect_legacy_overrides(project_dir) {
+        // #7326: one launch resolves the prompt twice — once for the
+        // `prepare_session` stash, once for the launch itself.
+        if !claim_legacy_warning(&path) {
+            continue;
+        }
         tracing::error!(
             path = %path.display(),
             migration = LEGACY_MIGRATION_HINT,
             "RETIRED override file is NO LONGER READ (#4286): its contents do not reach \
              the PM prompt"
         );
+    }
+}
+
+/// Files [`warn_legacy_overrides`] has already reported in this process.
+///
+/// Why (#7326): a launch resolves the prompt TWICE — `prepare_session` writes
+/// the inspectable stash from one resolution and the launcher builds the
+/// delivered prompt from a second — so a per-resolution log line said the same
+/// thing twice for one launch. Deduping inside the emitter rather than hoisting
+/// the call to a launch entry point keeps the signal where it is guaranteed to
+/// observe the condition; every launch path composes a prompt, while the set of
+/// launch entry points grows and a new one would silently ship without the
+/// signal. Process-global rather than a threaded parameter because the two
+/// resolutions sit in different modules with no shared handle between them, and
+/// the CLI process IS the launch. Keyed by PATH, not by a bare `Once`, so a
+/// distinct project still reports and each test's own `TempDir` stays
+/// independent of execution order.
+///
+/// Accepted tradeoff: a long-lived daemon reports a given file once per daemon
+/// lifetime rather than once per launch. `tm doctor`'s `legacy_overrides` check
+/// is the on-demand half of the same signal and is unaffected.
+/// What: lazily-initialized `Mutex`-guarded set of reported paths, accessed only
+/// via [`claim_legacy_warning`].
+/// Test: `the_retired_override_signal_is_emitted_once_per_launch`,
+/// `two_projects_each_report_their_own_retired_file`.
+static WARNED_LEGACY_PATHS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<std::path::PathBuf>>,
+> = std::sync::OnceLock::new();
+
+/// Claim the right to report `path`; true exactly once per process per path.
+///
+/// Why: see [`WARNED_LEGACY_PATHS`]. A poisoned lock EMITS rather than swallows —
+/// #4286's whole point is that a retired file is never silent, so the failure
+/// mode of the dedupe must be a duplicate line, never a missing one.
+/// What: inserts `path` into the process-global set and reports whether the
+/// insert was new.
+/// Test: `the_retired_override_signal_is_emitted_once_per_launch`.
+fn claim_legacy_warning(path: &Path) -> bool {
+    let set = WARNED_LEGACY_PATHS.get_or_init(|| std::sync::Mutex::new(Default::default()));
+    match set.lock() {
+        Ok(mut seen) => seen.insert(path.to_path_buf()),
+        Err(_) => true,
     }
 }
 

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -159,17 +159,31 @@ fn warn_legacy_overrides(project_dir: &Path) {
 /// launch entry points grows and a new one would silently ship without the
 /// signal. Process-global rather than a threaded parameter because the two
 /// resolutions sit in different modules with no shared handle between them, and
-/// the CLI process IS the launch. Keyed by PATH, not by a bare `Once`, so a
-/// distinct project still reports and each test's own `TempDir` stays
+/// the CLI process IS the launch.
+///
+/// Global state, named plainly: this is a keyed once-per-process set, and it
+/// goes beyond the codebase's one precedent under CLAUDE.md's "No global state"
+/// rule — `warn_once_about_the_keychain` in
+/// `crates/trusty-mpm/src/session_manager/worktree_reclaim_gh.rs` uses a bare
+/// `std::sync::Once`. A bare `Once` is insufficient here: it latches on the
+/// first call and is closed to every later one, so the daemon — one process
+/// that resolves prompts for many projects — would let the first project's
+/// leftover file silence the second project's. The key is the FILE PATH, so
+/// each project reports its own file once, and each test's own `TempDir` stays
 /// independent of execution order.
 ///
 /// Accepted tradeoff: a long-lived daemon reports a given file once per daemon
-/// lifetime rather than once per launch. `tm doctor`'s `legacy_overrides` check
-/// is the on-demand half of the same signal and is unaffected.
+/// lifetime rather than once per launch. Enforcement does not run through this
+/// log line at all — the on-demand `legacy_overrides` `tm doctor` check
+/// (`check_legacy_overrides`, in
+/// `crates/trusty-mpm/src/daemon/doctor_legacy_overrides.rs`) reads the same
+/// [`detect_legacy_overrides`] and `Fail`s while the file is present, however
+/// many times the line was logged (#4286).
 /// What: lazily-initialized `Mutex`-guarded set of reported paths, accessed only
 /// via [`claim_legacy_warning`].
 /// Test: `the_retired_override_signal_is_emitted_once_per_launch`,
-/// `two_projects_each_report_their_own_retired_file`.
+/// `two_projects_each_report_their_own_retired_file`,
+/// `a_poisoned_dedupe_lock_still_emits`.
 static WARNED_LEGACY_PATHS: std::sync::OnceLock<
     std::sync::Mutex<std::collections::HashSet<std::path::PathBuf>>,
 > = std::sync::OnceLock::new();
@@ -181,7 +195,8 @@ static WARNED_LEGACY_PATHS: std::sync::OnceLock<
 /// mode of the dedupe must be a duplicate line, never a missing one.
 /// What: inserts `path` into the process-global set and reports whether the
 /// insert was new.
-/// Test: `the_retired_override_signal_is_emitted_once_per_launch`.
+/// Test: `the_retired_override_signal_is_emitted_once_per_launch`,
+/// `a_poisoned_dedupe_lock_still_emits`.
 fn claim_legacy_warning(path: &Path) -> bool {
     let set = WARNED_LEGACY_PATHS.get_or_init(|| std::sync::Mutex::new(Default::default()));
     match set.lock() {

--- a/crates/trusty-mpm/src/core/instruction_overrides_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides_tests.rs
@@ -629,3 +629,74 @@ fn one_surface_rule_lives_in_core_and_survives_an_override_attempt() {
         );
     }
 }
+
+// ── #7326: the retired-override signal is emitted once per launch ─────────
+
+/// Every line the resolver logged while composing `project`'s prompt `times`.
+///
+/// Why: the defect is a COUNT, and the count is only observable in the emitted
+/// events — the composed prompt is byte-identical either way. Resolving twice
+/// in one capture is the launch shape: `prepare_session` writes the stash from
+/// one resolution and the launcher builds the delivered prompt from a second.
+/// What: installs a thread-local buffering subscriber, resolves `times` times,
+/// and returns what was recorded.
+/// Test: this is test scaffolding for the two tests below.
+fn resolved_log_lines(project: &Path, times: usize) -> Vec<String> {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    // #4931: `with_default` is thread-local and never raises the process-global
+    // MAX_LEVEL, so without this the capture records nothing.
+    crate::test_support::enable_event_capture();
+    let buffer = trusty_common::log_buffer::LogBuffer::new(64);
+    let subscriber = tracing_subscriber::registry().with(
+        trusty_common::log_buffer::LogBufferLayer::new(buffer.clone()),
+    );
+    tracing::subscriber::with_default(subscriber, || {
+        for _ in 0..times {
+            let _ =
+                resolve_pm_prompt_with_roster(project, || Some("## Delegation Authority".into()));
+        }
+    });
+    buffer.tail(64)
+}
+
+/// How many captured lines carry the retired-override signal.
+fn retired_signals(lines: &[String]) -> usize {
+    lines
+        .iter()
+        .filter(|l| l.contains("RETIRED override file is NO LONGER READ"))
+        .count()
+}
+
+#[test]
+#[serial_test::serial]
+fn the_retired_override_signal_is_emitted_once_per_launch() {
+    // #7326: one launch resolves the prompt twice, and both resolutions reached
+    // the emitter, so a project with one leftover retired file got the ERROR
+    // line twice for one launch. Against the pre-fix code this is 2.
+    let tmp = TempDir::new().unwrap();
+    write_override(tmp.path(), FILE_WORKFLOW, "leftover");
+    assert_eq!(detect_legacy_overrides(tmp.path()).len(), 1);
+
+    let lines = resolved_log_lines(tmp.path(), 2);
+    assert_eq!(
+        retired_signals(&lines),
+        1,
+        "one launch, one signal: {lines:#?}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn two_projects_each_report_their_own_retired_file() {
+    // The dedupe is keyed by PATH, not by a process-wide `Once` — a second
+    // project's leftover file must still be reported, or the fix would silence
+    // the condition it exists to make loud.
+    let a = TempDir::new().unwrap();
+    let b = TempDir::new().unwrap();
+    write_override(a.path(), FILE_MEMORY, "leftover");
+    write_override(b.path(), FILE_MEMORY, "leftover");
+
+    assert_eq!(retired_signals(&resolved_log_lines(a.path(), 2)), 1);
+    assert_eq!(retired_signals(&resolved_log_lines(b.path(), 2)), 1);
+}

--- a/crates/trusty-mpm/src/core/instruction_overrides_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides_tests.rs
@@ -700,3 +700,45 @@ fn two_projects_each_report_their_own_retired_file() {
     assert_eq!(retired_signals(&resolved_log_lines(a.path(), 2)), 1);
     assert_eq!(retired_signals(&resolved_log_lines(b.path(), 2)), 1);
 }
+
+#[test]
+#[serial_test::serial]
+fn a_poisoned_dedupe_lock_still_emits() {
+    // #7326: the dedupe's failure mode must be a DUPLICATE line, never a
+    // missing one — #4286 exists so a retired file is never silent. Flipping
+    // `claim_legacy_warning`'s `Err(_)` arm to `false` fails the final assert.
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("leftover-WORKFLOW.md");
+
+    // Claim once against a healthy lock: this initializes the `OnceLock` and
+    // puts `path` in the set, so a healthy lock would answer `false` below.
+    assert!(claim_legacy_warning(&path), "first claim on a healthy lock");
+
+    // Poison the lock by panicking while holding it. The panic is expected, so
+    // silence the default hook for the duration rather than printing a
+    // backtrace into a passing run's output.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let poisoner = std::thread::spawn(|| {
+        let _guard = WARNED_LEGACY_PATHS
+            .get()
+            .expect("initialized by the claim above")
+            .lock()
+            .expect("not poisoned yet");
+        panic!("poisoning the dedupe lock");
+    });
+    let outcome = poisoner.join();
+    std::panic::set_hook(previous_hook);
+    assert!(outcome.is_err(), "the poisoning thread must have panicked");
+
+    let set = WARNED_LEGACY_PATHS.get().expect("initialized");
+    assert!(set.is_poisoned(), "the lock must be poisoned");
+    assert!(
+        claim_legacy_warning(&path),
+        "an already-claimed path still emits once the lock is poisoned"
+    );
+
+    // Leave the process-global lock healthy for every other test in this
+    // binary; `#[serial]` guarantees none is mid-claim right now.
+    set.clear_poison();
+}


### PR DESCRIPTION
## Outcome
Refs #7326. One launch resolves the PM prompt twice (`prepare_session_inner` writes the stash, the launcher builds the delivered prompt), and both paths reached `warn_legacy_overrides`, so a retired `.trusty-mpm/*.md` override logged its #4286 ERROR twice. The emitter now dedupes per file path, once per process.

## Changes
- `crates/trusty-mpm/src/core/instruction_overrides.rs`: `WARNED_LEGACY_PATHS` keyed set and `claim_legacy_warning`; a poisoned lock emits rather than swallows. Why doc names why a bare `Once` is insufficient (one daemon process, many projects) and that `check_legacy_overrides` in `daemon/doctor_legacy_overrides.rs` stays the on-demand enforcement path.
- `instruction_overrides_tests.rs`: `the_retired_override_signal_is_emitted_once_per_launch`, `two_projects_each_report_their_own_retired_file`, `a_poisoned_dedupe_lock_still_emits`.
- `changelog.d/7326-retired-override-single-signal.md`.

## Risk
Normal, localized. Process-global dedupe is a deliberate exception to the no-global-state rule, documented at the site.

## Tests
Rung 3, `-p trusty-mpm`: fmt --check, check, clippy --all-targets -D warnings, `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — 56 targets, 11959 passed, 0 failed, 18 ignored. The once-per-launch test fails on origin/main (left: 2, right: 1); the poisoned-lock test fails with the arm flipped to `false`.

## Baseline
origin/main 132f557da, green.

## Docs
Why/What/Test on the new items; `// #7326:` at the change site. check_line_cap, check_changelog_fragment, check_test_pointers — OK.

## Review
code-critic APPROVE with two MEDIUM findings, both folded in 450174894. Credential scan of `origin/main...HEAD`: PASS.

https://claude.ai/code/session_0194bkFi1G1Wv3kh1bVbMw4q

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
