### PR TITLE
fix(trusty-mpm): tm session delete stops an errored session first, sharing the picker's decision (Refs #7388)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7388-session-delete-stops-errored.md
+++ b/crates/trusty-mpm/changelog.d/7388-session-delete-stops-errored.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `tm session delete <id>` on an errored session now stops its runtime and then
+  deletes the record, instead of exiting 1 with advice to run `tm session stop`
+  first. The verb reads the record's state and routes through the same
+  `route_delete_for_state` seam the `tm ls` picker uses, so the two surfaces
+  cannot answer the same state differently (#7388). A running
+  (`active`/`provisioning`) session still refuses without `--force`, and a stop
+  the daemon rejects issues no delete.

--- a/crates/trusty-mpm/src/bin/tm/commands/delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/delete.rs
@@ -4,8 +4,10 @@
 //! production cap) into its own file, mirroring how `commands::prune` already
 //! separates the `prune-idle` verb from the rest of the managed-session CLI
 //! handlers.
-//! What: [`session_delete`] POSTs the daemon's hard-delete endpoint and renders
-//! the 404/409/success outcomes for the terminal.
+//! What: [`session_delete`] reads the record's persisted state, routes the
+//! delete through the shared seam the `tm ls` picker uses (#7388 — an errored
+//! session is stopped first), and renders the 404/409/stop-failed/success
+//! outcomes for the terminal.
 //! Test: HTTP path covered by `delete_route_*` in tests/session_manager_mvp.rs;
 //! CLI parse by `cli_parses_session_delete`.
 
@@ -28,9 +30,22 @@
 /// refusal (the managed daemon's 409, or the local guard's own message) prints
 /// the actionable reason and returns an `Err` so scripts see a non-zero exit;
 /// success prints a confirmation naming the pre-deletion name and state.
+///
+/// #7388: the route is chosen from the record's persisted state
+/// ([`super::picker_delete::managed_state_for_delete`]) through the same
+/// [`super::picker_delete::route_delete_for_state`] seam the `tm ls` picker
+/// uses, so an `errored` session is stopped and then deleted here too instead
+/// of being refused with advice to go run `tm session stop`. A failed stop
+/// issues no delete; a running (`active`/`provisioning`) session still needs
+/// `--force`, since the delete goes out with the caller's own flag.
 /// Test: HTTP path covered by `delete_route_*` in tests/session_manager_mvp.rs;
 /// CLI parse by `cli_parses_session_delete`; the shared routing seam is
-/// unit-tested via `classify_managed_delete_*`.
+/// unit-tested via `classify_managed_delete_*`, and the verb's own route by
+/// `verb_delete_stops_an_errored_session_before_deleting_it`,
+/// `verb_delete_never_deletes_after_a_failed_stop`,
+/// `verb_delete_issues_no_stop_when_the_id_is_not_a_managed_record` and
+/// `picker_and_verb_route_each_state_identically` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
 pub(crate) async fn session_delete(
     client: &reqwest::Client,
     url: &str,
@@ -38,7 +53,12 @@ pub(crate) async fn session_delete(
     force: bool,
 ) -> anyhow::Result<()> {
     use super::picker_delete::DeleteReport;
-    match super::picker_delete::delete_managed_then_local(client, url, &id, force).await? {
+    // #7388: learn the state before routing — without it every delete took the
+    // plain branch and an errored session bounced off the daemon's 409.
+    let state = super::picker_delete::managed_state_for_delete(client, url, &id).await?;
+    match super::picker_delete::route_delete_for_state(client, url, &id, state.as_deref(), force)
+        .await?
+    {
         DeleteReport::Deleted {
             name,
             prior_state,
@@ -66,9 +86,9 @@ pub(crate) async fn session_delete(
             eprintln!("error: {msg}");
             Err(anyhow::anyhow!("delete refused: {msg}"))
         }
-        // #7224: unreachable from this verb (it never takes the stop-first
-        // route), but the variant is exhaustive and a silent `_` arm would
-        // swallow a future caller's failed stop as a success.
+        // #7388: reachable now that the verb takes the stop-first route for an
+        // errored session. Nothing reached the delete endpoint, so the record is
+        // exactly as it was — say so, and exit non-zero.
         DeleteReport::StopFailed(msg) => {
             eprintln!("error: {msg}");
             Err(anyhow::anyhow!("stop failed; {id} was not deleted: {msg}"))

--- a/crates/trusty-mpm/src/bin/tm/commands/picker_delete.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/picker_delete.rs
@@ -228,6 +228,71 @@ pub(crate) async fn route_delete(
     }
 }
 
+/// Route a delete for a record whose persisted state is `state` (#7388).
+///
+/// Why: the picker knows a row's state because it listed it; the
+/// `tm session delete <id>` verb is handed a bare id and used to route without
+/// one, so it always took the plain-delete branch and an errored session came
+/// back refused with advice to run a different command. Both surfaces now
+/// derive the route from the same state through this one function, so a state
+/// the picker stops first can never be a state the verb refuses.
+/// What: reads `stop_first` out of [`delete_route_flags`] and hands the call to
+/// [`route_delete`]. `state` is `None` when the id names no managed record —
+/// a project-only (local) session, or one the daemon could not report — which
+/// takes the plain-delete branch, exactly as before. `force` is the caller's
+/// own (the verb's `--force`, the picker's typed `force` confirm) and is never
+/// escalated here: the daemon's tmux probe stays the authority on whether a
+/// record may go.
+/// Test: `verb_delete_stops_an_errored_session_before_deleting_it` and
+/// `picker_and_verb_route_each_state_identically` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+pub(crate) async fn route_delete_for_state(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+    state: Option<&str>,
+    force: bool,
+) -> anyhow::Result<DeleteReport> {
+    let stop_first = state.is_some_and(|s| delete_route_flags(s).1);
+    route_delete(client, url, id, force, stop_first).await
+}
+
+/// Read a managed record's persisted state, for routing its delete (#7388).
+///
+/// Why: [`route_delete_for_state`] needs the state the picker already has in
+/// hand. The verb has only an id, so it asks the daemon for the same field the
+/// picker's list carries rather than guessing a route from the id alone.
+/// What: GETs `/api/v1/sessions/managed/{id}` and returns its `state` string.
+/// Answers `None` for a 404 (no managed record — a local session, or nothing at
+/// all) and for any other non-success status or unreadable body: an unknown
+/// state routes to the plain delete, which is the pre-#7388 behaviour, so a
+/// failed probe never escalates a delete it could not classify. A transport
+/// error propagates, since the delete that follows would fail the same way.
+/// Test: `verb_delete_stops_an_errored_session_before_deleting_it`,
+/// `verb_delete_issues_no_stop_when_the_id_is_not_a_managed_record` in
+/// `tests_behavior_d_stop_delete_tests.rs`.
+pub(crate) async fn managed_state_for_delete(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+) -> anyhow::Result<Option<String>> {
+    let resp = client
+        .get(format!("{url}/api/v1/sessions/managed/{id}"))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+    let body: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    Ok(body
+        .get("state")
+        .and_then(|v| v.as_str())
+        .map(str::to_string))
+}
+
 /// Map a managed-delete HTTP status to the next routing step.
 ///
 /// Why: pure seam for the family routing so 200/404/409/other are testable
@@ -540,8 +605,10 @@ pub(crate) async fn delete_confirmed(
     url: &str,
     session: &ManagedSessionSummary,
 ) -> anyhow::Result<bool> {
-    let (force, stop_first) = delete_route_flags(&session.state);
-    match route_delete(client, url, &session.id, force, stop_first).await? {
+    // #7388: routes through the same seam `tm session delete <id>` uses, so the
+    // two surfaces cannot answer the same state differently.
+    let (force, _) = delete_route_flags(&session.state);
+    match route_delete_for_state(client, url, &session.id, Some(&session.state), force).await? {
         DeleteReport::Deleted {
             name,
             prior_state,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_stop_delete_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_stop_delete_tests.rs
@@ -426,3 +426,234 @@ fn both_delete_surfaces_ask_the_same_errored_question() {
         "'tm-quiet-falcon' is errored. Stop it and delete it? Type y, then Enter."
     );
 }
+
+// ── the `tm session delete <id>` verb's own route (#7388) ───────────────────
+
+/// The three managed endpoints the VERB touches, with the state it reports
+/// dialled per test and the stop/delete legs recorded IN ORDER.
+///
+/// The order is the point: proving the verb stops an errored session *first*
+/// needs a server that can say which request arrived when, and a delete that
+/// refuses while the runtime is still up — exactly what the daemon does.
+#[derive(Clone)]
+struct VerbStub {
+    /// The `state` the managed GET reports, or `None` to answer 404 there —
+    /// the id then names no managed record (a project-only session).
+    state: Option<String>,
+    stop_status: axum::http::StatusCode,
+    /// While true the delete endpoint 409s, mirroring the daemon's tmux probe.
+    live: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    legs: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+}
+
+impl VerbStub {
+    fn new(state: Option<&str>, stop_status: axum::http::StatusCode, live: bool) -> Self {
+        Self {
+            state: state.map(str::to_string),
+            stop_status,
+            live: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(live)),
+            legs: Default::default(),
+        }
+    }
+
+    fn router(&self) -> axum::Router {
+        use std::sync::atomic::Ordering::SeqCst;
+
+        use axum::{
+            Router,
+            extract::State,
+            response::IntoResponse,
+            routing::{get, post},
+        };
+        let stub = self.clone();
+        Router::new()
+            .route(
+                "/api/v1/sessions/managed/{id}",
+                get(|State(s): State<VerbStub>| async move {
+                    match s.state {
+                        Some(state) => axum::Json(serde_json::json!({
+                            "id": "sid-verb",
+                            "name": "tm-quiet-falcon",
+                            "state": state,
+                        }))
+                        .into_response(),
+                        None => (axum::http::StatusCode::NOT_FOUND, "no such managed session")
+                            .into_response(),
+                    }
+                }),
+            )
+            .route(
+                "/api/v1/sessions/managed/{id}/runtime-stop",
+                post(|State(s): State<VerbStub>| async move {
+                    s.legs.lock().expect("legs lock").push("stop");
+                    if s.stop_status.is_success()
+                        || s.stop_status == axum::http::StatusCode::NOT_FOUND
+                    {
+                        s.live.store(false, SeqCst);
+                    }
+                    (s.stop_status, "stub stop body")
+                }),
+            )
+            .route(
+                "/api/v1/sessions/managed/{id}/delete",
+                post(|State(s): State<VerbStub>| async move {
+                    s.legs.lock().expect("legs lock").push("delete");
+                    if s.live.load(SeqCst) {
+                        return (
+                            axum::http::StatusCode::CONFLICT,
+                            "session 'tm-quiet-falcon' is errored — stop it first with \
+                             `tm session stop`",
+                        )
+                            .into_response();
+                    }
+                    axum::Json(serde_json::json!({
+                        "name": "tm-quiet-falcon",
+                        "state": "errored",
+                        "deleted": true,
+                    }))
+                    .into_response()
+                }),
+            )
+            .with_state(stub)
+    }
+
+    fn legs(&self) -> Vec<&'static str> {
+        self.legs.lock().expect("legs lock").clone()
+    }
+}
+
+/// #7388, the reported bug: `tm session delete <errored-id>` exited 1 telling
+/// the operator to go run `tm session stop` — the command they were already
+/// asking for. It must stop the runtime and THEN delete the record, in that
+/// order. A fix that deletes without stopping records `["delete"]` and gets the
+/// daemon's 409 back; a fix that special-cases `errored` by skipping the stop
+/// records the same. Only the real two-leg route records `["stop", "delete"]`.
+#[tokio::test]
+async fn verb_delete_stops_an_errored_session_before_deleting_it() {
+    let stub = VerbStub::new(Some("errored"), axum::http::StatusCode::OK, true);
+    let (url, handle) = serve_stub(stub.router()).await;
+
+    crate::commands::delete::session_delete(
+        &reqwest::Client::new(),
+        &url,
+        "sid-verb".to_string(),
+        false,
+    )
+    .await
+    .expect("an errored session must delete, not refuse");
+    assert_eq!(
+        stub.legs(),
+        vec!["stop", "delete"],
+        "the stop must arrive before the delete"
+    );
+    handle.abort();
+}
+
+/// Fail-open check on the verb's route: a stop the daemon REJECTED leaves the
+/// record alone, the delete endpoint is never reached, and the verb exits
+/// non-zero so a script sees the failure.
+#[tokio::test]
+async fn verb_delete_never_deletes_after_a_failed_stop() {
+    for status in [
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        axum::http::StatusCode::CONFLICT,
+    ] {
+        let stub = VerbStub::new(Some("errored"), status, true);
+        let (url, handle) = serve_stub(stub.router()).await;
+
+        let err = crate::commands::delete::session_delete(
+            &reqwest::Client::new(),
+            &url,
+            "sid-verb".to_string(),
+            false,
+        )
+        .await
+        .expect_err("a rejected stop must not report success");
+        assert!(
+            err.to_string().contains("stop failed"),
+            "must name the failed stop: {err}"
+        );
+        assert_eq!(
+            stub.legs(),
+            vec!["stop"],
+            "a rejected stop must issue NO delete request ({status})"
+        );
+        handle.abort();
+    }
+}
+
+/// The carve-out stays scoped on the verb too: an id the managed store does not
+/// know (a project-only session) gets no runtime-stop issued on its behalf, so
+/// the local-fallback route is unchanged.
+#[tokio::test]
+async fn verb_delete_issues_no_stop_when_the_id_is_not_a_managed_record() {
+    let stub = VerbStub::new(None, axum::http::StatusCode::OK, false);
+    let (url, handle) = serve_stub(stub.router()).await;
+
+    // The managed GET 404s, so the state is unknown and the plain delete goes
+    // out; the stub's delete endpoint answers it (the local fallback beyond it
+    // is covered by `local_delete_*` in `tests_behavior_d_tests.rs`).
+    crate::commands::delete::session_delete(
+        &reqwest::Client::new(),
+        &url,
+        "sid-verb".to_string(),
+        false,
+    )
+    .await
+    .expect("an unknown-state delete must route exactly as before");
+    assert_eq!(
+        stub.legs(),
+        vec!["delete"],
+        "an unclassifiable id must not pick up a stop leg"
+    );
+    handle.abort();
+}
+
+/// #7388: the two surfaces must decide the same route for the same state. The
+/// picker reads the state off the row it listed and the verb asks the daemon
+/// for it, but from there both go through `route_delete_for_state`, so the
+/// stop/delete legs they issue must match state for state.
+#[tokio::test]
+async fn picker_and_verb_route_each_state_identically() {
+    use crate::commands::picker_delete::delete_confirmed;
+    // Every variant of `ManagedSessionState`, in its serde (snake_case) spelling.
+    for state in [
+        "provisioning",
+        "active",
+        "stopped",
+        "errored",
+        "decommissioned",
+        "deleted",
+    ] {
+        // `live = false`: the delete succeeds either way, so what differs
+        // between the surfaces is the ROUTE, not the daemon's verdict.
+        let picker_stub = VerbStub::new(Some(state), axum::http::StatusCode::OK, false);
+        let (picker_url, picker_handle) = serve_stub(picker_stub.router()).await;
+        delete_confirmed(&reqwest::Client::new(), &picker_url, &row(state))
+            .await
+            .expect("the picker's delete driver must not error");
+        picker_handle.abort();
+
+        let verb_stub = VerbStub::new(Some(state), axum::http::StatusCode::OK, false);
+        let (verb_url, verb_handle) = serve_stub(verb_stub.router()).await;
+        // The picker force-confirms a running row by having the operator type
+        // `force`; `--force` is the verb's spelling of the same consent, so
+        // pass the flag the state calls for and compare like with like.
+        let force = crate::commands::picker_delete::delete_needs_force(state);
+        crate::commands::delete::session_delete(
+            &reqwest::Client::new(),
+            &verb_url,
+            "sid-verb".to_string(),
+            force,
+        )
+        .await
+        .expect("the verb must not error");
+        verb_handle.abort();
+
+        assert_eq!(
+            picker_stub.legs(),
+            verb_stub.legs(),
+            "the picker and `tm session delete` must route a {state} session the same way"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`tm session delete` refused an errored session with "stop it first" while the picker's delete already routed stop-then-delete. Both surfaces now enter one seam, `route_delete_for_state` in `commands/picker_delete.rs`, which reads `stop_first` from the state via the existing `delete_route_flags`; the verb resolves the managed state first (a 404 or unreadable probe answers None and routes to the plain delete, the pre-fix behaviour).

## Changes

- `route_delete_for_state` in `crates/trusty-mpm/src/bin/tm/commands/picker_delete.rs` is now the single seam both the picker and the `tm session delete` verb call.
- The verb resolves the managed state before deciding stop-then-delete vs. plain delete, sharing `delete_route_flags`'s `stop_first` read instead of a separate check.
- `--force` semantics are unchanged on both surfaces; a stop the daemon rejects issues no delete.
- Out of scope: no change to the picker's UI, to `delete_route_flags` itself, or to any other session lifecycle command.

## Risk

Low-to-normal, single-crate (`trusty-mpm`), localized to session delete routing. No public API or cross-crate surface touched.

## Test plan

Rung 3. `cargo fmt --check`, `cargo check -p trusty-mpm --all-targets`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `cargo test -p trusty-mpm --no-fail-fast` — 57 targets ok, largest 6646 passed / 0 failed / 8 ignored. Four new tests in `tests_behavior_d_stop_delete_tests.rs`; three proven to fail with `delete.rs` and `picker_delete.rs` restored to `origin/main` (`picker_and_verb_route_each_state_identically`: left `["stop","delete"]`, right `["delete"]`).

## Baseline

No pre-existing red encountered on this crate at the base commit; all failures observed were resolved by the fix itself.

## Docs

Fragment: `crates/trusty-mpm/changelog.d/7388-session-delete-stops-errored.md`. Doc gates run: `check_line_cap`, `check_test_pointers`, `check_changelog_fragment` (`--staged`, default, `--file`), `check-pr-version-bump`.

## Review

No prior review round on this PR; nothing to disposition yet.

Refs #7388
Refs #7224

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
