### PR TITLE
docs(trusty-mpm): resolve the compress.rs intra-doc link PR #7401 left broken (Refs #7384)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7384-rustdoc-link.md
+++ b/crates/trusty-mpm/changelog.d/7384-rustdoc-link.md
@@ -1,0 +1,3 @@
+Documentation
+
+- Fixed a broken intra-doc link in `run_compress`'s doc comment (`commands/compress.rs`) that pointed at `compress_tool_output_async_with_path`, a name not in scope in this module; it now points at `compress_with_raw_fallback`, the function `run_compress` actually calls (#7384).

--- a/crates/trusty-mpm/src/bin/tm/commands/compress.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/compress.rs
@@ -159,7 +159,7 @@ fn parse_exit_sentinel(line: &str) -> Option<i32> {
 /// fn's Tokio worker thread for the entire read, which is exactly the wrong
 /// tradeoff here since large piped output (the case this subcommand exists
 /// to compress) is the slow case (trusty-review finding, PR #1968).
-/// Compresses via [`compress_tool_output_async_with_path`], logs
+/// Compresses via [`compress_with_raw_fallback`], logs
 /// `tool_name`/`bytes_before`/`bytes_after`/`pct_reduction`/
 /// `compression_path` at `info` level, then writes the compressed text via
 /// [`tokio::io::AsyncWriteExt::write_all`] (rather than a synchronous


### PR DESCRIPTION
PR #7401 (squash a7369fecb) landed a doc comment in `commands/compress.rs` linking to `compress_tool_output_async_with_path`, a name not imported into this module's scope, so the link never resolved. The `Rustdoc intra-doc links` job has been red on main since.

The link now points at `compress_with_raw_fallback`, the function `run_compress` actually calls.

Refs #7384

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb