### PR TITLE
fix(trusty-agents-common): version-control checks conflicts with git merge-tree --write-tree, mergeable as tiebreak (Refs #7386)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7386-merge-tree-write-tree.md
+++ b/crates/trusty-agents-common/changelog.d/7386-merge-tree-write-tree.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The bundled `version-control` agent's conflict-detection instructions now name `git merge-tree --write-tree HEAD origin/main` as the check, with GitHub's `mergeable` field as the tiebreak — the legacy three-argument `git merge-tree <base> <a> <b>` form reported a merge clean when both flagged it as conflicting.

--- a/crates/trusty-agents-common/src/assets/agents/version-control.md
+++ b/crates/trusty-agents-common/src/assets/agents/version-control.md
@@ -305,11 +305,19 @@ The line is whether a `cargo publish` is bound to the tag: if it is, that is
 
 ## Conflict Resolution
 
-1. Check file sizes before reading diffs
-2. Extract conflict markers with `git diff --diff-filter=U`
-3. Resolve conflicts ONE file at a time
-4. Test after each resolution before moving to next
-5. Never retain full file contents — extract resolution patterns only
+<!-- #7386 -->
+1. Detect conflicts with `git merge-tree --write-tree HEAD origin/main`. Exit 0
+   means the merge is clean; exit 1 means conflicts, and stdout names the
+   conflicted paths. Never use the legacy three-argument
+   `git merge-tree <base> <a> <b>` form — it has reported a merge clean when
+   `--write-tree` and GitHub both flagged it as conflicting. When the two
+   disagree, trust `mergeable` from `gh pr view --json mergeable` as the
+   tiebreak.
+2. Check file sizes before reading diffs
+3. Extract conflict markers with `git diff --diff-filter=U`
+4. Resolve conflicts ONE file at a time
+5. Test after each resolution before moving to next
+6. Never retain full file contents — extract resolution patterns only
 
 ## Safety Rules
 


### PR DESCRIPTION
## Outcome

The bundled version-control agent's Conflict Resolution section named no detection command, and the legacy three-argument `git merge-tree` form has reported clean merges that GitHub flagged as conflicting.

## Changes

Names `git merge-tree --write-tree HEAD origin/main` (exit 0 clean, exit 1 conflicts with paths on stdout) and `gh pr view --json mergeable` as the tiebreak.

## Risk

Asset text only — no behavior change to any binary or crate logic.

## Tests

Rung 1/3. `cargo test -p trusty-agents-common --no-fail-fast`: 573 passed / 0 failed.

## Baseline

No pre-existing failures.

## Docs

Doc gates: `check_changelog_fragment` (--staged and post-commit), `check_sld`, `check_line_cap`. Fragment: `crates/trusty-agents-common/changelog.d/7386-merge-tree-write-tree.md`.

## Review

No outstanding review findings.

Link [#7386](https://github.com/bobmatnyc/trusty-tools/issues/7386).

Refs #7386

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
