### PR TITLE
fix(trusty-channels): honor Slack list limits and filters

### DIFF
--- a/crates/trusty-channels/changelog.d/7391-slack-list-parameters.md
+++ b/crates/trusty-channels/changelog.d/7391-slack-list-parameters.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Send Slack channel and user listing parameters as GET queries so Slack honors requested limits and channel types.

--- a/crates/trusty-channels/src/slack/api/client.rs
+++ b/crates/trusty-channels/src/slack/api/client.rs
@@ -7,7 +7,7 @@
 //! only encodes its own request/response shape.
 //! What: Holds a `reqwest::Client`, a resolved bearer token (or `None`), and
 //! the API base URL. `new()` resolves the token via the shared credential
-//! resolver; [`BaseClient::call_method`] performs a hardened POST that surfaces
+//! resolver; [`BaseClient::call_method`] performs a hardened request that surfaces
 //! auth failures as a typed error (never a silent anonymous retry) and honours
 //! `429 Retry-After` with a bounded backoff.
 //! Test: `new_succeeds_without_token` (constructor, CI-safe) here;
@@ -149,13 +149,15 @@ impl BaseClient {
         self.user_token.is_some()
     }
 
-    /// Call a Slack Web API `method` with a JSON `body`, returning the decoded
+    /// Call a Slack Web API `method` with serializable parameters, returning the decoded
     /// response envelope on success.
     ///
     /// Why: the single hardened request primitive every future tool handler
     /// reuses — one place for auth, error classification, and rate-limit
     /// backoff, so no handler re-implements (or forgets) them.
-    /// What: POSTs `{base_url}/{method}` with a bearer token. Maps HTTP 401 and
+    /// What: GETs `conversations.list` and `users.list` with query parameters;
+    /// other methods POST JSON. List parameters must serialize as a flat map
+    /// of scalar values. Every request carries a bearer token. Maps HTTP 401 and
     /// auth-class `ok:false` bodies to [`SlackError::Auth`] (never retried as
     /// anonymous); honours `429 Retry-After` with a bounded backoff up to
     /// [`MAX_RATE_LIMIT_RETRIES`], then returns [`SlackError::RateLimited`];
@@ -163,6 +165,8 @@ impl BaseClient {
     /// `Value` when `ok:true`.
     /// Test: `tests/client_http.rs` (`send_ok`, `auth_401`, `auth_ok_false`,
     /// `rate_limit_retries_then_succeeds`, `rate_limit_exhausted`).
+    /// List transport: `list_channels_sends_limit_and_types_as_get_query`,
+    /// `list_users_sends_limit_as_get_query` in `tests/slack_list_http.rs`.
     pub async fn call_method<B>(&self, method: &str, body: &B) -> Result<Value, SlackError>
     where
         B: Serialize + ?Sized,
@@ -248,7 +252,8 @@ impl BaseClient {
     /// Why: bot-scope and user-scope calls differ only in *which* token they
     /// present; every other concern (auth classification, rate-limit backoff,
     /// envelope decoding) is identical and must not be duplicated.
-    /// What: POSTs `{base_url}/{method}` with `token` as the bearer credential;
+    /// What: sends list parameters in the URL query and other parameters as
+    /// POST JSON to `{base_url}/{method}`, with `token` as the bearer credential;
     /// maps 401 / auth-class `ok:false` to [`SlackError::Auth`], honours
     /// `429 Retry-After` up to [`MAX_RATE_LIMIT_RETRIES`], and returns the
     /// decoded `Value` on `ok:true`.
@@ -262,13 +267,12 @@ impl BaseClient {
 
         let mut retries: u32 = 0;
         loop {
-            let response = self
-                .http
-                .post(&url)
-                .bearer_auth(token)
-                .json(body)
-                .send()
-                .await?;
+            // #7391: Slack's listing endpoints ignore parameters in POST JSON bodies.
+            let request = match method {
+                "conversations.list" | "users.list" => self.http.get(&url).query(body),
+                _ => self.http.post(&url).json(body),
+            };
+            let response = request.bearer_auth(token).send().await?;
             let status = response.status();
 
             if status == StatusCode::UNAUTHORIZED {

--- a/crates/trusty-channels/tests/client_http.rs
+++ b/crates/trusty-channels/tests/client_http.rs
@@ -16,7 +16,7 @@ use trusty_channels::slack::api::client::BaseClient;
 use trusty_channels::slack::api::constants::{MAX_DOWNLOAD_BYTES, SLACK_PROVIDER, SLACK_TOKEN_ENV};
 use trusty_channels::slack::api::error::SlackError;
 use trusty_common::credentials::{env_var_for, resolve_key_with, KeyStore, MemoryKeyStore};
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_json, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 // ── Credential resolution (fake KeyStore — no live token) ─────────────────
@@ -87,6 +87,9 @@ async fn send_ok_returns_envelope() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/chat.postMessage"))
+        .and(header("authorization", "Bearer xoxb-test"))
+        .and(header("content-type", "application/json"))
+        .and(body_json(serde_json::json!({"channel": "C123"})))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "ok": true,
             "channel": "C123",
@@ -175,17 +178,21 @@ async fn api_ok_false_maps_to_api_error() {
 #[tokio::test]
 async fn rate_limit_retries_then_succeeds() {
     let server = MockServer::start().await;
-    // Fallback 200 (mounted first → lower precedence).
+    // Explicit priority makes the 200 a fallback after the one-shot 429.
     Mock::given(method("POST"))
         .and(path("/chat.postMessage"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+        .with_priority(2)
+        .expect(1)
         .mount(&server)
         .await;
-    // One 429 with Retry-After: 0 (mounted last → matched first, once only).
+    // One 429 with Retry-After: 0 (lower priority number matches first).
     Mock::given(method("POST"))
         .and(path("/chat.postMessage"))
         .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
+        .with_priority(1)
         .up_to_n_times(1)
+        .expect(1)
         .mount(&server)
         .await;
 

--- a/crates/trusty-channels/tests/slack_list_http.rs
+++ b/crates/trusty-channels/tests/slack_list_http.rs
@@ -1,0 +1,140 @@
+//! Why: #7391 exposed list parameters silently ignored when sent as POST JSON.
+//! What: exercise dispatch and the shared client against strict GET/query routes.
+//! Test: this file covers list arguments, encoding, retries, and auth errors.
+
+use serde_json::json;
+use trusty_channels::slack::api::client::BaseClient;
+use trusty_channels::slack::api::error::SlackError;
+use trusty_channels::slack::handlers::dispatch;
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn client_for(server: &MockServer) -> BaseClient {
+    BaseClient::with_endpoint(server.uri(), Some("xoxb-test".into())).unwrap()
+}
+
+#[tokio::test]
+async fn list_channels_sends_limit_and_types_as_get_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/conversations.list"))
+        .and(header("authorization", "Bearer xoxb-test"))
+        .and(query_param("limit", "1"))
+        .and(query_param("types", "public_channel,private_channel"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true,
+            "channels": [{"id": "C1", "name": "secret", "is_private": true}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let result = dispatch(
+        &client_for(&server),
+        "slack_list_channels",
+        json!({"limit": 1, "types": "public_channel,private_channel"}),
+    )
+    .await
+    .expect("list parameters must reach Slack's query parser");
+    assert_eq!(result["count"], 1);
+    assert_eq!(result["channels"][0]["is_private"], true);
+    let requests = server.received_requests().await.unwrap();
+    assert!(requests[0].body.is_empty());
+    assert_eq!(
+        requests[0].url.query(),
+        Some("limit=1&types=public_channel%2Cprivate_channel")
+    );
+}
+
+#[tokio::test]
+async fn list_users_sends_limit_as_get_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/users.list"))
+        .and(query_param("limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "ok": true, "members": [{"id": "U1", "name": "alice"}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let result = dispatch(
+        &client_for(&server),
+        "slack_list_users",
+        json!({"limit": 1}),
+    )
+    .await
+    .expect("user list limit must reach Slack's query parser");
+    assert_eq!(result["count"], 1);
+    assert_eq!(result["users"][0]["id"], "U1");
+}
+
+#[tokio::test]
+async fn list_query_preserves_encoding_and_retry_parameters() {
+    let server = MockServer::start().await;
+    let cursor = "next+/=& page";
+    Mock::given(method("GET"))
+        .and(path("/conversations.list"))
+        .and(header("authorization", "Bearer xoxb-test"))
+        .and(query_param("cursor", cursor))
+        .and(query_param("exclude_archived", "true"))
+        .and(query_param("limit", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+        .with_priority(2)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/conversations.list"))
+        .respond_with(ResponseTemplate::new(429).insert_header("retry-after", "0"))
+        .with_priority(1)
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    client_for(&server)
+        .call_method(
+            "conversations.list",
+            &json!({
+                "cursor": cursor, "exclude_archived": true, "limit": 1
+            }),
+        )
+        .await
+        .expect("GET retry succeeds with the same arguments");
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].url, requests[1].url);
+    assert!(requests.iter().all(|request| request.body.is_empty()));
+}
+
+#[tokio::test]
+async fn list_get_auth_errors_are_not_retried() {
+    for response in [
+        ResponseTemplate::new(401),
+        ResponseTemplate::new(200).set_body_json(json!({"ok": false, "error": "invalid_auth"})),
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/conversations.list"))
+            .and(header("authorization", "Bearer xoxb-test"))
+            .respond_with(response)
+            .expect(1)
+            .mount(&server)
+            .await;
+        let error = client_for(&server)
+            .call_method("conversations.list", &json!({}))
+            .await
+            .expect_err("authentication failure stays typed");
+        assert!(matches!(error, SlackError::Auth { .. }));
+    }
+}
+
+#[tokio::test]
+async fn list_query_rejects_nested_parameters_before_network() {
+    let server = MockServer::start().await;
+    let error = client_for(&server)
+        .call_method("conversations.list", &json!({"limit": {"value": 1}}))
+        .await
+        .expect_err("query parameters must be scalar values");
+    assert!(matches!(error, SlackError::Transport(ref error) if error.is_builder()));
+    assert!(server.received_requests().await.unwrap().is_empty());
+}

--- a/crates/trusty-channels/tests/tools_http.rs
+++ b/crates/trusty-channels/tests/tools_http.rs
@@ -1,6 +1,6 @@
 //! Hermetic tests for the send + read Slack tool handlers (issue #2639).
 //!
-//! Why: the send/read/list handlers must POST the correct Slack method, shape a
+//! Why: the send/read/list handlers must call the correct Slack method, shape a
 //! compact result, and — critically — markup-escape untrusted inbound text so a
 //! hostile message cannot inject a `<!channel>` broadcast span into the
 //! model-facing output. These behaviours need coverage that runs in CI with no
@@ -35,9 +35,13 @@ fn client_with_user_for(server: &MockServer) -> BaseClient {
     .expect("construct client")
 }
 
-/// Mount a single POST route returning a 200 + JSON body.
+/// Mount the method's route returning a 200 + JSON body.
 async fn mount_ok(server: &MockServer, method_path: &str, body: serde_json::Value) {
-    Mock::given(method("POST"))
+    let verb = match method_path {
+        "conversations.list" | "users.list" => "GET",
+        _ => "POST",
+    };
+    Mock::given(method(verb))
         .and(path(format!("/{method_path}")))
         .respond_with(ResponseTemplate::new(200).set_body_json(body))
         .mount(server)


### PR DESCRIPTION
## Outcome
Slack channel and user listings now send query parameters that Slack honors. A request with `limit=1` previously sent POST JSON and could receive the default page size; the client now uses GET for `conversations.list` and `users.list`.

Refs #7391
Refs #7389

## Changes
Route those two listing methods through the existing authenticated request and retry implementation. Other methods retain POST JSON. Tests cover limits, channel types, encoding, retry parameter preservation, and authentication failures.

## Risk
Test ladder rung 6: external API transport behavior in trusty-channels. No public signature change. A clean debug binary passes live Slack reads; installed connector verification remains pending.

## Test evidence
`cargo test -p trusty-channels --no-fail-fast`: 207 passed, zero failed, zero ignored across all test targets. `cargo check -p trusty-channels`, `cargo clippy -p trusty-channels --all-targets -- -D warnings`, formatting, binary smoke, SLD, test pointers, line cap, changelog and post-commit version gates pass.

Regression before: `test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s`. The same four transport regressions pass after the change. Local evidence is retained in `target/slack-7391-evidence/`.

## Baseline failures
Live debug verification on commit `64f4e606e497c5b6a7431b8c429560cfa442798c`: MCP handshake reports version 0.1.0 and 22 tools. Managed bot channel and user listings each return exactly one item for limit=1. Search reports the expected missing user-token error. No messages were sent and the installed binary was unchanged. Binary SHA256: `41087ac2a5ec10e8d736da8b1bcb9ac98a50fff1f88cd7918f7f1136f55aaacf`.

No outstanding baseline failures reported for these gates. Installed verification for #7389 remains pending.

## Documentation and changelog
Updated request-contract documentation and added the trusty-channels changelog fragment for #7391.

## Review disposition
Independent critic APPROVE. Security review was CLEAN by manual review and targeted credential-signature checks, bound to SHA256 hashes of all five changed files. Automated scanners were unavailable; no automated scan pass is claimed. The user authorized merge and installation on 2026-09-10; installation follows merge verification.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
