### PR TITLE
feat(trusty-mpm): tm session disk — per-session disk usage over the disk_survey RPC (Refs #7313, slice 2)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7313-session-disk-cli.md
+++ b/crates/trusty-mpm/changelog.d/7313-session-disk-cli.md
@@ -1,0 +1,10 @@
+Added
+- `tm session disk [<id-or-name>] [--json]` reports disk usage per session. With
+  no argument it lists one row per session of the current project, bytes
+  descending, with a total; with a session id or friendly name it breaks that
+  session down into build-directory bytes against the rest and lists every
+  worktree it owns across every project. It runs no survey of its own — one
+  `disk_survey` call with `group_by: "session"` over the daemon's `POST /rpc`,
+  so the walk, the classification and the by-session fold stay the daemon's. An
+  id no worktree is attributed to exits non-zero rather than reporting zero
+  bytes. (#7313)

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -142,6 +142,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `decommission` — Decommission a managed session: stop runtime + remove workspace from disk
   - `decommission-ephemeral` — Tear down EVERY ephemeral (test/throwaway) managed session (#1508)
   - `delete` — Hard-delete a managed session RECORD from the store (#2012)
+  - `disk` — Report disk usage per session (#7313)
   - `events` — Show the recent hook-event feed for one session
   - `info` — Show detailed info for a specific session
   - `instructions` — Print the composed launch instructions a session would receive
@@ -176,6 +177,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `decommission` — Decommission a managed session: stop runtime + remove workspace from disk
   - `decommission-ephemeral` — Tear down EVERY ephemeral (test/throwaway) managed session (#1508)
   - `delete` — Hard-delete a managed session RECORD from the store (#2012)
+  - `disk` — Report disk usage per session (#7313)
   - `events` — Show the recent hook-event feed for one session
   - `info` — Show detailed info for a specific session
   - `instructions` — Print the composed launch instructions a session would receive

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
@@ -609,4 +609,35 @@ pub(crate) enum SessionAction {
         #[arg(long = "as")]
         as_session: String,
     },
+    /// Report disk usage per session (#7313).
+    ///
+    /// Why: a worktree an ended session left behind was charged to nobody, so
+    /// an operator deciding what to clear had a per-project tree and no way to
+    /// ask which SESSION is holding the bytes. #7313 slice 1 made the survey
+    /// attribute each worktree to its owning session; this is the shell view of
+    /// that attribution, beside the lifecycle verbs an operator already knows.
+    /// What: with no argument, one row per session of the current project,
+    /// sorted by bytes descending, with a total. With an id or friendly name,
+    /// that one session's breakdown — build-directory bytes against the rest,
+    /// then one row per worktree it owns across EVERY project, because a
+    /// session's worktrees are not confined to one repository. `--json` emits
+    /// the same structure; the table goes to stdout and diagnostics to stderr.
+    /// READ-ONLY: nothing here removes or prunes anything.
+    /// Test: `cli_parses_session_disk`, `cli_session_disk_takes_no_destructive_flag`.
+    Disk {
+        /// The session to break down, by id or friendly name. Omit for the
+        /// per-session listing of the current project.
+        id_or_name: Option<String>,
+        /// Print the report as JSON instead of the table.
+        #[arg(long)]
+        json: bool,
+        /// Wall-clock seconds the daemon's survey may spend.
+        ///
+        /// Defaults to the daemon's own clamp. A lower figure returns sooner
+        /// and marks the report partial; a higher one is clamped daemon-side,
+        /// because a survey the client's bound outlives cannot reach the
+        /// operator.
+        #[arg(long)]
+        budget_seconds: Option<u64>,
+    },
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -128,6 +128,9 @@ pub(crate) mod serve_stdio;
 pub(crate) mod services;
 pub(crate) mod sessctl;
 pub(crate) mod session;
+// #7313: `tm session disk` — the shell view of the per-session disk
+// attribution slice 1 added to the `disk_survey` tool.
+pub(crate) mod session_disk;
 pub(crate) mod session_ls_connector;
 pub(crate) mod session_picker;
 pub(crate) mod session_picker_filter;

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -446,6 +446,23 @@ pub(crate) async fn session(
         // #6497: the transfer the reconcile report can only propose. Explicit
         // by design — a tree that changes hands on its own is indistinguishable
         // from one taken out from under a working agent.
+        // #7313: read-only per-session disk reporting. One `disk_survey` call
+        // over `POST /rpc` — the walk, the classification and the by-session
+        // fold are all the daemon's, so this verb runs no survey of its own.
+        SessionAction::Disk {
+            id_or_name,
+            json,
+            budget_seconds,
+        } => {
+            crate::commands::session_disk::session_disk(
+                client,
+                url,
+                id_or_name,
+                json,
+                budget_seconds,
+            )
+            .await?
+        }
         SessionAction::AdoptWorktree { path, as_session } => {
             crate::commands::adopt_worktree::session_adopt_worktree(client, url, &path, &as_session)
                 .await?

--- a/crates/trusty-mpm/src/bin/tm/commands/session_disk.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_disk.rs
@@ -11,17 +11,22 @@
 //! back. It runs no survey of its own: the walk, the classification, the
 //! attribution and the by-session fold are all slice 1's, in the daemon, where
 //! the shared size index and the live claim set are. A second walker here
-//! would be a second answer to the same question.
+//! would be a second answer to the same question. The survey attributes by raw
+//! session UUID, so `<id-or-name>` is resolved against the daemon's session
+//! list through the canonical [`resolve_target`] before anything is filtered by
+//! it, and that same list labels the listing's rows.
 //! Test: `session_disk_tests`, and `crates/trusty-mpm/tests/tm_session_disk_cli.rs`
 //! for the built binary against a stub daemon.
 //!
 //! READ-ONLY. Nothing here removes, prunes, or writes anything.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, anyhow, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use trusty_mpm::client::{Resolvable, resolve_target};
 use trusty_mpm::disk::human_bytes;
 
 #[cfg(test)]
@@ -31,10 +36,11 @@ mod session_disk_tests;
 /// `tm session disk [<id-or-name>] [--json]` (#7313).
 ///
 /// Why: see the module docs.
-/// What: resolves the scope, calls the daemon once, folds the response into
-/// [`DiskReport`], and prints it — JSON when `json`, otherwise the table. An
-/// argument that names no session in the survey is an error, so a typo can
-/// never read as "that session holds nothing".
+/// What: resolves the argument to a session id, calls the daemon once, folds
+/// the response into [`DiskReport`], and prints it — JSON when `json`,
+/// otherwise the table. An argument naming no session and a session holding
+/// nothing are two DIFFERENT errors, so a typo can never read as "that session
+/// holds nothing".
 /// Test: `cli_parses_session_disk`, `sessions_report_sorts_by_bytes_descending`,
 /// `an_unknown_session_is_an_error`, and the binary-level
 /// `session_disk_json_reports_every_session` / `session_disk_rejects_an_unknown_session`.
@@ -45,19 +51,28 @@ pub(crate) async fn session_disk(
     json_out: bool,
     budget_seconds: Option<u64>,
 ) -> anyhow::Result<()> {
+    // #7313: the survey attributes by UUID, so the operator's `<id-or-name>`
+    // is resolved against the daemon's session list BEFORE anything is filtered
+    // by it. The same list supplies the friendly names the listing renders.
+    let directory = session_directory(client, url).await;
+    let target = match id_or_name {
+        Some(ref arg) => Some(resolve_session_id(&directory, arg)?),
+        None => None,
+    };
     // A named session's worktrees are not confined to one repository — an
     // isolation worktree, an install/verify throwaway tree and a `jobs/<id>/`
     // tree can sit under three — so the breakdown surveys the whole workspace.
     // The listing scopes to the current project, which is what an operator
     // standing in a checkout is asking about.
-    let project = match id_or_name {
+    let project = match target {
         Some(_) => None,
         None => current_project_filter(&std::env::current_dir()?),
     };
     let survey = fetch_survey(client, url, project.as_deref(), budget_seconds).await?;
-    let report = match id_or_name {
-        Some(ref target) => session_report(&survey, target)?,
-        None => sessions_report(&survey, project.clone()),
+    let names = session_names(&directory);
+    let report = match target {
+        Some(ref id) => session_report(&survey, id, &names)?,
+        None => sessions_report(&survey, project.clone(), &names),
     };
     if json_out {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -73,6 +88,123 @@ pub(crate) async fn session_disk(
         );
     }
     Ok(())
+}
+
+/// UUID → friendly name for the sessions the daemon still lists.
+pub(crate) type SessionNames = HashMap<String, String>;
+
+/// One session the daemon knows, flattened from whichever store holds it.
+///
+/// Why one row type over both stores: `owning_session` can be either a
+/// `ManagedSessionId` (a session worktree's sentinel, and the case every
+/// attributed row on a live machine turns out to be) or a project `SessionId`
+/// (an agent sentinel's `parent_session_id`). Flattening them means the ONE
+/// [`resolve_target`] sees every candidate at once, so an id-exact match always
+/// outranks a name-exact match in the other store — which two separate lookups,
+/// tried in order, would get backwards.
+/// Test: `a_friendly_name_resolves_to_its_session_uuid`.
+#[derive(Debug, Clone)]
+pub(crate) struct DirectoryRow {
+    /// The session's canonical id, as the survey attributes by.
+    pub id: String,
+    /// Its friendly name — `tmux_name` for a project session, `name` for a
+    /// managed one.
+    pub name: String,
+}
+
+impl Resolvable for DirectoryRow {
+    fn id_matches(&self, query: &str) -> bool {
+        self.id == query
+    }
+
+    fn resolve_name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Every session the daemon knows, for id-or-name resolution and labelling.
+///
+/// Why: `disk_survey` charges every worktree to a raw session UUID (slice 1
+/// reads `owner_session_id` or `agent.parent_session_id`), and neither an
+/// operator nor the listing wants to read UUIDs. Both stores are asked because
+/// either can hold the attributed id; the lists are also what labels the rows,
+/// so the same fetch serves the resolution and the table.
+/// What: the managed list and the project list, through the shared
+/// [`DaemonClient`] — the same two calls
+/// [`resolve_managed_summary`](super::managed_route::resolve_managed_summary)
+/// and [`resolve_project_session_id`](super::managed_route::resolve_project_session_id)
+/// make. An unreachable store contributes nothing: the survey call that follows
+/// reports an outage far better than a name lookup could, so this declines
+/// rather than pre-empting it.
+/// Test: the binary-level `session_disk_resolves_a_friendly_name` drives the
+/// real HTTP path against a stub daemon.
+///
+/// [`DaemonClient`]: trusty_mpm::client::DaemonClient
+async fn session_directory(client: &reqwest::Client, url: &str) -> Vec<DirectoryRow> {
+    let executor = super::managed_route::executor(client, url);
+    let managed = executor
+        .client()
+        .list_managed_sessions()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| DirectoryRow {
+            id: s.id,
+            name: s.name,
+        });
+    let project = executor
+        .client()
+        .sessions()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|r| DirectoryRow {
+            id: r.id.0.to_string(),
+            name: r.tmux_name,
+        });
+    managed.chain(project).collect()
+}
+
+/// Resolve the operator's `<id-or-name>` to the id the survey attributes by.
+///
+/// Why: `owning_session` is ALWAYS a UUID, so matching the operator's string
+/// against it directly meant a friendly name resolved to nothing and drew the
+/// same "no worktree attributed" message as a session that genuinely holds
+/// none — two different facts, one message, and the operator cannot tell a typo
+/// from an empty session. Resolution goes through the one canonical
+/// [`resolve_target`] (id-exact → name-exact → unambiguous prefix), the same
+/// precedence `stop`, `resume` and `events` already use.
+/// What: the matched row's UUID. A UUID the daemon no longer lists passes
+/// through unchanged, because an ENDED session's leftovers are still attributed
+/// by their ownership sentinel and are exactly what an operator asks about.
+/// Anything else is an error naming the argument, distinct from the
+/// holds-nothing arm in [`session_report`].
+/// Test: `a_friendly_name_resolves_to_its_session_uuid`,
+/// `an_ended_sessions_uuid_resolves_without_the_daemon_listing_it`,
+/// `an_unknown_name_is_a_distinct_error`.
+fn resolve_session_id(directory: &[DirectoryRow], id_or_name: &str) -> anyhow::Result<String> {
+    if let Some(row) = resolve_target(directory, id_or_name) {
+        return Ok(row.id.clone());
+    }
+    if uuid::Uuid::parse_str(id_or_name).is_ok() {
+        return Ok(id_or_name.to_string());
+    }
+    bail!(
+        "no session named `{id_or_name}` — `tm sessions ls` lists the sessions \
+         the daemon knows, and `tm session disk` with no argument lists the \
+         ones holding bytes"
+    )
+}
+
+/// Index the directory by UUID so a row can be labelled by name.
+///
+/// Test: `the_listing_renders_the_friendly_name_when_one_is_known`.
+fn session_names(directory: &[DirectoryRow]) -> SessionNames {
+    directory
+        .iter()
+        .filter(|row| !row.name.is_empty())
+        .map(|row| (row.id.clone(), row.name.clone()))
+        .collect()
 }
 
 /// The `<owner>/<repo>` label for the project the caller is standing in.
@@ -290,8 +422,10 @@ pub(crate) enum DiskReport {
         generated_at: String,
         /// Whether the survey's deadline truncated the pass.
         partial: bool,
-        /// The session this breaks down.
+        /// The session this breaks down, as the survey attributes it.
         session_id: String,
+        /// Its friendly name, when the daemon still lists the session.
+        session_name: Option<String>,
         /// The byte split by class, largest first.
         classes: Vec<ClassRow>,
         /// The worktrees behind it, bytes descending.
@@ -305,7 +439,13 @@ pub(crate) enum DiskReport {
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct SessionRow {
     /// The owning session, `None` for the unattributed bucket.
+    ///
+    /// Always the raw UUID, in `--json` as well as in the fold — a consumer
+    /// keys on it, and the name beside it can change or disappear.
     pub session_id: Option<String>,
+    /// Its friendly name, when the daemon still lists the session. The table
+    /// renders this in place of the UUID; `--json` carries both.
+    pub session_name: Option<String>,
     /// Bytes across its measured worktrees.
     pub bytes: u64,
     /// Build-directory bytes across them.
@@ -367,11 +507,19 @@ pub(crate) struct Totals {
 /// the total across every row.
 /// Test: `sessions_report_sorts_by_bytes_descending`,
 /// `sessions_report_totals_every_row`, `a_daemon_without_the_rollup_reports_nothing`.
-pub(crate) fn sessions_report(survey: &Survey, project: Option<String>) -> DiskReport {
+pub(crate) fn sessions_report(
+    survey: &Survey,
+    project: Option<String>,
+    names: &SessionNames,
+) -> DiskReport {
     let groups = survey.by_session.clone().unwrap_or_default();
     let sessions: Vec<SessionRow> = groups
         .into_iter()
         .map(|g| SessionRow {
+            session_name: g
+                .session_id
+                .as_ref()
+                .and_then(|id| names.get(id.as_str()).cloned()),
             session_id: g.session_id,
             bytes: g.bytes,
             build_dir_bytes: g.build_dir_bytes,
@@ -408,7 +556,11 @@ pub(crate) fn sessions_report(survey: &Survey, project: Option<String>) -> DiskR
 /// Test: `a_session_report_splits_build_bytes_from_the_rest`,
 /// `a_session_report_spans_projects`, `an_unknown_session_is_an_error`,
 /// `an_unmeasured_worktree_is_listed_and_adds_nothing`.
-pub(crate) fn session_report(survey: &Survey, target: &str) -> anyhow::Result<DiskReport> {
+pub(crate) fn session_report(
+    survey: &Survey,
+    target: &str,
+    names: &SessionNames,
+) -> anyhow::Result<DiskReport> {
     let mut worktrees: Vec<WorktreeRow> = Vec::new();
     for project in &survey.root.projects {
         for wt in &project.worktrees {
@@ -429,11 +581,15 @@ pub(crate) fn session_report(survey: &Survey, target: &str) -> anyhow::Result<Di
         }
     }
     if worktrees.is_empty() {
-        // #7313: an error, never an empty report. A mistyped id that answered
-        // "0 B across 0 worktrees" is indistinguishable from a session that
-        // genuinely holds nothing, and the operator would act on the wrong one.
+        // #7313: an error, never an empty report. "0 B across 0 worktrees"
+        // would be indistinguishable from a session that genuinely holds
+        // nothing, and the operator would act on the wrong one. A name that
+        // resolved to no session at all fails earlier, in
+        // `resolve_session_id`, with its own message — this arm is only for a
+        // session that exists and holds nothing.
+        let label = names.get(target).map_or(target, String::as_str);
         bail!(
-            "no worktree in the survey is attributed to session `{target}` — \
+            "session `{label}` holds no worktrees in the survey — \
              `tm session disk` with no argument lists the sessions that hold bytes"
         );
     }
@@ -467,6 +623,7 @@ pub(crate) fn session_report(survey: &Survey, target: &str) -> anyhow::Result<Di
         generated_at: survey.generated_at.clone(),
         partial: survey.partial,
         session_id: target.to_string(),
+        session_name: names.get(target).cloned(),
         classes,
         worktrees,
         total,
@@ -494,13 +651,13 @@ pub(crate) fn render(report: &DiskReport) -> String {
                 None => "every managed project\n".to_string(),
             });
             out.push_str(&format!(
-                "{:<38} {:>6} {:>11} {:>11} {:>11}\n",
+                "{:<SESSION_COLUMN$} {:>6} {:>11} {:>11} {:>11}\n",
                 "SESSION", "TREES", "BUILD", "SOURCE", "TOTAL"
             ));
             for row in sessions {
                 out.push_str(&format!(
-                    "{:<38} {:>6} {:>11} {:>11} {:>11}\n",
-                    row.session_id.clone().unwrap_or_else(unattributed),
+                    "{:<SESSION_COLUMN$} {:>6} {:>11} {:>11} {:>11}\n",
+                    session_label(row),
                     row.worktree_count,
                     human_bytes(row.build_dir_bytes),
                     human_bytes(row.source_bytes),
@@ -511,12 +668,16 @@ pub(crate) fn render(report: &DiskReport) -> String {
         }
         DiskReport::Session {
             session_id,
+            session_name,
             classes,
             worktrees,
             total,
             ..
         } => {
-            out.push_str(&format!("session {session_id}\n"));
+            out.push_str(&match session_name {
+                Some(name) => format!("session {name} ({session_id})\n"),
+                None => format!("session {session_id}\n"),
+            });
             for class in classes {
                 out.push_str(&format!(
                     "  {:<10} {:>11}\n",
@@ -544,10 +705,42 @@ pub(crate) fn render(report: &DiskReport) -> String {
     out
 }
 
+/// Width of the SESSION column, wide enough for a 36-character UUID.
+const SESSION_COLUMN: usize = 38;
+
+/// What the SESSION column says for one row.
+///
+/// Why: an operator reads names, not UUIDs, so the friendly name wins where the
+/// daemon still knows one; the UUID is the fallback because an ENDED session's
+/// leftovers have no name left to render, and `--json` carries the UUID either
+/// way. The result is capped so a long name cannot shift every numeric column
+/// right — the one failure that makes the table unreadable.
+/// Test: `the_listing_renders_the_friendly_name_when_one_is_known`,
+/// `a_long_session_name_is_truncated_to_keep_the_columns_aligned`.
+fn session_label(row: &SessionRow) -> String {
+    let label = row
+        .session_name
+        .clone()
+        .or_else(|| row.session_id.clone())
+        .unwrap_or_else(unattributed);
+    fit(&label, SESSION_COLUMN)
+}
+
+/// Cap `label` at `width` characters, marking a cut with an ellipsis.
+///
+/// Test: `a_long_session_name_is_truncated_to_keep_the_columns_aligned`.
+fn fit(label: &str, width: usize) -> String {
+    if label.chars().count() <= width {
+        return label.to_string();
+    }
+    let kept: String = label.chars().take(width.saturating_sub(1)).collect();
+    format!("{kept}…")
+}
+
 /// The bottom line both views end on.
 fn total_line(total: &Totals) -> String {
     format!(
-        "{:<38} {:>6} {:>11} {:>11} {:>11}\n",
+        "{:<SESSION_COLUMN$} {:>6} {:>11} {:>11} {:>11}\n",
         "TOTAL",
         total.worktree_count,
         human_bytes(total.build_dir_bytes),

--- a/crates/trusty-mpm/src/bin/tm/commands/session_disk.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_disk.rs
@@ -1,0 +1,570 @@
+//! `tm session disk` — per-session disk usage (#7313 slice 2).
+//!
+//! Why: #7313 slice 1 taught the `disk_survey` MCP tool to attribute every
+//! managed worktree to the session that created it and to roll the rows up by
+//! session. Nothing in the shell could ask for that — an operator wanting to
+//! know which session is holding the bytes had the console Disk view or
+//! nothing. This is the CLI half, beside `ls`/`rename`/`pause`/`resume`/`stop`
+//! where session lifecycle already lives.
+//! What: [`session_disk`] issues ONE `disk_survey` call over the daemon's
+//! loopback `POST /rpc` with `group_by: "session"`, then renders what came
+//! back. It runs no survey of its own: the walk, the classification, the
+//! attribution and the by-session fold are all slice 1's, in the daemon, where
+//! the shared size index and the live claim set are. A second walker here
+//! would be a second answer to the same question.
+//! Test: `session_disk_tests`, and `crates/trusty-mpm/tests/tm_session_disk_cli.rs`
+//! for the built binary against a stub daemon.
+//!
+//! READ-ONLY. Nothing here removes, prunes, or writes anything.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use trusty_mpm::disk::human_bytes;
+
+#[cfg(test)]
+#[path = "session_disk_tests.rs"]
+mod session_disk_tests;
+
+/// `tm session disk [<id-or-name>] [--json]` (#7313).
+///
+/// Why: see the module docs.
+/// What: resolves the scope, calls the daemon once, folds the response into
+/// [`DiskReport`], and prints it — JSON when `json`, otherwise the table. An
+/// argument that names no session in the survey is an error, so a typo can
+/// never read as "that session holds nothing".
+/// Test: `cli_parses_session_disk`, `sessions_report_sorts_by_bytes_descending`,
+/// `an_unknown_session_is_an_error`, and the binary-level
+/// `session_disk_json_reports_every_session` / `session_disk_rejects_an_unknown_session`.
+pub(crate) async fn session_disk(
+    client: &reqwest::Client,
+    url: &str,
+    id_or_name: Option<String>,
+    json_out: bool,
+    budget_seconds: Option<u64>,
+) -> anyhow::Result<()> {
+    // A named session's worktrees are not confined to one repository — an
+    // isolation worktree, an install/verify throwaway tree and a `jobs/<id>/`
+    // tree can sit under three — so the breakdown surveys the whole workspace.
+    // The listing scopes to the current project, which is what an operator
+    // standing in a checkout is asking about.
+    let project = match id_or_name {
+        Some(_) => None,
+        None => current_project_filter(&std::env::current_dir()?),
+    };
+    let survey = fetch_survey(client, url, project.as_deref(), budget_seconds).await?;
+    let report = match id_or_name {
+        Some(ref target) => session_report(&survey, target)?,
+        None => sessions_report(&survey, project.clone()),
+    };
+    if json_out {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", render(&report));
+    }
+    if survey.partial {
+        // stderr, so a `--json` consumer's stdout stays a clean document while
+        // the operator still learns the figures are a floor rather than a total.
+        eprintln!(
+            "warning: the survey hit its {}s budget — every figure here is a floor, not a total",
+            budget_seconds.unwrap_or(trusty_mpm::daemon::mcp_disk::MAX_BUDGET_SECONDS)
+        );
+    }
+    Ok(())
+}
+
+/// The `<owner>/<repo>` label for the project the caller is standing in.
+///
+/// Why: `disk_survey`'s `project` filter matches that label, and deriving it
+/// from the path is what makes the answer right from inside an agent worktree
+/// — `<root>/<owner>/<repo>/.claude/worktrees/<x>` is still that project.
+/// What: the first two components of `cwd` relative to the managed workspace
+/// root, or `None` when the caller is outside it, which surveys everything
+/// rather than filtering to a project that does not exist.
+/// Test: `a_worktree_cwd_still_names_its_project`,
+/// `a_cwd_outside_the_workspace_root_has_no_filter`.
+fn current_project_filter(cwd: &Path) -> Option<String> {
+    let root = trusty_mpm::core::trusty_tools_config::workspace_root(
+        &trusty_mpm::core::trusty_tools_config::TrustyToolsConfig::load(),
+    );
+    project_filter_within(cwd, &root)
+}
+
+/// The pure core of [`current_project_filter`], with the root injected.
+///
+/// Test: `a_worktree_cwd_still_names_its_project`,
+/// `a_cwd_outside_the_workspace_root_has_no_filter`.
+fn project_filter_within(cwd: &Path, root: &Path) -> Option<String> {
+    let rest = cwd.strip_prefix(root).ok()?;
+    let mut parts = rest.components();
+    let owner = parts.next()?.as_os_str().to_string_lossy().into_owned();
+    let repo = parts.next()?.as_os_str().to_string_lossy().into_owned();
+    Some(format!("{owner}/{repo}"))
+}
+
+/// Call `disk_survey` once, with the per-session roll-up asked for.
+///
+/// Why: `POST /rpc` is the daemon's MCP dispatch, and DOC-73 §16.4 makes the
+/// tool the only way in — there is no HTTP route for the survey, and adding one
+/// would be a second surface over one implementation.
+/// What: a `tools/call` envelope; the tool's result arrives as a JSON document
+/// inside an MCP text block, which is unwrapped here. `budget_seconds` defaults
+/// to the daemon's clamp so the pass always finishes inside
+/// [`DISK_SURVEY_REQUEST_TIMEOUT`](trusty_mpm::client::http_client::DISK_SURVEY_REQUEST_TIMEOUT).
+/// Test: the binary-level `session_disk_json_reports_every_session` drives this
+/// against a stub `POST /rpc`; `a_tool_error_is_reported_not_swallowed` covers
+/// the `isError` arm.
+async fn fetch_survey(
+    client: &reqwest::Client,
+    url: &str,
+    project: Option<&str>,
+    budget_seconds: Option<u64>,
+) -> anyhow::Result<Survey> {
+    let mut arguments = json!({
+        "group_by": "session",
+        "budget_seconds": budget_seconds
+            .unwrap_or(trusty_mpm::daemon::mcp_disk::MAX_BUDGET_SECONDS),
+    });
+    if let (Some(project), Value::Object(map)) = (project, &mut arguments) {
+        map.insert("project".to_string(), Value::String(project.to_string()));
+    }
+    let body: Value = client
+        .post(format!("{url}/rpc"))
+        .timeout(trusty_mpm::client::http_client::DISK_SURVEY_REQUEST_TIMEOUT)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "disk_survey", "arguments": arguments },
+        }))
+        .send()
+        .await
+        .with_context(|| format!("POST {url}/rpc: the trusty-mpm daemon is not reachable"))?
+        .error_for_status()?
+        .json()
+        .await
+        .context("the daemon's disk_survey response was not JSON")?;
+    survey_from_rpc(&body)
+}
+
+/// Unwrap one `tools/call` response into the survey it carries.
+///
+/// Why: separated from the request so the three failure shapes — a JSON-RPC
+/// error, an `isError` tool result, and a payload that will not deserialize —
+/// are testable without a daemon. Each becomes a distinct message; none becomes
+/// an empty report, which would read as "nothing on disk".
+/// Test: `a_tool_error_is_reported_not_swallowed`,
+/// `a_jsonrpc_error_is_reported_not_swallowed`, `a_survey_payload_round_trips`.
+fn survey_from_rpc(body: &Value) -> anyhow::Result<Survey> {
+    if let Some(err) = body.get("error") {
+        let message = err
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown daemon error");
+        bail!("disk_survey failed: {message}");
+    }
+    let text = body
+        .pointer("/result/content/0/text")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("the daemon returned no disk_survey result"))?;
+    if body
+        .pointer("/result/isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        bail!("disk_survey failed: {text}");
+    }
+    serde_json::from_str(text).context("the daemon's disk_survey payload did not parse")
+}
+
+// ── The survey, as this client reads it ─────────────────────────────────────
+// Only the fields the report needs. Serde ignores the rest, so a field slice 1
+// or a later slice adds costs nothing here.
+
+/// The `disk_survey` payload, narrowed to what this command renders.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Survey {
+    /// When the survey ran, RFC 3339.
+    pub generated_at: String,
+    /// Whether the daemon's deadline truncated the pass.
+    pub partial: bool,
+    /// The per-session roll-up, present because `group_by: "session"` was asked
+    /// for. `None` would mean a daemon predating slice 1.
+    pub by_session: Option<Vec<SurveyGroup>>,
+    /// The per-project tree, which is where the individual worktree rows are.
+    pub root: SurveyRoot,
+}
+
+/// The scanned workspace root.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SurveyRoot {
+    /// Every project the survey covered.
+    pub projects: Vec<SurveyProject>,
+}
+
+/// One project and its worktrees.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SurveyProject {
+    /// `<owner>/<repo>`.
+    pub name: String,
+    /// The worktrees under it.
+    pub worktrees: Vec<SurveyWorktree>,
+}
+
+/// One worktree row.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SurveyWorktree {
+    /// The worktree directory.
+    pub path: PathBuf,
+    /// Which tier it renders in — `stale`, `review`, `keep`, `missing`.
+    pub tier: String,
+    /// Bytes on disk, absent when the index could not measure it.
+    pub bytes: Option<u64>,
+    /// Bytes held by its top-level `target*` directories (#7313 slice 1).
+    pub build_dir_bytes: Option<u64>,
+    /// The session these bytes are charged to.
+    pub owning_session: Option<String>,
+}
+
+/// One session's roll-up, as slice 1's `group_by_session` produced it.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SurveyGroup {
+    /// The owning session, `None` for the unattributed bucket.
+    pub session_id: Option<String>,
+    /// Bytes across this session's measured worktrees.
+    pub bytes: u64,
+    /// Build-directory bytes across them.
+    pub build_dir_bytes: u64,
+    /// How many worktrees it owns, measured or not.
+    pub worktree_count: usize,
+    /// The tier split.
+    pub tiers: Tiers,
+}
+
+/// The per-tier counts, carried through both directions unchanged.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+pub(crate) struct Tiers {
+    /// Worktrees safe to clear.
+    pub stale: usize,
+    /// Worktrees needing an operator decision.
+    pub review: usize,
+    /// Worktrees something forbids clearing.
+    pub keep: usize,
+    /// Registrations whose directory is gone.
+    pub missing: usize,
+}
+
+// ── What this command reports ───────────────────────────────────────────────
+
+/// The report, in the one shape `--json` emits and the table renders.
+///
+/// Why an internally-tagged enum rather than one struct with optional halves:
+/// the two views answer different questions and share no rows, so a struct
+/// would carry a `sessions` and a `worktrees` field that are never both
+/// populated, and a consumer would have to guess which one it got. `view` says
+/// which it got.
+/// Test: `sessions_report_sorts_by_bytes_descending`,
+/// `a_session_report_splits_build_bytes_from_the_rest`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "view", rename_all = "snake_case")]
+pub(crate) enum DiskReport {
+    /// One row per session, for the listing.
+    Sessions {
+        /// When the underlying survey ran.
+        generated_at: String,
+        /// Whether the survey's deadline truncated the pass.
+        partial: bool,
+        /// The project the listing was scoped to, `None` for the whole
+        /// workspace.
+        project: Option<String>,
+        /// The rows, bytes descending.
+        sessions: Vec<SessionRow>,
+        /// Every row folded together.
+        total: Totals,
+    },
+    /// One session's breakdown.
+    Session {
+        /// When the underlying survey ran.
+        generated_at: String,
+        /// Whether the survey's deadline truncated the pass.
+        partial: bool,
+        /// The session this breaks down.
+        session_id: String,
+        /// The byte split by class, largest first.
+        classes: Vec<ClassRow>,
+        /// The worktrees behind it, bytes descending.
+        worktrees: Vec<WorktreeRow>,
+        /// Every worktree folded together.
+        total: Totals,
+    },
+}
+
+/// One session's row in the listing.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SessionRow {
+    /// The owning session, `None` for the unattributed bucket.
+    pub session_id: Option<String>,
+    /// Bytes across its measured worktrees.
+    pub bytes: u64,
+    /// Build-directory bytes across them.
+    pub build_dir_bytes: u64,
+    /// Everything that is not a build directory.
+    pub source_bytes: u64,
+    /// How many worktrees it owns.
+    pub worktree_count: usize,
+    /// The tier split.
+    pub tiers: Tiers,
+}
+
+/// One class of bytes within a session.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ClassRow {
+    /// `build` or `source` — the two classes slice 1's survey distinguishes.
+    pub class: String,
+    /// Bytes in this class.
+    pub bytes: u64,
+}
+
+/// One worktree's row in a session's breakdown.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct WorktreeRow {
+    /// The worktree directory.
+    pub path: PathBuf,
+    /// The project it sits under.
+    pub project: String,
+    /// Its tier.
+    pub tier: String,
+    /// Bytes on disk, `None` when the survey could not measure it.
+    pub bytes: Option<u64>,
+    /// Its build directories' bytes.
+    pub build_dir_bytes: Option<u64>,
+    /// Everything else, when both figures are known.
+    pub source_bytes: Option<u64>,
+}
+
+/// The bottom line of either view.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub(crate) struct Totals {
+    /// Bytes across every row.
+    pub bytes: u64,
+    /// Build-directory bytes across every row.
+    pub build_dir_bytes: u64,
+    /// Everything that is not a build directory.
+    pub source_bytes: u64,
+    /// How many worktrees the rows cover.
+    pub worktree_count: usize,
+}
+
+/// Fold the survey's by-session roll-up into the listing.
+///
+/// Why: pure, so the ordering and the total are testable without a daemon. The
+/// ORDER is slice 1's — `group_by_session` already sorts bytes descending with
+/// the unattributed bucket last — and is preserved rather than recomputed, so
+/// the CLI and the console cannot disagree about which session is first.
+/// What: one row per group, with `source_bytes` derived as the remainder, plus
+/// the total across every row.
+/// Test: `sessions_report_sorts_by_bytes_descending`,
+/// `sessions_report_totals_every_row`, `a_daemon_without_the_rollup_reports_nothing`.
+pub(crate) fn sessions_report(survey: &Survey, project: Option<String>) -> DiskReport {
+    let groups = survey.by_session.clone().unwrap_or_default();
+    let sessions: Vec<SessionRow> = groups
+        .into_iter()
+        .map(|g| SessionRow {
+            session_id: g.session_id,
+            bytes: g.bytes,
+            build_dir_bytes: g.build_dir_bytes,
+            source_bytes: g.bytes.saturating_sub(g.build_dir_bytes),
+            worktree_count: g.worktree_count,
+            tiers: g.tiers,
+        })
+        .collect();
+    let total = sessions.iter().fold(Totals::default(), |mut t, r| {
+        t.bytes = t.bytes.saturating_add(r.bytes);
+        t.build_dir_bytes = t.build_dir_bytes.saturating_add(r.build_dir_bytes);
+        t.source_bytes = t.source_bytes.saturating_add(r.source_bytes);
+        t.worktree_count += r.worktree_count;
+        t
+    });
+    DiskReport::Sessions {
+        generated_at: survey.generated_at.clone(),
+        partial: survey.partial,
+        project,
+        sessions,
+        total,
+    }
+}
+
+/// Fold one session's worktrees into its breakdown.
+///
+/// Why: an operator who knows which session is expensive next asks WHERE — and
+/// the answer that matters is how much of it is a build directory, because that
+/// is the part `cargo clean` reclaims without touching any work.
+/// What: every worktree the survey charged to `target`, across every project,
+/// bytes descending; the class split; and the total. An unmeasured worktree
+/// contributes nothing to the totals and is still listed, so the two disagreeing
+/// is visible rather than silently absorbed.
+/// Test: `a_session_report_splits_build_bytes_from_the_rest`,
+/// `a_session_report_spans_projects`, `an_unknown_session_is_an_error`,
+/// `an_unmeasured_worktree_is_listed_and_adds_nothing`.
+pub(crate) fn session_report(survey: &Survey, target: &str) -> anyhow::Result<DiskReport> {
+    let mut worktrees: Vec<WorktreeRow> = Vec::new();
+    for project in &survey.root.projects {
+        for wt in &project.worktrees {
+            if wt.owning_session.as_deref() != Some(target) {
+                continue;
+            }
+            worktrees.push(WorktreeRow {
+                path: wt.path.clone(),
+                project: project.name.clone(),
+                tier: wt.tier.clone(),
+                bytes: wt.bytes,
+                build_dir_bytes: wt.build_dir_bytes,
+                source_bytes: match (wt.bytes, wt.build_dir_bytes) {
+                    (Some(b), Some(d)) => Some(b.saturating_sub(d)),
+                    _ => None,
+                },
+            });
+        }
+    }
+    if worktrees.is_empty() {
+        // #7313: an error, never an empty report. A mistyped id that answered
+        // "0 B across 0 worktrees" is indistinguishable from a session that
+        // genuinely holds nothing, and the operator would act on the wrong one.
+        bail!(
+            "no worktree in the survey is attributed to session `{target}` — \
+             `tm session disk` with no argument lists the sessions that hold bytes"
+        );
+    }
+    worktrees.sort_by(|a, b| {
+        b.bytes
+            .unwrap_or(0)
+            .cmp(&a.bytes.unwrap_or(0))
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    let total = worktrees.iter().fold(Totals::default(), |mut t, r| {
+        t.bytes = t.bytes.saturating_add(r.bytes.unwrap_or(0));
+        t.build_dir_bytes = t
+            .build_dir_bytes
+            .saturating_add(r.build_dir_bytes.unwrap_or(0));
+        t.source_bytes = t.source_bytes.saturating_add(r.source_bytes.unwrap_or(0));
+        t.worktree_count += 1;
+        t
+    });
+    let mut classes = vec![
+        ClassRow {
+            class: "build".to_string(),
+            bytes: total.build_dir_bytes,
+        },
+        ClassRow {
+            class: "source".to_string(),
+            bytes: total.source_bytes,
+        },
+    ];
+    classes.sort_by(|a, b| b.bytes.cmp(&a.bytes).then_with(|| a.class.cmp(&b.class)));
+    Ok(DiskReport::Session {
+        generated_at: survey.generated_at.clone(),
+        partial: survey.partial,
+        session_id: target.to_string(),
+        classes,
+        worktrees,
+        total,
+    })
+}
+
+/// Render either view as the operator's table.
+///
+/// Why: a `String` rather than a series of `println!`s so the layout is
+/// testable — the column widths and the total line are the part that breaks.
+/// What: a fixed-width table, byte figures through the one
+/// [`human_bytes`](trusty_mpm::disk::human_bytes) the doctor row also uses.
+/// Test: `the_listing_renders_a_total_line`, `the_breakdown_names_every_class`.
+pub(crate) fn render(report: &DiskReport) -> String {
+    let mut out = String::new();
+    match report {
+        DiskReport::Sessions {
+            project,
+            sessions,
+            total,
+            ..
+        } => {
+            out.push_str(&match project {
+                Some(name) => format!("project {name}\n"),
+                None => "every managed project\n".to_string(),
+            });
+            out.push_str(&format!(
+                "{:<38} {:>6} {:>11} {:>11} {:>11}\n",
+                "SESSION", "TREES", "BUILD", "SOURCE", "TOTAL"
+            ));
+            for row in sessions {
+                out.push_str(&format!(
+                    "{:<38} {:>6} {:>11} {:>11} {:>11}\n",
+                    row.session_id.clone().unwrap_or_else(unattributed),
+                    row.worktree_count,
+                    human_bytes(row.build_dir_bytes),
+                    human_bytes(row.source_bytes),
+                    human_bytes(row.bytes),
+                ));
+            }
+            out.push_str(&total_line(total));
+        }
+        DiskReport::Session {
+            session_id,
+            classes,
+            worktrees,
+            total,
+            ..
+        } => {
+            out.push_str(&format!("session {session_id}\n"));
+            for class in classes {
+                out.push_str(&format!(
+                    "  {:<10} {:>11}\n",
+                    class.class,
+                    human_bytes(class.bytes)
+                ));
+            }
+            out.push('\n');
+            out.push_str(&format!(
+                "{:<9} {:>11} {:>11}  {}\n",
+                "TIER", "BUILD", "TOTAL", "WORKTREE"
+            ));
+            for row in worktrees {
+                out.push_str(&format!(
+                    "{:<9} {:>11} {:>11}  {}\n",
+                    row.tier,
+                    row.build_dir_bytes.map_or_else(unmeasured, human_bytes),
+                    row.bytes.map_or_else(unmeasured, human_bytes),
+                    row.path.display(),
+                ));
+            }
+            out.push_str(&total_line(total));
+        }
+    }
+    out
+}
+
+/// The bottom line both views end on.
+fn total_line(total: &Totals) -> String {
+    format!(
+        "{:<38} {:>6} {:>11} {:>11} {:>11}\n",
+        "TOTAL",
+        total.worktree_count,
+        human_bytes(total.build_dir_bytes),
+        human_bytes(total.source_bytes),
+        human_bytes(total.bytes),
+    )
+}
+
+/// The label for the bucket nothing attributed.
+fn unattributed() -> String {
+    "(unattributed)".to_string()
+}
+
+/// The label for a figure the survey could not measure.
+///
+/// Why a word rather than `0 B`: a zero would read as an empty directory, which
+/// is the one thing an unmeasured worktree is not known to be.
+fn unmeasured() -> String {
+    "?".to_string()
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/session_disk_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_disk_tests.rs
@@ -1,0 +1,485 @@
+//! Unit tests for `tm session disk`'s row computation, sorting, and rendering
+//! (#7313 slice 2).
+//!
+//! Why: everything worth pinning here is pure — the fold, the order, the class
+//! split, the error arm, and the project filter — so none of it needs a daemon,
+//! a workspace, or a byte walk. The one thing that does touch the filesystem is
+//! the project filter, which gets a temp-dir fixture standing in for a managed
+//! workspace root.
+//! Test: this file.
+
+use std::path::{Path, PathBuf};
+
+use super::*;
+
+/// Build a survey payload from JSON, through the SAME deserialization the
+/// daemon response goes through.
+///
+/// Why: a hand-built `Survey` literal would prove the fold and nothing about
+/// the schema. Going through `serde_json` means a field slice 1 renames breaks
+/// these tests, which is the point.
+fn survey(value: serde_json::Value) -> Survey {
+    serde_json::from_value(value).expect("the fixture must match the survey schema")
+}
+
+/// A survey with two attributed sessions and the unattributed bucket, ordered
+/// exactly as slice 1's `group_by_session` emits it (bytes descending, `null`
+/// last).
+fn two_sessions() -> Survey {
+    survey(json!({
+        "generated_at": "2026-09-10T00:00:00Z",
+        "partial": false,
+        "by_session": [
+            {
+                "session_id": "trusty-tools-95",
+                "bytes": 30_000_000_000u64,
+                "build_dir_bytes": 24_000_000_000u64,
+                "worktree_count": 3,
+                "tiers": { "stale": 1, "review": 1, "keep": 1, "missing": 0 },
+                "worktree_paths": []
+            },
+            {
+                "session_id": "trusty-tools-12",
+                "bytes": 10_000_000_000u64,
+                "build_dir_bytes": 9_000_000_000u64,
+                "worktree_count": 1,
+                "tiers": { "stale": 0, "review": 0, "keep": 1, "missing": 0 },
+                "worktree_paths": []
+            },
+            {
+                "session_id": null,
+                "bytes": 5_000_000_000u64,
+                "build_dir_bytes": 4_000_000_000u64,
+                "worktree_count": 2,
+                "tiers": { "stale": 2, "review": 0, "keep": 0, "missing": 0 },
+                "worktree_paths": []
+            }
+        ],
+        "root": { "projects": [] }
+    }))
+}
+
+/// A survey whose two projects both hold a worktree owned by one session.
+fn one_session_across_two_projects() -> Survey {
+    survey(json!({
+        "generated_at": "2026-09-10T00:00:00Z",
+        "partial": false,
+        "by_session": [],
+        "root": { "projects": [
+            {
+                "name": "bobmatnyc/trusty-tools",
+                "path": "/w/bobmatnyc/trusty-tools",
+                "bytes": 40_000_000_000u64,
+                "worktrees": [
+                    {
+                        "path": "/w/bobmatnyc/trusty-tools/.claude/worktrees/a",
+                        "tier": "stale",
+                        "bytes": 20_000_000_000u64,
+                        "build_dir_bytes": 18_000_000_000u64,
+                        "owning_session": "trusty-tools-95"
+                    },
+                    {
+                        "path": "/w/bobmatnyc/trusty-tools/.claude/worktrees/b",
+                        "tier": "keep",
+                        "bytes": 1_000_000_000u64,
+                        "build_dir_bytes": 0,
+                        "owning_session": "trusty-tools-12"
+                    }
+                ]
+            },
+            {
+                "name": "bobmatnyc/other",
+                "path": "/w/bobmatnyc/other",
+                "bytes": 5_000_000_000u64,
+                "worktrees": [
+                    {
+                        "path": "/w/bobmatnyc/other/.claude/worktrees/c",
+                        "tier": "review",
+                        "bytes": 30_000_000_000u64,
+                        "build_dir_bytes": 25_000_000_000u64,
+                        "owning_session": "trusty-tools-95"
+                    },
+                    {
+                        "path": "/w/bobmatnyc/other/.claude/worktrees/d",
+                        "tier": "missing",
+                        "bytes": null,
+                        "build_dir_bytes": null,
+                        "owning_session": "trusty-tools-95"
+                    }
+                ]
+            }
+        ] }
+    }))
+}
+
+/// The listing preserves slice 1's byte-descending order, unattributed last.
+///
+/// Why this is the contract and not merely the current behaviour: the order is
+/// decided once, in `disk::survey::group_by_session`, so the console and the
+/// CLI name the same session first. Re-sorting here would be a second answer.
+#[test]
+fn sessions_report_sorts_by_bytes_descending() {
+    let DiskReport::Sessions { sessions, .. } = sessions_report(&two_sessions(), None) else {
+        panic!("the no-argument view must be the sessions view");
+    };
+    let ids: Vec<Option<&str>> = sessions
+        .iter()
+        .map(|r| r.session_id.as_deref())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ids,
+        vec![Some("trusty-tools-95"), Some("trusty-tools-12"), None],
+        "bytes descending, with the unattributed bucket last"
+    );
+    let bytes: Vec<u64> = sessions.iter().map(|r| r.bytes).collect();
+    assert!(
+        bytes.windows(2).all(|w| w[0] >= w[1]),
+        "each row must be at least as large as the next: {bytes:?}"
+    );
+}
+
+/// Every row folds into the total, and `source_bytes` is the remainder.
+#[test]
+fn sessions_report_totals_every_row() {
+    let DiskReport::Sessions {
+        sessions, total, ..
+    } = sessions_report(&two_sessions(), Some("bobmatnyc/trusty-tools".to_string()))
+    else {
+        panic!("the no-argument view must be the sessions view");
+    };
+    assert_eq!(total.bytes, 45_000_000_000);
+    assert_eq!(total.build_dir_bytes, 37_000_000_000);
+    assert_eq!(
+        total.source_bytes, 8_000_000_000,
+        "source is what is left after the build directories"
+    );
+    assert_eq!(total.worktree_count, 6);
+    assert_eq!(sessions[0].source_bytes, 6_000_000_000);
+}
+
+/// A daemon predating slice 1 answers with no roll-up, and that must read as an
+/// empty listing rather than panic.
+///
+/// Why: `by_session` is `skip_serializing_if = "Option::is_none"`, so an older
+/// daemon simply omits the field. Deserializing it as required would turn a
+/// version skew into "the payload did not parse".
+#[test]
+fn a_daemon_without_the_rollup_reports_nothing() {
+    let older = survey(json!({
+        "generated_at": "2026-09-10T00:00:00Z",
+        "partial": false,
+        "root": { "projects": [] }
+    }));
+    let DiskReport::Sessions {
+        sessions, total, ..
+    } = sessions_report(&older, None)
+    else {
+        panic!("the no-argument view must be the sessions view");
+    };
+    assert!(sessions.is_empty());
+    assert_eq!(total.bytes, 0);
+}
+
+/// A session's breakdown separates the build directories from the rest.
+#[test]
+fn a_session_report_splits_build_bytes_from_the_rest() {
+    let report = session_report(&one_session_across_two_projects(), "trusty-tools-95")
+        .expect("the session owns worktrees");
+    let DiskReport::Session { classes, total, .. } = report else {
+        panic!("an argument must produce the session view");
+    };
+    assert_eq!(total.bytes, 50_000_000_000);
+    assert_eq!(total.build_dir_bytes, 43_000_000_000);
+    assert_eq!(total.source_bytes, 7_000_000_000);
+    // Largest class first, so the reclaimable majority leads.
+    assert_eq!(classes[0].class, "build");
+    assert_eq!(classes[0].bytes, 43_000_000_000);
+    assert_eq!(classes[1].class, "source");
+    assert_eq!(classes[1].bytes, 7_000_000_000);
+}
+
+/// A session's worktrees are gathered across EVERY project, bytes descending.
+///
+/// Why: an isolation worktree, an install/verify throwaway tree, and a
+/// `jobs/<id>/` tree can sit under three different repositories while belonging
+/// to one dispatching session — the per-project tree cannot express that, which
+/// is the whole reason slice 1 added the roll-up.
+#[test]
+fn a_session_report_spans_projects() {
+    let report = session_report(&one_session_across_two_projects(), "trusty-tools-95")
+        .expect("the session owns worktrees");
+    let DiskReport::Session { worktrees, .. } = report else {
+        panic!("an argument must produce the session view");
+    };
+    let projects: Vec<&str> = worktrees.iter().map(|w| w.project.as_str()).collect();
+    assert!(
+        projects.contains(&"bobmatnyc/trusty-tools") && projects.contains(&"bobmatnyc/other"),
+        "both projects must appear: {projects:?}"
+    );
+    assert_eq!(
+        worktrees[0].path,
+        PathBuf::from("/w/bobmatnyc/other/.claude/worktrees/c"),
+        "the largest worktree leads, whichever project it is under"
+    );
+    let bytes: Vec<u64> = worktrees.iter().map(|w| w.bytes.unwrap_or(0)).collect();
+    assert!(
+        bytes.windows(2).all(|w| w[0] >= w[1]),
+        "bytes descending: {bytes:?}"
+    );
+}
+
+/// An unmeasured worktree is listed and contributes nothing to the totals.
+///
+/// Why a zero would be wrong: the survey could not measure it, which is not the
+/// same claim as "it is empty" — folding it in as zero would make a truncated
+/// pass read as a complete one.
+#[test]
+fn an_unmeasured_worktree_is_listed_and_adds_nothing() {
+    let report = session_report(&one_session_across_two_projects(), "trusty-tools-95")
+        .expect("the session owns worktrees");
+    let DiskReport::Session {
+        worktrees, total, ..
+    } = report
+    else {
+        panic!("an argument must produce the session view");
+    };
+    let unmeasured = worktrees
+        .iter()
+        .find(|w| w.path.ends_with("d"))
+        .expect("the unmeasured worktree must still be listed");
+    assert_eq!(unmeasured.bytes, None);
+    assert_eq!(unmeasured.source_bytes, None);
+    assert_eq!(
+        total.worktree_count, 3,
+        "it counts as a worktree even though it adds no bytes"
+    );
+    assert_eq!(total.bytes, 50_000_000_000);
+}
+
+/// An id no worktree is attributed to is an error, never an empty report.
+///
+/// Why: "0 B across 0 worktrees" for a typo is indistinguishable from a session
+/// that genuinely holds nothing, and the operator acts on the wrong one.
+#[test]
+fn an_unknown_session_is_an_error() {
+    let err = session_report(&one_session_across_two_projects(), "no-such-session")
+        .expect_err("an unattributed id must not produce a report");
+    let message = err.to_string();
+    assert!(message.contains("no-such-session"), "{message}");
+    assert!(
+        message.contains("tm session disk"),
+        "the error must name the command that lists what IS attributed: {message}"
+    );
+}
+
+/// A JSON-RPC-level error reaches the operator rather than being swallowed.
+#[test]
+fn a_jsonrpc_error_is_reported_not_swallowed() {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": { "code": -32603, "message": "daemon is shutting down" }
+    });
+    let err = survey_from_rpc(&body).expect_err("a JSON-RPC error must not parse as a survey");
+    assert!(err.to_string().contains("daemon is shutting down"), "{err}");
+}
+
+/// A tool-level `isError` reaches the operator with the tool's own message.
+///
+/// Why this arm is separate: `dispatch_tool_call` returns HTTP 200 with a
+/// JSON-RPC *result* whose `isError` is true — a caller that only checks the
+/// `error` member reads the message as a survey and fails on the parse instead,
+/// losing the reason.
+#[test]
+fn a_tool_error_is_reported_not_swallowed() {
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "content": [{
+                "type": "text",
+                "text": "disk_survey: unknown `group_by` value `project`"
+            }],
+            "isError": true
+        }
+    });
+    let err = survey_from_rpc(&body).expect_err("an isError result must not parse as a survey");
+    assert!(
+        err.to_string().contains("unknown `group_by` value"),
+        "{err}"
+    );
+}
+
+/// A well-formed tool result unwraps into the survey it carries.
+#[test]
+fn a_survey_payload_round_trips() {
+    let payload = json!({
+        "generated_at": "2026-09-10T00:00:00Z",
+        "partial": true,
+        "by_session": [],
+        "root": { "projects": [] }
+    });
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "content": [{ "type": "text", "text": payload.to_string() }],
+            "isError": false
+        }
+    });
+    let survey = survey_from_rpc(&body).expect("a well-formed result must parse");
+    assert_eq!(survey.generated_at, "2026-09-10T00:00:00Z");
+    assert!(survey.partial);
+}
+
+/// A cwd inside an agent worktree still names the project it belongs to.
+///
+/// Why: this is where an agent and most operators actually stand, and
+/// `<root>/<owner>/<repo>/.claude/worktrees/<x>` must filter to `<owner>/<repo>`
+/// rather than to nothing.
+#[test]
+fn a_worktree_cwd_still_names_its_project() {
+    let root = tempfile::tempdir().expect("temp workspace root");
+    let cwd = root
+        .path()
+        .join("bobmatnyc")
+        .join("trusty-tools")
+        .join(".claude")
+        .join("worktrees")
+        .join("agent-a82c1d86143c79d5f");
+    std::fs::create_dir_all(&cwd).expect("create the worktree fixture");
+    assert_eq!(
+        project_filter_within(&cwd, root.path()),
+        Some("bobmatnyc/trusty-tools".to_string())
+    );
+    // The project directory itself resolves to the same label.
+    assert_eq!(
+        project_filter_within(
+            &root.path().join("bobmatnyc").join("trusty-tools"),
+            root.path()
+        ),
+        Some("bobmatnyc/trusty-tools".to_string())
+    );
+}
+
+/// A cwd outside the managed workspace root filters nothing.
+///
+/// Why not an error: an operator running this from `/tmp` wants the whole
+/// fleet's answer, not a refusal — and a filter derived from a path the survey
+/// does not cover would silently return an empty listing.
+#[test]
+fn a_cwd_outside_the_workspace_root_has_no_filter() {
+    let root = tempfile::tempdir().expect("temp workspace root");
+    let elsewhere = tempfile::tempdir().expect("temp cwd");
+    assert_eq!(project_filter_within(elsewhere.path(), root.path()), None);
+    // Directly at the root, with no `<owner>/<repo>` beneath it.
+    assert_eq!(project_filter_within(root.path(), root.path()), None);
+    // One component short of a project.
+    assert_eq!(
+        project_filter_within(&root.path().join("bobmatnyc"), root.path()),
+        None
+    );
+}
+
+/// The listing renders a header, one row per session, and a total line.
+#[test]
+fn the_listing_renders_a_total_line() {
+    let report = sessions_report(&two_sessions(), Some("bobmatnyc/trusty-tools".to_string()));
+    let text = render(&report);
+    assert!(text.contains("project bobmatnyc/trusty-tools"), "{text}");
+    assert!(text.contains("trusty-tools-95"), "{text}");
+    assert!(
+        text.contains("(unattributed)"),
+        "the null bucket needs a label an operator can read: {text}"
+    );
+    let total = text
+        .lines()
+        .find(|l| l.starts_with("TOTAL"))
+        .expect("a total line");
+    assert!(
+        total.contains("41.9 GiB"),
+        "the total renders through the shared byte formatter: {total}"
+    );
+}
+
+/// A UUID session id still leaves the columns aligned.
+///
+/// Why this is a real failure and not a cosmetic one: slice 1's attribution
+/// hands back full 36-character UUIDs, not friendly names, and the first live
+/// run of this command shifted every numeric column right on exactly those
+/// rows — the table stopped being readable at the one width that matters.
+///
+/// Fails before the change: the session column was 34 wide.
+#[test]
+fn a_uuid_session_id_keeps_the_columns_aligned() {
+    let uuid = "0b318c84-bae9-4a50-8832-65ed61f8ab22";
+    assert_eq!(uuid.len(), 36, "the id width this test exists for");
+    let wide = survey(json!({
+        "generated_at": "2026-09-10T00:00:00Z",
+        "partial": false,
+        "by_session": [{
+            "session_id": uuid,
+            "bytes": 1_000_000_000u64,
+            "build_dir_bytes": 400_000_000u64,
+            "worktree_count": 1,
+            "tiers": { "stale": 0, "review": 0, "keep": 1, "missing": 0 },
+            "worktree_paths": []
+        }],
+        "root": { "projects": [] }
+    }));
+    let text = render(&sessions_report(&wide, None));
+    let lines: Vec<&str> = text.lines().collect();
+    // The header, the one row, and the total must put `TOTAL`'s figure in the
+    // same column — which only holds while the id fits its field.
+    let header = lines
+        .iter()
+        .find(|l| l.starts_with("SESSION"))
+        .expect("a header line");
+    let row = lines
+        .iter()
+        .find(|l| l.starts_with(uuid))
+        .expect("the session's own row");
+    let total = lines
+        .iter()
+        .find(|l| l.starts_with("TOTAL"))
+        .expect("a total line");
+    assert_eq!(
+        header.len(),
+        row.len(),
+        "a UUID must not push the row wider than the header:\n{header}\n{row}"
+    );
+    assert_eq!(
+        header.len(),
+        total.len(),
+        "and the total must line up with both:\n{header}\n{total}"
+    );
+}
+
+/// The breakdown names both classes and every worktree.
+#[test]
+fn the_breakdown_names_every_class() {
+    let report = session_report(&one_session_across_two_projects(), "trusty-tools-95")
+        .expect("the session owns worktrees");
+    let text = render(&report);
+    assert!(text.contains("session trusty-tools-95"), "{text}");
+    assert!(text.contains("build"), "{text}");
+    assert!(text.contains("source"), "{text}");
+    assert!(
+        text.contains("/w/bobmatnyc/other/.claude/worktrees/d"),
+        "an unmeasured worktree is still listed: {text}"
+    );
+    assert!(
+        text.contains('?'),
+        "and its figures read as unmeasured, not as zero: {text}"
+    );
+}
+
+/// A relative cwd is not a workspace path; the filter declines it rather than
+/// producing a label the survey cannot match.
+#[test]
+fn a_relative_cwd_has_no_filter() {
+    assert_eq!(
+        project_filter_within(Path::new("bobmatnyc/trusty-tools"), Path::new("/w")),
+        None
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/session_disk_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_disk_tests.rs
@@ -22,6 +22,20 @@ fn survey(value: serde_json::Value) -> Survey {
     serde_json::from_value(value).expect("the fixture must match the survey schema")
 }
 
+/// No friendly names known — the shape when the daemon lists no session, which
+/// is also every fixture whose ids stand in for themselves.
+fn no_names() -> SessionNames {
+    SessionNames::new()
+}
+
+/// One directory row, as `session_directory` flattens either store into.
+fn session_row(id: &str, name: &str) -> DirectoryRow {
+    DirectoryRow {
+        id: id.to_string(),
+        name: name.to_string(),
+    }
+}
+
 /// A survey with two attributed sessions and the unattributed bucket, ordered
 /// exactly as slice 1's `group_by_session` emits it (bytes descending, `null`
 /// last).
@@ -119,7 +133,8 @@ fn one_session_across_two_projects() -> Survey {
 /// CLI name the same session first. Re-sorting here would be a second answer.
 #[test]
 fn sessions_report_sorts_by_bytes_descending() {
-    let DiskReport::Sessions { sessions, .. } = sessions_report(&two_sessions(), None) else {
+    let DiskReport::Sessions { sessions, .. } = sessions_report(&two_sessions(), None, &no_names())
+    else {
         panic!("the no-argument view must be the sessions view");
     };
     let ids: Vec<Option<&str>> = sessions
@@ -143,7 +158,11 @@ fn sessions_report_sorts_by_bytes_descending() {
 fn sessions_report_totals_every_row() {
     let DiskReport::Sessions {
         sessions, total, ..
-    } = sessions_report(&two_sessions(), Some("bobmatnyc/trusty-tools".to_string()))
+    } = sessions_report(
+        &two_sessions(),
+        Some("bobmatnyc/trusty-tools".to_string()),
+        &no_names(),
+    )
     else {
         panic!("the no-argument view must be the sessions view");
     };
@@ -172,7 +191,7 @@ fn a_daemon_without_the_rollup_reports_nothing() {
     }));
     let DiskReport::Sessions {
         sessions, total, ..
-    } = sessions_report(&older, None)
+    } = sessions_report(&older, None, &no_names())
     else {
         panic!("the no-argument view must be the sessions view");
     };
@@ -183,8 +202,12 @@ fn a_daemon_without_the_rollup_reports_nothing() {
 /// A session's breakdown separates the build directories from the rest.
 #[test]
 fn a_session_report_splits_build_bytes_from_the_rest() {
-    let report = session_report(&one_session_across_two_projects(), "trusty-tools-95")
-        .expect("the session owns worktrees");
+    let report = session_report(
+        &one_session_across_two_projects(),
+        "trusty-tools-95",
+        &no_names(),
+    )
+    .expect("the session owns worktrees");
     let DiskReport::Session { classes, total, .. } = report else {
         panic!("an argument must produce the session view");
     };
@@ -206,8 +229,12 @@ fn a_session_report_splits_build_bytes_from_the_rest() {
 /// is the whole reason slice 1 added the roll-up.
 #[test]
 fn a_session_report_spans_projects() {
-    let report = session_report(&one_session_across_two_projects(), "trusty-tools-95")
-        .expect("the session owns worktrees");
+    let report = session_report(
+        &one_session_across_two_projects(),
+        "trusty-tools-95",
+        &no_names(),
+    )
+    .expect("the session owns worktrees");
     let DiskReport::Session { worktrees, .. } = report else {
         panic!("an argument must produce the session view");
     };
@@ -235,8 +262,12 @@ fn a_session_report_spans_projects() {
 /// pass read as a complete one.
 #[test]
 fn an_unmeasured_worktree_is_listed_and_adds_nothing() {
-    let report = session_report(&one_session_across_two_projects(), "trusty-tools-95")
-        .expect("the session owns worktrees");
+    let report = session_report(
+        &one_session_across_two_projects(),
+        "trusty-tools-95",
+        &no_names(),
+    )
+    .expect("the session owns worktrees");
     let DiskReport::Session {
         worktrees, total, ..
     } = report
@@ -262,8 +293,12 @@ fn an_unmeasured_worktree_is_listed_and_adds_nothing() {
 /// that genuinely holds nothing, and the operator acts on the wrong one.
 #[test]
 fn an_unknown_session_is_an_error() {
-    let err = session_report(&one_session_across_two_projects(), "no-such-session")
-        .expect_err("an unattributed id must not produce a report");
+    let err = session_report(
+        &one_session_across_two_projects(),
+        "no-such-session",
+        &no_names(),
+    )
+    .expect_err("an unattributed id must not produce a report");
     let message = err.to_string();
     assert!(message.contains("no-such-session"), "{message}");
     assert!(
@@ -384,7 +419,11 @@ fn a_cwd_outside_the_workspace_root_has_no_filter() {
 /// The listing renders a header, one row per session, and a total line.
 #[test]
 fn the_listing_renders_a_total_line() {
-    let report = sessions_report(&two_sessions(), Some("bobmatnyc/trusty-tools".to_string()));
+    let report = sessions_report(
+        &two_sessions(),
+        Some("bobmatnyc/trusty-tools".to_string()),
+        &no_names(),
+    );
     let text = render(&report);
     assert!(text.contains("project bobmatnyc/trusty-tools"), "{text}");
     assert!(text.contains("trusty-tools-95"), "{text}");
@@ -427,7 +466,7 @@ fn a_uuid_session_id_keeps_the_columns_aligned() {
         }],
         "root": { "projects": [] }
     }));
-    let text = render(&sessions_report(&wide, None));
+    let text = render(&sessions_report(&wide, None, &no_names()));
     let lines: Vec<&str> = text.lines().collect();
     // The header, the one row, and the total must put `TOTAL`'s figure in the
     // same column — which only holds while the id fits its field.
@@ -458,8 +497,12 @@ fn a_uuid_session_id_keeps_the_columns_aligned() {
 /// The breakdown names both classes and every worktree.
 #[test]
 fn the_breakdown_names_every_class() {
-    let report = session_report(&one_session_across_two_projects(), "trusty-tools-95")
-        .expect("the session owns worktrees");
+    let report = session_report(
+        &one_session_across_two_projects(),
+        "trusty-tools-95",
+        &no_names(),
+    )
+    .expect("the session owns worktrees");
     let text = render(&report);
     assert!(text.contains("session trusty-tools-95"), "{text}");
     assert!(text.contains("build"), "{text}");
@@ -482,4 +525,172 @@ fn a_relative_cwd_has_no_filter() {
         project_filter_within(Path::new("bobmatnyc/trusty-tools"), Path::new("/w")),
         None
     );
+}
+
+/// A friendly name resolves to the UUID the survey attributes by.
+///
+/// Why this is the whole point: `owning_session` is always a raw UUID, so
+/// matching the operator's `trusty-tools-95` against it directly found nothing
+/// — while the help text promises "by id or friendly name".
+///
+/// Fails before the change: there was no resolution step; the argument went
+/// straight into `session_report` and matched no worktree.
+#[test]
+fn a_friendly_name_resolves_to_its_session_uuid() {
+    let uuid = "0b318c84-bae9-4a50-8832-65ed61f8ab22";
+    let directory = vec![
+        session_row(uuid, "trusty-tools-95"),
+        session_row("11111111-2222-3333-4444-555555555555", "trusty-tools-12"),
+    ];
+    assert_eq!(
+        resolve_session_id(&directory, "trusty-tools-95").expect("the name names a session"),
+        uuid
+    );
+    // The id resolves to itself, and an unambiguous prefix resolves too,
+    // because this is the one canonical `resolve_target`.
+    assert_eq!(
+        resolve_session_id(&directory, uuid).expect("an id resolves to itself"),
+        uuid
+    );
+    assert_eq!(
+        resolve_session_id(&directory, "trusty-tools-9").expect("an unambiguous prefix resolves"),
+        uuid
+    );
+}
+
+/// A UUID the daemon no longer lists still resolves.
+///
+/// Why: slice 1 attributes an ENDED session's leftovers from their ownership
+/// sentinel, and those are the bytes an operator goes looking for. A resolver
+/// that insisted on a live row would refuse the one case the attribution exists
+/// to cover.
+#[test]
+fn an_ended_sessions_uuid_resolves_without_the_daemon_listing_it() {
+    let gone = "0b318c84-bae9-4a50-8832-65ed61f8ab22";
+    assert_eq!(
+        resolve_session_id(&[], gone).expect("a UUID passes through an empty directory"),
+        gone
+    );
+}
+
+/// A name that resolves to nothing is a DIFFERENT error from a session that
+/// holds nothing.
+///
+/// Why: one is a typo, the other is a fact about disk. Answering both with "no
+/// worktree attributed" made a mistyped name look like an empty session.
+///
+/// Fails before the change: both arms produced the same "no worktree ...
+/// attributed" message, so nothing could tell them apart.
+#[test]
+fn an_unknown_name_is_a_distinct_error() {
+    let directory = vec![session_row(
+        "0b318c84-bae9-4a50-8832-65ed61f8ab22",
+        "trusty-tools-95",
+    )];
+    let unknown = resolve_session_id(&directory, "no-such-session")
+        .expect_err("a name matching nothing must not resolve");
+    assert!(
+        unknown.to_string().contains("no session named"),
+        "the unresolvable-name arm must say so: {unknown}"
+    );
+    assert!(unknown.to_string().contains("no-such-session"), "{unknown}");
+
+    let empty = session_report(
+        &one_session_across_two_projects(),
+        "0b318c84-bae9-4a50-8832-65ed61f8ab22",
+        &no_names(),
+    )
+    .expect_err("a session owning no worktree must not produce a report");
+    assert!(
+        empty.to_string().contains("holds no worktrees"),
+        "the holds-nothing arm must say so instead: {empty}"
+    );
+    assert!(
+        !empty.to_string().contains("no session named"),
+        "the two arms must not share a message: {empty}"
+    );
+}
+
+/// The listing renders the friendly name; `--json` keeps the UUID.
+#[test]
+fn the_listing_renders_the_friendly_name_when_one_is_known() {
+    let uuid = "0b318c84-bae9-4a50-8832-65ed61f8ab22";
+    let names = session_names(&[session_row(uuid, "trusty-tools-95")]);
+    let report = sessions_report(&one_attributed_session(uuid), None, &names);
+    let DiskReport::Sessions { ref sessions, .. } = report else {
+        panic!("the no-argument view must be the sessions view");
+    };
+    assert_eq!(
+        sessions[0].session_id.as_deref(),
+        Some(uuid),
+        "`--json` keys on the UUID, which a name cannot replace"
+    );
+    assert_eq!(sessions[0].session_name.as_deref(), Some("trusty-tools-95"));
+
+    let text = render(&report);
+    assert!(text.contains("trusty-tools-95"), "{text}");
+    assert!(
+        !text.contains(uuid),
+        "the table renders the name in the UUID's place: {text}"
+    );
+}
+
+/// A long name is truncated so the numeric columns stay where the header put
+/// them.
+///
+/// Why: `{:<38}` pads but never truncates, so a 50-character name shifted
+/// TREES, BUILD, SOURCE and TOTAL right on that row alone.
+///
+/// Fails before the change: the label went into the format unbounded.
+#[test]
+fn a_long_session_name_is_truncated_to_keep_the_columns_aligned() {
+    let uuid = "0b318c84-bae9-4a50-8832-65ed61f8ab22";
+    let long = "trusty-tools-a-very-long-friendly-session-name-xyz";
+    assert_eq!(long.chars().count(), 50, "the width this test exists for");
+    let names = session_names(&[session_row(uuid, long)]);
+    let text = render(&sessions_report(
+        &one_attributed_session(uuid),
+        None,
+        &names,
+    ));
+    let lines: Vec<&str> = text.lines().collect();
+    let header = lines
+        .iter()
+        .find(|l| l.starts_with("SESSION"))
+        .expect("a header line");
+    let row = lines
+        .iter()
+        .find(|l| l.starts_with("trusty-tools-a-very-long"))
+        .expect("the session's own row");
+    let total = lines
+        .iter()
+        .find(|l| l.starts_with("TOTAL"))
+        .expect("a total line");
+    assert_eq!(
+        header.chars().count(),
+        row.chars().count(),
+        "a long name must not push the row wider than the header:\n{header}\n{row}"
+    );
+    assert_eq!(header.chars().count(), total.chars().count());
+    assert!(
+        row.contains('…'),
+        "and the cut must be visible rather than silent: {row}"
+    );
+}
+
+/// One attributed session's roll-up, for the labelling tests.
+fn one_attributed_session(uuid: &str) -> Survey {
+    survey(json!({
+        "generated_at": "2026-09-10T00:00:00Z",
+        "partial": false,
+        "by_session": [{
+            "session_id": uuid,
+            "bytes": 1_000_000_000u64,
+            "build_dir_bytes": 400_000_000u64,
+            "worktree_count": 1,
+            "tiers": { "stale": 0, "review": 0, "keep": 1, "missing": 0 },
+            "worktree_paths": []
+        }],
+        "root": { "projects": [] }
+    }))
 }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -699,6 +699,74 @@ fn cli_reconcile_worktrees_takes_no_destructive_flag() {
     }
 }
 
+/// #7313: `disk` parses bare, with a session argument, and with `--json`.
+#[test]
+fn cli_parses_session_disk() {
+    let bare = Cli::try_parse_from(["trusty-mpm", "session", "disk"]).unwrap();
+    match bare.command.unwrap() {
+        Command::Session {
+            action:
+                SessionAction::Disk {
+                    id_or_name,
+                    json,
+                    budget_seconds,
+                },
+        } => {
+            assert_eq!(
+                id_or_name, None,
+                "no argument means the per-session listing"
+            );
+            assert!(!json, "the default must be the table, not JSON");
+            assert_eq!(
+                budget_seconds, None,
+                "an unset budget defers to the daemon's own clamp"
+            );
+        }
+        other => panic!("expected session disk, got {other:?}"),
+    }
+    let scoped = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "disk",
+        "trusty-tools-95",
+        "--json",
+        "--budget-seconds",
+        "20",
+    ])
+    .unwrap();
+    match scoped.command.unwrap() {
+        Command::Session {
+            action:
+                SessionAction::Disk {
+                    id_or_name,
+                    json,
+                    budget_seconds,
+                },
+        } => {
+            assert_eq!(id_or_name.as_deref(), Some("trusty-tools-95"));
+            assert!(json);
+            assert_eq!(budget_seconds, Some(20));
+        }
+        other => panic!("expected session disk, got {other:?}"),
+    }
+}
+
+/// #7313: `disk` has NO destructive flag, and gains one only over this test.
+///
+/// Why: it reports what is on disk beside `prune-worktrees`, which deletes.
+/// The way a reporting verb stops being report-only is that someone adds a
+/// flag to it; clap refusing these at parse time is the mechanical form of
+/// "there is no destructive form of this command".
+#[test]
+fn cli_session_disk_takes_no_destructive_flag() {
+    for flag in ["--force", "--discard-dirty", "--dry-run"] {
+        assert!(
+            Cli::try_parse_from(["trusty-mpm", "session", "disk", flag]).is_err(),
+            "`session disk {flag}` must not parse — this verb writes nothing"
+        );
+    }
+}
+
 /// #6497: the adoption verb parses a path and the session taking it over.
 #[test]
 fn cli_parses_session_adopt_worktree() {

--- a/crates/trusty-mpm/src/client/http_client/config.rs
+++ b/crates/trusty-mpm/src/client/http_client/config.rs
@@ -151,6 +151,24 @@ pub(super) const DOCTOR_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 /// crate boundary [`super::default_client`] exists to cross.
 pub const RECLAIM_SURVEY_REQUEST_TIMEOUT: Duration = Duration::from_secs(1800);
 
+/// Per-request timeout override for the `disk_survey` call `tm session disk`
+/// makes over `POST /rpc` (#7313).
+///
+/// Why: the daemon clamps that survey's own budget to
+/// [`crate::daemon::mcp_disk::MAX_BUDGET_SECONDS`] and then still has to
+/// serialize a survey covering every managed worktree. Under
+/// [`DEFAULT_REQUEST_TIMEOUT`] the client hangs up at 10s while the daemon
+/// keeps surveying, so the operator sees a transport error where a truncated
+/// survey was available — the #6929 failure mode reached through the client's
+/// bound instead of the tool's. This is the same rule the stdio bridge's
+/// `REQUEST_TIMEOUT` applies for the same clamp, with more headroom because
+/// this caller also pays for the survey's own serialization.
+/// What: 75s, passed to `reqwest::RequestBuilder::timeout` at the
+/// `session_disk` call site alone; every other request keeps the 10s default.
+/// Test: `tests::default_client_uses_default_bounds` pins the value and its
+/// headroom over the daemon's clamp.
+pub const DISK_SURVEY_REQUEST_TIMEOUT: Duration = Duration::from_secs(75);
+
 /// Build the `reqwest::Client` [`super::DaemonClient::new`] uses by default.
 ///
 /// Why: the one production call site for [`build_client`], pinned to this
@@ -272,6 +290,17 @@ mod tests {
             RECLAIM_SURVEY_REQUEST_TIMEOUT > PROVISION_REQUEST_TIMEOUT,
             "the merged-PR survey outlasts a first-clone provision, so its bound \
              must exceed the provisioning one"
+        );
+        // #7313: the disk survey's bound must clear the daemon's own budget
+        // clamp with room for serialization, or `tm session disk` hangs up on a
+        // survey the daemon was about to hand back.
+        assert_eq!(DISK_SURVEY_REQUEST_TIMEOUT, Duration::from_secs(75));
+        assert!(
+            DISK_SURVEY_REQUEST_TIMEOUT
+                > Duration::from_secs(crate::daemon::mcp_disk::MAX_BUDGET_SECONDS)
+                    + Duration::from_secs(5),
+            "the disk-survey bound must leave more than five seconds over the \
+             daemon's budget clamp for serialization and the round trip"
         );
         let _ = default_client();
     }

--- a/crates/trusty-mpm/src/client/http_client/mod.rs
+++ b/crates/trusty-mpm/src/client/http_client/mod.rs
@@ -39,6 +39,10 @@ pub(crate) use config::PROVISION_REQUEST_TIMEOUT;
 // `default_client` below is a public seam.
 pub use config::RECLAIM_SURVEY_REQUEST_TIMEOUT;
 
+// #7313: `tm session disk` lives in the binary crate, so its per-request bound
+// is re-exported publicly for the same reason the merged-PR one above is.
+pub use config::DISK_SURVEY_REQUEST_TIMEOUT;
+
 pub use types::{
     BreakerRow, ChatMessage, ConfigRecommendation, CoordinatorChatOutcome, CoordinatorContext,
     CoordinatorSession, DiscoveredProjectRow, EventRow, FleetByProjectWireResponse,

--- a/crates/trusty-mpm/src/daemon/doctor_worktree_disk.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_worktree_disk.rs
@@ -67,26 +67,10 @@ const SURVEY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 /// Test: `worktree_disk_timeout_is_a_bounded_constant`.
 const SURVEY_TIMEOUT_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
 
-/// Render a byte count the way an operator reads a disk figure.
-///
-/// Why: "1180591620717411303424" is not an early warning. The 1.1 TiB in the
-/// post-mortem is only legible in binary units.
-/// What: binary units (1024-based), one decimal place above KiB.
-/// Test: `human_bytes_renders_binary_units`.
-fn human_bytes(n: u64) -> String {
-    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
-    let mut value = n as f64;
-    let mut unit = 0usize;
-    while value >= 1024.0 && unit + 1 < UNITS.len() {
-        value /= 1024.0;
-        unit += 1;
-    }
-    if unit == 0 {
-        format!("{n} B")
-    } else {
-        format!("{value:.1} {}", UNITS[unit])
-    }
-}
+// #7313: the byte formatter moved to `crate::disk::human_bytes` so `tm session
+// disk` — a separate crate from the library — renders the same figures through
+// the same code.
+use crate::disk::human_bytes;
 
 /// The pure verdict for [`check_worktree_disk`], separated for hermetic tests.
 ///

--- a/crates/trusty-mpm/src/daemon/doctor_worktree_disk_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_worktree_disk_tests.rs
@@ -60,16 +60,6 @@ fn candidate(bytes: Option<u64>, pr: BranchPrState, verdict: ReclaimVerdict) -> 
 }
 
 #[test]
-fn human_bytes_renders_binary_units() {
-    assert_eq!(human_bytes(512), "512 B");
-    assert_eq!(human_bytes(1024), "1.0 KiB");
-    assert_eq!(human_bytes(1024 * 1024 * 3), "3.0 MiB");
-    // The figure from the 2026-07-21 post-mortem must render as terabytes,
-    // not as an unreadable integer.
-    assert_eq!(human_bytes(1_209_462_790_553), "1.1 TiB");
-}
-
-#[test]
 fn worktree_disk_check_is_ok_with_no_worktrees() {
     let check = build_worktree_disk_check(&survey_of(vec![]));
     assert_eq!(check.status, CheckStatus::Ok);

--- a/crates/trusty-mpm/src/disk/mod.rs
+++ b/crates/trusty-mpm/src/disk/mod.rs
@@ -34,3 +34,45 @@ pub mod size_index;
 // tool is the only consumer.
 pub(crate) mod survey;
 pub(crate) mod survey_run;
+
+/// Render a byte count the way an operator reads a disk figure.
+///
+/// Why: "1180591620717411303424" is not an early warning. The 1.1 TiB in the
+/// 2026-07-21 post-mortem is only legible in binary units. It lives here, on
+/// the module that owns disk accounting, rather than in
+/// [`crate::daemon::doctor_worktree_disk`] where it started (#7313): `tm
+/// session disk` renders the same figures from the `tm` binary, which is a
+/// separate crate from the library and so cannot reach a private daemon
+/// helper. One formatter, so the doctor row and the CLI never disagree about
+/// what 1.1 TiB looks like.
+/// What: binary units (1024-based), one decimal place above KiB.
+/// Test: `human_bytes_renders_binary_units`.
+pub fn human_bytes(n: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = n as f64;
+    let mut unit = 0usize;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{n} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::human_bytes;
+
+    #[test]
+    fn human_bytes_renders_binary_units() {
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(1024), "1.0 KiB");
+        assert_eq!(human_bytes(1024 * 1024 * 3), "3.0 MiB");
+        // The figure from the 2026-07-21 post-mortem must render as terabytes,
+        // not as an unreadable integer.
+        assert_eq!(human_bytes(1_209_462_790_553), "1.1 TiB");
+    }
+}

--- a/crates/trusty-mpm/tests/tm_session_disk_cli.rs
+++ b/crates/trusty-mpm/tests/tm_session_disk_cli.rs
@@ -1,0 +1,328 @@
+//! `tm session disk` end-to-end against a stub `POST /rpc` daemon (#7313).
+//!
+//! Why: the unit tests in `commands::session_disk_tests` pin the fold, the
+//! order and the error arms as pure functions; none of them proves that the
+//! BINARY reaches the daemon, sends `group_by: "session"`, or puts the report
+//! on stdout and its diagnostics on stderr. That wiring is what an operator
+//! actually runs, and it is exactly what a unit test cannot see.
+//! What: serves one axum route at `/rpc` that answers `tools/call` with a fixed
+//! `disk_survey` payload, points the binary at it with `TRUSTY_MPM_URL`
+//! (`--url`'s env form, which every resolver honours ahead of the lock file and
+//! the gateway probe), and asserts the JSON schema, the table, and the
+//! unknown-session error. The stub also RECORDS the arguments it was called
+//! with, so the `group_by` contract is asserted rather than assumed.
+//! Test: this file; run with
+//! `cargo test -p trusty-mpm --test tm_session_disk_cli`.
+
+use std::future::IntoFuture;
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::{Value, json};
+
+/// The survey the stub daemon answers with: two sessions plus the unattributed
+/// bucket, and one session owning worktrees under two different projects.
+fn survey_payload() -> Value {
+    json!({
+        "generated_at": "2026-09-10T00:00:00Z",
+        "partial": false,
+        "keep_list": { "patterns": [], "invalid": [] },
+        "by_session": [
+            {
+                "session_id": "trusty-tools-95",
+                "bytes": 30_000_000_000u64,
+                "build_dir_bytes": 24_000_000_000u64,
+                "worktree_count": 2,
+                "tiers": { "stale": 1, "review": 1, "keep": 0, "missing": 0 },
+                "worktree_paths": [
+                    "/w/bobmatnyc/trusty-tools/.claude/worktrees/a",
+                    "/w/bobmatnyc/other/.claude/worktrees/c"
+                ]
+            },
+            {
+                "session_id": null,
+                "bytes": 5_000_000_000u64,
+                "build_dir_bytes": 4_000_000_000u64,
+                "worktree_count": 1,
+                "tiers": { "stale": 1, "review": 0, "keep": 0, "missing": 0 },
+                "worktree_paths": ["/w/bobmatnyc/trusty-tools/.claude/worktrees/z"]
+            }
+        ],
+        "root": {
+            "path": "/w",
+            "bytes": 35_000_000_000u64,
+            "counts": { "stale": 2, "review": 1, "keep": 0, "missing": 0 },
+            "stale_bytes": 5_000_000_000u64,
+            "stale_measured": 2,
+            "projects": [
+                {
+                    "name": "bobmatnyc/trusty-tools",
+                    "path": "/w/bobmatnyc/trusty-tools",
+                    "bytes": 25_000_000_000u64,
+                    "worktrees": [
+                        {
+                            "path": "/w/bobmatnyc/trusty-tools/.claude/worktrees/a",
+                            "tier": "review",
+                            "bytes": 20_000_000_000u64,
+                            "build_dir_bytes": 18_000_000_000u64,
+                            "owning_session": "trusty-tools-95"
+                        },
+                        {
+                            "path": "/w/bobmatnyc/trusty-tools/.claude/worktrees/z",
+                            "tier": "stale",
+                            "bytes": 5_000_000_000u64,
+                            "build_dir_bytes": 4_000_000_000u64,
+                            "owning_session": null
+                        }
+                    ]
+                },
+                {
+                    "name": "bobmatnyc/other",
+                    "path": "/w/bobmatnyc/other",
+                    "bytes": 10_000_000_000u64,
+                    "worktrees": [
+                        {
+                            "path": "/w/bobmatnyc/other/.claude/worktrees/c",
+                            "tier": "stale",
+                            "bytes": 10_000_000_000u64,
+                            "build_dir_bytes": 6_000_000_000u64,
+                            "owning_session": "trusty-tools-95"
+                        }
+                    ]
+                }
+            ]
+        }
+    })
+}
+
+/// Serve one `/rpc` route answering `disk_survey`, recording each call's
+/// arguments; return the base URL and the recorder.
+async fn serve_stub() -> (String, Arc<Mutex<Vec<Value>>>) {
+    let calls: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let recorder = Arc::clone(&calls);
+    let router = Router::new().route(
+        "/rpc",
+        post(move |Json(req): Json<Value>| {
+            let recorder = Arc::clone(&recorder);
+            async move {
+                let args = req
+                    .pointer("/params/arguments")
+                    .cloned()
+                    .unwrap_or(Value::Null);
+                recorder.lock().expect("record the call").push(args);
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": req.get("id").cloned().unwrap_or(Value::Null),
+                    "result": {
+                        "content": [{
+                            "type": "text",
+                            "text": survey_payload().to_string()
+                        }],
+                        "isError": false
+                    }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind an ephemeral loopback port");
+    let addr = listener.local_addr().expect("read the bound address");
+    tokio::spawn(axum::serve(listener, router).into_future());
+    (format!("http://{addr}"), calls)
+}
+
+/// Run the built `tm` binary against the stub, from a hermetic temp cwd.
+///
+/// The cwd is outside any managed workspace root, so the project filter
+/// declines and the survey covers everything — which is what makes the
+/// assertions independent of the developer's own machine.
+fn run_tm(url: &str, cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_tm"))
+        .env("TRUSTY_MPM_URL", url)
+        .args(args)
+        .current_dir(cwd)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("spawn the tm binary")
+}
+
+/// `tm session disk --json` reports every session, in bytes-descending order,
+/// with a total — and asks the daemon for the per-session roll-up.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_disk_json_reports_every_session() {
+    let (url, calls) = serve_stub().await;
+    let cwd = tempfile::tempdir().expect("temp cwd");
+
+    let out = tokio::task::spawn_blocking({
+        let url = url.clone();
+        let cwd = cwd.path().to_path_buf();
+        move || run_tm(&url, &cwd, &["session", "disk", "--json"])
+    })
+    .await
+    .expect("the binary run must not panic");
+
+    assert!(
+        out.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let report: Value =
+        serde_json::from_slice(&out.stdout).expect("`--json` must put a JSON document on stdout");
+
+    assert_eq!(report["view"], "sessions");
+    let sessions = report["sessions"].as_array().expect("a sessions array");
+    assert_eq!(sessions.len(), 2, "{report}");
+    assert_eq!(sessions[0]["session_id"], "trusty-tools-95");
+    assert_eq!(sessions[0]["bytes"], 30_000_000_000u64);
+    assert_eq!(
+        sessions[0]["source_bytes"], 6_000_000_000u64,
+        "source is the remainder after the build directories"
+    );
+    assert_eq!(
+        sessions[1]["session_id"],
+        Value::Null,
+        "the unattributed bucket sorts last: {report}"
+    );
+    assert_eq!(report["total"]["bytes"], 35_000_000_000u64);
+    assert_eq!(report["total"]["worktree_count"], 3);
+    assert_eq!(report["partial"], false);
+    assert_eq!(report["generated_at"], "2026-09-10T00:00:00Z");
+
+    // The roll-up is what slice 1 added; asking for it is the whole contract
+    // between this command and the tool.
+    let recorded = calls.lock().expect("read the recorded calls");
+    assert_eq!(recorded.len(), 1, "exactly one survey call: {recorded:?}");
+    assert_eq!(recorded[0]["group_by"], "session");
+    assert!(
+        recorded[0]["budget_seconds"].is_u64(),
+        "the call must carry a budget the client's own timeout outlives: {:?}",
+        recorded[0]
+    );
+}
+
+/// Naming a session prints its breakdown by class and its worktrees across
+/// every project.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_disk_breaks_one_session_down_by_class() {
+    let (url, _calls) = serve_stub().await;
+    let cwd = tempfile::tempdir().expect("temp cwd");
+
+    let out = tokio::task::spawn_blocking({
+        let url = url.clone();
+        let cwd = cwd.path().to_path_buf();
+        move || {
+            run_tm(
+                &url,
+                &cwd,
+                &["session", "disk", "trusty-tools-95", "--json"],
+            )
+        }
+    })
+    .await
+    .expect("the binary run must not panic");
+
+    assert!(
+        out.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let report: Value = serde_json::from_slice(&out.stdout).expect("a JSON document on stdout");
+
+    assert_eq!(report["view"], "session");
+    assert_eq!(report["session_id"], "trusty-tools-95");
+    let classes = report["classes"].as_array().expect("a classes array");
+    assert_eq!(classes[0]["class"], "build");
+    assert_eq!(classes[0]["bytes"], 24_000_000_000u64);
+    assert_eq!(classes[1]["class"], "source");
+    assert_eq!(classes[1]["bytes"], 6_000_000_000u64);
+
+    let worktrees = report["worktrees"].as_array().expect("a worktrees array");
+    assert_eq!(worktrees.len(), 2, "{report}");
+    assert_eq!(
+        worktrees[0]["path"], "/w/bobmatnyc/trusty-tools/.claude/worktrees/a",
+        "bytes descending: {report}"
+    );
+    let projects: Vec<&str> = worktrees
+        .iter()
+        .map(|w| w["project"].as_str().expect("a project label"))
+        .collect();
+    assert!(
+        projects.contains(&"bobmatnyc/trusty-tools") && projects.contains(&"bobmatnyc/other"),
+        "a session's worktrees span projects: {projects:?}"
+    );
+}
+
+/// The human table goes to stdout, with a header and a total line.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_disk_prints_a_table_without_json() {
+    let (url, _calls) = serve_stub().await;
+    let cwd = tempfile::tempdir().expect("temp cwd");
+
+    let out = tokio::task::spawn_blocking({
+        let url = url.clone();
+        let cwd = cwd.path().to_path_buf();
+        move || run_tm(&url, &cwd, &["session", "disk"])
+    })
+    .await
+    .expect("the binary run must not panic");
+
+    assert!(out.status.success(), "{:?}", out.status);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("SESSION"), "{stdout}");
+    assert!(stdout.contains("trusty-tools-95"), "{stdout}");
+    assert!(stdout.contains("(unattributed)"), "{stdout}");
+    assert!(
+        stdout.lines().any(|l| l.starts_with("TOTAL")),
+        "the table must end on a total line: {stdout}"
+    );
+    assert!(
+        !stdout.contains('{'),
+        "the default form is a table, not JSON: {stdout}"
+    );
+}
+
+/// An unknown session exits non-zero with the reason on stderr and nothing on
+/// stdout.
+///
+/// Why this matters more than it looks: an empty report for a typo is
+/// indistinguishable from a session that genuinely holds nothing, and an
+/// operator would clear the wrong thing — or nothing — on the strength of it.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_disk_rejects_an_unknown_session() {
+    let (url, _calls) = serve_stub().await;
+    let cwd = tempfile::tempdir().expect("temp cwd");
+
+    let out = tokio::task::spawn_blocking({
+        let url = url.clone();
+        let cwd = cwd.path().to_path_buf();
+        move || {
+            run_tm(
+                &url,
+                &cwd,
+                &["session", "disk", "no-such-session", "--json"],
+            )
+        }
+    })
+    .await
+    .expect("the binary run must not panic");
+
+    assert!(
+        !out.status.success(),
+        "an unknown session must exit non-zero; stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no-such-session"),
+        "stderr must name the session that matched nothing: {stderr}"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).trim().is_empty(),
+        "nothing may reach stdout — a partial document would parse as a report"
+    );
+}

--- a/crates/trusty-mpm/tests/tm_session_disk_cli.rs
+++ b/crates/trusty-mpm/tests/tm_session_disk_cli.rs
@@ -5,12 +5,14 @@
 //! BINARY reaches the daemon, sends `group_by: "session"`, or puts the report
 //! on stdout and its diagnostics on stderr. That wiring is what an operator
 //! actually runs, and it is exactly what a unit test cannot see.
-//! What: serves one axum route at `/rpc` that answers `tools/call` with a fixed
-//! `disk_survey` payload, points the binary at it with `TRUSTY_MPM_URL`
-//! (`--url`'s env form, which every resolver honours ahead of the lock file and
-//! the gateway probe), and asserts the JSON schema, the table, and the
-//! unknown-session error. The stub also RECORDS the arguments it was called
-//! with, so the `group_by` contract is asserted rather than assumed.
+//! What: serves two axum routes — `/rpc`, which answers `tools/call` with a
+//! fixed `disk_survey` payload, and `GET /sessions`, which maps the survey's
+//! session UUID to its friendly name — points the binary at them with
+//! `TRUSTY_MPM_URL` (`--url`'s env form, which every resolver honours ahead of
+//! the lock file and the gateway probe), and asserts the JSON schema, the
+//! table, the name resolution, and the two distinct error arms. The stub also
+//! RECORDS the arguments it was called with, so the `group_by` contract is
+//! asserted rather than assumed.
 //! Test: this file; run with
 //! `cargo test -p trusty-mpm --test tm_session_disk_cli`.
 
@@ -18,9 +20,16 @@ use std::future::IntoFuture;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 
-use axum::routing::post;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde_json::{Value, json};
+
+/// The session the survey attributes bytes to — a raw UUID, which is the only
+/// thing `owning_session` is ever set to (#7313).
+const OWNER: &str = "0b318c84-bae9-4a50-8832-65ed61f8ab22";
+
+/// The friendly name the daemon knows that session by.
+const OWNER_NAME: &str = "trusty-tools-95";
 
 /// The survey the stub daemon answers with: two sessions plus the unattributed
 /// bucket, and one session owning worktrees under two different projects.
@@ -31,7 +40,7 @@ fn survey_payload() -> Value {
         "keep_list": { "patterns": [], "invalid": [] },
         "by_session": [
             {
-                "session_id": "trusty-tools-95",
+                "session_id": OWNER,
                 "bytes": 30_000_000_000u64,
                 "build_dir_bytes": 24_000_000_000u64,
                 "worktree_count": 2,
@@ -67,7 +76,7 @@ fn survey_payload() -> Value {
                             "tier": "review",
                             "bytes": 20_000_000_000u64,
                             "build_dir_bytes": 18_000_000_000u64,
-                            "owning_session": "trusty-tools-95"
+                            "owning_session": OWNER
                         },
                         {
                             "path": "/w/bobmatnyc/trusty-tools/.claude/worktrees/z",
@@ -88,7 +97,7 @@ fn survey_payload() -> Value {
                             "tier": "stale",
                             "bytes": 10_000_000_000u64,
                             "build_dir_bytes": 6_000_000_000u64,
-                            "owning_session": "trusty-tools-95"
+                            "owning_session": OWNER
                         }
                     ]
                 }
@@ -97,35 +106,58 @@ fn survey_payload() -> Value {
     })
 }
 
-/// Serve one `/rpc` route answering `disk_survey`, recording each call's
-/// arguments; return the base URL and the recorder.
+/// Serve the two routes the command uses — `/rpc` for the survey (recording
+/// each call's arguments) and `GET /sessions` for the name↔id directory —
+/// returning the base URL and the recorder.
+///
+/// Why `/sessions` belongs here: the survey attributes by UUID, so a friendly
+/// name only resolves through this list. A stub without it would prove the
+/// fallback path and nothing about the resolution (#7313).
 async fn serve_stub() -> (String, Arc<Mutex<Vec<Value>>>) {
     let calls: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
     let recorder = Arc::clone(&calls);
-    let router = Router::new().route(
-        "/rpc",
-        post(move |Json(req): Json<Value>| {
-            let recorder = Arc::clone(&recorder);
-            async move {
-                let args = req
-                    .pointer("/params/arguments")
-                    .cloned()
-                    .unwrap_or(Value::Null);
-                recorder.lock().expect("record the call").push(args);
+    let router = Router::new()
+        .route(
+            "/rpc",
+            post(move |Json(req): Json<Value>| {
+                let recorder = Arc::clone(&recorder);
+                async move {
+                    let args = req
+                        .pointer("/params/arguments")
+                        .cloned()
+                        .unwrap_or(Value::Null);
+                    recorder.lock().expect("record the call").push(args);
+                    Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": req.get("id").cloned().unwrap_or(Value::Null),
+                        "result": {
+                            "content": [{
+                                "type": "text",
+                                "text": survey_payload().to_string()
+                            }],
+                            "isError": false
+                        }
+                    }))
+                }
+            }),
+        )
+        // The MANAGED store is where an attributed session actually lives on a
+        // live machine (#7313); the project store answers empty beside it, so
+        // both halves of the directory are exercised.
+        .route(
+            "/api/v1/sessions/managed",
+            get(|| async {
                 Json(json!({
-                    "jsonrpc": "2.0",
-                    "id": req.get("id").cloned().unwrap_or(Value::Null),
-                    "result": {
-                        "content": [{
-                            "type": "text",
-                            "text": survey_payload().to_string()
-                        }],
-                        "isError": false
-                    }
+                    "sessions": [{
+                        "id": OWNER,
+                        "name": OWNER_NAME,
+                        "state": "active",
+                        "persisted_state": "active",
+                    }]
                 }))
-            }
-        }),
-    );
+            }),
+        )
+        .route("/sessions", get(|| async { Json(json!({"sessions": []})) }));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind an ephemeral loopback port");
@@ -176,7 +208,14 @@ async fn session_disk_json_reports_every_session() {
     assert_eq!(report["view"], "sessions");
     let sessions = report["sessions"].as_array().expect("a sessions array");
     assert_eq!(sessions.len(), 2, "{report}");
-    assert_eq!(sessions[0]["session_id"], "trusty-tools-95");
+    assert_eq!(
+        sessions[0]["session_id"], OWNER,
+        "`--json` keys on the UUID the survey attributes by"
+    );
+    assert_eq!(
+        sessions[0]["session_name"], OWNER_NAME,
+        "with the friendly name beside it: {report}"
+    );
     assert_eq!(sessions[0]["bytes"], 30_000_000_000u64);
     assert_eq!(
         sessions[0]["source_bytes"], 6_000_000_000u64,
@@ -204,37 +243,43 @@ async fn session_disk_json_reports_every_session() {
     );
 }
 
-/// Naming a session prints its breakdown by class and its worktrees across
-/// every project.
+/// Naming a session by its FRIENDLY NAME prints its breakdown by class and its
+/// worktrees across every project.
+///
+/// Why the name and not the UUID: the help text promises "by id or friendly
+/// name", and the survey attributes by UUID only, so this is the whole
+/// resolution contract in one run.
+///
+/// Fails before the change: `trusty-tools-95` was matched against
+/// `owning_session` directly, matched no worktree, and the binary exited
+/// non-zero with "no worktree in the survey is attributed to session".
 #[tokio::test(flavor = "multi_thread")]
-async fn session_disk_breaks_one_session_down_by_class() {
+async fn session_disk_resolves_a_friendly_name() {
     let (url, _calls) = serve_stub().await;
     let cwd = tempfile::tempdir().expect("temp cwd");
 
     let out = tokio::task::spawn_blocking({
         let url = url.clone();
         let cwd = cwd.path().to_path_buf();
-        move || {
-            run_tm(
-                &url,
-                &cwd,
-                &["session", "disk", "trusty-tools-95", "--json"],
-            )
-        }
+        move || run_tm(&url, &cwd, &["session", "disk", OWNER_NAME, "--json"])
     })
     .await
     .expect("the binary run must not panic");
 
     assert!(
         out.status.success(),
-        "stdout={} stderr={}",
+        "a friendly name must resolve; stdout={} stderr={}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
     let report: Value = serde_json::from_slice(&out.stdout).expect("a JSON document on stdout");
 
     assert_eq!(report["view"], "session");
-    assert_eq!(report["session_id"], "trusty-tools-95");
+    assert_eq!(
+        report["session_id"], OWNER,
+        "the name resolved to the session's UUID: {report}"
+    );
+    assert_eq!(report["session_name"], OWNER_NAME);
     let classes = report["classes"].as_array().expect("a classes array");
     assert_eq!(classes[0]["class"], "build");
     assert_eq!(classes[0]["bytes"], 24_000_000_000u64);
@@ -274,7 +319,14 @@ async fn session_disk_prints_a_table_without_json() {
     assert!(out.status.success(), "{:?}", out.status);
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("SESSION"), "{stdout}");
-    assert!(stdout.contains("trusty-tools-95"), "{stdout}");
+    assert!(
+        stdout.contains(OWNER_NAME),
+        "the table names the session an operator recognises: {stdout}"
+    );
+    assert!(
+        !stdout.contains(OWNER),
+        "and renders the name in the UUID's place: {stdout}"
+    );
     assert!(stdout.contains("(unattributed)"), "{stdout}");
     assert!(
         stdout.lines().any(|l| l.starts_with("TOTAL")),
@@ -322,7 +374,46 @@ async fn session_disk_rejects_an_unknown_session() {
         "stderr must name the session that matched nothing: {stderr}"
     );
     assert!(
+        stderr.contains("no session named"),
+        "a name that resolves to nothing says so, not 'holds no worktrees': {stderr}"
+    );
+    assert!(
         String::from_utf8_lossy(&out.stdout).trim().is_empty(),
         "nothing may reach stdout — a partial document would parse as a report"
+    );
+}
+
+/// A session that exists but owns no worktree gets its OWN message.
+///
+/// Why the two must differ: a typo and an empty session are different facts,
+/// and before this they shared one message — so an operator could not tell
+/// which they were looking at.
+///
+/// Fails before the change: the argument was matched against `owning_session`
+/// directly, so a valid UUID owning nothing produced the same "no worktree ...
+/// attributed" text as a mistyped name.
+#[tokio::test(flavor = "multi_thread")]
+async fn session_disk_separates_an_empty_session_from_an_unknown_name() {
+    let (url, _calls) = serve_stub().await;
+    let cwd = tempfile::tempdir().expect("temp cwd");
+    let empty = "11111111-2222-3333-4444-555555555555";
+
+    let out = tokio::task::spawn_blocking({
+        let url = url.clone();
+        let cwd = cwd.path().to_path_buf();
+        move || run_tm(&url, &cwd, &["session", "disk", empty, "--json"])
+    })
+    .await
+    .expect("the binary run must not panic");
+
+    assert!(!out.status.success(), "{:?}", out.status);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("holds no worktrees"),
+        "a resolved session owning nothing says so: {stderr}"
+    );
+    assert!(
+        !stderr.contains("no session named"),
+        "and never borrows the unresolvable-name message: {stderr}"
     );
 }


### PR DESCRIPTION
## Outcome
Refs #7313, slice 2 of 3. `tm session disk [<id-or-name>] [--json] [--budget-seconds N]` reports per-session disk usage from slice 1's survey: one row per session sorted as the survey orders them, or one session's build/source breakdown. Friendly names resolve across both the managed and project session stores; an unknown name and a resolved-but-empty session are distinct errors.

## Changes
- `crates/trusty-mpm/src/bin/tm/commands/session_disk.rs` (new): one `disk_survey` call with `group_by: "session"` over `POST /rpc`; no walker of its own. `session_directory` + `resolve_session_id`; `SESSION_COLUMN` render with `…` truncation.
- `cli/actions/session.rs`: `SessionAction::Disk` beside `ls|rename|pause|resume|stop`. `commands/session.rs`: one delegating arm.
- `disk/mod.rs`: `human_bytes` moved here from `daemon/doctor_worktree_disk.rs` (bin cannot reach a daemon-private helper; no fourth formatter).
- `client/http_client/config.rs`: `DISK_SURVEY_REQUEST_TIMEOUT` (75s), applied at this call site only; pinned to clear `MAX_BUDGET_SECONDS` by more than 5s.
- `src/assets/skills/tm-capabilities/references/cli.md`: regenerated (two lines).
- Tests: `session_disk_tests.rs` (21 unit), `tests/tm_session_disk_cli.rs` (6 against a stub `/rpc` daemon on an ephemeral loopback port), 2 CLI-parse.
- `changelog.d/7313-session-disk-cli.md`.

## Risk
Normal. Read-only command; no destructive flag exists and a test pins that. Known limit carried to slice 3: with a session argument the project filter is dropped and a whole-workspace survey can exhaust the budget, and the empty-breakdown error fires before the `partial` warning prints, so a truncated survey reads as "holds no worktrees".

## Tests
Rung 4, `-p trusty-mpm`: fmt --check, clippy --all-targets -D warnings, `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — 57 targets, 12007 passed, 0 failed, 18 ignored; `cargo check --workspace` clean; no crate declares trusty-mpm as a dependency, so the dependent leg is empty. Fails-before: the column-width test on 34 chars; the five friendly-name/error-arm binary tests on 4eff612e8. Live: `tm session disk --budget-seconds 20` against the running daemon renders `tm-r55337-01 … 514.2 GiB` where it printed a bare UUID before.

## Baseline
origin/main 132f557da, green.

## Docs
Why/What/Test on `session_disk`, `session_report`, `sessions_report`, `fetch_survey`, `survey_from_rpc`, the `Disk` variant; `// #7313:` at integration sites. Doc gates: check_line_cap, check_changelog_fragment, check_test_pointers, check_sld, check_doc_paths, check_capabilities, check-pr-version-bump — all OK.

## Review
code-critic WARN (one HIGH: friendly-name resolution; one LOW: name truncation), both folded in 518510272. Credential scan of `origin/main...HEAD`: PASS.

https://claude.ai/code/session_0194bkFi1G1Wv3kh1bVbMw4q

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
