### PR TITLE
fix(trusty-mpm): divert and skip-compress line-numbered source reads in bypass mode (Refs #7120)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7120-compress-bypass-mode.md
+++ b/crates/trusty-mpm/changelog.d/7120-compress-bypass-mode.md
@@ -1,0 +1,10 @@
+Fixed
+- `tm hook --divert-check` now diverts `cat -n <path>`, the whole-file read
+  bypass-permissions mode instructs the agent to use. Every single-dash flag
+  used to count as a bound, which is true of `head -n 40` and false of `cat -n`,
+  so a large source read escaped diversion in bypass mode while the identical
+  `Read` payload was diverted. A `cat <flags> <source file>` command is also no
+  longer wrapped in `| tm compress`: the flag displaced the path out of the
+  derived tool name, so the read reached the file-read filter the #6986
+  passthrough exists to keep source away from, and paid a compress process spawn
+  to get its own bytes back.

--- a/crates/trusty-mpm/src/bin/tm/commands/divert_check.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/divert_check.rs
@@ -49,6 +49,21 @@ use crate::commands::pm_guard::build_pretooluse_deny_response;
 /// Test: `divert_targets_matches_bulk_bash_readers`.
 const BULK_READ_COMMANDS: [&str; 5] = ["cat", "head", "tail", "less", "more"];
 
+/// The bulk readers whose short flags actually cap how much is printed.
+///
+/// Why (#7120): the classifier used to decline EVERY single-dash flag as
+/// already-bounding. That is true of `head -n 40` and false of `cat -n`, where
+/// `-n` only numbers the lines it prints. Claude Code's bypass-permissions
+/// instruction tells the agent to read files with `cat`, which it spells
+/// `cat -n <path>`, so that one rule let every bypass-mode whole-file read past
+/// the diverter while the identical `Read` payload was diverted.
+/// What: `head` and `tail` take a count through a short flag (`-n 40`,
+/// `-c 200`, `-40`); for the rest of [`BULK_READ_COMMANDS`] a short flag is
+/// formatting, so the file operands still name an unbounded read.
+/// Test: `divert_targets_diverts_a_line_numbered_cat`,
+/// `divert_targets_skips_bounded_reads`.
+const BOUNDED_BY_SHORT_FLAG: [&str; 2] = ["head", "tail"];
+
 /// What the hook decided about one tool call.
 ///
 /// Why: separating the decision from the I/O (stdin, the filesystem, stdout)
@@ -219,8 +234,9 @@ pub(crate) fn block_reason(path: &str, lines: u32) -> String {
 /// `Bash`, the file operands of a SINGLE simple [`BULK_READ_COMMANDS`]
 /// invocation: a command containing a pipe, redirect, or separator is left
 /// alone (it is not a plain read), and a `head`/`tail` carrying an explicit
-/// count (`-n`, `-c`, `-100`) is already bounded. Every other tool yields
-/// nothing.
+/// count (`-n`, `-c`, `-100`) is already bounded. A `cat` flag is formatting,
+/// not a bound, so `cat -n <path>` diverts exactly like the `Read` payload for
+/// the same file (#7120). Every other tool yields nothing.
 /// Test: `divert_targets_matches_bulk_bash_readers`,
 /// `divert_targets_skips_bounded_reads`, `divert_targets_ignores_other_tools`.
 pub(crate) fn divert_targets(tool_name: &str, tool_input: Option<&Value>) -> Vec<String> {
@@ -255,10 +271,12 @@ pub(crate) fn divert_targets(tool_name: &str, tool_input: Option<&Value>) -> Vec
 /// agent legitimately needs.
 /// What: returns empty when the command contains a shell composition character
 /// (`| & ; < > $ ( ` \n`), when the first word is not in
-/// [`BULK_READ_COMMANDS`], or when a bounding flag is present. Otherwise
-/// returns every non-flag operand after the command word.
+/// [`BULK_READ_COMMANDS`], or when a bounding flag is present on one of the
+/// [`BOUNDED_BY_SHORT_FLAG`] commands. Otherwise returns every non-flag operand
+/// after the command word.
 /// Test: `divert_targets_matches_bulk_bash_readers`,
-/// `divert_targets_skips_bounded_reads`.
+/// `divert_targets_skips_bounded_reads`,
+/// `divert_targets_diverts_a_line_numbered_cat`.
 fn bash_read_targets(command: &str) -> Vec<String> {
     if command
         .chars()
@@ -279,10 +297,12 @@ fn bash_read_targets(command: &str) -> Vec<String> {
     }
 
     let rest: Vec<&str> = words.collect();
-    // A bounding flag (`-n 40`, `-c 200`, `-40`) already caps the read.
-    if rest
-        .iter()
-        .any(|w| w.starts_with('-') && w.len() > 1 && !w.starts_with("--"))
+    // #7120: a bounding flag (`-n 40`, `-c 200`, `-40`) caps the read only for
+    // the commands that take a count that way — `cat -n` prints the whole file.
+    if BOUNDED_BY_SHORT_FLAG.contains(&bare)
+        && rest
+            .iter()
+            .any(|w| w.starts_with('-') && w.len() > 1 && !w.starts_with("--"))
     {
         return Vec::new();
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/divert_check_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/divert_check_tests.rs
@@ -213,6 +213,62 @@ fn divert_targets_skips_bounded_reads() {
     }
 }
 
+/// Why (#7120): Claude Code's bypass-permissions instruction tells the agent to
+/// read files with `cat`, and the spelling it uses is `cat -n <path>`. The
+/// classifier read every single-dash flag as a bound, so that whole-file read
+/// went through undiverted while the `Read` payload naming the same file was
+/// diverted — the two modes disagreed about the identical read.
+/// What: for one oversized file and one small one, the `Bash` `cat -n` payload
+/// must reach the same [`super::DivertDecision`] as the `Read` payload.
+/// `head -n 40` stays bounded, because there the flag really is a count.
+#[test]
+fn divert_targets_diverts_a_line_numbered_cat() {
+    let read = read_input("/repo/huge.rs");
+    let numbered = serde_json::json!({ "command": "cat -n /repo/huge.rs" });
+    assert_eq!(
+        divert_targets("Bash", Some(&numbered)),
+        vec!["/repo/huge.rs".to_string()],
+        "`cat -n` prints the whole file; the flag is formatting, not a bound"
+    );
+
+    // Over threshold: both modes block, naming the same file.
+    let via_read = decide("Read", Some(&read), 350, true, &fixed(900));
+    let via_cat = decide("Bash", Some(&numbered), 350, true, &fixed(900));
+    assert!(
+        matches!(via_cat, DivertDecision::Block(_)),
+        "bypass-mode `cat -n` must divert like the Read tool, got {via_cat:?}"
+    );
+    assert_eq!(
+        via_cat, via_read,
+        "the two modes must reach the same decision for the same file"
+    );
+
+    // Under threshold: both modes leave a small read untouched.
+    let small_cat = decide("Bash", Some(&numbered), 350, true, &fixed(12));
+    assert_eq!(
+        small_cat,
+        decide("Read", Some(&read), 350, true, &fixed(12)),
+        "a small read must stay untouched in both modes"
+    );
+    assert_eq!(small_cat, DivertDecision::Allow);
+
+    // The flag really is a count for `head`/`tail`, so those stay bounded.
+    for cmd in ["head -n 40 /repo/huge.rs", "tail -100 /repo/huge.rs"] {
+        let bash = serde_json::json!({ "command": cmd });
+        assert!(
+            divert_targets("Bash", Some(&bash)).is_empty(),
+            "an explicit count still bounds the read: {cmd}"
+        );
+    }
+
+    // Every other `cat` flag has the same shape.
+    let squeezed = serde_json::json!({ "command": "cat -s -n /repo/huge.rs" });
+    assert_eq!(
+        divert_targets("Bash", Some(&squeezed)),
+        vec!["/repo/huge.rs".to_string()]
+    );
+}
+
 /// Why: the hook is registered with matcher `Read` and matcher `Bash`, but
 /// Claude Code matchers are regex — a future matcher change must not silently
 /// start diverting edits. Scope is bulk READS only (#6887).

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs
@@ -42,6 +42,8 @@
 // #6566: the tool-name coverage predicate lives beside the filter dispatch it
 // predicts, in `trusty-agents-common`, so the two cannot drift apart.
 use trusty_agents_common::compress::has_filter_for;
+// #7120: the #6986 source-read predicate, asked of the whole command.
+use trusty_agents_common::compress::tool_output::is_source_file_read;
 
 /// Day-one orchestrator-command exclusion list.
 ///
@@ -106,7 +108,13 @@ const ORCHESTRATOR_EXCLUSIONS: &[&str] = &[
 /// stays in `trusty-agents-common` — this module asks
 /// `compress::has_filter_for` rather than keeping a second copy that could
 /// drift from the dispatch it is meant to predict.
+/// It also returns `None` for a read verb applied to a source file (#7120),
+/// asked of the whole command rather than the derived name: `cat foo.rs`
+/// already fails `has_filter_for`, but `cat -n foo.rs` derives `"cat -n"` and
+/// reaches the file-read filter, so the flagged spelling bypass-permissions
+/// mode uses paid a compress spawn for its own bytes back.
 /// Test: `rewrite_appends_compress_pipe_for_plain_command`,
+/// `rewrite_skips_a_flagged_source_read`,
 /// `rewrite_appends_compress_pipe_with_subcommand_tool_name`,
 /// `rewrite_skips_orchestrator_commands`, `rewrite_skips_piped_commands`,
 /// `rewrite_skips_chained_commands`, `rewrite_skips_empty_command`,
@@ -127,6 +135,14 @@ pub(crate) fn rewrite_bash_command_for_compression(command: &str) -> Option<Stri
     // #7384: a comment or a trailing `\` would swallow or absorb the brace
     // group's own `printf`, so such a command is never wrapped.
     if cannot_be_brace_wrapped(trimmed) {
+        return None;
+    }
+    // #7120: asked of the WHOLE command, because `effective_tool_name` keeps
+    // only the first two tokens and a flag displaces the path out of them —
+    // `cat -n <file>.rs` derives `"cat -n"`, which `classify_tool` routes to
+    // the file-read filter the #6986 passthrough exists to keep source away
+    // from.
+    if is_source_file_read(trimmed) {
         return None;
     }
     let tool = effective_tool_name(trimmed);
@@ -829,6 +845,37 @@ mod tests {
                 "expected no compress wrap for uncovered tool: {cmd}"
             );
         }
+    }
+
+    #[test]
+    fn rewrite_skips_a_flagged_source_read() {
+        // #7120: bypass-permissions mode reads files with `cat -n <path>`.
+        // `effective_tool_name` keeps only the first two tokens, so the flag
+        // pushed the path out and `"cat -n"` reached the file-read filter —
+        // one compress spawn per read, returning every byte it was given. The
+        // unflagged spelling was already skipped by #6986's passthrough.
+        for cmd in [
+            "cat -n crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs",
+            "cat crates/trusty-mpm/src/bin/tm/commands/hook_rewrite.rs",
+            "cat -s src/lib.rs",
+            "/bin/cat -n README.md",
+        ] {
+            assert_eq!(
+                rewrite_bash_command_for_compression(cmd),
+                None,
+                "a source read must never be wrapped for compression: {cmd}"
+            );
+        }
+
+        // The negative bound: `> /tmp/gate.txt` then `cat` it back is this
+        // project's gate-capture pattern, which is real gate output and still
+        // reaches the file-read filter.
+        let expected = expected_rewrite("cat -n /tmp/gate.txt", "cat -n");
+        assert_eq!(
+            rewrite_bash_command_for_compression("cat -n /tmp/gate.txt").as_deref(),
+            Some(expected.as_str()),
+            "a captured gate log is not a source read"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Outcome

Refs #7120. In bypass-permissions mode, a source read runs as `cat -n <path>`; the `-n` displaced the path so the compress hook wrapped every such read and returned it unchanged, while `divert_check` treated `cat -n` as a bounded read.

## Changes

Only `head`/`tail` are now bounded by a short flag; a source read is never wrapped whatever its flags. Changed: `divert_check.rs`, new `divert_check_tests.rs` cases, `hook_rewrite.rs`.

## Risk

Localized to trusty-mpm's bypass-mode compress/divert path (rung 3). No public API or cross-crate surface touched.

## Tests

`cargo fmt --check`, `cargo check -p trusty-mpm --all-targets`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, and `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` all exit 0 (largest target 6646 passed, 0 failed, 8 ignored). Two regression tests proved red pre-fix: `divert_targets_diverts_a_line_numbered_cat`, `rewrite_skips_a_flagged_source_read`.

## Baseline

No pre-existing red. Doc gates initially failed on this branch's stale base (a rustdoc intra-doc link already fixed on `origin/main`); rebased onto `origin/main` (new head `9ba7d6715`) to pick up the fix before re-running gates.

## Docs

`check_line_cap.sh` PASS, `check_changelog_fragment.sh` PASS, `check_test_pointers.sh` PASS, `check_rustdoc_links.sh` PASS (26 crates examined, 0 broken links). Changelog fragment: `crates/trusty-mpm/changelog.d/7120-compress-bypass-mode.md`.

## Review

No outstanding review findings; this is the initial submission.

Refs #7120

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
