### PR TITLE
fix(trusty-mpm): tm ls deletes an errored session by stopping it first, on both delete surfaces (Refs #7224)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7224-tm-ls-delete-errored.md
+++ b/crates/trusty-mpm/changelog.d/7224-tm-ls-delete-errored.md
@@ -1,0 +1,2 @@
+Fixed
+- `tm ls` now deletes an errored session by stopping its runtime first, as one confirmed action, instead of refusing with a hint to run `tm session stop` in a shell. A stop the daemon rejects issues no delete at all, and the picker's status line wraps instead of clipping, so a refusal's session id is never cut mid-token.

--- a/crates/trusty-mpm/src/bin/tm/commands/delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/delete.rs
@@ -66,5 +66,12 @@ pub(crate) async fn session_delete(
             eprintln!("error: {msg}");
             Err(anyhow::anyhow!("delete refused: {msg}"))
         }
+        // #7224: unreachable from this verb (it never takes the stop-first
+        // route), but the variant is exhaustive and a silent `_` arm would
+        // swallow a future caller's failed stop as a success.
+        DeleteReport::StopFailed(msg) => {
+            eprintln!("error: {msg}");
+            Err(anyhow::anyhow!("stop failed; {id} was not deleted: {msg}"))
+        }
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/picker_delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/picker_delete.rs
@@ -173,6 +173,61 @@ pub(crate) fn classify_stop_first(status: reqwest::StatusCode) -> StopFirstNext 
     }
 }
 
+/// The `(force, stop_first)` pair a delete of a session in `state` uses (#7224).
+///
+/// Why: `tm ls` has two delete surfaces — the ratatui TUI and the numbered
+/// picker it falls back to when the terminal has no raw mode — and they must
+/// answer "what kind of delete is this?" identically. They did not: the TUI
+/// learned the stop-first leg and the numbered picker kept issuing the bare
+/// delete, so the same errored row was deleted in one surface and refused in
+/// the other. One function is what makes that divergence unrepresentable.
+/// What: `force` from [`delete_needs_force`] (running rows demand the word
+/// `force`), `stop_first` from [`delete_needs_stop_first`] (an errored row's
+/// runtime is stopped before the delete goes out).
+/// Test: `delete_route_flags_match_the_two_guards` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+pub(crate) fn delete_route_flags(state: &str) -> (bool, bool) {
+    (delete_needs_force(state), delete_needs_stop_first(state))
+}
+
+/// The question both delete surfaces ask before an ERRORED row's delete (#7224).
+///
+/// Why: confirming an errored row runs two legs — stop the runtime, then delete
+/// the record — and an operator who agrees to that in one surface must be
+/// agreeing to the same thing in the other. Holding the sentence in one place
+/// is what keeps the numbered picker's prompt and the TUI overlay's from
+/// drifting into describing different actions.
+/// Test: `both_delete_surfaces_ask_the_same_errored_question` in
+/// `tests_behavior_d_stop_delete_tests.rs`, and the overlay render in
+/// `confirm_overlay_asks_the_shared_errored_question`.
+pub(crate) fn errored_confirm_ask(name: &str) -> String {
+    format!("'{name}' is errored. Stop it and delete it? Type y, then Enter.")
+}
+
+/// Issue a confirmed delete by the route `stop_first` selects (#7224).
+///
+/// Why: both delete surfaces had this two-branch choice written out inline, and
+/// only one of them had both branches. Naming the route once removes the branch
+/// a surface can forget to write.
+/// What: `stop_first` sends the delete through [`stop_then_delete`]; otherwise
+/// straight to [`delete_managed_then_local`]. `force` is threaded unchanged
+/// either way — the stop leg never escalates it.
+/// Test: the `picker_delete_*` and `stop_then_delete_*` round trips in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+pub(crate) async fn route_delete(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+    force: bool,
+    stop_first: bool,
+) -> anyhow::Result<DeleteReport> {
+    if stop_first {
+        stop_then_delete(client, url, id, force).await
+    } else {
+        delete_managed_then_local(client, url, id, force).await
+    }
+}
+
 /// Map a managed-delete HTTP status to the next routing step.
 ///
 /// Why: pure seam for the family routing so 200/404/409/other are testable
@@ -406,13 +461,15 @@ async fn delete_local(
 /// Why: the interactive delete must be explicit and, for a running session,
 /// force-confirmed — never a silent destructive default. This is the TTY driver
 /// that renders the confirm prompt and calls the shared routing helper.
-/// What: computes [`delete_needs_force`] from the session state; for a running
-/// session it prints a force warning and requires the operator to type `force`
-/// ([`confirm_is_force`]); otherwise it requires `y`/`yes` ([`confirm_is_yes`]).
-/// On confirm it calls [`delete_managed_then_local`] with the matching `force`
-/// flag and renders the [`DeleteReport`]. Returns `Ok(true)` only when a record
-/// was actually removed (so the caller knows the list changed); a cancel, an EOF,
-/// a 409 refusal, or a not-found all return `Ok(false)`.
+/// What: computes the route with [`delete_route_flags`]; for a running session
+/// it prints a force warning and requires the operator to type `force`
+/// ([`confirm_is_force`]); an errored session is asked the shared
+/// [`errored_confirm_ask`] question, which names the stop leg as well; every
+/// other state is asked plainly. All three then require the same `y`/`yes`
+/// ([`confirm_is_yes`]) except the force case. On confirm it hands off to
+/// [`delete_confirmed`], which routes and renders. Returns `Ok(true)` only when
+/// a record was actually removed (so the caller knows the list changed); a
+/// cancel, an EOF, a 409 refusal, or a not-found all return `Ok(false)`.
 /// Test: stdin/HTTP path is side-effect-only (manual smoke + e2e); the pure
 /// confirm/route/guard seams it composes are unit-tested (see module doc).
 pub(crate) async fn confirm_and_delete(
@@ -420,13 +477,18 @@ pub(crate) async fn confirm_and_delete(
     url: &str,
     session: &ManagedSessionSummary,
 ) -> anyhow::Result<bool> {
-    let force = delete_needs_force(&session.state);
+    let (force, stop_first) = delete_route_flags(&session.state);
     if force {
         eprintln!(
             "tm: '{}' is {} (running) — deleting will FORCE-remove the record.",
             session.name, session.state
         );
         eprint!("tm: type 'force' to confirm, or anything else to cancel > ");
+    } else if stop_first {
+        // #7224: an errored row's confirm covers BOTH legs, so say so before
+        // the operator agrees rather than after.
+        eprintln!("tm: {}", errored_confirm_ask(&session.name));
+        eprint!("tm: [y/N] > ");
     } else {
         eprintln!(
             "tm: delete '{}' ({})? this permanently removes the session record.",
@@ -455,7 +517,31 @@ pub(crate) async fn confirm_and_delete(
         return Ok(false);
     }
 
-    match delete_managed_then_local(client, url, &session.id, force).await? {
+    delete_confirmed(client, url, session).await
+}
+
+/// Route an already-confirmed delete and report what the daemon did (#7224).
+///
+/// Why: the confirm half of [`confirm_and_delete`] reads stdin, so while the
+/// routing lived inside it the numbered picker's delete could not be proven
+/// against a stub daemon the way the TUI's can. Splitting the two is what let
+/// the missing stop-first leg be caught: the ROUTING is now decidable without a
+/// terminal.
+/// What: recomputes the delete's route from `session.state`, issues it, and
+/// prints the [`DeleteReport`]. Returns `Ok(true)` only when a record was
+/// actually removed, so the caller knows the list changed.
+/// Test: `picker_delete_stops_an_errored_session_before_deleting_it`,
+/// `picker_delete_treats_a_not_found_stop_as_nothing_to_stop`,
+/// `picker_delete_never_deletes_after_a_failed_stop`,
+/// `picker_delete_issues_no_stop_for_a_non_errored_row` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+pub(crate) async fn delete_confirmed(
+    client: &reqwest::Client,
+    url: &str,
+    session: &ManagedSessionSummary,
+) -> anyhow::Result<bool> {
+    let (force, stop_first) = delete_route_flags(&session.state);
+    match route_delete(client, url, &session.id, force, stop_first).await? {
         DeleteReport::Deleted {
             name,
             prior_state,

--- a/crates/trusty-mpm/src/bin/tm/commands/picker_delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/picker_delete.rs
@@ -71,6 +71,13 @@ pub(crate) enum DeleteReport {
     NotFound,
     /// The managed running-guard (409) refused the delete; carries its message.
     Refused(String),
+    /// The stop-first leg failed, so NO delete was attempted (#7224).
+    ///
+    /// Carries the daemon's full status + body. Distinct from [`Self::Refused`]
+    /// because nothing reached the delete endpoint at all: the session is still
+    /// exactly as it was, and the operator has to deal with the stop failure
+    /// before a delete can mean anything.
+    StopFailed(String),
 }
 
 /// Next step after the managed-delete attempt, keyed on the HTTP status.
@@ -109,6 +116,61 @@ pub(crate) enum ManagedDeleteNext {
 /// `delete_needs_force_errored_false` in `tests_behavior_d_tests.rs`.
 pub(crate) fn delete_needs_force(state: &str) -> bool {
     !super::guided_resume::needs_restart(state)
+}
+
+/// Does deleting a session in state `state` need a runtime-stop first (#7224)?
+///
+/// Why: an `errored` record can still have a LIVE tmux session behind it —
+/// provisioning failed after the session was created, or the runtime died in a
+/// way that left the pane up. [`delete_needs_force`] answers `false` for it (no
+/// force word needed), the delete then goes out with `force = false`, and the
+/// daemon's own tmux-liveness probe 409s. That refusal is correct and the
+/// operator's only recourse used to be dropping to `tm session stop` in a
+/// shell — a bounce out of the surface they were already in. Doing the stop
+/// leg here is the automation of exactly that step, and nothing more: the
+/// delete that follows still goes out UNFORCED, so the daemon's probe stays the
+/// authority on whether the record may go.
+/// What: `true` only for `errored`. A `stopped` record has no runtime to stop,
+/// and `active`/`provisioning` take the force-confirm path instead.
+/// Test: `delete_needs_stop_first_only_for_errored` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+pub(crate) fn delete_needs_stop_first(state: &str) -> bool {
+    state == "errored"
+}
+
+/// What the stop-first leg's HTTP status means for the delete that follows.
+///
+/// Why: the fail-open risk in a stop-then-delete sequence is downgrading a
+/// failed stop to "close enough" and deleting anyway. Making the status→meaning
+/// mapping a pure enum is what keeps that carve-out keyed on the daemon's
+/// EXPLICIT answer rather than on "an error happened".
+/// What: `Stopped` = 2xx (the runtime is down); `NothingToStop` = 404, the
+/// daemon's answer for a record it has no live lifecycle for — no managed
+/// record, or a terminal one (`runtime_stop_core` maps both to 404), neither of
+/// which is a running session; `Failed` = every other status.
+/// Test: `classify_stop_first_maps_each_status` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum StopFirstNext {
+    /// 2xx — the runtime is stopped; proceed to the delete.
+    Stopped,
+    /// 404 — the daemon has no live session to stop; proceed to the delete,
+    /// which does its own not-found routing.
+    NothingToStop,
+    /// Anything else — report it and delete NOTHING.
+    Failed,
+}
+
+/// Map the stop-first leg's HTTP status to [`StopFirstNext`].
+///
+/// Test: `classify_stop_first_maps_each_status` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+pub(crate) fn classify_stop_first(status: reqwest::StatusCode) -> StopFirstNext {
+    match status {
+        s if s.is_success() => StopFirstNext::Stopped,
+        reqwest::StatusCode::NOT_FOUND => StopFirstNext::NothingToStop,
+        _ => StopFirstNext::Failed,
+    }
 }
 
 /// Map a managed-delete HTTP status to the next routing step.
@@ -247,6 +309,45 @@ pub(crate) async fn delete_managed_then_local(
     }
 }
 
+/// Stop a session's runtime, then delete its record — one operator action (#7224).
+///
+/// Why: the `tm ls` surface must not answer a delete with instructions for a
+/// different surface. An `errored` record whose tmux session is still up gets
+/// refused by the daemon's liveness probe, and the refusal's own advice is
+/// "stop it first" — a step the caller can perform. This performs it.
+/// What: POSTs `/api/v1/sessions/managed/{id}/runtime-stop`, classifies the
+/// status through [`classify_stop_first`], and only then calls
+/// [`delete_managed_then_local`] with the SAME `force` flag the caller passed —
+/// never an escalated one, so the daemon's tmux probe still decides whether the
+/// record may go. A `Failed` status returns [`DeleteReport::StopFailed`] with
+/// the status and body, and NO delete request is issued: there is no branch in
+/// which a stop the daemon rejected is downgraded into a delete. A transport
+/// error on the stop leg propagates as `Err` for the same reason.
+/// Test: `stop_then_delete_deletes_after_a_successful_stop`,
+/// `stop_then_delete_treats_not_found_as_nothing_to_stop`,
+/// `stop_then_delete_never_deletes_after_a_failed_stop` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+pub(crate) async fn stop_then_delete(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+    force: bool,
+) -> anyhow::Result<DeleteReport> {
+    let resp = client
+        .post(format!("{url}/api/v1/sessions/managed/{id}/runtime-stop"))
+        .send()
+        .await?;
+    let status = resp.status();
+    if classify_stop_first(status) == StopFirstNext::Failed {
+        let body = resp.text().await.unwrap_or_default();
+        return Ok(DeleteReport::StopFailed(format!(
+            "stop returned HTTP {status}: {}",
+            body.trim()
+        )));
+    }
+    delete_managed_then_local(client, url, id, force).await
+}
+
 /// Delete a project-session record via `DELETE /sessions/{id}` (the local path),
 /// refusing a still-running session unless `force` is set (#2304 CRITICAL fix).
 ///
@@ -376,6 +477,13 @@ pub(crate) async fn confirm_and_delete(
         }
         DeleteReport::Refused(msg) => {
             eprintln!("tm: delete refused: {msg}");
+            Ok(false)
+        }
+        DeleteReport::StopFailed(msg) => {
+            eprintln!(
+                "tm: stop failed — '{}' was NOT deleted: {msg}",
+                session.name
+            );
             Ok(false)
         }
         DeleteReport::NotFound => {

--- a/crates/trusty-mpm/src/bin/tm/commands/picker_delete_glob.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/picker_delete_glob.rs
@@ -510,6 +510,13 @@ pub(crate) async fn confirm_and_delete_glob(
                 missing += 1;
                 eprintln!("tm: '{}' not found — already gone.", s.name);
             }
+            // #7224: unreachable here — this loop calls the plain delete, never
+            // the stop-first route — but counted as a failure rather than
+            // matched by a `_` arm that would silently read as a success.
+            Ok(DeleteReport::StopFailed(msg)) => {
+                failed += 1;
+                eprintln!("tm: '{}' NOT deleted — {msg}", s.name);
+            }
             Err(e) => {
                 failed += 1;
                 eprintln!("tm: '{}' failed: {e}", s.name);

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
@@ -54,7 +54,7 @@ use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifier
 use trusty_mpm::client::ManagedSessionSummary;
 use trusty_mpm::tui::terminal::{self, TerminalGuard};
 
-use super::picker_delete::{DeleteReport, delete_managed_then_local, stop_then_delete};
+use super::picker_delete::{DeleteReport, route_delete};
 use super::session_picker::{PickerScope, fetch_live_sessions};
 use state::{Action, Input, Severity, TuiState};
 
@@ -181,12 +181,9 @@ pub(crate) async fn run_session_tui(
                 let session = &sessions[index];
                 // #7224: an errored row takes the stop-then-delete route, which
                 // is the CLI step the daemon's refusal used to send the operator
-                // out of this surface to run by hand.
-                let report = if stop_first {
-                    stop_then_delete(client, url, &session.id, force).await
-                } else {
-                    delete_managed_then_local(client, url, &session.id, force).await
-                };
+                // out of this surface to run by hand. The numbered fallback
+                // picker shares this routing rather than re-deciding it.
+                let report = route_delete(client, url, &session.id, force, stop_first).await;
                 let (text, severity) = delete_outcome(&session.name, report);
                 state.set_message(text, severity);
             }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
@@ -54,7 +54,7 @@ use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifier
 use trusty_mpm::client::ManagedSessionSummary;
 use trusty_mpm::tui::terminal::{self, TerminalGuard};
 
-use super::picker_delete::{DeleteReport, delete_managed_then_local};
+use super::picker_delete::{DeleteReport, delete_managed_then_local, stop_then_delete};
 use super::session_picker::{PickerScope, fetch_live_sessions};
 use state::{Action, Input, Severity, TuiState};
 
@@ -173,9 +173,20 @@ pub(crate) async fn run_session_tui(
                     }
                 }
             }
-            Action::Delete { index, force } => {
+            Action::Delete {
+                index,
+                force,
+                stop_first,
+            } => {
                 let session = &sessions[index];
-                let report = delete_managed_then_local(client, url, &session.id, force).await;
+                // #7224: an errored row takes the stop-then-delete route, which
+                // is the CLI step the daemon's refusal used to send the operator
+                // out of this surface to run by hand.
+                let report = if stop_first {
+                    stop_then_delete(client, url, &session.id, force).await
+                } else {
+                    delete_managed_then_local(client, url, &session.id, force).await
+                };
                 let (text, severity) = delete_outcome(&session.name, report);
                 state.set_message(text, severity);
             }
@@ -216,10 +227,14 @@ pub(crate) async fn run_session_tui(
 /// the TUI say them in one line instead of two.
 /// What: `Deleted` reports the store it came from (a managed record is SOFT
 /// deleted and stays in the listing, #2012); `Refused` carries the daemon's own
-/// 409 text; `NotFound` says the record was already gone. A transport error
-/// becomes an error line rather than ending the TUI.
+/// 409 text; `StopFailed` (#7224) says the stop leg failed and NOTHING was
+/// deleted, carrying the daemon's full status and body; `NotFound` says the
+/// record was already gone. A transport error becomes an error line rather than
+/// ending the TUI.
 /// Test: `delete_outcome_names_the_soft_delete`,
-/// `delete_outcome_surfaces_a_refusal`, `delete_outcome_reports_not_found`,
+/// `delete_outcome_surfaces_a_refusal`,
+/// `delete_outcome_reports_a_failed_stop_as_not_deleted`,
+/// `delete_outcome_reports_not_found`,
 /// `delete_outcome_reports_a_transport_error`.
 pub(crate) fn delete_outcome(
     name: &str,
@@ -246,6 +261,10 @@ pub(crate) fn delete_outcome(
         Ok(DeleteReport::Refused(msg)) => {
             (format!("delete refused: {}", msg.trim()), Severity::Error)
         }
+        Ok(DeleteReport::StopFailed(msg)) => (
+            format!("'{name}' NOT deleted — {}", msg.trim()),
+            Severity::Error,
+        ),
         Ok(DeleteReport::NotFound) => {
             (format!("'{name}' not found — already gone"), Severity::Info)
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/layout.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/layout.rs
@@ -13,11 +13,13 @@
 //! ellipsis through the same [`super::super::managed_render::truncate`] the
 //! static table uses. [`visible_window`] is the scroll seam: which slice of the
 //! rows a viewport of `height` shows with `selected` inside it.
+//! [`wrap_message`] is the same idea for the status line: how many rows a
+//! message needs at a given width, and what goes on each of them.
 //!
 //! Column vocabulary matches the console's (#7224): friendly name, short id,
 //! project, state, tmux pane.
 //!
-//! Test: `layout_*` and `window_*` in `super::tests`.
+//! Test: `layout_*`, `window_*` and `wrap_*` in `super::tests`.
 
 use trusty_mpm::client::ManagedSessionSummary;
 
@@ -216,4 +218,78 @@ pub(crate) fn visible_window(
         start = selected + 1 - len;
     }
     (start, len)
+}
+
+/// How many rows the status line may grow to before its tail is elided (#7224).
+///
+/// Four is what the daemon's longest refusal — the delete guard's, which ends
+/// with a full UUID on its own line — needs at 80 columns.
+pub(crate) const STATUS_MAX_LINES: usize = 4;
+
+/// Wrap a status message to `width`, on whitespace, never mid-token (#7224).
+///
+/// Why: the status line was a one-row unwrapped `Paragraph`, so ratatui clipped
+/// whatever did not fit — and what did not fit was the tail of the delete
+/// guard's refusal, cutting a session UUID in half. A half-UUID is worse than
+/// no UUID: it looks copy-pasteable and is not. Wrapping here rather than
+/// through ratatui's own `Wrap` is what lets the caller size the status region
+/// from the SAME lines it will draw, so the height and the content cannot
+/// disagree.
+/// What: splits on `'\n'` first (the refusal puts the id on its own line), then
+/// packs whitespace-separated tokens greedily into lines of at most `width`
+/// characters. A token longer than `width` is emitted alone and intact — at
+/// that width no wrapping could show it whole, and splitting it is the exact
+/// failure this exists to prevent. Beyond `max_lines` the last kept line drops
+/// whole tokens and ends in an ellipsis. A `width` or `max_lines` of zero
+/// yields no lines.
+/// Test: `wrap_message_keeps_a_uuid_whole_at_eighty_columns`,
+/// `wrap_message_honours_explicit_newlines`,
+/// `wrap_message_elides_on_a_token_boundary`,
+/// `wrap_message_zero_width_is_empty`.
+pub(crate) fn wrap_message(text: &str, width: usize, max_lines: usize) -> Vec<String> {
+    if width == 0 || max_lines == 0 {
+        return Vec::new();
+    }
+    let mut lines: Vec<String> = Vec::new();
+    for paragraph in text.split('\n') {
+        let mut current = String::new();
+        for token in paragraph.split_whitespace() {
+            let fits = current.chars().count() + 1 + token.chars().count() <= width;
+            if current.is_empty() {
+                current.push_str(token);
+            } else if fits {
+                current.push(' ');
+                current.push_str(token);
+            } else {
+                lines.push(std::mem::take(&mut current));
+                current.push_str(token);
+            }
+        }
+        lines.push(current);
+    }
+    // A message ending in a newline (or made only of whitespace) would otherwise
+    // reserve a blank row under the table.
+    while lines.last().is_some_and(String::is_empty) {
+        lines.pop();
+    }
+    if lines.len() > max_lines {
+        lines.truncate(max_lines);
+        if let Some(last) = lines.last_mut() {
+            elide(last, width);
+        }
+    }
+    lines
+}
+
+/// Trim `line` back to a whole-token boundary and mark it elided.
+///
+/// Drops trailing tokens until the ellipsis fits within `width`. A line with no
+/// whitespace to cut at is left exactly as it is rather than gaining a mark that
+/// would push it further over.
+fn elide(line: &mut String, width: usize) {
+    while line.chars().count() + 1 > width {
+        let Some(cut) = line.rfind(' ') else { return };
+        line.truncate(cut);
+    }
+    line.push('…');
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/layout.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/layout.rs
@@ -234,15 +234,24 @@ pub(crate) const STATUS_MAX_LINES: usize = 4;
 /// no UUID: it looks copy-pasteable and is not. Wrapping here rather than
 /// through ratatui's own `Wrap` is what lets the caller size the status region
 /// from the SAME lines it will draw, so the height and the content cannot
-/// disagree.
-/// What: splits on `'\n'` first (the refusal puts the id on its own line), then
-/// packs whitespace-separated tokens greedily into lines of at most `width`
-/// characters. A token longer than `width` is emitted alone and intact — at
-/// that width no wrapping could show it whole, and splitting it is the exact
-/// failure this exists to prevent. Beyond `max_lines` the last kept line drops
-/// whole tokens and ends in an ellipsis. A `width` or `max_lines` of zero
+/// disagree. Packing greedily from the front had the same end result at a
+/// narrow width by a different route: below about 70 columns the refusal's
+/// first paragraph filled all four rows on its own and the id paragraph behind
+/// it was truncated away whole.
+/// What: splits on `'\n'` first (the refusal puts the id on its own line) and
+/// packs each paragraph's whitespace-separated tokens greedily into lines of at
+/// most `width` characters. A token longer than `width` is emitted alone and
+/// intact — at that width no wrapping could show it whole, and splitting it is
+/// the exact failure this exists to prevent. The LAST paragraph's rows are then
+/// reserved before anything ahead of them is kept, so the identifier a message
+/// ends with survives every width; the paragraphs in front of it fill what
+/// budget remains and the last of them is elided on a token boundary. A single
+/// paragraph has nothing to reserve behind it and is simply capped at
+/// `max_lines` with its last line elided. A `width` or `max_lines` of zero
 /// yields no lines.
 /// Test: `wrap_message_keeps_a_uuid_whole_at_eighty_columns`,
+/// `wrap_message_keeps_the_session_id_at_narrow_widths`,
+/// `wrap_message_keeps_an_overlong_token_whole`,
 /// `wrap_message_honours_explicit_newlines`,
 /// `wrap_message_elides_on_a_token_boundary`,
 /// `wrap_message_zero_width_is_empty`.
@@ -250,34 +259,70 @@ pub(crate) fn wrap_message(text: &str, width: usize, max_lines: usize) -> Vec<St
     if width == 0 || max_lines == 0 {
         return Vec::new();
     }
-    let mut lines: Vec<String> = Vec::new();
-    for paragraph in text.split('\n') {
-        let mut current = String::new();
-        for token in paragraph.split_whitespace() {
-            let fits = current.chars().count() + 1 + token.chars().count() <= width;
-            if current.is_empty() {
-                current.push_str(token);
-            } else if fits {
-                current.push(' ');
-                current.push_str(token);
-            } else {
-                lines.push(std::mem::take(&mut current));
-                current.push_str(token);
+    let mut paragraphs: Vec<Vec<String>> = text
+        .split('\n')
+        .map(|paragraph| wrap_paragraph(paragraph, width))
+        .collect();
+    // A message ending in a newline (or made only of whitespace) would otherwise
+    // reserve a blank row under the table. An empty line is only ever a whole
+    // paragraph, so dropping trailing empty paragraphs is the same trim.
+    while paragraphs
+        .last()
+        .is_some_and(|p| p.len() == 1 && p[0].is_empty())
+    {
+        paragraphs.pop();
+    }
+    let Some(mut tail) = paragraphs.pop() else {
+        return Vec::new();
+    };
+    if paragraphs.is_empty() {
+        if tail.len() > max_lines {
+            tail.truncate(max_lines);
+            if let Some(last) = tail.last_mut() {
+                elide(last, width);
             }
         }
-        lines.push(current);
+        return tail;
     }
-    // A message ending in a newline (or made only of whitespace) would otherwise
-    // reserve a blank row under the table.
-    while lines.last().is_some_and(String::is_empty) {
-        lines.pop();
+    // #7224: the last paragraph is where the caller put the identifier, so its
+    // rows are reserved first. A tail longer than the whole budget keeps its
+    // FINAL rows — the end of the identifier is what must survive.
+    if tail.len() > max_lines {
+        let drop = tail.len() - max_lines;
+        tail = tail.split_off(drop);
     }
-    if lines.len() > max_lines {
-        lines.truncate(max_lines);
+    let mut lines: Vec<String> = paragraphs.into_iter().flatten().collect();
+    let head_budget = max_lines - tail.len();
+    if lines.len() > head_budget {
+        lines.truncate(head_budget);
         if let Some(last) = lines.last_mut() {
             elide(last, width);
         }
     }
+    lines.extend(tail);
+    lines
+}
+
+/// Pack one newline-free paragraph into `width`-wide lines, never mid-token.
+///
+/// Always returns at least one line, empty when the paragraph holds no tokens —
+/// which is what lets [`wrap_message`] recognise and trim a trailing blank.
+fn wrap_paragraph(paragraph: &str, width: usize) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for token in paragraph.split_whitespace() {
+        let fits = current.chars().count() + 1 + token.chars().count() <= width;
+        if current.is_empty() {
+            current.push_str(token);
+        } else if fits {
+            current.push(' ');
+            current.push_str(token);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(token);
+        }
+    }
+    lines.push(current);
     lines
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/render.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/render.rs
@@ -240,7 +240,7 @@ fn confirm_body(name: &str, force: bool, stop_first: bool, typed: &str) -> Vec<L
     let ask = if force {
         format!("'{name}' is RUNNING. Type the word force, then Enter, to delete it.")
     } else if stop_first {
-        format!("'{name}' is errored. Stop it and delete it? Type y, then Enter.")
+        crate::commands::picker_delete::errored_confirm_ask(name)
     } else {
         format!("Delete '{name}'? Type y, then Enter.")
     };

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/render.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/render.rs
@@ -43,10 +43,18 @@ const FOOTER: &str = "↑↓ move · Enter open · r rename · d delete · R ref
 /// `render_tiny_terminal_does_not_panic`, `render_*_overlay_*`.
 pub(crate) fn render(frame: &mut Frame, sessions: &[ManagedSessionSummary], state: &mut TuiState) {
     let area = frame.area();
+    // #7224: the status region is sized from the wrapped message BEFORE the
+    // split, so a multi-line refusal gets the rows it needs instead of being
+    // clipped mid-token by a fixed one-row `Paragraph`. Capped so the table
+    // keeps at least one row on a short terminal.
+    let status_text = status_lines(state, area.width);
+    let status_rows = (status_text.len().max(1) as u16)
+        .min(area.height.saturating_sub(3).max(1))
+        .max(1);
     let [title, body, status, footer] = Layout::vertical([
         Constraint::Length(1),
         Constraint::Min(1),
-        Constraint::Length(1),
+        Constraint::Length(status_rows),
         Constraint::Length(1),
     ])
     .areas(area);
@@ -57,7 +65,7 @@ pub(crate) fn render(frame: &mut Frame, sessions: &[ManagedSessionSummary], stat
         title,
     );
     render_table(frame, body, sessions, state);
-    frame.render_widget(Paragraph::new(status_line(state)), status);
+    frame.render_widget(Paragraph::new(status_text), status);
     frame.render_widget(
         Paragraph::new(FOOTER).style(Style::default().fg(Color::DarkGray)),
         footer,
@@ -69,10 +77,12 @@ pub(crate) fn render(frame: &mut Frame, sessions: &[ManagedSessionSummary], stat
         Mode::Confirm {
             index,
             force,
+            stop_first,
             typed,
         } => {
             let name = sessions.get(*index).map_or("?", |s| s.name.as_str());
-            overlay(frame, area, "delete", confirm_body(name, *force, typed));
+            let body = confirm_body(name, *force, *stop_first, typed);
+            overlay(frame, area, "delete", body);
         }
         Mode::Rename { index, typed } => {
             let was = sessions.get(*index).map_or("?", |s| s.name.as_str());
@@ -93,22 +103,28 @@ fn title_line(sessions: &[ManagedSessionSummary], state: &TuiState) -> String {
     )
 }
 
-/// The status line: the last outcome, or a hint when there is none.
-fn status_line(state: &TuiState) -> Line<'static> {
-    match state.message() {
-        Some((text, Severity::Error)) => Line::from(Span::styled(
-            text.to_string(),
-            Style::default().fg(Color::Red),
-        )),
-        Some((text, Severity::Info)) => Line::from(Span::styled(
-            text.to_string(),
-            Style::default().fg(Color::Green),
-        )),
-        None => Line::from(Span::styled(
-            "".to_string(),
-            Style::default().fg(Color::DarkGray),
-        )),
-    }
+/// The status region: the last outcome, wrapped to `width`, or nothing.
+///
+/// Why: a refusal from the daemon can run past 150 characters, and the one that
+/// matters most — the delete guard's — ends in a session UUID. Wrapping it
+/// through [`layout::wrap_message`] rather than letting a one-row `Paragraph`
+/// clip it is what keeps that id whole (#7224).
+/// What: one styled [`Line`] per wrapped row, red for a refusal and green for an
+/// outcome; an empty `Vec` when there is no message.
+/// Test: `render_wraps_a_long_refusal_without_cutting_the_uuid`,
+/// `render_status_uses_one_row_when_there_is_no_message`.
+fn status_lines(state: &TuiState, width: u16) -> Vec<Line<'static>> {
+    let Some((text, severity)) = state.message() else {
+        return Vec::new();
+    };
+    let color = match severity {
+        Severity::Error => Color::Red,
+        Severity::Info => Color::Green,
+    };
+    layout::wrap_message(text, width as usize, layout::STATUS_MAX_LINES)
+        .into_iter()
+        .map(|line| Line::from(Span::styled(line, Style::default().fg(color))))
+        .collect()
 }
 
 /// Render the session table into `area` for whatever columns fit its width.
@@ -216,9 +232,15 @@ fn overlay(frame: &mut Frame, area: Rect, title: &str, body: Vec<Line<'static>>)
 }
 
 /// The delete confirmation's text — the word required, and what typing it does.
-fn confirm_body(name: &str, force: bool, typed: &str) -> Vec<Line<'static>> {
+///
+/// `stop_first` (#7224) states the second leg up front: confirming an errored
+/// row stops its runtime AND deletes the record, so the prompt must say so
+/// before the operator agrees to it rather than after.
+fn confirm_body(name: &str, force: bool, stop_first: bool, typed: &str) -> Vec<Line<'static>> {
     let ask = if force {
         format!("'{name}' is RUNNING. Type the word force, then Enter, to delete it.")
+    } else if stop_first {
+        format!("'{name}' is errored. Stop it and delete it? Type y, then Enter.")
     } else {
         format!("Delete '{name}'? Type y, then Enter.")
     };

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/state.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/state.rs
@@ -22,9 +22,7 @@
 use trusty_mpm::client::ManagedSessionSummary;
 use trusty_mpm::session_manager::rename::validate_session_name;
 
-use super::super::picker_delete::{
-    confirm_is_force, confirm_is_yes, delete_needs_force, delete_needs_stop_first,
-};
+use super::super::picker_delete::{confirm_is_force, confirm_is_yes, delete_route_flags};
 
 /// How far `PageUp`/`PageDown` move the selection.
 const PAGE: usize = 10;
@@ -329,11 +327,11 @@ impl TuiState {
     /// a visible message rather than a silent no-op, because a key that does
     /// nothing reads as a broken key.
     /// What: [`is_self_session`] decides; otherwise the mode becomes `Confirm`,
-    /// with `force` set by the same [`delete_needs_force`] the line picker uses,
-    /// so a running session demands the word `force` in both surfaces, and
-    /// `stop_first` set by [`delete_needs_stop_first`] — the errored row whose
-    /// runtime the daemon will refuse to delete around (#7224). One `y` covers
-    /// both legs; the overlay says so before it is typed.
+    /// with `force` and `stop_first` both read from [`delete_route_flags`] — the
+    /// same pair the numbered fallback picker computes, so a running session
+    /// demands the word `force` and an errored session takes the stop-first leg
+    /// (#7224) in either surface. One `y` covers both legs; the overlay says so
+    /// before it is typed.
     /// Test: `state_delete_refuses_the_attached_self_session`,
     /// `state_delete_on_a_running_row_requires_the_force_word`,
     /// `state_delete_on_an_errored_row_asks_to_stop_and_delete`.
@@ -356,10 +354,11 @@ impl TuiState {
             );
             return Action::Redraw;
         }
+        let (force, stop_first) = delete_route_flags(&session.state);
         self.mode = Mode::Confirm {
             index: self.selected,
-            force: delete_needs_force(&session.state),
-            stop_first: delete_needs_stop_first(&session.state),
+            force,
+            stop_first,
             typed: String::new(),
         };
         self.message = None;

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/state.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/state.rs
@@ -22,7 +22,9 @@
 use trusty_mpm::client::ManagedSessionSummary;
 use trusty_mpm::session_manager::rename::validate_session_name;
 
-use super::super::picker_delete::{confirm_is_force, confirm_is_yes, delete_needs_force};
+use super::super::picker_delete::{
+    confirm_is_force, confirm_is_yes, delete_needs_force, delete_needs_stop_first,
+};
 
 /// How far `PageUp`/`PageDown` move the selection.
 const PAGE: usize = 10;
@@ -86,6 +88,9 @@ pub(crate) enum Action {
         index: usize,
         /// Whether the running-session force flag is required and confirmed.
         force: bool,
+        /// Stop the runtime first, then delete — the errored-session path
+        /// (#7224). Never set together with `force`.
+        stop_first: bool,
     },
     /// Rename the session at this index to an ALREADY-VALIDATED name.
     Rename {
@@ -116,6 +121,9 @@ pub(crate) enum Mode {
         index: usize,
         /// True when the row is running, so the word `force` is required.
         force: bool,
+        /// True when confirming also stops the runtime first (#7224), so the
+        /// prompt can say so before the operator agrees to it.
+        stop_first: bool,
         /// What the operator has typed so far.
         typed: String,
     },
@@ -271,8 +279,9 @@ impl TuiState {
             Mode::Confirm {
                 index,
                 force,
+                stop_first,
                 typed,
-            } => self.apply_confirm(input, index, force, typed),
+            } => self.apply_confirm(input, index, force, stop_first, typed),
             Mode::Rename { index, typed } => self.apply_rename(input, index, typed, sessions),
         }
     }
@@ -321,9 +330,13 @@ impl TuiState {
     /// nothing reads as a broken key.
     /// What: [`is_self_session`] decides; otherwise the mode becomes `Confirm`,
     /// with `force` set by the same [`delete_needs_force`] the line picker uses,
-    /// so a running session demands the word `force` in both surfaces.
+    /// so a running session demands the word `force` in both surfaces, and
+    /// `stop_first` set by [`delete_needs_stop_first`] — the errored row whose
+    /// runtime the daemon will refuse to delete around (#7224). One `y` covers
+    /// both legs; the overlay says so before it is typed.
     /// Test: `state_delete_refuses_the_attached_self_session`,
-    /// `state_delete_on_a_running_row_requires_the_force_word`.
+    /// `state_delete_on_a_running_row_requires_the_force_word`,
+    /// `state_delete_on_an_errored_row_asks_to_stop_and_delete`.
     fn begin_delete(&mut self, sessions: &[ManagedSessionSummary]) -> Action {
         let Some(session) = sessions.get(self.selected) else {
             return Action::Ignore;
@@ -346,6 +359,7 @@ impl TuiState {
         self.mode = Mode::Confirm {
             index: self.selected,
             force: delete_needs_force(&session.state),
+            stop_first: delete_needs_stop_first(&session.state),
             typed: String::new(),
         };
         self.message = None;
@@ -374,12 +388,14 @@ impl TuiState {
     /// from disagreeing about what counts as a confirmation.
     /// Test: `state_delete_on_a_stopped_row_confirms_with_yes`,
     /// `state_delete_on_a_running_row_requires_the_force_word`,
+    /// `state_delete_on_an_errored_row_asks_to_stop_and_delete`,
     /// `state_confirm_backspace_and_escape_both_step_back`.
     fn apply_confirm(
         &mut self,
         input: Input,
         index: usize,
         force: bool,
+        stop_first: bool,
         mut typed: String,
     ) -> Action {
         match input {
@@ -393,6 +409,7 @@ impl TuiState {
                 self.mode = Mode::Confirm {
                     index,
                     force,
+                    stop_first,
                     typed,
                 };
                 Action::Redraw
@@ -402,6 +419,7 @@ impl TuiState {
                 self.mode = Mode::Confirm {
                     index,
                     force,
+                    stop_first,
                     typed,
                 };
                 Action::Redraw
@@ -416,7 +434,11 @@ impl TuiState {
                     self.set_message("delete cancelled", Severity::Info);
                     return Action::Redraw;
                 }
-                Action::Delete { index, force }
+                Action::Delete {
+                    index,
+                    force,
+                    stop_first,
+                }
             }
             _ => Action::Ignore,
         }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/tests.rs
@@ -338,6 +338,7 @@ fn state_delete_on_a_stopped_row_confirms_with_yes() {
         &Mode::Confirm {
             index: 1,
             force: false,
+            stop_first: false,
             typed: String::new()
         }
     );
@@ -346,9 +347,66 @@ fn state_delete_on_a_stopped_row_confirms_with_yes() {
         state.apply(Input::Enter, &sessions),
         Action::Delete {
             index: 1,
-            force: false
+            force: false,
+            stop_first: false
         }
     );
+}
+
+/// An ERRORED row confirms with a plain `y`, and the action it yields carries
+/// `stop_first` — the runtime-stop leg the daemon's refusal used to send the
+/// operator out to a shell to run (#7224). `force` stays false: the delete that
+/// follows the stop is still unforced, so the daemon's tmux probe remains the
+/// authority on whether the record may go.
+#[test]
+fn state_delete_on_an_errored_row_asks_to_stop_and_delete() {
+    let mut sessions = fleet();
+    sessions[1].state = "errored".to_string();
+    let mut state = browsing();
+    state.sync(&sessions);
+    state.apply(Input::Down, &sessions); // tm-bravo-02, errored
+    assert_eq!(state.apply(Input::Char('d'), &sessions), Action::Redraw);
+    assert_eq!(
+        state.mode(),
+        &Mode::Confirm {
+            index: 1,
+            force: false,
+            stop_first: true,
+            typed: String::new()
+        },
+        "an errored row must open a stop-and-delete confirm, not a plain one"
+    );
+    state.apply(Input::Char('y'), &sessions);
+    assert_eq!(
+        state.apply(Input::Enter, &sessions),
+        Action::Delete {
+            index: 1,
+            force: false,
+            stop_first: true
+        }
+    );
+}
+
+/// The stop-first leg is scoped to `errored`: a `stopped` row has no runtime to
+/// stop, and a running one takes the force-confirm path instead — neither may
+/// pick up a stop request it does not need (#7224).
+#[test]
+fn state_delete_sets_stop_first_only_for_errored() {
+    let sessions = fleet();
+    for (index, expect_stop) in [(0usize, false), (1, false)] {
+        let mut state = browsing();
+        state.apply(
+            if index == 0 { Input::Home } else { Input::Down },
+            &sessions,
+        );
+        state.apply(Input::Char('d'), &sessions);
+        match state.mode() {
+            Mode::Confirm { stop_first, .. } => {
+                assert_eq!(*stop_first, expect_stop, "row {index}");
+            }
+            other => panic!("row {index} must open a confirm, got {other:?}"),
+        }
+    }
 }
 
 #[test]
@@ -377,7 +435,8 @@ fn state_delete_on_a_running_row_requires_the_force_word() {
         state.apply(Input::Enter, &sessions),
         Action::Delete {
             index: 0,
-            force: true
+            force: true,
+            stop_first: false
         }
     );
 }
@@ -565,6 +624,22 @@ fn delete_outcome_surfaces_a_refusal() {
     );
     assert_eq!(severity, Severity::Error);
     assert_eq!(text, "delete refused: session is running");
+}
+
+/// A failed stop leg must read as "nothing was deleted", carrying the daemon's
+/// own status and body — never as a delete that merely did not happen (#7224).
+#[test]
+fn delete_outcome_reports_a_failed_stop_as_not_deleted() {
+    let (text, severity) = delete_outcome(
+        "tm-bravo-02",
+        Ok(DeleteReport::StopFailed(
+            "stop returned HTTP 500 Internal Server Error: tmux driver unavailable".to_string(),
+        )),
+    );
+    assert_eq!(severity, Severity::Error);
+    assert!(text.contains("NOT deleted"), "{text}");
+    assert!(text.contains("tmux driver unavailable"), "{text}");
+    assert!(text.contains("500"), "{text}");
 }
 
 #[test]
@@ -813,4 +888,92 @@ fn render_shows_a_rename_after_the_refetch() {
         "tm-renamed-02",
         "selection must follow the renamed session across the re-fetch"
     );
+}
+
+// ── status-line wrapping: never cut a token in half (#7224) ─────────────────
+
+/// The exact refusal the daemon's delete guard produces, for a session whose
+/// friendly name and UUID are both realistic. This is the string the owner saw
+/// cut off mid-UUID in the picker.
+const GUARD_REFUSAL: &str = "delete refused: session 'tm-quiet-falcon' is errored — stop it first \
+     with `tm session stop` (or `tm session decommission`), or pass --force to delete the record \
+     anyway. Session id:\n8fc5db8f-b0a5-5c47-9a5b-59cd2a1e4f77";
+
+/// The UUID in the guard refusal, which no wrap may split.
+const GUARD_UUID: &str = "8fc5db8f-b0a5-5c47-9a5b-59cd2a1e4f77";
+
+#[test]
+fn wrap_message_keeps_a_uuid_whole_at_eighty_columns() {
+    let lines = layout::wrap_message(GUARD_REFUSAL, 80, layout::STATUS_MAX_LINES);
+    for line in &lines {
+        assert!(
+            line.chars().count() <= 80,
+            "wrapped line exceeds the width: {line}"
+        );
+    }
+    assert!(
+        lines.iter().any(|l| l.contains(GUARD_UUID)),
+        "the full session id must survive the wrap, got:\n{lines:#?}"
+    );
+}
+
+#[test]
+fn wrap_message_honours_explicit_newlines() {
+    let lines = layout::wrap_message("first line\nsecond line", 80, 4);
+    assert_eq!(lines, vec!["first line", "second line"]);
+}
+
+#[test]
+fn wrap_message_elides_on_a_token_boundary() {
+    // Ten five-character tokens at width 12 need five lines; capped at two, the
+    // second must end in an ellipsis and never inside a token.
+    let text = "aaaaa bbbbb ccccc ddddd eeeee fffff ggggg hhhhh iiiii jjjjj";
+    let lines = layout::wrap_message(text, 12, 2);
+    assert_eq!(lines.len(), 2);
+    assert!(lines[1].ends_with('…'), "{lines:#?}");
+    for line in &lines {
+        assert!(line.chars().count() <= 12, "{line}");
+        for token in line.trim_end_matches('…').split_whitespace() {
+            assert_eq!(token.chars().count(), 5, "token cut mid-word: {token}");
+        }
+    }
+}
+
+#[test]
+fn wrap_message_zero_width_is_empty() {
+    assert!(layout::wrap_message("anything", 0, 4).is_empty());
+    assert!(layout::wrap_message("anything", 80, 0).is_empty());
+}
+
+/// The regression the owner reported: at 80 columns the picker's status line
+/// showed the delete refusal cut off inside the session UUID. The full id must
+/// now appear somewhere on screen, unbroken (#7224).
+#[test]
+fn render_wraps_a_long_refusal_without_cutting_the_uuid() {
+    let sessions = fleet();
+    let mut state = browsing();
+    state.set_message(GUARD_REFUSAL, Severity::Error);
+    let screen = draw(80, 24, &sessions, &mut state);
+    let joined = screen.join("\n");
+    assert!(
+        joined.contains(GUARD_UUID),
+        "the session id was cut by the status line:\n{joined}"
+    );
+    for line in &screen {
+        assert!(line.chars().count() <= 80, "overlong row: {line}");
+    }
+    // The table and the key footer must survive the taller status region.
+    assert!(joined.contains("NAME"), "{joined}");
+    assert!(joined.contains("q quit"), "{joined}");
+}
+
+#[test]
+fn render_status_uses_one_row_when_there_is_no_message() {
+    let sessions = fleet();
+    let mut state = browsing();
+    let screen = draw(80, 24, &sessions, &mut state);
+    // Three sessions plus a header, a title, an empty status row and a footer —
+    // the layout must not have grown a status region with nothing in it.
+    assert_eq!(screen.len(), 24);
+    assert!(screen.last().is_some_and(|l| l.contains("q quit")));
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/tests.rs
@@ -747,6 +747,20 @@ fn render_at_two_hundred_by_fifty_shows_every_column() {
     assert!(joined.contains("%11"), "{joined}");
 }
 
+/// The TUI overlay renders the SHARED errored question (#7224), so an operator
+/// who learns what `y` does in the numbered fallback picker reads the same
+/// promise here.
+#[test]
+fn confirm_overlay_asks_the_shared_errored_question() {
+    let sessions = vec![session("tm-quiet-falcon", "errored", 4)];
+    let mut state = TuiState::new(None, None);
+    state.sync(&sessions);
+    state.apply(Input::Char('d'), &sessions);
+    let joined = draw(200, 50, &sessions, &mut state).join("\n");
+    let ask = crate::commands::picker_delete::errored_confirm_ask("tm-quiet-falcon");
+    assert!(joined.contains(&ask), "expected {ask:?} in\n{joined}");
+}
+
 #[test]
 fn render_tiny_terminal_does_not_panic() {
     let sessions = fleet();
@@ -937,6 +951,42 @@ fn wrap_message_elides_on_a_token_boundary() {
             assert_eq!(token.chars().count(), 5, "token cut mid-word: {token}");
         }
     }
+}
+
+/// #7224: the session id is the point of the refusal, so it has to survive the
+/// wrap at the narrow widths a split pane actually has. Packing greedily from
+/// the front filled all four lines with the first paragraph at 40 and 60
+/// columns and dropped the id paragraph entirely.
+#[test]
+fn wrap_message_keeps_the_session_id_at_narrow_widths() {
+    for width in [40usize, 60, 80] {
+        let lines = layout::wrap_message(GUARD_REFUSAL, width, layout::STATUS_MAX_LINES);
+        assert!(
+            lines.len() <= layout::STATUS_MAX_LINES,
+            "width {width} overflowed the status region:\n{lines:#?}"
+        );
+        for line in &lines {
+            assert!(
+                line.chars().count() <= width,
+                "width {width}: line exceeds it: {line}"
+            );
+        }
+        assert!(
+            lines.iter().any(|l| l.contains(GUARD_UUID)),
+            "width {width}: the full session id must survive, got:\n{lines:#?}"
+        );
+    }
+}
+
+/// A token longer than the width has no wrap that shows it whole, so it is
+/// emitted alone and intact — splitting it is the exact failure the wrap exists
+/// to prevent, and the elide helper must leave a line it cannot cut at a
+/// whitespace boundary exactly as it is.
+#[test]
+fn wrap_message_keeps_an_overlong_token_whole() {
+    let token = "z".repeat(200);
+    let lines = layout::wrap_message(&token, 40, layout::STATUS_MAX_LINES);
+    assert_eq!(lines, vec![token]);
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -92,6 +92,12 @@ mod tests_behavior_d;
 #[path = "tests_behavior_d_ls_connector_tests.rs"]
 mod tests_behavior_d_ls_connector;
 
+// #7224: the errored-session stop-then-delete route, split out for the same
+// reason — `tests_behavior_d_tests.rs` has no room left under the test cap.
+#[cfg(test)]
+#[path = "tests_behavior_d_stop_delete_tests.rs"]
+mod tests_behavior_d_stop_delete;
+
 #[cfg(test)]
 #[path = "tests_behavior_e_tests.rs"]
 mod tests_behavior_e;

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_stop_delete_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_stop_delete_tests.rs
@@ -1,0 +1,211 @@
+//! `tm ls` stop-then-delete: the errored-session route and its fail-open check (#7224).
+//!
+//! Why: split out of `tests_behavior_d_tests.rs`, which sits within a few
+//! dozen lines of the 3000-SLOC test cap — the same reason
+//! `tests_behavior_d_ls_connector_tests.rs` exists. The block is cohesive on
+//! its own: everything here is about ONE route, `picker_delete::stop_then_delete`.
+//!
+//! What: the two pure seams the route is built from
+//! ([`delete_needs_stop_first`](crate::commands::picker_delete::delete_needs_stop_first)
+//! and [`classify_stop_first`](crate::commands::picker_delete::classify_stop_first)),
+//! plus real-HTTP round trips against a counting stub daemon. The counting is
+//! the point: proving a REJECTED stop issues no delete needs a server that can
+//! say the delete endpoint was never called, which a message assertion cannot.
+
+use std::net::SocketAddr;
+
+use crate::commands::picker_delete::DeleteReport;
+
+/// #7224: the stop-first leg is scoped to `errored` and nothing else. A
+/// `stopped` record has no runtime to stop, and `active`/`provisioning` take the
+/// force-confirm path — neither may pick up a stop it does not need.
+#[test]
+fn delete_needs_stop_first_only_for_errored() {
+    use crate::commands::picker_delete::delete_needs_stop_first;
+    assert!(delete_needs_stop_first("errored"));
+    for state in [
+        "stopped",
+        "active",
+        "provisioning",
+        "decommissioned",
+        "deleted",
+    ] {
+        assert!(
+            !delete_needs_stop_first(state),
+            "{state} must not take the stop-first route"
+        );
+    }
+}
+
+/// #7224 fail-open check: only an explicit 2xx or 404 lets the delete proceed.
+/// Every other status — a 409, a 500, a 503 — is `Failed`, which the caller
+/// turns into "nothing was deleted". A carve-out keyed on "an error happened"
+/// rather than on the daemon's own answer is exactly how a stop-then-delete
+/// sequence deletes a session the daemon still considers live.
+#[test]
+fn classify_stop_first_maps_each_status() {
+    use crate::commands::picker_delete::{StopFirstNext, classify_stop_first};
+    assert_eq!(
+        classify_stop_first(reqwest::StatusCode::OK),
+        StopFirstNext::Stopped
+    );
+    assert_eq!(
+        classify_stop_first(reqwest::StatusCode::ACCEPTED),
+        StopFirstNext::Stopped,
+        "any 2xx means the daemon accepted the stop"
+    );
+    assert_eq!(
+        classify_stop_first(reqwest::StatusCode::NOT_FOUND),
+        StopFirstNext::NothingToStop,
+        "404 is the daemon's explicit 'no live session here'"
+    );
+    for status in [
+        reqwest::StatusCode::CONFLICT,
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        reqwest::StatusCode::BAD_REQUEST,
+    ] {
+        assert_eq!(
+            classify_stop_first(status),
+            StopFirstNext::Failed,
+            "{status} must NOT be downgraded into a delete"
+        );
+    }
+}
+
+/// A hermetic stand-in for the two managed endpoints the stop-first route
+/// touches, so the STOP status can be dialled to anything and the delete leg
+/// can be OBSERVED — the fail-open check needs to prove no delete request was
+/// issued, which only a counting server can show.
+#[derive(Clone)]
+struct StopStub {
+    stop_status: axum::http::StatusCode,
+    stops: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    deletes: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl StopStub {
+    fn new(stop_status: axum::http::StatusCode) -> Self {
+        Self {
+            stop_status,
+            stops: Default::default(),
+            deletes: Default::default(),
+        }
+    }
+
+    fn router(&self) -> axum::Router {
+        use axum::{Router, extract::State, routing::post};
+        let stub = self.clone();
+        Router::new()
+            .route(
+                "/api/v1/sessions/managed/{id}/runtime-stop",
+                post(|State(s): State<StopStub>| async move {
+                    s.stops.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    (s.stop_status, "stub stop body")
+                }),
+            )
+            .route(
+                "/api/v1/sessions/managed/{id}/delete",
+                post(|State(s): State<StopStub>| async move {
+                    s.deletes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    axum::Json(serde_json::json!({
+                        "name": "tm-stub-01",
+                        "state": "errored",
+                        "deleted": true,
+                    }))
+                }),
+            )
+            .with_state(stub)
+    }
+
+    fn counts(&self) -> (usize, usize) {
+        use std::sync::atomic::Ordering::SeqCst;
+        (self.stops.load(SeqCst), self.deletes.load(SeqCst))
+    }
+}
+
+/// Serve `router` on a fresh loopback port; returns the base URL and the task.
+async fn serve_stub(router: axum::Router) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback port");
+    let addr: SocketAddr = listener.local_addr().expect("resolve bound addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    (format!("http://{addr}"), handle)
+}
+
+/// The whole point of the route: an errored session whose runtime is up gets
+/// stopped and then deleted, in one operator action, with no bounce to the CLI.
+#[tokio::test]
+async fn stop_then_delete_deletes_after_a_successful_stop() {
+    use crate::commands::picker_delete::stop_then_delete;
+    let stub = StopStub::new(axum::http::StatusCode::OK);
+    let (url, handle) = serve_stub(stub.router()).await;
+
+    let report = stop_then_delete(&reqwest::Client::new(), &url, "sid-1", false)
+        .await
+        .expect("routing call must not error");
+    assert!(
+        matches!(report, DeleteReport::Deleted { local: false, .. }),
+        "expected a managed delete, got {report:?}"
+    );
+    assert_eq!(stub.counts(), (1, 1), "one stop, then one delete");
+    handle.abort();
+}
+
+/// "Nothing to stop" is the daemon's EXPLICIT 404, not a guess: the delete still
+/// goes out, and its own not-found routing decides what that means.
+#[tokio::test]
+async fn stop_then_delete_treats_not_found_as_nothing_to_stop() {
+    use crate::commands::picker_delete::stop_then_delete;
+    let stub = StopStub::new(axum::http::StatusCode::NOT_FOUND);
+    let (url, handle) = serve_stub(stub.router()).await;
+
+    let report = stop_then_delete(&reqwest::Client::new(), &url, "sid-2", false)
+        .await
+        .expect("routing call must not error");
+    assert!(
+        matches!(report, DeleteReport::Deleted { .. }),
+        "a 404 stop must not block the delete, got {report:?}"
+    );
+    assert_eq!(stub.counts(), (1, 1));
+    handle.abort();
+}
+
+/// Fail-open check. A stop the daemon REJECTED (500, and separately 409) must
+/// leave the record alone: the report says nothing was deleted, and — the part
+/// a message assertion alone would not prove — the delete endpoint is never
+/// called at all.
+#[tokio::test]
+async fn stop_then_delete_never_deletes_after_a_failed_stop() {
+    use crate::commands::picker_delete::stop_then_delete;
+    for status in [
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        axum::http::StatusCode::CONFLICT,
+    ] {
+        let stub = StopStub::new(status);
+        let (url, handle) = serve_stub(stub.router()).await;
+
+        let report = stop_then_delete(&reqwest::Client::new(), &url, "sid-3", false)
+            .await
+            .expect("routing call must not error");
+        match report {
+            DeleteReport::StopFailed(msg) => {
+                assert!(
+                    msg.contains(status.as_str()),
+                    "must carry the status: {msg}"
+                );
+                assert!(msg.contains("stub stop body"), "must carry the body: {msg}");
+            }
+            other => panic!("a {status} stop must report StopFailed, got {other:?}"),
+        }
+        assert_eq!(
+            stub.counts(),
+            (1, 0),
+            "a rejected stop must issue NO delete request ({status})"
+        );
+        handle.abort();
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_stop_delete_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_stop_delete_tests.rs
@@ -209,3 +209,220 @@ async fn stop_then_delete_never_deletes_after_a_failed_stop() {
         handle.abort();
     }
 }
+
+// ── the numbered picker's own delete route (#7224) ──────────────────────────
+
+/// The daemon's answer for an ERRORED session whose tmux pane is still up: the
+/// delete guard 409s until the runtime has actually been stopped. This is the
+/// shape of the reported bug — a delete that never stops first bounces off that
+/// 409 with advice to leave the surface and run `tm session stop` by hand.
+#[derive(Clone)]
+struct LiveErroredStub {
+    stop_status: axum::http::StatusCode,
+    runtime_down: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    stops: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    deletes: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl LiveErroredStub {
+    fn new(stop_status: axum::http::StatusCode) -> Self {
+        Self {
+            stop_status,
+            runtime_down: Default::default(),
+            stops: Default::default(),
+            deletes: Default::default(),
+        }
+    }
+
+    fn router(&self) -> axum::Router {
+        use std::sync::atomic::Ordering::SeqCst;
+
+        use axum::{Router, extract::State, response::IntoResponse, routing::post};
+        let stub = self.clone();
+        Router::new()
+            .route(
+                "/api/v1/sessions/managed/{id}/runtime-stop",
+                post(|State(s): State<LiveErroredStub>| async move {
+                    s.stops.fetch_add(1, SeqCst);
+                    // 2xx and 404 are both "no live runtime remains"; anything
+                    // else leaves the session exactly as it was.
+                    if s.stop_status.is_success()
+                        || s.stop_status == axum::http::StatusCode::NOT_FOUND
+                    {
+                        s.runtime_down.store(true, SeqCst);
+                    }
+                    (s.stop_status, "stub stop body")
+                }),
+            )
+            .route(
+                "/api/v1/sessions/managed/{id}/delete",
+                post(|State(s): State<LiveErroredStub>| async move {
+                    s.deletes.fetch_add(1, SeqCst);
+                    if !s.runtime_down.load(SeqCst) {
+                        return (
+                            axum::http::StatusCode::CONFLICT,
+                            "session is errored — stop it first with `tm session stop`",
+                        )
+                            .into_response();
+                    }
+                    axum::Json(serde_json::json!({
+                        "name": "tm-quiet-falcon",
+                        "state": "errored",
+                        "deleted": true,
+                    }))
+                    .into_response()
+                }),
+            )
+            .with_state(stub)
+    }
+
+    fn counts(&self) -> (usize, usize) {
+        use std::sync::atomic::Ordering::SeqCst;
+        (self.stops.load(SeqCst), self.deletes.load(SeqCst))
+    }
+}
+
+/// A managed row in `state`, with the id the stub answers for.
+fn row(state: &str) -> trusty_mpm::client::ManagedSessionSummary {
+    trusty_mpm::client::ManagedSessionSummary {
+        id: "sid-picker".to_string(),
+        name: "tm-quiet-falcon".to_string(),
+        state: state.to_string(),
+        persisted_state: None,
+        workspace_path: None,
+        repo_url: None,
+        branch: None,
+        created_at: None,
+        last_activity_at: None,
+        pending_decision: None,
+        proposed_default: None,
+        source_id: None,
+        task: None,
+        cwd: None,
+        claude_session_id: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: None,
+        unresumable: false,
+        stale_assets: false,
+        stale_assets_unchecked: false,
+        attached: false,
+        slot: 1,
+        deleted: false,
+        auto_resume_parked: None,
+    }
+}
+
+/// The reported bug, on the surface it was reported from. `tm ls` falls back to
+/// the NUMBERED picker whenever the terminal has no raw mode, and that picker's
+/// delete driver used to issue the delete alone — so an errored row whose tmux
+/// pane was still up got the daemon's 409 and the operator got told to go run a
+/// different command in a different surface.
+#[tokio::test]
+async fn picker_delete_stops_an_errored_session_before_deleting_it() {
+    use crate::commands::picker_delete::delete_confirmed;
+    let stub = LiveErroredStub::new(axum::http::StatusCode::OK);
+    let (url, handle) = serve_stub(stub.router()).await;
+
+    let deleted = delete_confirmed(&reqwest::Client::new(), &url, &row("errored"))
+        .await
+        .expect("the delete driver must not error");
+    assert!(deleted, "the errored row must end up deleted, not refused");
+    assert_eq!(stub.counts(), (1, 1), "one stop, then one delete");
+    handle.abort();
+}
+
+/// A 404 stop is the daemon's explicit "no live session here", not a failure —
+/// the delete still goes out and does its own not-found routing.
+#[tokio::test]
+async fn picker_delete_treats_a_not_found_stop_as_nothing_to_stop() {
+    use crate::commands::picker_delete::delete_confirmed;
+    let stub = LiveErroredStub::new(axum::http::StatusCode::NOT_FOUND);
+    let (url, handle) = serve_stub(stub.router()).await;
+
+    let deleted = delete_confirmed(&reqwest::Client::new(), &url, &row("errored"))
+        .await
+        .expect("the delete driver must not error");
+    assert!(deleted, "a 404 stop must not block the delete");
+    assert_eq!(stub.counts(), (1, 1));
+    handle.abort();
+}
+
+/// Fail-open check on the picker's own route: a stop the daemon REJECTED leaves
+/// the record alone, and the delete endpoint is never reached at all.
+#[tokio::test]
+async fn picker_delete_never_deletes_after_a_failed_stop() {
+    use crate::commands::picker_delete::delete_confirmed;
+    for status in [
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        axum::http::StatusCode::CONFLICT,
+    ] {
+        let stub = LiveErroredStub::new(status);
+        let (url, handle) = serve_stub(stub.router()).await;
+
+        let deleted = delete_confirmed(&reqwest::Client::new(), &url, &row("errored"))
+            .await
+            .expect("the delete driver must not error");
+        assert!(!deleted, "a {status} stop must not report a deletion");
+        assert_eq!(
+            stub.counts(),
+            (1, 0),
+            "a rejected stop must issue NO delete request ({status})"
+        );
+        handle.abort();
+    }
+}
+
+/// The carve-out stays scoped: a `stopped` row is deleted exactly as before,
+/// with no runtime-stop request issued on its behalf.
+#[tokio::test]
+async fn picker_delete_issues_no_stop_for_a_non_errored_row() {
+    use crate::commands::picker_delete::delete_confirmed;
+    let stub = StopStub::new(axum::http::StatusCode::OK);
+    let (url, handle) = serve_stub(stub.router()).await;
+
+    let deleted = delete_confirmed(&reqwest::Client::new(), &url, &row("stopped"))
+        .await
+        .expect("the delete driver must not error");
+    assert!(deleted);
+    assert_eq!(
+        stub.counts(),
+        (0, 1),
+        "a stopped row has no runtime to stop — one delete, no stop"
+    );
+    handle.abort();
+}
+
+/// The pair is the whole reason the two surfaces cannot diverge again, so it
+/// must stay exactly the two guards it composes — never a third opinion.
+#[test]
+fn delete_route_flags_match_the_two_guards() {
+    use crate::commands::picker_delete::{
+        delete_needs_force, delete_needs_stop_first, delete_route_flags,
+    };
+    for state in [
+        "errored",
+        "stopped",
+        "active",
+        "provisioning",
+        "decommissioned",
+        "deleted",
+    ] {
+        assert_eq!(
+            delete_route_flags(state),
+            (delete_needs_force(state), delete_needs_stop_first(state)),
+            "{state}"
+        );
+    }
+}
+
+/// Confirming an errored row runs two legs, and both surfaces must promise the
+/// same two before the operator agrees — one sentence, not two spellings.
+#[test]
+fn both_delete_surfaces_ask_the_same_errored_question() {
+    use crate::commands::picker_delete::errored_confirm_ask;
+    assert_eq!(
+        errored_confirm_ask("tm-quiet-falcon"),
+        "'tm-quiet-falcon' is errored. Stop it and delete it? Type y, then Enter."
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/delete.rs
+++ b/crates/trusty-mpm/src/session_manager/delete.rs
@@ -51,7 +51,10 @@ impl SessionManager {
     /// real probe, not the persisted `state` field), returns
     /// [`ManagedError::InvalidState`] with an actionable message telling the
     /// operator to stop the session first or pass `--force` — no record is
-    /// touched. A record whose `state` still says `Active`/`Provisioning` but
+    /// touched. That message names the session's FRIENDLY name and puts the full
+    /// UUID alone on a trailing line (#7224), so a width-clamped surface — the
+    /// `tm ls` TUI status line — can wrap it without cutting the id in half.
+    /// A record whose `state` still says `Active`/`Provisioning` but
     /// whose tmux session is actually gone is NOT running by this probe, so it
     /// deletes cleanly without `--force`. Otherwise transitions the record to
     /// `Deleted`, persists it, and returns the PRE-deletion [`SessionRecord`]
@@ -78,13 +81,17 @@ impl SessionManager {
         // #5859: `?` — a probe that could not reach tmux refuses the delete
         // instead of answering "not running" and dropping a live session.
         if !force && is_running(&record, self.tmux.as_ref())? {
+            // #7224: the refusal used to inline the 36-character UUID twice, mid
+            // sentence, which any width-clamped surface cut mid-token. The
+            // friendly name carries the identity; the id gets its own line.
             return Err(ManagedError::InvalidState(
                 id.to_string(),
                 format!(
-                    "session is {} — stop it first with `tm session stop {id}` \
-                     (or `tm session decommission {id}`), or pass --force to \
-                     delete the record anyway",
-                    record.state
+                    "session '{name}' is {state} — stop it first with \
+                     `tm session stop` (or `tm session decommission`), or pass \
+                     --force to delete the record anyway. Session id:\n{id}",
+                    name = record.tmux_name,
+                    state = record.state,
                 ),
             ));
         }


### PR DESCRIPTION
## Summary

`tm ls` refused to delete an errored session on one of its two delete surfaces (the numbered fallback picker) because that surface never issued the stop call before the delete; the TUI surface did. Both surfaces now route through one shared decision (`delete_route_flags` / `route_delete` in `crates/trusty-mpm/src/bin/tm/commands/picker_delete.rs`) and ask the same errored-session confirmation. Separately, the status-line wrapper dropped the session-id paragraph below about 70 columns; it now reserves the last paragraph's rows first.

## Why

Refs #7224. Round 1 (b01e33cb3) fixed the TUI path; the code-critic fold found the picker path still went straight to delete, reproduced as zero stop requests and one delete on a row the daemon rejects with 409.

## What changed

Shared routing helpers in picker_delete.rs, consumed by session_tui.rs, session_tui/state.rs, session_tui/render.rs; `wrap_message` in session_tui/layout.rs wraps per paragraph and keeps the last paragraph; new tests in tests_behavior_d_stop_delete_tests.rs and session_tui/tests.rs. Changelog fragment `crates/trusty-mpm/changelog.d/7224-tm-ls-delete-errored.md`.

## Test ladder rung

Rung 3 (localized behavior inside trusty-mpm). Command: `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4`.

## Verification

fmt --check exit 0; clippy -p trusty-mpm --all-targets -D warnings exit 0; test -p trusty-mpm --no-fail-fast, 57 targets all ok, 0 failed (lib 6646 passed, tm bin 2514 passed). Fails-before on b01e33cb3: `picker_delete_stops_an_errored_session_before_deleting_it`, `picker_delete_never_deletes_after_a_failed_stop` (left (0,1) right (1,0)), `picker_delete_treats_a_not_found_stop_as_nothing_to_stop`, `wrap_message_keeps_the_session_id_at_narrow_widths` (width 40 dropped the id). Doc gates: check_line_cap 0 violations, check_test_pointers 0 dangling, check_sld exit 0, check_changelog_fragment OK. Security scan PASS over origin/main...HEAD.

## Review gate

code-critic WARN on b01e33cb3 (HIGH: picker not wired to stop-then-delete; MEDIUM: wrap_message drops UUID paragraph); both findings folded in 63b25a83d with failing-before tests.

## Follow-ups

Live verification needs a tm reinstall with a patch bump, owner-authorized; #7224 stays status:merged until then.

Session: trusty-tools-95 (tm-dogfood:0:@1), snapshot .trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-153636.md

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
