### PR TITLE
docs(trusty-mpm): resolve the shell_lex intra-doc link PR #7405 left broken

### DIFF
--- a/crates/trusty-mpm/changelog.d/7399-rustdoc-link.md
+++ b/crates/trusty-mpm/changelog.d/7399-rustdoc-link.md
@@ -1,0 +1,3 @@
+Documentation
+
+- Fixed the `shell_lex.rs` intra-doc link to `git_output_file`, left broken by the `git_file_write_target` rename in #7405.

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -460,7 +460,7 @@ pub(crate) fn git_subcommand(segment: &str) -> Option<String> {
 
 /// The parsed argv of a git segment, and the index of its subcommand token.
 ///
-/// Why: [`git_subcommand`] answers "which subcommand", and [`git_output_file`]
+/// Why: [`git_subcommand`] answers "which subcommand", and [`git_file_write_target`]
 /// asks the same parser "and what did that subcommand's arguments say". One
 /// walk over the global options serves both, so a rule about a git ARGUMENT
 /// cannot drift from the rule about the git VERB — a second argv parser is the


### PR DESCRIPTION
PR #7405 (squash 05413b1e5) renamed `git_output_file` to `git_file_write_target` in `shell_lex.rs` but left one doc-comment link pointing at the old name, which reddens the `Rustdoc intra-doc links` job on main. This links it to the current item name.

Refs #7399

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb