### PR TITLE
fix(trusty-mpm): tm compress logs the wrapped exit status and falls back when rtk returns nothing (Refs #7384, #7377)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7377-compress-rtk-empty-output-fallback.md
+++ b/crates/trusty-mpm/changelog.d/7377-compress-rtk-empty-output-fallback.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `tm compress` returns the raw text, and warns, when compression emptied a
+  non-empty input. The `rtk_binary` path handed back whatever the subprocess
+  printed, so an rtk that exited zero having printed nothing turned an
+  824-byte `git diff --stat` into 0 bytes and reported it as a successful 100%
+  reduction. The backstop added for the native filter chain never covered the
+  rtk subprocess.

--- a/crates/trusty-mpm/changelog.d/7384-compress-logs-wrapped-exit-status.md
+++ b/crates/trusty-mpm/changelog.d/7384-compress-logs-wrapped-exit-status.md
@@ -1,0 +1,10 @@
+Fixed
+
+- `tm compress`'s stats line now carries the wrapped command's exit status as
+  `exit=N`, so an empty result no longer reads the same whether the command
+  found nothing, failed, or had its stdout redirected away. The `tm hook`
+  PreToolUse rewrite wraps the command in a brace group whose trailing `printf`
+  reports `$?`, and the filter strips that sentinel before compressing, so it
+  never reaches the caller's output. A signal-killed command reports the
+  shell's `128 + signal`; an unwrapped `tm compress < file` reports
+  `exit=unknown`.

--- a/crates/trusty-mpm/changelog.d/7384-compress-logs-wrapped-exit-status.md
+++ b/crates/trusty-mpm/changelog.d/7384-compress-logs-wrapped-exit-status.md
@@ -7,4 +7,6 @@ Fixed
   reports `$?`, and the filter strips that sentinel before compressing, so it
   never reaches the caller's output. A signal-killed command reports the
   shell's `128 + signal`; an unwrapped `tm compress < file` reports
-  `exit=unknown`.
+  `exit=unknown`. A command a brace group cannot wrap is left alone: a `#`
+  would comment out the group's own `printf` and closing brace, and a trailing
+  unescaped `\` would escape its `;` and turn the `printf` into arguments.

--- a/crates/trusty-mpm/src/bin/tm/commands/compress.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/compress.rs
@@ -73,11 +73,15 @@ const EXIT_SENTINEL_SUFFIX: &str = "__";
 /// argument before any element runs — so the status is appended to the stream
 /// the filter already reads, by a `printf` that runs after the command in the
 /// same brace group.
-/// What: `{ <command>; printf '\n<sentinel>\n' "$?"; }`. The rewrite only ever
-/// reaches a simple command (`hook_rewrite::has_unsafe_pipe_composition`
-/// rejects `|`, `&`, `;`, `>` and `<` first), so the brace group is valid in
-/// sh, bash and zsh alike. The leading newline keeps the sentinel on its own
-/// line whether or not the command's output ended in one, and
+/// What: `{ <command>; printf '\n<sentinel>\n' "$?"; }`. The whole group is one
+/// physical line, so the caller owes this function a command that cannot break
+/// it: `hook_rewrite::has_unsafe_pipe_composition` rejects `|`, `&`, `;`, `>`
+/// and `<`, and `hook_rewrite::cannot_be_brace_wrapped` rejects a `#` (which
+/// would comment out the `printf` and the closing brace) and a trailing
+/// unescaped `\` (which would escape the `;` and turn the `printf` into
+/// arguments). What reaches here is a simple command, and the group is then
+/// valid in sh, bash and zsh alike. The leading newline keeps the sentinel on
+/// its own line whether or not the command's output ended in one, and
 /// [`split_exit_sentinel`] removes exactly the bytes this adds.
 /// Test: `wrap_command_reporting_exit_round_trips_through_split`,
 /// `rewrite_appends_compress_pipe_for_plain_command`, and the process-level

--- a/crates/trusty-mpm/src/bin/tm/commands/compress.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/compress.rs
@@ -25,12 +25,18 @@
 //! run that actually shrank its input (see
 //! [`trusty_mpm::core::savings_compress`], which is what puts bash and gate
 //! output into the `💸` statusline segment), and writes the compressed text to
-//! stdout.
+//! stdout. Two things ride on top of that: the stats line reports the WRAPPED
+//! command's exit status, which the rewritten pipeline appends as a sentinel
+//! line and [`split_exit_sentinel`] strips back off (#7384), and a compression
+//! that emptied a non-empty input hands the raw text back with a warning
+//! instead of returning nothing ([`compress_with_raw_fallback`], #7377).
 //! Test: `run_compress_shrinks_repetitive_cargo_test_output`,
 //! `log_compression_stats_pct_reduction_is_zero_for_empty_input`,
 //! `log_compression_stats_pct_reduction_can_be_negative_when_output_expands`,
 //! `native_fallback_elision_reports_a_matching_non_zero_reduction`,
 //! `run_compress_passes_through_short_output_unchanged`,
+//! `split_exit_sentinel_reads_and_strips_a_trailing_status`,
+//! `rtk_returning_nothing_falls_back_to_the_raw_output_and_warns_once`,
 //! `append_compression_record_creates_file`,
 //! `append_compression_record_appends` below; the full stdin→stdout process
 //! contract (including this function's now-async write) is exercised end to
@@ -39,7 +45,88 @@
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use trusty_agents_common::compress::compress_tool_output_async_with_path;
+use trusty_agents_common::compress::{
+    CompressionPath, RtkResolver, compress_tool_output_async_with_path_using, default_rtk_resolver,
+};
+
+/// Head of the exit-status line the rewritten pipeline appends to stdin (#7384).
+///
+/// Why: a pipeline hands its filter stdout, never the upstream command's exit
+/// status, so `bytes_before=0` read the same whether the command found nothing,
+/// failed, or had its stdout redirected away. The shell knows the status; a
+/// trailing sentinel line is the one way to carry it into a process the shell
+/// started concurrently.
+/// What: the producer is [`wrap_command_reporting_exit`], the consumer
+/// [`split_exit_sentinel`]. A wrapped command that prints this exact line
+/// itself would have it stripped and its status misreported — accepted, since
+/// the spelling is not one real output produces.
+/// Test: `split_exit_sentinel_reads_and_strips_a_trailing_status`.
+const EXIT_SENTINEL_PREFIX: &str = "__tm_compress_exit=";
+
+/// Tail of the exit-status sentinel line. See [`EXIT_SENTINEL_PREFIX`].
+const EXIT_SENTINEL_SUFFIX: &str = "__";
+
+/// Wrap a Bash command so its exit status reaches this filter (#7384).
+///
+/// Why: `commands::hook_rewrite` pipes the wrapped command into `tm compress`.
+/// `$?` cannot be read from inside that pipeline — the shell expands every
+/// argument before any element runs — so the status is appended to the stream
+/// the filter already reads, by a `printf` that runs after the command in the
+/// same brace group.
+/// What: `{ <command>; printf '\n<sentinel>\n' "$?"; }`. The rewrite only ever
+/// reaches a simple command (`hook_rewrite::has_unsafe_pipe_composition`
+/// rejects `|`, `&`, `;`, `>` and `<` first), so the brace group is valid in
+/// sh, bash and zsh alike. The leading newline keeps the sentinel on its own
+/// line whether or not the command's output ended in one, and
+/// [`split_exit_sentinel`] removes exactly the bytes this adds.
+/// Test: `wrap_command_reporting_exit_round_trips_through_split`,
+/// `rewrite_appends_compress_pipe_for_plain_command`, and the process-level
+/// `tm_compress_reports_the_wrapped_commands_exit_status`.
+pub(crate) fn wrap_command_reporting_exit(command: &str) -> String {
+    format!(
+        "{{ {command}; printf '\\n{EXIT_SENTINEL_PREFIX}%s{EXIT_SENTINEL_SUFFIX}\\n' \"$?\"; }}"
+    )
+}
+
+/// Split stdin into the wrapped command's own output and its exit status.
+///
+/// Why: the sentinel is telemetry, not output — leaving it in would put a
+/// `__tm_compress_exit=0__` line in front of every agent reading a wrapped
+/// command's result (#7384).
+/// What: looks at the last line, ignoring one trailing newline. When it is a
+/// sentinel, returns everything before the newline that introduced it plus the
+/// parsed status; otherwise returns the input untouched and `None`, which is
+/// what an unwrapped invocation (`tm compress < file`) and an older rewrite
+/// both produce.
+/// Test: `split_exit_sentinel_reads_and_strips_a_trailing_status`,
+/// `split_exit_sentinel_leaves_unwrapped_input_untouched`,
+/// `wrap_command_reporting_exit_round_trips_through_split`.
+fn split_exit_sentinel(stdin_text: &str) -> (&str, Option<i32>) {
+    let body = stdin_text.strip_suffix('\n').unwrap_or(stdin_text);
+    let (head, last) = match body.rfind('\n') {
+        Some(newline) => (&body[..newline], &body[newline + 1..]),
+        None => ("", body),
+    };
+    match parse_exit_sentinel(last) {
+        Some(code) => (head, Some(code)),
+        None => (stdin_text, None),
+    }
+}
+
+/// Parse one sentinel line into a shell exit status.
+///
+/// A signal-killed command reaches the shell as `128 + signal`, so the same
+/// numeric range covers it — 137 for `SIGKILL`, no separate spelling (#7384).
+/// Values outside a shell's `0..=255` are rejected so a line that merely looks
+/// like the sentinel cannot be mistaken for one.
+/// Test: `parse_exit_sentinel_rejects_out_of_range_and_malformed_lines`.
+fn parse_exit_sentinel(line: &str) -> Option<i32> {
+    let digits = line
+        .strip_prefix(EXIT_SENTINEL_PREFIX)?
+        .strip_suffix(EXIT_SENTINEL_SUFFIX)?;
+    let code: i32 = digits.parse().ok()?;
+    (0..=255).contains(&code).then_some(code)
+}
 
 /// Run `tm compress --tool <tool>`: read stdin, compress, log stats, print.
 ///
@@ -86,13 +173,16 @@ use trusty_agents_common::compress::compress_tool_output_async_with_path;
 pub(crate) async fn run_compress(tool: &str) -> anyhow::Result<()> {
     init_stats_log_subscriber();
 
-    let mut input = String::new();
-    tokio::io::stdin().read_to_string(&mut input).await?;
+    let mut stdin_text = String::new();
+    tokio::io::stdin().read_to_string(&mut stdin_text).await?;
+    // #7384: the wrapped command's status rides in on a trailing sentinel line;
+    // strip it here so it never reaches the caller's output.
+    let (input, exit) = split_exit_sentinel(&stdin_text);
 
     let started = std::time::Instant::now();
-    let (compressed, path) = compress_tool_output_async_with_path(tool, &input).await;
+    let (compressed, path) = compress_with_raw_fallback(default_rtk_resolver(), tool, input).await;
     let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
-    let _pct = log_compression_stats(tool, input.len(), compressed.len(), path.as_str());
+    let _pct = log_compression_stats(tool, input.len(), compressed.len(), path.as_str(), exit);
     // #3870: durable sink, awaited (not spawned) because `tm compress` is a
     // short-lived pipe filter — see `append_compression_record`'s doc
     // comment for why a detached `tokio::spawn` would race process exit.
@@ -119,6 +209,42 @@ pub(crate) async fn run_compress(tool: &str) -> anyhow::Result<()> {
     stdout.write_all(compressed.as_bytes()).await?;
     stdout.flush().await?;
     Ok(())
+}
+
+/// Compress `input`, handing back the raw text when compression emptied it.
+///
+/// Why: the `rtk_binary` path returns whatever the subprocess printed, and rtk
+/// can exit zero having printed nothing — an 824-byte `git diff --stat` came
+/// back as 0 bytes, reported as a successful 100% reduction, and the caller
+/// lost the diff (#7377). #6986 put the same backstop inside
+/// [`trusty_agents_common::compress::compress_tool_output`], but that guard
+/// only covers the native filter chain; the rtk subprocess never reaches it.
+/// What: runs [`compress_tool_output_async_with_path_using`] against `resolve`,
+/// then returns `input` verbatim when the result is blank and the input was
+/// not. The warning carries the tool, the input size and the path that emptied
+/// it, so the fallback is visible in the same stderr stream as the stats line
+/// rather than being silently indistinguishable from a real reduction. The
+/// reported [`CompressionPath`] stays the path that actually ran.
+/// Test: `rtk_returning_nothing_falls_back_to_the_raw_output_and_warns_once`,
+/// `a_real_compression_is_not_treated_as_an_empty_result`.
+async fn compress_with_raw_fallback(
+    resolve: RtkResolver,
+    tool: &str,
+    input: &str,
+) -> (String, CompressionPath) {
+    let (compressed, path) = compress_tool_output_async_with_path_using(resolve, tool, input).await;
+    // #7377: an empty result for a non-empty input destroyed the caller's
+    // output rather than shortening it.
+    if compressed.trim().is_empty() && !input.trim().is_empty() {
+        tracing::warn!(
+            tool_name = %tool,
+            bytes_before = input.len(),
+            compression_path = %path.as_str(),
+            "compression returned no output for a non-empty input; falling back to the raw output"
+        );
+        return (input.to_string(), path);
+    }
+    (compressed, path)
 }
 
 /// Append this run's savings row to the ledger the `💸` statusline segment folds.
@@ -208,15 +334,24 @@ fn init_stats_log_subscriber() {
 /// assert the number the stats line carries. The two edge-case tests below
 /// previously proved only that logging did not panic, which left a claim of
 /// `pct_reduction=0.0` on an eliding path unfalsifiable.
+///
+/// #7384: the line also carries `exit`, the WRAPPED command's status — not
+/// this filter's, which is always 0. Without it `bytes_before=0` read
+/// identically whether the command found nothing, failed, or had its stdout
+/// dropped; a zsh `no matches found:` error was invisible on one such call.
+/// `exit=unknown` when stdin carried no sentinel, which is what an unwrapped
+/// `tm compress < file` produces.
 /// Test: `log_compression_stats_pct_reduction_is_zero_for_empty_input`,
 /// `log_compression_stats_pct_reduction_can_be_negative_when_output_expands`,
 /// `native_fallback_elision_reports_a_matching_non_zero_reduction`,
-/// exercised end-to-end via `run_compress_*` tests below.
+/// exercised end-to-end via `run_compress_*` tests below and, for the exit
+/// field, by `tm_compress_reports_the_wrapped_commands_exit_status`.
 fn log_compression_stats(
     tool_name: &str,
     bytes_before: usize,
     bytes_after: usize,
     path: &str,
+    exit: Option<i32>,
 ) -> f64 {
     // #7180: the emitted percentage is also RETURNED so a test can assert the
     // number itself, not merely that logging did not panic.
@@ -225,12 +360,15 @@ fn log_compression_stats(
     } else {
         0.0
     };
+    // #7384: `%` so the field renders as `exit=3`, not a quoted `exit="3"`.
+    let exit_status = exit.map_or_else(|| "unknown".to_string(), |code| code.to_string());
     tracing::info!(
         tool_name = %tool_name,
         bytes_before,
         bytes_after,
         pct_reduction,
         compression_path = %path,
+        exit = %exit_status,
         "tool output compressed"
     );
     pct_reduction
@@ -394,9 +532,7 @@ async fn append_compression_record(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use trusty_agents_common::compress::{
-        CompressionPath, compress_tool_output_async_with_path_using, no_rtk,
-    };
+    use trusty_agents_common::compress::no_rtk;
 
     /// Compress through the native chain, whatever the host has installed.
     ///
@@ -416,7 +552,10 @@ mod tests {
     fn log_compression_stats_pct_reduction_is_zero_for_empty_input() {
         // Guards the division-by-zero edge case: an empty tool output must
         // report 0.0% reduction, not NaN/panic.
-        assert_eq!(log_compression_stats("bash", 0, 0, "native_fallback"), 0.0);
+        assert_eq!(
+            log_compression_stats("bash", 0, 0, "native_fallback", None),
+            0.0
+        );
     }
 
     #[tokio::test]
@@ -445,7 +584,13 @@ mod tests {
         );
         assert!(compressed.len() < input.len(), "expected fewer bytes out");
 
-        let pct = log_compression_stats("grep -n", input.len(), compressed.len(), path.as_str());
+        let pct = log_compression_stats(
+            "grep -n",
+            input.len(),
+            compressed.len(),
+            path.as_str(),
+            Some(0),
+        );
         let expected = (1.0 - compressed.len() as f64 / input.len() as f64) * 100.0;
         assert!(
             (pct - expected).abs() < f64::EPSILON,
@@ -463,7 +608,7 @@ mod tests {
         // doc comment for why we don't clamp). This test only proves no
         // panic/NaN occurs for `bytes_after > bytes_before`.
         assert_eq!(
-            log_compression_stats("bash", 10, 20, "native_fallback"),
+            log_compression_stats("bash", 10, 20, "native_fallback", None),
             -100.0
         );
     }
@@ -620,5 +765,231 @@ mod tests {
     fn compression_log_path_ends_with_trusty_mpm_compression_jsonl() {
         let path = compression_log_path();
         assert!(path.ends_with(".trusty-mpm/compression.jsonl"));
+    }
+
+    // -- #7384: the wrapped command's exit status ---------------------------
+
+    #[test]
+    fn split_exit_sentinel_reads_and_strips_a_trailing_status() {
+        // The exact stream `wrap_command_reporting_exit` produces for a command
+        // whose own output already ended in a newline.
+        let (payload, exit) = split_exit_sentinel("boom\n\n__tm_compress_exit=3__\n");
+        assert_eq!(payload, "boom\n", "the sentinel must not reach the caller");
+        assert_eq!(exit, Some(3));
+
+        // A command whose output did NOT end in a newline: the newline the
+        // sentinel brought with it is the one that gets removed.
+        let (payload, exit) = split_exit_sentinel("boom\n__tm_compress_exit=0__\n");
+        assert_eq!(payload, "boom");
+        assert_eq!(exit, Some(0));
+
+        // A command that printed nothing at all.
+        let (payload, exit) = split_exit_sentinel("\n__tm_compress_exit=127__\n");
+        assert_eq!(payload, "");
+        assert_eq!(exit, Some(127));
+
+        // Signal-killed reaches the shell as 128 + signal; 137 is SIGKILL.
+        let (_, exit) = split_exit_sentinel("out\n\n__tm_compress_exit=137__\n");
+        assert_eq!(exit, Some(137));
+    }
+
+    #[test]
+    fn split_exit_sentinel_leaves_unwrapped_input_untouched() {
+        // `tm compress < file`, and any rewrite older than #7384, carry no
+        // sentinel — the payload must come back byte-for-byte.
+        for raw in ["plain output\n", "no trailing newline", "", "\n"] {
+            let (payload, exit) = split_exit_sentinel(raw);
+            assert_eq!(payload, raw, "unwrapped input must pass through: {raw:?}");
+            assert_eq!(exit, None);
+        }
+    }
+
+    #[test]
+    fn parse_exit_sentinel_rejects_out_of_range_and_malformed_lines() {
+        assert_eq!(parse_exit_sentinel("__tm_compress_exit=3__"), Some(3));
+        assert_eq!(parse_exit_sentinel("__tm_compress_exit=255__"), Some(255));
+        // A shell status is 0..=255; anything else is a line that merely looks
+        // like the sentinel.
+        assert_eq!(parse_exit_sentinel("__tm_compress_exit=256__"), None);
+        assert_eq!(parse_exit_sentinel("__tm_compress_exit=-1__"), None);
+        assert_eq!(parse_exit_sentinel("__tm_compress_exit=ok__"), None);
+        assert_eq!(parse_exit_sentinel("__tm_compress_exit=3"), None);
+        assert_eq!(parse_exit_sentinel("test result: ok. 3 passed"), None);
+    }
+
+    #[test]
+    fn wrap_command_reporting_exit_round_trips_through_split() {
+        // The producer and the consumer must agree on the exact spelling; this
+        // pins them to each other rather than to two hand-written literals.
+        let wrapped = wrap_command_reporting_exit("cargo test");
+        assert!(
+            wrapped.starts_with("{ cargo test; printf "),
+            "the command must run first inside the brace group: {wrapped}"
+        );
+        assert!(
+            wrapped.contains(EXIT_SENTINEL_PREFIX) && wrapped.contains("\"$?\""),
+            "the sentinel must carry the command's own status: {wrapped}"
+        );
+        // What the shell would emit for a command printing "out\n" and exiting 3.
+        let stream = format!("out\n\n{EXIT_SENTINEL_PREFIX}3{EXIT_SENTINEL_SUFFIX}\n");
+        assert_eq!(split_exit_sentinel(&stream), ("out\n", Some(3)));
+    }
+
+    // -- #7377: an empty compression falls back to the raw output -----------
+
+    /// Raise the process-global tracing level so the thread-local capture below
+    /// can see `warn!` (#4931).
+    ///
+    /// Why: `tracing`'s macros short-circuit on a process-global `MAX_LEVEL`
+    /// that only a GLOBAL default subscriber raises, so a `with_default`
+    /// capture records nothing unless something else in the binary happened to
+    /// install one first. `trusty_mpm::test_support::enable_event_capture` is
+    /// the library's copy of this and is not reachable from this bin target.
+    /// What: installs a bare registry once per process, then asserts the
+    /// resulting level admits `WARN` so a filtered global installed elsewhere
+    /// fails here by name instead of as an empty capture.
+    /// Test: the capture test below is vacuous without it.
+    fn enable_event_capture() {
+        static RAISE_MAX_LEVEL: std::sync::Once = std::sync::Once::new();
+        RAISE_MAX_LEVEL.call_once(|| {
+            let _ = tracing::subscriber::set_global_default(tracing_subscriber::registry());
+        });
+        assert!(
+            tracing::level_filters::LevelFilter::current() >= tracing::Level::WARN,
+            "the process-global tracing level is {:?}, which discards WARN before \
+             any subscriber sees it (#4931)",
+            tracing::level_filters::LevelFilter::current()
+        );
+    }
+
+    /// Collects a subscriber's output so a test can read back what was logged.
+    #[derive(Clone, Default)]
+    struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("capture lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Path of this process's stub rtk. See [`empty_rtk`].
+    #[cfg(unix)]
+    fn empty_rtk_stub_path() -> PathBuf {
+        std::env::temp_dir().join(format!("tm-compress-empty-rtk-{}.sh", std::process::id()))
+    }
+
+    /// An [`RtkResolver`] naming a stub rtk that prints nothing.
+    ///
+    /// Why: [`RtkResolver`] is a plain `fn` pointer, so it cannot close over a
+    /// `TempDir` — the stub is written by the resolver itself, at a path keyed
+    /// on this process's pid so two test binaries never share one.
+    /// What: an `/bin/sh` script that drains stdin (otherwise the writer in
+    /// `compress_via_rtk_binary` takes `EPIPE`, the rtk arm reports failure,
+    /// and the native chain would answer instead) and exits zero having
+    /// written nothing — exactly the #7377 shape.
+    /// Test: `rtk_returning_nothing_falls_back_to_the_raw_output_and_warns_once`.
+    #[cfg(unix)]
+    fn empty_rtk(_name: &str) -> Option<PathBuf> {
+        use std::os::unix::fs::PermissionsExt;
+        let path = empty_rtk_stub_path();
+        std::fs::write(&path, "#!/bin/sh\ncat >/dev/null\nexit 0\n").ok()?;
+        let mut perms = std::fs::metadata(&path).ok()?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).ok()?;
+        Some(path)
+    }
+
+    /// Run `body` with a thread-local capturing subscriber, returning its
+    /// result and everything logged at `WARN` or above.
+    fn with_captured_warnings<T>(body: impl FnOnce() -> T) -> (T, String) {
+        enable_event_capture();
+        let capture = CaptureWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(capture.clone())
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+        let out = tracing::subscriber::with_default(subscriber, body);
+        let logged = String::from_utf8(capture.0.lock().expect("capture lock").clone())
+            .expect("the captured log must be utf-8");
+        (out, logged)
+    }
+
+    /// A `git diff --stat`-shaped payload — the input #7377 was reported on.
+    fn diff_stat_payload() -> String {
+        let mut input = String::new();
+        for i in 0..40 {
+            input.push_str(&format!(" crates/x/src/file_{i}.rs | 4 ++--\n"));
+        }
+        input.push_str(" 40 files changed, 80 insertions(+), 80 deletions(-)\n");
+        input
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rtk_returning_nothing_falls_back_to_the_raw_output_and_warns_once() {
+        // #7377: rtk exited zero having printed nothing and an 824-byte diff
+        // was reported as a successful 100% reduction. The caller must get its
+        // bytes back, and the substitution must be visible.
+        let input = diff_stat_payload();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+
+        let ((compressed, path), logged) = with_captured_warnings(|| {
+            runtime.block_on(compress_with_raw_fallback(empty_rtk, "git diff", &input))
+        });
+        let _ = std::fs::remove_file(empty_rtk_stub_path());
+
+        assert_eq!(
+            path.as_str(),
+            "rtk_binary",
+            "the stub must have been taken as the rtk arm, else this test proves \
+             nothing about #7377's path: {logged}"
+        );
+        assert_eq!(
+            compressed, input,
+            "the caller must receive the original text byte-for-byte"
+        );
+        assert_eq!(
+            logged.matches("falling back to the raw output").count(),
+            1,
+            "the fallback must be announced exactly once: {logged}"
+        );
+        assert!(
+            logged.contains("rtk_binary"),
+            "the warning must name the path that emptied the output: {logged}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_real_compression_is_not_treated_as_an_empty_result() {
+        // The other half of the guard: a compression that shortened its input
+        // must pass through untouched, with no warning and no fallback.
+        let mut input = String::new();
+        for i in 0..50 {
+            input.push_str(&format!("test mod::t{i} ... ok\n"));
+        }
+        input.push_str("test result: ok. 50 passed; 0 failed\n");
+        let (compressed, path) = compress_with_raw_fallback(no_rtk, "cargo test", &input).await;
+        assert_eq!(path.as_str(), "native_fallback");
+        assert!(
+            compressed.len() < input.len(),
+            "the guard must not have replaced a real compression"
+        );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
@@ -20,12 +20,16 @@
 //! `&`, `;`, `>`, `<`) since appending another pipe to those is the same class of
 //! risk (redirection in particular: piping `tm compress` after an
 //! already-redirected stdout gets it empty input for no benefit — a
-//! trusty-review finding, PR #1968), and any command whose derived tool
+//! trusty-review finding, PR #1968), any command a brace group cannot wrap —
+//! a `#`, or a trailing unescaped `\` (see [`cannot_be_brace_wrapped`]) —
+//! and any command whose derived tool
 //! name would embed shell metacharacters (see
-//! [`is_safe_tool_name`]). Otherwise it returns `Some(rewritten)` with
+//! [`is_safe_tool_name`]). Otherwise it returns `Some(rewritten)`: the command
+//! inside a brace group that reports its exit status, with
 //! `| tm compress --tool "<effective tool name>"` appended — see
 //! [`effective_tool_name`] for why the tool value is derived from the
-//! command rather than a hardcoded `"bash"`.
+//! command rather than a hardcoded `"bash"`, and
+//! [`crate::commands::compress::wrap_command_reporting_exit`] for the group.
 //! [`build_pretooluse_rewrite_response`] builds the
 //! `hookSpecificOutput.updatedInput` JSON body `tm hook` prints to stdout so
 //! Claude Code substitutes the rewritten command before executing it — this
@@ -82,8 +86,10 @@ const ORCHESTRATOR_EXCLUSIONS: &[&str] = &[
 /// the brace group and its trailing `printf` come from
 /// [`crate::commands::compress::wrap_command_reporting_exit`], which is what
 /// carries the wrapped command's exit status into a filter the shell started
-/// concurrently (#7384); every guard above runs against the bare command, and
-/// the group is only ever wrapped around a simple one —
+/// concurrently (#7384). Every guard above runs against the bare command, and
+/// [`cannot_be_brace_wrapped`] adds the two the group itself needs: a `#`
+/// comments out the group's own `printf` and closing brace, and a trailing `\`
+/// escapes its `;`. A command carrying either is forwarded unmodified —
 /// the `--tool` value comes from [`effective_tool_name`], **not** a
 /// hardcoded `"bash"`: `compress_tool_output`'s dispatch table
 /// (`trusty-agents-common::compress::tool_output`) matches filters by
@@ -116,6 +122,11 @@ pub(crate) fn rewrite_bash_command_for_compression(command: &str) -> Option<Stri
         return None;
     }
     if has_unsafe_pipe_composition(trimmed) {
+        return None;
+    }
+    // #7384: a comment or a trailing `\` would swallow or absorb the brace
+    // group's own `printf`, so such a command is never wrapped.
+    if cannot_be_brace_wrapped(trimmed) {
         return None;
     }
     let tool = effective_tool_name(trimmed);
@@ -423,6 +434,30 @@ fn has_unsafe_pipe_composition(command: &str) -> bool {
         || command.contains('<')
 }
 
+/// Whether wrapping `command` in a brace group would change what runs.
+///
+/// Why: #7384 puts the command, the exit-status `printf` and the closing `}` on
+/// ONE physical line, which two shapes break. An unquoted `#` starts a comment
+/// that swallows the rest of that line, so the group never closes — sh, bash
+/// and zsh all abort with a syntax error and the command does not run at all. A
+/// trailing unescaped `\` escapes the template's `;`, so the `printf`, its
+/// format string and `"$?"` become extra arguments to the command — no error,
+/// wrong output, status lost. [`has_unsafe_pipe_composition`] catches neither,
+/// because neither character composes anything on its own.
+/// What: rejects any `#`, and any command whose trailing run of backslashes is
+/// odd. `#` is rejected wherever it appears: `grep -c '#include' f` is quoted
+/// and would be safe, but telling that from a comment needs a shell parser, and
+/// under-rewriting is the safe side here for exactly the reason
+/// [`has_unsafe_pipe_composition`] already gives. Such a command is forwarded
+/// unmodified and simply goes uncompressed.
+/// Test: `rewrite_skips_a_command_a_brace_group_cannot_wrap`,
+/// `cannot_be_brace_wrapped_counts_trailing_backslashes`,
+/// `every_rewrite_this_module_emits_runs_correctly_in_a_real_shell`.
+fn cannot_be_brace_wrapped(command: &str) -> bool {
+    let trailing_backslashes = command.chars().rev().take_while(|c| *c == '\\').count();
+    command.contains('#') || trailing_backslashes % 2 == 1
+}
+
 /// Build the `hookSpecificOutput.updatedInput` JSON body for a `PreToolUse`
 /// Bash command rewrite.
 ///
@@ -504,6 +539,147 @@ mod tests {
             out.as_deref(),
             Some(expected_rewrite("git diff HEAD~1", "git diff").as_str())
         );
+    }
+
+    #[test]
+    fn cannot_be_brace_wrapped_counts_trailing_backslashes() {
+        // An ODD trailing run escapes the template's `;`; an even run is an
+        // escaped backslash and leaves the `;` alone.
+        assert!(cannot_be_brace_wrapped("ls -la \\"));
+        assert!(!cannot_be_brace_wrapped("ls -la \\\\"));
+        assert!(cannot_be_brace_wrapped("ls -la \\\\\\"));
+        // A backslash that is not at the end escapes something in the command
+        // itself and cannot reach the template's `;`.
+        assert!(!cannot_be_brace_wrapped("grep -n hi\\ there f"));
+        // `#` anywhere, quoted or not — see the function's doc comment.
+        assert!(cannot_be_brace_wrapped("cargo test # explain"));
+        assert!(cannot_be_brace_wrapped("grep -c '#include' f"));
+        assert!(!cannot_be_brace_wrapped("cargo test -p trusty-mpm"));
+    }
+
+    #[test]
+    fn rewrite_skips_a_command_a_brace_group_cannot_wrap() {
+        // #7384 round 2: both shapes reached the rewrite and both broke it —
+        // the comment swallowed the group's own `printf` and closing brace
+        // (syntax error, command never ran), the trailing backslash escaped the
+        // `;` and turned the `printf` into arguments (silently wrong output).
+        // The documented no-op is the safe answer for both.
+        for cmd in [
+            "cargo test # explain",
+            "grep -c '#include' src/lib.rs",
+            "cargo test -p x \\",
+            "git diff HEAD~1 \\",
+        ] {
+            assert_eq!(
+                rewrite_bash_command_for_compression(cmd),
+                None,
+                "a brace group cannot wrap this safely: {cmd}"
+            );
+        }
+    }
+
+    /// Whether `shell` can be spawned on this host.
+    fn shell_is_available(shell: &str) -> bool {
+        std::process::Command::new(shell)
+            .arg("-c")
+            .arg("exit 0")
+            .output()
+            .is_ok()
+    }
+
+    /// Run `script` under `shell`, returning its exit code, stdout and stderr.
+    fn run_script(shell: &str, script: &str) -> (Option<i32>, String, String) {
+        let out = std::process::Command::new(shell)
+            .arg("-c")
+            .arg(script)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run {shell}: {e}"));
+        (
+            out.status.code(),
+            String::from_utf8_lossy(&out.stdout).into_owned(),
+            String::from_utf8_lossy(&out.stderr).into_owned(),
+        )
+    }
+
+    /// Execute what this module emits, in a real shell, for the four shapes.
+    ///
+    /// Why: every other test here asserts the SHAPE of the rewritten string,
+    /// which is how #7384 round 1 shipped a string all three shells reject with
+    /// `unexpected end of file` — the assertions matched and the command could
+    /// never have run. This one runs it.
+    /// What: for each shape, either the rewrite exists and its brace group must
+    /// run cleanly and preserve both the command's output and the sentinel, or
+    /// the rewrite is the documented no-op and the bare command must still do
+    /// its own job with nothing from the template leaking into it. The filter
+    /// stage is swapped for `cat` — `tm` need not be installed where unit tests
+    /// run, and `tm compress`'s own behaviour is proven in `tm_compress_pipe`;
+    /// the brace group, which is what this test is about, is untouched.
+    /// Test: itself.
+    #[test]
+    fn every_rewrite_this_module_emits_runs_correctly_in_a_real_shell() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let payload = dir.path().join("payload.txt");
+        std::fs::write(&payload, "alpha\nhi there\nomega\n").expect("write payload");
+        let path = payload.display().to_string();
+        let plain = format!("grep -n hi {path}");
+
+        // (command, what its own stdout must contain when it runs bare)
+        let cases = [
+            (plain.clone(), "2:hi there"),
+            (format!("{plain} # explain"), "2:hi there"),
+            (format!("grep -c '#include' {path}"), "0"),
+            (format!("{plain} \\"), "hi there"),
+        ];
+
+        for shell in ["sh", "bash", "zsh"] {
+            if !shell_is_available(shell) {
+                // Announce the skip: a silently-skipped shell reads as a pass.
+                eprintln!(
+                    "SKIP every_rewrite_this_module_emits_runs_correctly_in_a_real_shell: no {shell} on this host"
+                );
+                continue;
+            }
+            for (command, expected) in &cases {
+                let Some(rewritten) = rewrite_bash_command_for_compression(command) else {
+                    // The no-op arm: forwarded unmodified, so it must still
+                    // work and must carry nothing from the template.
+                    let (_code, stdout, stderr) = run_script(shell, command);
+                    assert!(
+                        stdout.contains(expected),
+                        "{shell}: an un-rewritten `{command}` must still run: \
+                         stdout={stdout:?} stderr={stderr:?}"
+                    );
+                    assert!(
+                        !stdout.contains("__tm_compress_exit=")
+                            && !stderr.contains("__tm_compress_exit="),
+                        "{shell}: nothing from the template may reach an \
+                         un-rewritten command: stdout={stdout:?} stderr={stderr:?}"
+                    );
+                    continue;
+                };
+                let (group, _filter) = rewritten
+                    .split_once("| tm compress")
+                    .expect("the rewrite always ends in the compress filter stage");
+                let script = format!("{group}| cat");
+                let (code, stdout, stderr) = run_script(shell, &script);
+                assert_eq!(
+                    code,
+                    Some(0),
+                    "{shell}: the rewritten `{command}` must run cleanly: \
+                     script={script:?} stdout={stdout:?} stderr={stderr:?}"
+                );
+                assert!(
+                    stdout.starts_with(expected),
+                    "{shell}: the command's own output must survive the wrap: \
+                     stdout={stdout:?} stderr={stderr:?}"
+                );
+                assert!(
+                    stdout.ends_with("\n__tm_compress_exit=0__\n"),
+                    "{shell}: the sentinel must reach the filter intact: \
+                     stdout={stdout:?} stderr={stderr:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
@@ -78,7 +78,12 @@ const ORCHESTRATOR_EXCLUSIONS: &[&str] = &[
 /// trusty-review-flagged injection risk, PR #1968: the derived name is
 /// embedded verbatim inside a double-quoted shell argument below, and
 /// double quotes do not stop POSIX command substitution). Otherwise returns
-/// `Some("<command> | tm compress --tool \"<effective tool name>\"")` —
+/// `Some("{ <command>; <exit sentinel>; } | tm compress --tool \"<effective tool name>\"")` —
+/// the brace group and its trailing `printf` come from
+/// [`crate::commands::compress::wrap_command_reporting_exit`], which is what
+/// carries the wrapped command's exit status into a filter the shell started
+/// concurrently (#7384); every guard above runs against the bare command, and
+/// the group is only ever wrapped around a simple one —
 /// the `--tool` value comes from [`effective_tool_name`], **not** a
 /// hardcoded `"bash"`: `compress_tool_output`'s dispatch table
 /// (`trusty-agents-common::compress::tool_output`) matches filters by
@@ -122,7 +127,12 @@ pub(crate) fn rewrite_bash_command_for_compression(command: &str) -> Option<Stri
     if !has_filter_for(&tool) {
         return None;
     }
-    Some(format!("{trimmed} | tm compress --tool \"{tool}\""))
+    // #7384: the brace group carries the wrapped command's exit status into the
+    // filter, which a pipeline otherwise discards.
+    Some(format!(
+        "{} | tm compress --tool \"{tool}\"",
+        crate::commands::compress::wrap_command_reporting_exit(trimmed)
+    ))
 }
 
 /// Derive the `compress_tool_output` dispatch key from a Bash command.
@@ -453,12 +463,33 @@ pub(crate) fn build_pretooluse_rewrite_response(rewritten_command: &str) -> serd
 mod tests {
     use super::*;
 
+    /// The one place the whole rewritten string is spelled out.
+    ///
+    /// #7384 put the command inside a brace group with a trailing exit-status
+    /// `printf`; the producer of that group is `commands::compress`, so every
+    /// expectation below is built from it rather than from a second literal
+    /// that could drift away from what the filter parses.
+    fn expected_rewrite(command: &str, tool: &str) -> String {
+        format!(
+            "{} | tm compress --tool \"{tool}\"",
+            crate::commands::compress::wrap_command_reporting_exit(command)
+        )
+    }
+
     #[test]
     fn rewrite_appends_compress_pipe_for_plain_command() {
         let out = rewrite_bash_command_for_compression("cargo test");
         assert_eq!(
             out.as_deref(),
-            Some("cargo test | tm compress --tool \"cargo test\"")
+            Some(expected_rewrite("cargo test", "cargo test").as_str())
+        );
+        // #7384: the command still runs first and the pipe still terminates in
+        // the filter — the group only adds the status report.
+        let out = out.expect("a covered tool must be wrapped");
+        assert!(out.starts_with("{ cargo test; printf "), "{out}");
+        assert!(
+            out.ends_with("} | tm compress --tool \"cargo test\""),
+            "{out}"
         );
     }
 
@@ -471,7 +502,7 @@ mod tests {
         let out = rewrite_bash_command_for_compression("git diff HEAD~1");
         assert_eq!(
             out.as_deref(),
-            Some("git diff HEAD~1 | tm compress --tool \"git diff\"")
+            Some(expected_rewrite("git diff HEAD~1", "git diff").as_str())
         );
     }
 
@@ -585,7 +616,7 @@ mod tests {
             ("grep -n foo src/", "grep -n"),
             ("ls -la", "ls -la"),
         ] {
-            let expected = format!("{cmd} | tm compress --tool \"{tool}\"");
+            let expected = expected_rewrite(cmd, tool);
             assert_eq!(
                 rewrite_bash_command_for_compression(cmd).as_deref(),
                 Some(expected.as_str()),

--- a/crates/trusty-mpm/tests/tm_compress_pipe.rs
+++ b/crates/trusty-mpm/tests/tm_compress_pipe.rs
@@ -77,6 +77,107 @@ fn run_tm_compress_with(env: &[(&str, &str)], tool: &str, input: &str) -> (bool,
     )
 }
 
+/// Drop ANSI CSI sequences so a whole `field=value` pair can be asserted.
+///
+/// Why: the stats line interleaves colour escapes around `=`, so a raw
+/// `contains("exit=3")` never matches even when the field is right there
+/// (#7384). The sibling rtk test works around this by matching the value
+/// alone, which cannot distinguish `exit=3` from a `3` anywhere else.
+/// What: removes `ESC [ … <final byte>` runs; every escape `tracing`'s fmt
+/// layer emits is of that form.
+fn strip_ansi(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        if chars.next() != Some('[') {
+            continue;
+        }
+        for c in chars.by_ref() {
+            if ('@'..='~').contains(&c) {
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// Run `inner` through the pipeline shape `tm hook` rewrites a Bash call into.
+///
+/// Why: the exit status the stats line reports is the WRAPPED command's, which
+/// only a real shell can supply — asserting it against a hand-fed stdin would
+/// prove nothing about the mechanism (#7384).
+/// What: builds `{ sh -c '<inner>'; printf '\n<sentinel>\n' "$?"; } | tm
+/// compress --tool '<tool>'`, the exact string
+/// `commands::compress::wrap_command_reporting_exit` produces, and returns the
+/// filter's stdout plus its ANSI-stripped stderr. `inner` must not contain a
+/// single quote.
+fn run_wrapped_pipeline(inner: &str, tool: &str) -> (String, String) {
+    let bin = env!("CARGO_BIN_EXE_tm");
+    let script = format!(
+        "{{ sh -c '{inner}'; printf '\\n__tm_compress_exit=%s__\\n' \"$?\"; }} \
+         | '{bin}' compress --tool '{tool}'"
+    );
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(&script)
+        .env(ENV_COMPRESS_NO_RTK, "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run the rewritten pipeline");
+    (
+        String::from_utf8(output.stdout).expect("stdout is utf8"),
+        strip_ansi(&String::from_utf8_lossy(&output.stderr)),
+    )
+}
+
+#[test]
+fn tm_compress_reports_the_wrapped_commands_exit_status() {
+    // #7384: `bytes_before=0 … compression_path=rtk_binary` read identically
+    // whether the command found nothing, failed, or had its stdout dropped. The
+    // filter's OWN status is always 0, so a fix that logged that would report
+    // `exit=0` here and fail.
+    let (stdout, stderr) = run_wrapped_pipeline("printf boom; exit 3", "cargo test");
+    assert!(
+        stderr.contains("exit=3"),
+        "the stats line must carry the wrapped command's status: {stderr}"
+    );
+    assert_eq!(
+        stdout, "boom",
+        "the exit sentinel must never reach the caller's output"
+    );
+}
+
+#[test]
+fn tm_compress_reports_a_signal_killed_wrapped_command() {
+    // A signal-killed command reaches the shell as 128 + signal — 137 for
+    // SIGKILL — so it needs no separate spelling, but it does need proving.
+    let (_stdout, stderr) = run_wrapped_pipeline("kill -9 $$", "cargo test");
+    assert!(
+        stderr.contains("exit=137"),
+        "a SIGKILLed command must report 128+9: {stderr}"
+    );
+}
+
+#[test]
+fn tm_compress_reports_unknown_for_an_unwrapped_invocation() {
+    // `tm compress < file`, and any rewrite older than #7384, carry no
+    // sentinel. The field must still be present, and must not claim a status.
+    let (success, stdout, stderr) = run_tm_compress("cargo test", "ok\n");
+    assert!(success, "tm compress exited non-zero: stderr={stderr}");
+    assert_eq!(stdout, "ok\n", "an unwrapped payload passes through");
+    let stderr = strip_ansi(&stderr);
+    assert!(
+        stderr.contains("exit=unknown"),
+        "a missing sentinel must read as unknown, not as success: {stderr}"
+    );
+}
+
 fn repetitive_cargo_test_payload() -> String {
     let mut input = String::new();
     for i in 0..50 {

--- a/crates/trusty-mpm/tests/tm_hook_pretooluse_rewrite.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pretooluse_rewrite.rs
@@ -28,6 +28,16 @@
 //! against a real running Claude Code session.
 
 use std::io::Write;
+
+/// What `tm hook` rewrites `cargo test` into.
+///
+/// #7384 put the command inside a brace group whose trailing `printf` reports
+/// its exit status, because a pipeline hands its filter stdout and nothing
+/// else. `commands::compress::wrap_command_reporting_exit` is the producer and
+/// `split_exit_sentinel` the consumer; this file is outside the binary, so the
+/// spelling is repeated here — the unit tests build theirs from the producer,
+/// which is what keeps the two from drifting apart unnoticed.
+const EXPECTED_CARGO_TEST_REWRITE: &str = "{ cargo test; printf '\\n__tm_compress_exit=%s__\\n' \"$?\"; } | tm compress --tool \"cargo test\"";
 use std::process::{Command, Stdio};
 
 /// Spawn `tm hook` with the given `CLAUDE_HOOK_EVENT` and stdin JSON,
@@ -74,7 +84,7 @@ fn hook_rewrites_plain_bash_command_on_pretooluse() {
     assert_eq!(parsed["hookSpecificOutput"]["hookEventName"], "PreToolUse");
     assert_eq!(
         parsed["hookSpecificOutput"]["updatedInput"]["command"],
-        "cargo test | tm compress --tool \"cargo test\""
+        EXPECTED_CARGO_TEST_REWRITE
     );
 }
 
@@ -180,6 +190,6 @@ fn hook_rewrites_using_stdin_hook_event_name_without_env_var() {
         serde_json::from_str(stdout.trim()).expect("stdout must be valid JSON when rewriting");
     assert_eq!(
         parsed["hookSpecificOutput"]["updatedInput"]["command"],
-        "cargo test | tm compress --tool \"cargo test\""
+        EXPECTED_CARGO_TEST_REWRITE
     );
 }


### PR DESCRIPTION
## Outcome

Fixes two trusty-mpm defects.

#7384 — the PreToolUse rewrite now wraps a compressible command as
`{ <cmd>; printf '\n__tm_compress_exit=%s__\n' "$?"; } | tm compress …`; `tm
compress` strips the sentinel and logs `exit=N` (or `exit=unknown` with no
sentinel). `cannot_be_brace_wrapped` skips the rewrite for any command
containing `#` or ending in an odd run of backslashes, since those break the
one-line brace group.

#7377 — when the rtk subprocess returns empty output for non-empty input, the
raw text is returned unchanged with one warn line instead of a silent empty
result.

Refs #7384

Refs #7377

## Changes

- `crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs` — brace-wraps a
  compressible command with the exit-status sentinel, and adds
  `cannot_be_brace_wrapped` to skip commands a brace group cannot safely wrap
  (`#` comments, trailing odd backslash runs).
- `crates/trusty-mpm/src/bin/tm/commands/compress.rs` — strips the sentinel
  and logs `exit=N` / `exit=unknown`; falls back to the raw rtk text with a
  warn line when rtk returns empty output for non-empty input.
- Out of scope: the #6986 guard in trusty-agents-common is untouched.

## Risk

Localized to the trusty-mpm hook-rewrite and compress paths (rung 3, one
crate). Rollout skew for one reinstall cycle: new hook + old compress shows a
stray sentinel line in the log; old hook + new compress logs `exit=unknown`.
Both are cosmetic log states, not functional breaks.

## Tests

`cargo fmt --check`, `cargo check -p trusty-mpm --all-targets`, `cargo clippy
-p trusty-mpm --all-targets -- -D warnings`, `cargo test -p trusty-mpm
--no-fail-fast` — 57 targets ok, tm bin 2585 passed / 0 failed, lib 6646
passed / 0 failed; `tm_compress_pipe` 7/7, `tm_hook_pretooluse_rewrite` 6/6.
Two regression tests proven to fail before the fix, two more added ahead of
code-critic round 2. New test
`every_rewrite_this_module_emits_runs_correctly_in_a_real_shell` executes each
emitted shape through sh, bash and zsh.

## Baseline

No pre-existing red on this crate; nothing excluded from the run.

## Docs

Changelog fragments added:
`crates/trusty-mpm/changelog.d/7384-compress-logs-wrapped-exit-status.md`,
`crates/trusty-mpm/changelog.d/7377-compress-rtk-empty-output-fallback.md`.
Doc gates run: check_line_cap, check_test_pointers, check_sld,
check_changelog_fragment (--file, --staged, default), check-pr-version-bump.

## Review

code-critic round 1 BLOCK (two findings: the brace-wrap safety gap and
missing real-shell verification), round 2 APPROVE after both were fixed in
this branch. No findings deferred.

Links: [#7384](https://github.com/bobmatnyc/trusty-tools/issues/7384),
[#7377](https://github.com/bobmatnyc/trusty-tools/issues/7377),
[#6986](https://github.com/bobmatnyc/trusty-tools/issues/6986).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
