### PR TITLE
chore(sessions): pause snapshot 2026-09-11 02:02Z (session trusty-tools-95)

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-020211.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-020211.md
@@ -1,0 +1,42 @@
+# Session Pause - 2026-09-11T02:02:11.865112+00:00
+
+## Summary
+Owner-invoked pause 2026-09-11 ~02:1xZ, session trusty-tools-95 (bug close-out leg). Owner standing: "keep going, merge them when green" (reaffirmed 4x), "Prioritize bug fixes." tm 1.5.27 installed, signed, daemon restarted (pid 49785). Main checkout c7e38dbfa is far behind origin/main and carries ~141 uncommitted trusty-agents files from another workstream — never touch it; every dispatch takes a harness worktree reset to origin/main. FOUR ENGINEERS WERE LIVE at pause (commit-only, no push; harness agents may survive a pause — check ListAgents / artifacts before re-dispatching): #7066 spawn-gate is_known_repo canonical path (security, needs critic before arming), #7357 project_register worktree backfill, #7120 compress bypass on large source reads, #7406 tm ls new-session picker polish. Each next: security scan → critic if High → version-control push+PR+arm → ticketing status:coded → status:merged on merge. Every rust-engineer brief now includes `bash scripts/check_rustdoc_links.sh` (two rustdoc reds today). Palace board drawer 2e19c574 (fact_key ws:trusty-tools-95/resume) carries the full state.
+
+## Completed
+- Filed #7390 and fixed: PR #7393 merged d4df8e914
+- Fixed #7386 (version-control merge-tree text): PR #7394 merged f02332b10
+- Fixed #7388 (session delete stops errored first): PR #7398 merged 5628a276e
+- Feature #7395 tm ls `n` new session: PR #7400 merged 189da1cf0; owner live-verified; closed
+- Fixed #7384+#7377 compress exit sentinel + rtk fallback: PR #7401 merged a7369fecb (critic BLOCK→APPROVE)
+- Fixed #7374 guard shlex lexer + #7399(b): PR #7402 merged 5ae55b377 (critic BLOCK→APPROVE)
+- Fixed #7399(a) git output-file writes: PR #7405 merged 05413b1e5 (critic BLOCK→APPROVE)
+- Rustdoc link fixes: PR #7403 merged baf7772; PR #7408 armed f3d0563dd
+- tm 1.5.27 bump PR #7404 merged 10ba7287f; installed, signed, daemon restarted
+- Closed 14 issues this leg: #7226 #7312 #7313 #7244 #7278 #7271 #7270 #7368(dup #6982) #7386 #7384 #7377 #7374 #7092(dup #6982) #7395
+- duetto config: registered domain-services-poc + 7 hotstats-org repos with gh-duetto identity; tokens stripped from two hotstats remotes with repo-local credential helper; hotstats-product-poc crossed checkouts deliberately left as-is
+- Labelled 12 census defects `bug`; #7266 follow-up PR #7407 armed (critic BLOCK/BLOCK/APPROVE)
+
+## In Progress
+- #7066 rust-engineer (opus) — spawn-gate is_known_repo canonical-path fix, committing in its harness worktree; security-critical, critic round required before arming
+- #7357 rust-engineer (opus) — project_register backfills pre-existing worktree records
+- #7120 rust-engineer (opus) — compress/divert path for large source reads in bypass-permissions mode
+- #7406 rust-engineer (opus) — new-session picker: preselect cursor project, owner/repo rows, filter temp/scratchpad/missing/non-git registrations
+- PR #7407 (fix #7266 follow-up, head 3fdd6a1ae) auto-merge armed → on merge `tm issue transition 7266 status:merged`
+- PR #7408 (rustdoc link, head f3d0563dd) auto-merge armed
+
+## Next Steps
+- ListAgents first; for each of the four engineers, read its report or check its worktree for a commit before re-dispatching
+- Per landed branch: security scan (three-dot diff) → code-critic for #7066 → version-control push + tm pr open + arm (never --admin) → ticketing status:coded → status:merged on merge
+- Queued bugs: #7118+#7117+#7381 worktree-provisioning cluster (one PR); #7104 gh pr merge --delete-branch from a worktree; #7229 Write tool NUL byte (research first — may be harness); #4751 #3715 (M, vague); skip #4612 (trusty-agents, other workstream)
+- After wave 1 lands: ask owner to authorize tm reinstall (patch bump 1.5.28), then live-verify and close #7390 #7388 #7399 #7266 #7406 and the held #7263 #7365 #7267 #7282
+- Not attempted, status:merged: #7288 (CI apt infra), #7112 #6900 #6838 (console saver, owner-observable), #5220 (tga Bitbucket credentials)
+- Pending improvement recs (not filed, per stop-over-filing): CLAUDE.md pitfall on log-level tests using trusty_common::log_buffer::capture_logs; tm_hook_pm_guard tests sharing _default.json budget across runs; check_line_cap --list flag; HARNESS_REFUSED_SHAPES additions for ls/grep/HOME= refusals
+
+## Git Context
+Branch: main
+Last commit: c7e38dbfa chore(trusty-mpm): bump to 1.5.21 for owner-authorized reinstall (#7292)
+Uncommitted changes: 141 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -111,3 +111,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-030816.md","timestamp":"2026-09-10T03:08:16.885626+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-105850.md","timestamp":"2026-09-10T10:58:50.679246+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-153636.md","timestamp":"2026-09-10T15:36:36.117706+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-020211.md","timestamp":"2026-09-11T02:02:11.865112+00:00"}


### PR DESCRIPTION
Session-pause snapshot published by hand after `tm pr open` failed on a missing `ws/<session-uuid>` label (Refs #7282). Docs-only.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb