### PR TITLE
fix(trusty-mpm): guard refuses git output-file writes — --output, format-patch -o, archive -o, bundle create (Refs #7399)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7399-git-diff-output-refused.md
+++ b/crates/trusty-mpm/changelog.d/7399-git-diff-output-refused.md
@@ -1,12 +1,18 @@
 Fixed
 
-- `tm hook --pm-guard` now refuses a git `--output` option — `git diff
-  --output=/tmp/o.diff` and the separated `git diff --output /tmp/o.diff` — with
-  the reason a `>` redirection denies with. `--output` writes a file with no
-  `>` in the command, so `has_file_write_redirection` never saw it and the PM
-  could write past the ADR-0044 / ADR-0048 boundary. `--output` is a git DIFF
-  option, so `log`, `show` and `format-patch` are covered by the same rule.
-  The option is matched whole rather than by prefix, leaving
-  `--output-indicator-new=+` alone, and the scan stops at `--`, where git parses
-  pathspecs rather than options; `git diff --no-index a b` and every other
-  read-only diff shape stay allowed (#7399).
+- `tm hook --pm-guard` now refuses the git invocations that write a file with
+  no `>` in the command, which `has_file_write_redirection` never saw, letting
+  the PM write past the ADR-0044 / ADR-0048 boundary. Each spelling was
+  verified to write against git 2.54.0 (#7399):
+  - `--output=<file>` and `--output <file>` on any subcommand — it is a git
+    diff option, so `diff`, `log`, `show` and `format-patch` all take it
+  - `git format-patch` with `-o <dir>`, `-o<dir>`,
+    `--output-directory <dir>` or `--output-directory=<dir>`, and a bare
+    `git format-patch`, which drops `NNNN-*.patch` into the working directory
+  - `git archive` with `-o <file>`, `-o<file>` or `--output=<file>`
+  - `git bundle create <file>`, whose output is a positional
+- Read-only spellings stay allowed: `git format-patch --stdout`, an archive to
+  stdout, `git bundle create -`, `git diff --no-index a b`, `git diff -o` (a
+  revision there), `git clone -o` (the origin remote), and
+  `--output-indicator-new=+` — every option is matched whole, never by prefix,
+  and option scanning stops at `--`, where git parses pathspecs (#7399).

--- a/crates/trusty-mpm/changelog.d/7399-git-diff-output-refused.md
+++ b/crates/trusty-mpm/changelog.d/7399-git-diff-output-refused.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `tm hook --pm-guard` now refuses a git `--output` option — `git diff
+  --output=/tmp/o.diff` and the separated `git diff --output /tmp/o.diff` — with
+  the reason a `>` redirection denies with. `--output` writes a file with no
+  `>` in the command, so `has_file_write_redirection` never saw it and the PM
+  could write past the ADR-0044 / ADR-0048 boundary. `--output` is a git DIFF
+  option, so `log`, `show` and `format-patch` are covered by the same rule.
+  The option is matched whole rather than by prefix, leaving
+  `--output-indicator-new=+` alone, and the scan stops at `--`, where git parses
+  pathspecs rather than options; `git diff --no-index a b` and every other
+  read-only diff shape stay allowed (#7399).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -428,9 +428,10 @@ fn classify_bash_segment(segment: &str, depth: usize) -> Option<&'static str> {
             "git" if shell_lex::git_subcommand(trimmed).as_deref() == Some("apply") => {
                 return Some(SHELL_EDIT_REASON);
             }
-            // #7399: `git diff --output=<file>` writes a file with no `>`, so
-            // the redirection check below never saw it.
-            "git" if shell_lex::git_output_file(trimmed).is_some() => {
+            // #7399: `git diff --output=<file>`, `git format-patch -o <dir>`,
+            // `git archive -o <file>` and `git bundle create <file>` all write
+            // with no `>`, so the redirection check below never saw them.
+            "git" if shell_lex::git_file_write_target(trimmed).is_some() => {
                 return Some(SHELL_EDIT_REASON);
             }
             _ => {}
@@ -573,8 +574,8 @@ fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'stati
 /// (which name it directly in `tool_input.file_path`), a Bash command only has
 /// its target embedded in the command text itself.
 /// What: scans each composition segment ([`split_shell_segments`]) for a real
-/// file-write redirect ([`redirection_target`]), for the file a git
-/// `--output` option names ([`shell_lex::git_output_file`], #7399), or, for a
+/// file-write redirect ([`redirection_target`]), for the file a git write
+/// option names ([`shell_lex::git_file_write_target`], #7399), or, for a
 /// sed/awk-family/`patch`/`git apply` segment, the command's trailing
 /// non-flag token ([`trailing_file_token`]) — the conventional position of the
 /// target file for those verbs. Returns the first match found; `None` when no
@@ -594,10 +595,11 @@ pub(crate) fn extract_shell_edit_target(command: &str) -> Option<String> {
         }
         if let Some(program) = first_command_token(trimmed) {
             let program = program.as_str();
-            // #7399: the file `--output` names is the target, and it sits in
-            // the option rather than the trailing position the verbs below use.
+            // #7399: the file a git write option names is the target, and it
+            // sits in the option rather than the trailing position the verbs
+            // below use.
             if program == "git"
-                && let Some(target) = shell_lex::git_output_file(trimmed)
+                && let Some(target) = shell_lex::git_file_write_target(trimmed)
                 && !target.is_empty()
             {
                 return Some(target);

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -428,6 +428,11 @@ fn classify_bash_segment(segment: &str, depth: usize) -> Option<&'static str> {
             "git" if shell_lex::git_subcommand(trimmed).as_deref() == Some("apply") => {
                 return Some(SHELL_EDIT_REASON);
             }
+            // #7399: `git diff --output=<file>` writes a file with no `>`, so
+            // the redirection check below never saw it.
+            "git" if shell_lex::git_output_file(trimmed).is_some() => {
+                return Some(SHELL_EDIT_REASON);
+            }
             _ => {}
         }
     }
@@ -567,8 +572,9 @@ fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'stati
 /// Routing by content type needs the target path; unlike the Edit/Write tools
 /// (which name it directly in `tool_input.file_path`), a Bash command only has
 /// its target embedded in the command text itself.
-/// What: scans each composition segment ([`split_shell_segments`]) for either
-/// a real file-write redirect ([`redirection_target`]) or, for a
+/// What: scans each composition segment ([`split_shell_segments`]) for a real
+/// file-write redirect ([`redirection_target`]), for the file a git
+/// `--output` option names ([`shell_lex::git_output_file`], #7399), or, for a
 /// sed/awk-family/`patch`/`git apply` segment, the command's trailing
 /// non-flag token ([`trailing_file_token`]) — the conventional position of the
 /// target file for those verbs. Returns the first match found; `None` when no
@@ -588,6 +594,14 @@ pub(crate) fn extract_shell_edit_target(command: &str) -> Option<String> {
         }
         if let Some(program) = first_command_token(trimmed) {
             let program = program.as_str();
+            // #7399: the file `--output` names is the target, and it sits in
+            // the option rather than the trailing position the verbs below use.
+            if program == "git"
+                && let Some(target) = shell_lex::git_output_file(trimmed)
+                && !target.is_empty()
+            {
+                return Some(target);
+            }
             let is_sed_awk_family =
                 matches!(program, "patch" | "sed" | "awk" | "gawk" | "nawk" | "mawk");
             let is_git_apply =

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -430,7 +430,8 @@ const GIT_GLOBAL_OPTS_WITH_ARG: &[&str] = &[
 /// -` and `command git worktree remove --force <path>` reached the git guards
 /// unresolved. It now shares [`crate::commands::hook_rewrite::strip_wrapper_prefix`]
 /// with that function instead of re-enumerating.
-/// What: shlex-splits `segment` (quote-aware; `None` on unbalanced quotes →
+/// What: through [`git_argv_at_subcommand`], shlex-splits `segment`
+/// (quote-aware; `None` on unbalanced quotes →
 /// caller falls back), delegates the leading `KEY=value`/wrapper skip to
 /// [`strip_wrapper_prefix`], requires the program basename to be `git`, then
 /// walks past global options — those in [`GIT_GLOBAL_OPTS_WITH_ARG`] consume
@@ -453,6 +454,24 @@ const GIT_GLOBAL_OPTS_WITH_ARG: &[&str] = &[
 /// `git_is_only_a_git_command_in_command_position`,
 /// `git_in_command_position_is_still_a_git_command`.
 pub(crate) fn git_subcommand(segment: &str) -> Option<String> {
+    let (argv, i) = git_argv_at_subcommand(segment)?;
+    Some(argv[i].clone())
+}
+
+/// The parsed argv of a git segment, and the index of its subcommand token.
+///
+/// Why: [`git_subcommand`] answers "which subcommand", and [`git_output_file`]
+/// asks the same parser "and what did that subcommand's arguments say". One
+/// walk over the global options serves both, so a rule about a git ARGUMENT
+/// cannot drift from the rule about the git VERB — a second argv parser is the
+/// defect this shape prevents.
+/// What: the body [`git_subcommand`] used to carry — shlex-split (`None` on
+/// unbalanced quotes), [`strip_wrapper_prefix`], a `git` basename check, then
+/// the global-option walk described on [`git_subcommand`]. Returns the argv
+/// alongside the index of the first non-option token.
+/// Test: every `git_subcommand_*` test, plus
+/// `git_output_file_finds_both_spellings`.
+fn git_argv_at_subcommand(segment: &str) -> Option<(Vec<String>, usize)> {
     let argv = shlex::split(segment)?;
     let mut i = strip_wrapper_prefix(&argv)?;
     let program = argv.get(i)?;
@@ -489,7 +508,55 @@ pub(crate) fn git_subcommand(segment: &str) -> Option<String> {
             i += 1;
             continue;
         }
-        return Some(tok.clone());
+        return Some((argv, i));
+    }
+    None
+}
+
+/// The file a git command's `--output` option would write, if it names one.
+///
+/// Why (#7399): `git diff --output=/tmp/o.diff` writes a file exactly as
+/// `git diff > /tmp/o.diff` does, but carries no `>`, so
+/// [`super::has_file_write_redirection`] never saw it and the PM's write
+/// boundary (ADR-0044, ADR-0048) had an uncaught hole. `--output` is a git
+/// DIFF option, so every diff-generating subcommand takes it — `diff`, `log`,
+/// `show`, `format-patch` — which is why this asks about the option rather
+/// than enumerating subcommands.
+/// What: walks the subcommand's own arguments from
+/// [`git_argv_at_subcommand`] and returns the value of the first `--output`
+/// it finds, in either spelling git accepts: `--output=<file>` (attached) and
+/// `--output <file>` (separated, verified against git 2.x). The match is on
+/// the whole option token, never a prefix, so the sibling
+/// `--output-indicator-new=+` — which changes one character of the patch body
+/// and writes nothing — is untouched. Scanning stops at `--`, past which git
+/// parses pathspecs rather than options. `Some("")` when `--output` is the
+/// last token and names no file: the flag is present, so the caller still
+/// denies, and there is no path to report. `None` when the segment is not a
+/// git command, cannot be lexed, or carries no `--output` — a lexing failure
+/// therefore withholds a NEW deny and can never turn an existing deny into an
+/// allow.
+/// Test: `git_output_file_finds_both_spellings`,
+/// `git_output_file_ignores_the_indicator_options`,
+/// `git_output_file_stops_at_the_pathspec_separator`,
+/// `git_output_file_none_when_unbalanced`, and end to end in
+/// `git_diff_output_flag_is_refused_as_a_file_write`.
+pub(crate) fn git_output_file(segment: &str) -> Option<String> {
+    let (argv, subcommand) = git_argv_at_subcommand(segment)?;
+    let mut i = subcommand + 1;
+    while i < argv.len() {
+        let tok = &argv[i];
+        if tok == "--" {
+            // Everything past the POSIX end-of-options marker is a pathspec,
+            // so an `--output=…` there names a path, not a write target.
+            return None;
+        }
+        if let Some(value) = tok.strip_prefix("--output=") {
+            return Some(value.to_string());
+        }
+        if tok == "--output" {
+            return Some(argv.get(i + 1).cloned().unwrap_or_default());
+        }
+        i += 1;
     }
     None
 }
@@ -621,5 +688,61 @@ mod tests {
             git_subcommand("nice git reset --hard").as_deref(),
             Some("reset")
         );
+    }
+
+    // #7399: both spellings of `--output` name a file git writes.
+    #[test]
+    fn git_output_file_finds_both_spellings() {
+        assert_eq!(
+            git_output_file("git diff --output=/tmp/o.diff").as_deref(),
+            Some("/tmp/o.diff")
+        );
+        assert_eq!(
+            git_output_file("git diff --output /tmp/o.diff HEAD").as_deref(),
+            Some("/tmp/o.diff")
+        );
+        assert_eq!(
+            git_output_file("git -C /repo --no-pager log -1 --output=/tmp/l.txt").as_deref(),
+            Some("/tmp/l.txt")
+        );
+        assert_eq!(
+            git_output_file(r#"git diff --output="/tmp/my out.diff""#).as_deref(),
+            Some("/tmp/my out.diff")
+        );
+        // Present but valueless: still a flag to deny on, with no path to
+        // report.
+        assert_eq!(git_output_file("git diff --output").as_deref(), Some(""));
+    }
+
+    // #7399: the rule matches the option, never its prefix.
+    #[test]
+    fn git_output_file_ignores_the_indicator_options() {
+        for command in [
+            "git diff --output-indicator-new=+",
+            "git diff --output-indicator-old=- --stat",
+            "git diff --output-indicator-context= ",
+            "git diff --stat -- docs/",
+            "git diff --no-index /tmp/a.txt /tmp/b.txt",
+        ] {
+            assert_eq!(git_output_file(command), None, "{command}");
+        }
+    }
+
+    // #7399: past `--`, git parses pathspecs, so `--output=…` writes nothing.
+    #[test]
+    fn git_output_file_stops_at_the_pathspec_separator() {
+        assert_eq!(git_output_file("git diff -- --output=/tmp/o.diff"), None);
+        assert_eq!(
+            git_output_file("git diff --output=/tmp/o.diff -- docs/").as_deref(),
+            Some("/tmp/o.diff")
+        );
+    }
+
+    // #7399: a segment that will not lex withholds the deny; it never grants
+    // an allow that did not already exist.
+    #[test]
+    fn git_output_file_none_when_unbalanced() {
+        assert_eq!(git_output_file("git diff --output='/tmp/o.diff"), None);
+        assert_eq!(git_output_file("cargo run -- --output=/tmp/o.diff"), None);
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -513,50 +513,155 @@ fn git_argv_at_subcommand(segment: &str) -> Option<(Vec<String>, usize)> {
     None
 }
 
-/// The file a git command's `--output` option would write, if it names one.
+/// Per-subcommand options whose value is a path git WRITES, beyond the
+/// `--output` every diff-generating subcommand takes.
+///
+/// Why (#7399 round 2): `--output` alone left three writes through —
+/// `git format-patch -o <dir>`, `git format-patch --output-directory=<dir>`
+/// and `git archive -o <file>` each produced a file against git 2.54.0. The
+/// options are subcommand-specific, unlike `--output`: `-o` on `git diff` is
+/// a revision (git answers `fatal: ambiguous argument`), and `-o` on
+/// `git clone` names the origin remote, so a global `-o` rule would deny
+/// reads. A row here is a spelling verified against `git <sub> --help`.
+/// What: `(subcommand, options)`; each option is matched whole and takes its
+/// value attached (`-o<dir>`, `--output-directory=<dir>`) or separated.
+/// Test: `git_file_write_target_finds_the_short_output_options`.
+const GIT_SUBCOMMAND_WRITE_OPTS: &[(&str, &[&str])] = &[
+    ("format-patch", &["-o", "--output-directory"]),
+    ("archive", &["-o"]),
+];
+
+/// The `--output` option every diff-generating subcommand accepts.
+///
+/// Why: `diff`, `log`, `show` and `format-patch` all take it, so it is asked
+/// of every subcommand rather than listed per row above.
+const GIT_OUTPUT_OPT: &[&str] = &["--output"];
+
+/// The file or directory a git command would WRITE, if its arguments name one.
 ///
 /// Why (#7399): `git diff --output=/tmp/o.diff` writes a file exactly as
 /// `git diff > /tmp/o.diff` does, but carries no `>`, so
 /// [`super::has_file_write_redirection`] never saw it and the PM's write
-/// boundary (ADR-0044, ADR-0048) had an uncaught hole. `--output` is a git
-/// DIFF option, so every diff-generating subcommand takes it — `diff`, `log`,
-/// `show`, `format-patch` — which is why this asks about the option rather
-/// than enumerating subcommands.
+/// boundary (ADR-0044, ADR-0048) had an uncaught hole. Round 2 found three
+/// more spellings of the same hole — `format-patch -o`,
+/// `format-patch --output-directory=`, `archive -o` — plus two writes that
+/// need no option at all: a bare `git format-patch` drops `NNNN-*.patch`
+/// files into the working directory, and `git bundle create <file>` names its
+/// output as a positional.
 /// What: walks the subcommand's own arguments from
-/// [`git_argv_at_subcommand`] and returns the value of the first `--output`
-/// it finds, in either spelling git accepts: `--output=<file>` (attached) and
-/// `--output <file>` (separated, verified against git 2.x). The match is on
-/// the whole option token, never a prefix, so the sibling
-/// `--output-indicator-new=+` — which changes one character of the patch body
-/// and writes nothing — is untouched. Scanning stops at `--`, past which git
-/// parses pathspecs rather than options. `Some("")` when `--output` is the
-/// last token and names no file: the flag is present, so the caller still
-/// denies, and there is no path to report. `None` when the segment is not a
-/// git command, cannot be lexed, or carries no `--output` — a lexing failure
-/// therefore withholds a NEW deny and can never turn an existing deny into an
-/// allow.
-/// Test: `git_output_file_finds_both_spellings`,
-/// `git_output_file_ignores_the_indicator_options`,
-/// `git_output_file_stops_at_the_pathspec_separator`,
-/// `git_output_file_none_when_unbalanced`, and end to end in
-/// `git_diff_output_flag_is_refused_as_a_file_write`.
-pub(crate) fn git_output_file(segment: &str) -> Option<String> {
+/// [`git_argv_at_subcommand`] and returns the first write target it finds —
+/// [`GIT_OUTPUT_OPT`] on any subcommand, plus that subcommand's row in
+/// [`GIT_SUBCOMMAND_WRITE_OPTS`], in the attached and separated spellings git
+/// accepts (all verified against git 2.54.0). Every match is on the whole
+/// option token, never a prefix, so `--output-indicator-new=+` — which
+/// changes one character of the patch body and writes nothing — is untouched.
+/// Option scanning stops at `--`, past which git parses pathspecs rather than
+/// options. Two subcommands are decided by shape rather than by an option:
+/// `format-patch` writes unless `--stdout` is present, and `bundle create`
+/// writes to its first positional unless that positional is `-` (stdout).
+/// `Some("")` when the write is real but names no readable path — a valueless
+/// flag, or `format-patch`'s implicit working directory: the caller still
+/// denies and has no path to report. `None` when the segment is not a git
+/// command, cannot be lexed, or names no write — a lexing failure therefore
+/// withholds a NEW deny and can never turn an existing deny into an allow.
+/// Test: `git_file_write_target_finds_both_output_spellings`,
+/// `git_file_write_target_finds_the_short_output_options`,
+/// `git_file_write_target_reads_format_patch_and_bundle_by_shape`,
+/// `git_file_write_target_ignores_the_indicator_options`,
+/// `git_file_write_target_stops_at_the_pathspec_separator`,
+/// `git_file_write_target_none_when_unbalanced`, and end to end in
+/// `git_diff_output_flag_is_refused_as_a_file_write` and
+/// `git_short_output_options_are_refused_as_file_writes`.
+pub(crate) fn git_file_write_target(segment: &str) -> Option<String> {
     let (argv, subcommand) = git_argv_at_subcommand(segment)?;
-    let mut i = subcommand + 1;
-    while i < argv.len() {
-        let tok = &argv[i];
+    let sub = argv[subcommand].as_str();
+    let args = &argv[subcommand + 1..];
+    if sub == "bundle" {
+        return bundle_create_target(args);
+    }
+    let extra = GIT_SUBCOMMAND_WRITE_OPTS
+        .iter()
+        .find(|(name, _)| *name == sub)
+        .map_or(&[] as &[&str], |(_, opts)| *opts);
+    let mut stdout_requested = false;
+    for (i, tok) in args.iter().enumerate() {
         if tok == "--" {
-            // Everything past the POSIX end-of-options marker is a pathspec,
-            // so an `--output=…` there names a path, not a write target.
-            return None;
+            break;
         }
-        if let Some(value) = tok.strip_prefix("--output=") {
+        if tok == "--stdout" {
+            stdout_requested = true;
+            continue;
+        }
+        let next = args.get(i + 1);
+        if let Some(target) =
+            option_value(tok, next, GIT_OUTPUT_OPT).or_else(|| option_value(tok, next, extra))
+        {
+            return Some(target);
+        }
+    }
+    // A `format-patch` that was not told to write to stdout writes its patch
+    // files into the working directory, naming no path at all.
+    if sub == "format-patch" && !stdout_requested {
+        return Some(String::new());
+    }
+    None
+}
+
+/// The value `tok` carries for one of `opts`, in either spelling.
+///
+/// Why: an option's value reaches git three ways — a separate token, joined
+/// with `=` on a long option, or attached to a short one (`-o/tmp/d`, which
+/// git 2.54.0 accepts). Deciding all three in one place is what keeps the
+/// match on the whole option and off its prefix.
+/// What: `Some(value)` when `tok` IS one of `opts` (value = the next token, or
+/// `""` when the option ends the argv), when it is `<opt>=<value>`, or when it
+/// is a short option with the value attached. `None` otherwise.
+/// Test: `git_file_write_target_finds_the_short_output_options`.
+fn option_value(tok: &str, next: Option<&String>, opts: &[&str]) -> Option<String> {
+    for opt in opts {
+        if tok == *opt {
+            return Some(next.cloned().unwrap_or_default());
+        }
+        if let Some(rest) = tok.strip_prefix(opt)
+            && let Some(value) = rest.strip_prefix('=')
+        {
             return Some(value.to_string());
         }
-        if tok == "--output" {
-            return Some(argv.get(i + 1).cloned().unwrap_or_default());
+        // A short option (`-o`) takes its value attached; a long one does not.
+        if !opt.starts_with("--")
+            && let Some(value) = tok.strip_prefix(opt)
+            && !value.is_empty()
+        {
+            return Some(value.to_string());
         }
-        i += 1;
+    }
+    None
+}
+
+/// The file `git bundle create` would write, if it names one.
+///
+/// Why: `bundle create` takes its output as a POSITIONAL — `git bundle create
+/// /tmp/x.bundle HEAD` wrote 6477 bytes against git 2.54.0 — so no option
+/// scan can see it. `-` is the documented stdout spelling and stays allowed.
+/// What: requires `create` as the first argument, skips its own valueless
+/// flags (`-q`, `--quiet`, `--progress`, `--version=<n>`), and returns the
+/// first positional. `None` for `-`, for another `bundle` subcommand
+/// (`verify`, `list-heads`, `unbundle` name a file they READ), and when no
+/// positional follows.
+/// Test: `git_file_write_target_reads_format_patch_and_bundle_by_shape`.
+fn bundle_create_target(args: &[String]) -> Option<String> {
+    let mut rest = args.iter();
+    if rest.next().map(String::as_str) != Some("create") {
+        return None;
+    }
+    for tok in rest {
+        if tok == "-" {
+            return None;
+        }
+        if tok.starts_with('-') {
+            continue;
+        }
+        return Some(tok.clone());
     }
     None
 }
@@ -692,48 +797,126 @@ mod tests {
 
     // #7399: both spellings of `--output` name a file git writes.
     #[test]
-    fn git_output_file_finds_both_spellings() {
+    fn git_file_write_target_finds_both_output_spellings() {
         assert_eq!(
-            git_output_file("git diff --output=/tmp/o.diff").as_deref(),
+            git_file_write_target("git diff --output=/tmp/o.diff").as_deref(),
             Some("/tmp/o.diff")
         );
         assert_eq!(
-            git_output_file("git diff --output /tmp/o.diff HEAD").as_deref(),
+            git_file_write_target("git diff --output /tmp/o.diff HEAD").as_deref(),
             Some("/tmp/o.diff")
         );
         assert_eq!(
-            git_output_file("git -C /repo --no-pager log -1 --output=/tmp/l.txt").as_deref(),
+            git_file_write_target("git -C /repo --no-pager log -1 --output=/tmp/l.txt").as_deref(),
             Some("/tmp/l.txt")
         );
         assert_eq!(
-            git_output_file(r#"git diff --output="/tmp/my out.diff""#).as_deref(),
+            git_file_write_target(r#"git diff --output="/tmp/my out.diff""#).as_deref(),
             Some("/tmp/my out.diff")
         );
         // Present but valueless: still a flag to deny on, with no path to
         // report.
-        assert_eq!(git_output_file("git diff --output").as_deref(), Some(""));
+        assert_eq!(
+            git_file_write_target("git diff --output").as_deref(),
+            Some("")
+        );
+    }
+
+    // #7399 round 2: the short and directory spellings, each verified to write
+    // against git 2.54.0.
+    #[test]
+    fn git_file_write_target_finds_the_short_output_options() {
+        for (command, target) in [
+            ("git format-patch -o /tmp/d -1 HEAD", "/tmp/d"),
+            ("git format-patch -1 -o/tmp/d HEAD", "/tmp/d"),
+            (
+                "git format-patch --output-directory=/tmp/d -1 HEAD",
+                "/tmp/d",
+            ),
+            (
+                "git format-patch --output-directory /tmp/d -1 HEAD",
+                "/tmp/d",
+            ),
+            ("git archive -o /tmp/a.tar HEAD", "/tmp/a.tar"),
+            ("git archive -o/tmp/a.tar HEAD", "/tmp/a.tar"),
+            ("git archive --output=/tmp/a.tar HEAD", "/tmp/a.tar"),
+        ] {
+            assert_eq!(
+                git_file_write_target(command).as_deref(),
+                Some(target),
+                "{command}"
+            );
+        }
+        // `-o` is subcommand-scoped: on `diff` it is a revision (git answers
+        // `fatal: ambiguous argument`), on `clone` it names the origin remote.
+        assert_eq!(git_file_write_target("git diff -o /tmp/o.diff HEAD"), None);
+        assert_eq!(
+            git_file_write_target("git clone -o upstream https://x/y.git"),
+            None
+        );
+    }
+
+    // #7399 round 2: two writes carry no option at all.
+    #[test]
+    fn git_file_write_target_reads_format_patch_and_bundle_by_shape() {
+        // A `format-patch` writes `NNNN-*.patch` into the working directory
+        // unless it was told to write to stdout.
+        assert_eq!(
+            git_file_write_target("git format-patch -1 HEAD").as_deref(),
+            Some("")
+        );
+        assert_eq!(
+            git_file_write_target("git format-patch --stdout -1 HEAD"),
+            None
+        );
+        assert_eq!(
+            git_file_write_target("git format-patch -1 HEAD --stdout"),
+            None
+        );
+        // `bundle create` names its output as a positional; `-` is stdout.
+        assert_eq!(
+            git_file_write_target("git bundle create /tmp/x.bundle HEAD").as_deref(),
+            Some("/tmp/x.bundle")
+        );
+        assert_eq!(
+            git_file_write_target("git bundle create -q /tmp/x.bundle --all").as_deref(),
+            Some("/tmp/x.bundle")
+        );
+        assert_eq!(git_file_write_target("git bundle create - HEAD"), None);
+        assert_eq!(
+            git_file_write_target("git bundle verify /tmp/x.bundle"),
+            None
+        );
+        assert_eq!(
+            git_file_write_target("git bundle list-heads /tmp/x.bundle"),
+            None
+        );
     }
 
     // #7399: the rule matches the option, never its prefix.
     #[test]
-    fn git_output_file_ignores_the_indicator_options() {
+    fn git_file_write_target_ignores_the_indicator_options() {
         for command in [
             "git diff --output-indicator-new=+",
             "git diff --output-indicator-old=- --stat",
             "git diff --output-indicator-context= ",
             "git diff --stat -- docs/",
             "git diff --no-index /tmp/a.txt /tmp/b.txt",
+            "git archive --format=tar HEAD",
         ] {
-            assert_eq!(git_output_file(command), None, "{command}");
+            assert_eq!(git_file_write_target(command), None, "{command}");
         }
     }
 
     // #7399: past `--`, git parses pathspecs, so `--output=…` writes nothing.
     #[test]
-    fn git_output_file_stops_at_the_pathspec_separator() {
-        assert_eq!(git_output_file("git diff -- --output=/tmp/o.diff"), None);
+    fn git_file_write_target_stops_at_the_pathspec_separator() {
         assert_eq!(
-            git_output_file("git diff --output=/tmp/o.diff -- docs/").as_deref(),
+            git_file_write_target("git diff -- --output=/tmp/o.diff"),
+            None
+        );
+        assert_eq!(
+            git_file_write_target("git diff --output=/tmp/o.diff -- docs/").as_deref(),
             Some("/tmp/o.diff")
         );
     }
@@ -741,8 +924,14 @@ mod tests {
     // #7399: a segment that will not lex withholds the deny; it never grants
     // an allow that did not already exist.
     #[test]
-    fn git_output_file_none_when_unbalanced() {
-        assert_eq!(git_output_file("git diff --output='/tmp/o.diff"), None);
-        assert_eq!(git_output_file("cargo run -- --output=/tmp/o.diff"), None);
+    fn git_file_write_target_none_when_unbalanced() {
+        assert_eq!(
+            git_file_write_target("git diff --output='/tmp/o.diff"),
+            None
+        );
+        assert_eq!(
+            git_file_write_target("cargo run -- --output=/tmp/o.diff"),
+            None
+        );
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -2149,3 +2149,112 @@ fn a_quoted_path_to_a_forbidden_verb_is_still_refused() {
     );
     assert_eq!(evaluate_bash_command(r#""/opt/make tools/echo" hi"#), None);
 }
+
+/// #7399: a git `--output` option writes a file and is refused as one.
+///
+/// Why: `git diff --output=/tmp/o.diff` puts the same bytes on disk that
+/// `git diff > /tmp/o.diff` does, but carries no `>`, so
+/// [`has_file_write_redirection`] never saw it and the write boundary
+/// (ADR-0044, ADR-0048) had a hole a PM could walk through. `--output` is a
+/// git DIFF option, so the rows below cover every subcommand that generates a
+/// diff, both spellings git accepts, and the wrapper and global-flag
+/// positions that hid other git verbs before.
+/// What: asserts each spelling denies with [`SHELL_EDIT_REASON`] — the same
+/// reason a `>` redirection denies with — and that the denial names the file,
+/// so the routing hint points at the written path rather than falling back.
+/// Test: itself.
+#[test]
+fn git_diff_output_flag_is_refused_as_a_file_write() {
+    for command in [
+        "git diff --output=/tmp/o.diff",
+        "git diff --output=/tmp/o.diff origin/main...HEAD",
+        "git diff --output /tmp/o.diff origin/main...HEAD",
+        "git diff origin/main...HEAD --output=/tmp/o.diff -- docs/",
+        "git --no-pager diff --output=/tmp/o.diff",
+        "git -C /repo diff --output /tmp/o.diff",
+        "git log -1 --output=/tmp/log.txt",
+        "git show HEAD --output=/tmp/show.txt",
+        "git format-patch -1 --output=/tmp/p.patch",
+        r#"git diff --output="/tmp/my out.diff""#,
+        "sh -c 'git diff --output=/tmp/o.diff'",
+        "cargo check -p trusty-mpm && git diff --output=/tmp/o.diff",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(command),
+            Some(SHELL_EDIT_REASON),
+            "a git --output option is a file write: {command}"
+        );
+    }
+    assert_eq!(
+        extract_shell_edit_target("git diff --output=/tmp/o.diff"),
+        Some("/tmp/o.diff".to_string())
+    );
+    assert_eq!(
+        extract_shell_edit_target("git diff --output /tmp/o.diff HEAD"),
+        Some("/tmp/o.diff".to_string())
+    );
+}
+
+/// #7399: the read-only `git diff` shapes stay allowed beside that deny.
+///
+/// Why: the deny above must match the OPTION, not its prefix.
+/// `--output-indicator-new=+` changes one character of the patch body and
+/// writes nothing; a `--output=…` past the `--` separator is a pathspec git
+/// never parses as an option (verified against git 2.x — no file appears).
+/// `git diff --no-index a b` between two readable paths is a pure read and is
+/// the shape #7368 already pinned as allowed.
+/// What: asserts each row still allows, in both bands —
+/// [`unclassifiable_command`] and [`evaluate_bash_command`].
+/// Test: itself.
+#[test]
+fn git_diff_read_only_shapes_survive_the_output_deny() {
+    for command in [
+        "git diff --no-index /tmp/a.txt /tmp/b.txt",
+        "git diff --stat",
+        "git diff -- docs/",
+        "git diff --output-indicator-new=+",
+        "git diff --output-indicator-old=- --stat main..HEAD",
+        "git diff -- --output=/tmp/o.diff",
+        "git log --oneline -5",
+        "git show HEAD --stat",
+    ] {
+        assert_eq!(
+            unclassifiable_command(command),
+            None,
+            "read-only diff must stay classifiable: {command}"
+        );
+        assert_eq!(
+            evaluate_bash_command(command),
+            None,
+            "read-only diff must stay allowed: {command}"
+        );
+    }
+}
+
+/// #7399: a git segment the guard cannot lex loses no existing deny.
+///
+/// Why: the `--output` rule reads its answer from a shlex split, which fails
+/// on unbalanced quotes. The failure direction must be "no NEW deny", never
+/// "an existing deny becomes an allow" — a bypass that would be worse than
+/// the hole being closed.
+/// What: asserts the unlexable spellings of already-denied shapes still deny,
+/// and that the unlexable `--output` spelling is merely no worse than before
+/// the fix (it allows here, as it did before, and bash refuses to run an
+/// unterminated quote at all).
+/// Test: itself.
+#[test]
+fn an_unlexable_git_segment_keeps_every_deny_it_already_had() {
+    assert_eq!(
+        evaluate_bash_command("git diff '/tmp/o.diff > /tmp/w.diff"),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        evaluate_bash_command("sed -i s/a/b/ '/tmp/f.rs"),
+        Some(SHELL_EDIT_REASON)
+    );
+    assert_eq!(
+        shell_lex::git_output_file("git diff --output='/tmp/o.diff"),
+        None,
+        "an unbalanced segment withholds the new deny rather than granting one"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -2195,6 +2195,62 @@ fn git_diff_output_flag_is_refused_as_a_file_write() {
     );
 }
 
+/// #7399 round 2: `-o`, `--output-directory` and `bundle create` write too.
+///
+/// Why: the round-1 rule matched only `--output`, and a critic ran the three
+/// gaps against git 2.54.0 in a scratch repo: `git format-patch -o <dir> -1
+/// HEAD` wrote `0001-init.patch`, `git format-patch --output-directory=<dir>
+/// -1 HEAD` wrote a patch, `git archive -o <file> HEAD` wrote a 10KB tar. Two
+/// more writes carry no option at all — a bare `git format-patch` drops patch
+/// files into the working directory, and `git bundle create <file>` names its
+/// output as a positional.
+/// What: asserts every write spelling denies with [`SHELL_EDIT_REASON`], and
+/// that the read-only siblings still allow — `--stdout`, an archive to stdout,
+/// `git diff -o` (a revision there), and `git clone -o` (the origin remote).
+/// Test: itself.
+#[test]
+fn git_short_output_options_are_refused_as_file_writes() {
+    for command in [
+        "git format-patch -o /tmp/d -1 HEAD",
+        "git format-patch -1 -o/tmp/d HEAD",
+        "git format-patch --output-directory=/tmp/d -1 HEAD",
+        "git format-patch --output-directory /tmp/d -1 HEAD",
+        "git format-patch -1 HEAD",
+        "git archive -o /tmp/a.tar HEAD",
+        "git archive -o/tmp/a.tar HEAD",
+        "git archive --output=/tmp/a.tar HEAD",
+        "git bundle create /tmp/x.bundle HEAD",
+        "git bundle create -q /tmp/x.bundle --all",
+        "git -C /repo format-patch -o /tmp/d -1 HEAD",
+        "sh -c 'git archive -o /tmp/a.tar HEAD'",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(command),
+            Some(SHELL_EDIT_REASON),
+            "a git write option is a file write: {command}"
+        );
+    }
+    for command in [
+        "git format-patch --stdout -1 HEAD",
+        "git format-patch -1 HEAD --stdout",
+        "git archive --format=tar HEAD | tar -t",
+        "git bundle create - HEAD",
+        "git bundle verify /tmp/x.bundle",
+        "git diff -o /tmp/o.diff HEAD",
+        "git clone -o upstream https://x/y.git",
+    ] {
+        assert_eq!(
+            evaluate_bash_command(command),
+            None,
+            "a read-only spelling must stay allowed: {command}"
+        );
+    }
+    assert_eq!(
+        extract_shell_edit_target("git archive -o /tmp/a.tar HEAD"),
+        Some("/tmp/a.tar".to_string())
+    );
+}
+
 /// #7399: the read-only `git diff` shapes stay allowed beside that deny.
 ///
 /// Why: the deny above must match the OPTION, not its prefix.
@@ -2253,8 +2309,13 @@ fn an_unlexable_git_segment_keeps_every_deny_it_already_had() {
         Some(SHELL_EDIT_REASON)
     );
     assert_eq!(
-        shell_lex::git_output_file("git diff --output='/tmp/o.diff"),
+        shell_lex::git_file_write_target("git diff --output='/tmp/o.diff"),
         None,
         "an unbalanced segment withholds the new deny rather than granting one"
+    );
+    assert_eq!(
+        shell_lex::git_file_write_target("git archive -o '/tmp/a.tar"),
+        None,
+        "the round-2 spellings inherit the same withhold-only failure"
     );
 }


### PR DESCRIPTION
## Outcome

`tm hook --pm-guard` allowed `git diff --output=<file>` and sibling write
options, an uncaught PM file write past the ADR-0044/0048 boundary. Finding
(b) of #7399; finding (a) landed in #7402.

Refs [#7399](https://github.com/bobmatnyc/trusty-tools/issues/7399)
Refs [#7402](https://github.com/bobmatnyc/trusty-tools/pull/7402)
Refs [#7374](https://github.com/bobmatnyc/trusty-tools/issues/7374)

## Changes

One new arm beside `git apply` in `classify_bash_segment`, fed by
`git_file_write_target` on the existing git argv walk. Refused (each verified
to write against git 2.54.0): any subcommand `--output=`/`--output <f>`;
format-patch `-o`, `--output-directory`, and the bare form without
`--stdout`; archive `-o`; `bundle create <file>`. Deny is budget-tiered like a
`>` redirection.

Out of scope: still allowed — `--stdout` forms, `archive --format=tar HEAD |
…`, `bundle create -`, `git diff -o` (a revision), `git clone -o`, `git
commit -o`, `--output-indicator-*`, `--no-index`, anything past `--`.
Unlexable segments withhold only the new deny.

## Risk

Rung 3, High risk — a guard-refusal change inside the PM safety boundary.
Localized to `crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/`.

## Tests

- `cargo fmt --check`, `cargo check -p trusty-mpm`,
  `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: pass
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4`: 57 targets
  ok, lib 6646/0
- Targeted `pm_guard_bash`+`shell_lex`: 286/0
- 12-row write table: 11 ALLOW pre-round-1, all DENY now; pre-fix failures
  pasted in the commits

## Baseline

No pre-existing red observed on this crate; nothing to attribute.

## Docs

Changelog fragment:
`crates/trusty-mpm/changelog.d/7399-git-diff-output-refused.md`

## Review

code-critic round 1 BLOCK (format-patch `-o` / `--output-directory` /
archive `-o` missed), round 2 APPROVE — fixed here.

Refs #7399

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
