### PR TITLE
fix(trusty-mpm): tm pr open accepts a trailing session link after the attribution footer (Refs #7297)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7297-pr-open-footer-session-line.md
+++ b/crates/trusty-mpm/changelog.d/7297-pr-open-footer-session-line.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `tm pr open` no longer rejects a PR body that ends with the attribution footer, a blank line, and the `https://claude.ai/code/session_…` link — the exact shape Claude Code's provisioned attribution tells a session to write. The footer may now be the last non-blank line or the last one above a single trailing session link, in either the bare or `Claude-Session:`-labelled form; a session link before the footer still passes and a body with no footer at all is still refused (#7297).

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/body.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/body.rs
@@ -259,14 +259,29 @@ const SESSION_LINE_LABEL: &str = "Claude-Session:";
 
 /// Is `line` a session link belonging to the attribution block?
 ///
-/// Why/What/Test: see [`SESSION_LINK_PREFIX`]. A bare prefix with no session id
-/// after it is not a link, so it cannot stand in for the footer.
+/// Why: see [`SESSION_LINK_PREFIX`]. A prefix test alone accepted anything that
+/// merely STARTED with the URL, so a line of prose trailing the link — or an
+/// entire sentence after it — passed as attribution and could close a body or
+/// be skipped as section content.
+/// What: the whole line, after an optional [`SESSION_LINE_LABEL`] and the
+/// whitespace behind it, must be the prefix plus a non-empty session id of
+/// ASCII alphanumerics, `_` and `-`. Anything else — an empty id, a space, a
+/// trailing word, punctuation — is not a session link.
+/// Test: `footer_accepts_the_trailing_session_link`,
+/// `footer_accepts_a_session_link_before_the_footer`,
+/// `footer_rejects_a_session_link_with_trailing_junk`.
 fn is_session_link(line: &str) -> bool {
     let text = line.trim();
     let url = text
         .strip_prefix(SESSION_LINE_LABEL)
         .map_or(text, str::trim_start);
-    url.len() > SESSION_LINK_PREFIX.len() && url.starts_with(SESSION_LINK_PREFIX)
+    let Some(id) = url.strip_prefix(SESSION_LINK_PREFIX) else {
+        return false;
+    };
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
 /// Does `body` end with the attribution block?
@@ -280,7 +295,9 @@ fn is_session_link(line: &str) -> bool {
 /// body with no footer at all is false, whatever else it ends with.
 /// Test: `footer_must_be_last_line`, `footer_accepts_the_trailing_session_link`,
 /// `footer_accepts_a_session_link_before_the_footer`,
-/// `footer_rejects_a_body_with_no_attribution_line`.
+/// `footer_rejects_a_body_with_no_attribution_line`,
+/// `footer_rejects_a_session_link_with_trailing_junk`,
+/// `footer_rejects_two_stacked_session_links`.
 fn footer_closes(body: &str) -> bool {
     let mut tail = body.lines().rev().filter(|l| !l.trim().is_empty());
     match tail.next() {
@@ -336,7 +353,8 @@ impl IssueLink {
 /// `issue_link_rejects_a_closing_keyword_outside_field_one`,
 /// `issue_link_rejects_a_negated_closing_keyword`,
 /// `issue_link_allows_prose_that_only_looks_like_a_keyword`,
-/// `issue_link_without_issue_leaves_body_alone`.
+/// `issue_link_without_issue_leaves_body_alone`,
+/// `issue_link_lands_above_a_footer_a_session_link_trails`.
 pub(crate) fn apply_issue_link(
     body: &str,
     issue: Option<u64>,

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/body.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/body.rs
@@ -19,7 +19,8 @@
 //! are string-shaped facts about a file, so both are checkable.
 //!
 //! What: [`Field`] names the seven, [`validate`] reports which are missing or
-//! empty and whether the footer is the last non-blank line, and
+//! empty and whether the body ends with the attribution block — the footer,
+//! optionally followed by the harness's session link (#7297) — and
 //! [`apply_issue_link`] resolves this repo's `Refs #N` / `Closes #N` rule
 //! (root `CLAUDE.md`, "Key Conventions": fix PRs use `Refs #N`, **never**
 //! `Closes #N`).
@@ -120,7 +121,7 @@ pub(crate) struct BodyReport {
     pub(crate) missing: Vec<Field>,
     /// Fields whose heading exists but whose section body is blank.
     pub(crate) empty: Vec<Field>,
-    /// Whether [`ATTRIBUTION_FOOTER`] is the last non-blank line.
+    /// Whether the body ends with the attribution block — see [`footer_closes`].
     pub(crate) footer_ok: bool,
     /// Fields that were present AND non-empty, in contract order.
     pub(crate) supplied: Vec<Field>,
@@ -146,7 +147,8 @@ impl BodyReport {
         }
         if !self.footer_ok {
             out.push(format!(
-                "attribution footer is not the last non-blank line (expected `{ATTRIBUTION_FOOTER}`)"
+                "body does not end with the attribution footer `{ATTRIBUTION_FOOTER}` \
+                 (a single trailing `{SESSION_LINK_PREFIX}…` line after it is allowed)"
             ));
         }
         out
@@ -187,12 +189,16 @@ fn heading_text(line: &str) -> Option<String> {
 /// What: walks the body once. Each ATX heading claims the FIRST contract field
 /// it matches that is not already claimed, so `## Docs / changelog` cannot
 /// also satisfy `## Review`. A field's section is its lines up to the next
-/// heading; the attribution footer line never counts as section content, so a
-/// section holding only the footer is reported empty. The footer must be the
-/// last non-blank line of the file.
+/// heading; no line of the attribution block — the footer, and the session link
+/// the harness pairs with it — counts as section content, so a section holding
+/// only those is reported empty. The footer must be the last non-blank line,
+/// or the last one above a single trailing session link (#7297).
 /// Test: `body_accepts_a_complete_body`, `body_reports_each_missing_field`,
 /// `body_reports_empty_section`, `footer_must_be_last_line`,
-/// `footer_alone_does_not_fill_a_section`.
+/// `footer_alone_does_not_fill_a_section`,
+/// `footer_accepts_the_trailing_session_link`,
+/// `footer_accepts_a_session_link_before_the_footer`,
+/// `footer_rejects_a_body_with_no_attribution_line`.
 pub(crate) fn validate(body: &str) -> BodyReport {
     // (field, heading seen, section held content) — one row per contract field.
     let mut seen: Vec<(Field, bool, bool)> = FIELDS.iter().map(|f| (*f, false, false)).collect();
@@ -209,7 +215,9 @@ pub(crate) fn validate(body: &str) -> BodyReport {
             continue;
         }
         let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed == ATTRIBUTION_FOOTER {
+        // #7297: the session link is part of the attribution block, so like the
+        // footer it can never be what fills a section.
+        if trimmed.is_empty() || trimmed == ATTRIBUTION_FOOTER || is_session_link(trimmed) {
             continue;
         }
         if let Some(idx) = current {
@@ -217,11 +225,7 @@ pub(crate) fn validate(body: &str) -> BodyReport {
         }
     }
 
-    let footer_ok = body
-        .lines()
-        .rev()
-        .find(|l| !l.trim().is_empty())
-        .is_some_and(|l| l.trim() == ATTRIBUTION_FOOTER);
+    let footer_ok = footer_closes(body);
 
     let mut report = BodyReport {
         footer_ok,
@@ -235,6 +239,57 @@ pub(crate) fn validate(body: &str) -> BodyReport {
         }
     }
     report
+}
+
+/// The Claude Code session link the harness pairs with the footer.
+///
+/// Why (#7297): Claude Code's provisioned attribution instructs a session to
+/// end a PR body with the footer, a blank line, then this link. The validator
+/// required the footer to be the LAST non-blank line, so a session that
+/// followed its own instructions could not open a PR with `tm pr open` and fell
+/// back to `gh pr create` — which skips the seven-field gate entirely.
+/// What: the URL prefix, matched with or without the `Claude-Session:` label
+/// the commit-message form of the same block uses.
+/// Test: `footer_accepts_the_trailing_session_link`,
+/// `footer_accepts_a_session_link_before_the_footer`.
+const SESSION_LINK_PREFIX: &str = "https://claude.ai/code/session_";
+
+/// Label the commit-message form of the session line carries.
+const SESSION_LINE_LABEL: &str = "Claude-Session:";
+
+/// Is `line` a session link belonging to the attribution block?
+///
+/// Why/What/Test: see [`SESSION_LINK_PREFIX`]. A bare prefix with no session id
+/// after it is not a link, so it cannot stand in for the footer.
+fn is_session_link(line: &str) -> bool {
+    let text = line.trim();
+    let url = text
+        .strip_prefix(SESSION_LINE_LABEL)
+        .map_or(text, str::trim_start);
+    url.len() > SESSION_LINK_PREFIX.len() && url.starts_with(SESSION_LINK_PREFIX)
+}
+
+/// Does `body` end with the attribution block?
+///
+/// Why: the block is the footer, optionally followed by the session link — both
+/// orderings are in live use, because agents blocked by the old rule moved the
+/// link ABOVE the footer to get a PR open (#7297). Accepting both keeps those
+/// bodies valid while letting a session follow its own attribution instruction.
+/// What: true when the last non-blank line is [`ATTRIBUTION_FOOTER`], or when it
+/// is a single session link whose preceding non-blank line is that footer. A
+/// body with no footer at all is false, whatever else it ends with.
+/// Test: `footer_must_be_last_line`, `footer_accepts_the_trailing_session_link`,
+/// `footer_accepts_a_session_link_before_the_footer`,
+/// `footer_rejects_a_body_with_no_attribution_line`.
+fn footer_closes(body: &str) -> bool {
+    let mut tail = body.lines().rev().filter(|l| !l.trim().is_empty());
+    match tail.next() {
+        Some(last) if last.trim() == ATTRIBUTION_FOOTER => true,
+        Some(last) if is_session_link(last) => {
+            tail.next().is_some_and(|l| l.trim() == ATTRIBUTION_FOOTER)
+        }
+        _ => false,
+    }
 }
 
 /// How an issue reference must appear in the body.

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
@@ -334,6 +334,42 @@ fn footer_rejects_a_body_with_no_attribution_line() {
     );
 }
 
+#[test]
+fn footer_rejects_a_session_link_with_trailing_junk() {
+    // `is_session_link` tested only the URL PREFIX, so a line that merely
+    // STARTED with the link — link plus a sentence — closed the body as
+    // attribution. The session id must be the whole rest of the line.
+    let body = format!("{}\n{SESSION_LINK} some trailing junk\n", full_body());
+    assert!(!body::validate(&body).footer_ok, "{body}");
+
+    // The same holds for the labelled form.
+    let labelled = format!(
+        "{}\nClaude-Session: {SESSION_LINK} some trailing junk\n",
+        full_body()
+    );
+    assert!(!body::validate(&labelled).footer_ok, "{labelled}");
+
+    // A bare prefix with no session id is not a link either.
+    let bare = format!("{}\nhttps://claude.ai/code/session_\n", full_body());
+    assert!(!body::validate(&bare).footer_ok, "{bare}");
+}
+
+#[test]
+fn footer_rejects_two_stacked_session_links() {
+    // The block is the footer plus AT MOST ONE session link. Two stacked links
+    // leave a link, not the footer, as the line before the last one.
+    let body = format!("{}\n{SESSION_LINK}\n\n{SESSION_LINK}\n", full_body());
+    let report = body::validate(&body);
+    assert!(!report.footer_ok, "{report:?}");
+    assert!(
+        report
+            .failures()
+            .iter()
+            .any(|f| f.contains("attribution footer")),
+        "{report:?}"
+    );
+}
+
 // ── Refs vs Closes ───────────────────────────────────────────────────────
 
 #[test]
@@ -366,6 +402,30 @@ fn issue_link_is_inserted_above_the_footer() {
     assert!(refs_at < footer_at, "{out}");
     // Still the last non-blank line.
     assert!(body::validate(&out).footer_ok);
+}
+
+#[test]
+fn issue_link_lands_above_a_footer_a_session_link_trails() {
+    // #7297 made the session link a legal LAST line, and the insertion point is
+    // the footer rather than the end of the body — so the issue line must still
+    // land above the footer and leave the link closing the body.
+    let body = format!("{}\n{SESSION_LINK}\n", full_body());
+    let out =
+        body::apply_issue_link(&body, Some(7297), IssueLink::Refs).expect("refs link applies");
+
+    let at = |needle: &str| {
+        out.lines()
+            .position(|l| l.trim() == needle)
+            .unwrap_or_else(|| panic!("`{needle}` missing from:\n{out}"))
+    };
+    assert!(at("Refs #7297") < at(ATTRIBUTION_FOOTER), "{out}");
+    assert!(at(ATTRIBUTION_FOOTER) < at(SESSION_LINK), "{out}");
+    assert_eq!(
+        out.lines().rev().find(|l| !l.trim().is_empty()),
+        Some(SESSION_LINK),
+        "{out}"
+    );
+    assert!(body::validate(&out).footer_ok, "{out}");
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
@@ -286,6 +286,54 @@ fn footer_alone_does_not_fill_a_section() {
     assert_eq!(report.empty, vec![Field::Review], "{report:?}");
 }
 
+/// The session link Claude Code appends after the footer in a PR body.
+const SESSION_LINK: &str = "https://claude.ai/code/session_0194bkFi1G1Wv3kh1bVbMw4q";
+
+#[test]
+fn footer_accepts_the_trailing_session_link() {
+    // #7297: this IS the shape Claude Code's provisioned attribution tells a
+    // session to write — footer, blank line, session link. Rejecting it sent
+    // version-control agents to `gh pr create`, skipping this gate entirely.
+    let body = format!("{}\n{SESSION_LINK}\n", full_body());
+    let report = body::validate(&body);
+    assert!(report.footer_ok, "{report:?}");
+    assert!(report.failures().is_empty(), "{report:?}");
+
+    // The labelled form the commit message uses is the same block.
+    let labelled = format!("{}\nClaude-Session: {SESSION_LINK}\n", full_body());
+    assert!(body::validate(&labelled).footer_ok);
+}
+
+#[test]
+fn footer_accepts_a_session_link_before_the_footer() {
+    // The workaround shape agents adopted while #7297 stood. Bodies already
+    // written this way must keep passing.
+    let mut s = String::new();
+    for f in FIELDS {
+        s.push_str(&format!("## {}\n\nsomething real.\n\n", f.heading()));
+    }
+    s.push_str(&format!("{SESSION_LINK}\n\n{ATTRIBUTION_FOOTER}\n"));
+    let report = body::validate(&s);
+    assert!(report.footer_ok, "{report:?}");
+    assert!(report.failures().is_empty(), "{report:?}");
+}
+
+#[test]
+fn footer_rejects_a_body_with_no_attribution_line() {
+    // A session link alone is not attribution — the footer is still required.
+    let body = full_body().replace(ATTRIBUTION_FOOTER, SESSION_LINK);
+    assert!(!body.contains(ATTRIBUTION_FOOTER));
+    let report = body::validate(&body);
+    assert!(!report.footer_ok, "{report:?}");
+    assert!(
+        report
+            .failures()
+            .iter()
+            .any(|f| f.contains("attribution footer")),
+        "{report:?}"
+    );
+}
+
 // ── Refs vs Closes ───────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Outcome
Refs #7297. The PR-body validator demanded the attribution footer be the last non-blank line, so the harness's own attribution shape (footer, blank, `https://claude.ai/code/session_…`) was rejected. `footer_closes` now accepts footer-last, footer then exactly one trailing session link (bare or `Claude-Session:`-labelled), and link-then-footer; it still rejects a missing footer, trailing prose, a junk-suffixed link, and two stacked links.

## Changes
- `crates/trusty-mpm/src/bin/tm/commands/pr/body.rs`: `footer_closes`, `is_session_link` (remainder must be a session-id token), session link excluded from section content.
- `pr/tests.rs`: five footer tests plus `footer_rejects_a_session_link_with_trailing_junk`, `footer_rejects_two_stacked_session_links`, `issue_link_lands_above_a_footer_a_session_link_trails`.
- `changelog.d/7297-pr-open-footer-session-line.md`.

## Risk
Normal, localized to the validator.

## Tests
Rung 3, `-p trusty-mpm`: fmt --check, check, clippy --all-targets -D warnings, `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — 56 targets, 11968 passed, 0 failed, 18 ignored. `footer_accepts_the_trailing_session_link` fails on origin/main; the junk-suffix test fails on the prefix-only check.

## Baseline
origin/main 132f557da, green.

## Docs
Why/What/Test on `footer_closes`; `// #7297:` at the change site. check_line_cap, check_changelog_fragment, check_test_pointers — OK. Related gap, not fixed here: from a checkout whose HEAD is not the PR branch, `tm pr open --head` requires `--docs-only`, so this session's PRs were opened with `gh pr create`.

## Review
code-critic APPROVE with two MEDIUM and one LOW, all folded in 7e92d63b5. Credential scan of `origin/main...HEAD`: PASS.

https://claude.ai/code/session_0194bkFi1G1Wv3kh1bVbMw4q

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
