### PR TITLE
feat(trusty-mpm): new-session picker preselects the cursor project, shows owner/repo rows, hides throwaway registrations (Refs #7406)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7406-new-session-picker-polish.md
+++ b/crates/trusty-mpm/changelog.d/7406-new-session-picker-polish.md
@@ -1,0 +1,6 @@
+Changed
+- `tm ls`'s new-session picker now opens on the project of the session the
+  cursor was on, renders each row as `owner/repo` (or `<basename> (local)` for a
+  path-only registration) instead of the stored URL or path, and hides
+  registrations nobody can work in — a temp-directory or `scratchpad` path, a
+  path that is gone, or a directory that is not a git checkout (#7406).

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/mod.rs
@@ -20,6 +20,8 @@
 pub(crate) mod convert;
 pub(crate) mod deliverables;
 pub(crate) mod milestones;
+// #7406: the one predicate every surface that OFFERS a project shares.
+pub(crate) mod offerable;
 pub(crate) mod registry;
 
 use crate::cli::ProjectsAction;

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/offerable.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/offerable.rs
@@ -1,0 +1,182 @@
+//! Which registry rows a user surface may offer as a place to work (#7406).
+//!
+//! Why: the registry is an upsert store that anything can write to — a probe, a
+//! test harness, an agent working in a scratch directory — so it accumulates
+//! rows that name a directory which is temporary, already deleted, or was never
+//! a checkout. Offering one of those as a place to start a session can only
+//! fail, and the owner saw exactly that: a `mcp-probe-scratch-4181` row
+//! registered at a `/private/tmp/…/scratchpad/…` path sitting in the `tm ls`
+//! new-session picker.
+//!
+//! What: [`is_offerable_project`] is the ONE predicate every surface that
+//! offers a project to an operator routes through. It judges only rows whose
+//! `repo_url` is a local absolute PATH; a remote URL is always offerable,
+//! because nothing on this host can contradict it.
+//!
+//! `tm project list` deliberately does NOT filter (#7406): it is the surface an
+//! operator uses to SEE the registry and remove a bad row, so hiding rows there
+//! would hide the thing being pruned. Only surfaces that offer a project as a
+//! target for new work call this.
+//!
+//! Test: `offerable_*` in this file's `tests` module.
+
+use std::path::{Path, PathBuf};
+
+use trusty_mpm::project::Project;
+
+/// Path segment that marks an agent's scratch directory.
+const SCRATCHPAD_SEGMENT: &str = "scratchpad";
+
+/// Absolute prefixes under which every registration is throwaway.
+const TEMP_PREFIXES: [&str; 3] = ["/tmp", "/private/tmp", "/var/folders"];
+
+/// True when this registry row may be offered as a place to start work.
+///
+/// Why: see the module doc — an unusable row in a picker is worse than a
+/// missing one, because the failure only arrives after the operator commits to
+/// it.
+/// What: a `repo_url` that is not a local absolute path (a git URL, or empty)
+/// is always offerable. A local path is offerable only when it is outside every
+/// temp directory, carries no `scratchpad` segment, still exists, and sits in a
+/// git checkout.
+/// Test: `offerable_keeps_url_projects`, `offerable_drops_a_temp_scratchpad`,
+/// `offerable_drops_a_path_that_is_gone`, `offerable_keeps_a_real_checkout`.
+pub(crate) fn is_offerable_project(project: &Project) -> bool {
+    match local_checkout_path(&project.repo_url) {
+        Some(path) => is_offerable_checkout(&path),
+        None => true,
+    }
+}
+
+/// The local directory a `repo_url` names, when it names one at all.
+///
+/// A registry row's `repo_url` is a git URL for a cloned project and an
+/// absolute checkout path for a locally-registered one; only the second kind
+/// can be checked against this host's disk.
+pub(crate) fn local_checkout_path(repo_url: &str) -> Option<PathBuf> {
+    let trimmed = repo_url.trim();
+    trimmed.starts_with('/').then(|| PathBuf::from(trimmed))
+}
+
+/// True when `path` is a durable git checkout an operator would work in.
+///
+/// Why: split from [`is_offerable_project`] so the four rules can be read (and
+/// tested) against a bare path, without a `Project` around it.
+/// What: rejects a temp-directory path, a `scratchpad` segment, a path that is
+/// no longer a directory, and a directory with no `.git` at or above it.
+/// Test: `offerable_drops_a_temp_scratchpad`, `offerable_drops_a_path_that_is_gone`,
+/// `offerable_keeps_a_real_checkout`.
+pub(crate) fn is_offerable_checkout(path: &Path) -> bool {
+    !under_temp_dir(path) && !has_scratchpad_segment(path) && path.is_dir() && in_git_checkout(path)
+}
+
+/// True when `path` is inside a temp directory, `$TMPDIR` included.
+///
+/// `Path::starts_with` compares whole components, so `/tmpfoo` is not `/tmp`.
+fn under_temp_dir(path: &Path) -> bool {
+    let tmpdir = std::env::var_os("TMPDIR").map(PathBuf::from);
+    TEMP_PREFIXES
+        .iter()
+        .map(Path::new)
+        .any(|prefix| path.starts_with(prefix))
+        || tmpdir.is_some_and(|dir| {
+            let dir = dir.to_string_lossy().trim_end_matches('/').to_string();
+            !dir.is_empty() && path.starts_with(&dir)
+        })
+}
+
+/// True when any component of `path` is a `scratchpad` directory.
+fn has_scratchpad_segment(path: &Path) -> bool {
+    path.components().any(|c| {
+        c.as_os_str()
+            .to_string_lossy()
+            .eq_ignore_ascii_case(SCRATCHPAD_SEGMENT)
+    })
+}
+
+/// True when `path` or one of its ancestors holds a `.git` entry.
+///
+/// A git worktree's `.git` is a FILE rather than a directory, and a registered
+/// path can be a subdirectory of the checkout, so both shapes count.
+fn in_git_checkout(path: &Path) -> bool {
+    path.ancestors().any(|dir| dir.join(".git").exists())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A registry row, built the way the daemon's own listing yields one.
+    fn project(name: &str, repo_url: &str) -> Project {
+        serde_json::from_value(serde_json::json!({
+            "name": name,
+            "repo_url": repo_url,
+            "default_branch": "main",
+        }))
+        .expect("project fixture")
+    }
+
+    /// The acceptance fixture (#7406): a temp scratchpad row, a row whose path
+    /// is gone, and two rows that must survive.
+    fn fixture() -> Vec<Project> {
+        vec![
+            project(
+                "mcp-probe-scratch-4181",
+                "/private/tmp/claude-502/abc/scratchpad/mcp-probe-scratch-4181",
+            ),
+            project("gone", "/nonexistent/7406/no-such-checkout"),
+            project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+            project("apex", "git@github.com:duetto/apex.git"),
+        ]
+    }
+
+    #[test]
+    fn offerable_drops_the_throwaway_rows_and_keeps_the_rest() {
+        let rows = fixture();
+        let kept: Vec<&str> = rows
+            .iter()
+            .filter(|p| is_offerable_project(p))
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(kept, vec!["trusty-tools", "apex"]);
+    }
+
+    #[test]
+    fn offerable_keeps_url_projects() {
+        assert!(is_offerable_project(&project(
+            "t",
+            "https://github.com/bobmatnyc/trusty-tools"
+        )));
+        // An empty `repo_url` names no directory, so there is nothing to judge.
+        assert!(is_offerable_project(&project("t", "")));
+    }
+
+    #[test]
+    fn offerable_drops_a_temp_scratchpad() {
+        assert!(!is_offerable_checkout(Path::new("/private/tmp/x/y")));
+        assert!(!is_offerable_checkout(Path::new("/tmp/x")));
+        assert!(!is_offerable_checkout(Path::new("/var/folders/ab/cd/T/x")));
+        // A `scratchpad` segment is throwaway wherever it sits.
+        assert!(!is_offerable_checkout(Path::new(
+            "/Users/me/work/scratchpad/probe"
+        )));
+        // The prefix match is by component, not by string.
+        assert!(!under_temp_dir(Path::new("/tmpfoo/bar")));
+    }
+
+    #[test]
+    fn offerable_drops_a_path_that_is_gone() {
+        assert!(!is_offerable_checkout(Path::new(
+            "/nonexistent/7406/no-such-checkout"
+        )));
+    }
+
+    #[test]
+    fn offerable_keeps_a_real_checkout() {
+        // This crate's own source directory is a subdirectory of a checkout
+        // whose `.git` may be a file (a worktree) or a directory.
+        let here = Path::new(env!("CARGO_MANIFEST_DIR"));
+        assert!(in_git_checkout(here), "{here:?} is not in a checkout");
+        assert!(is_offerable_checkout(here), "{here:?} was rejected");
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
@@ -165,7 +165,11 @@ pub(crate) async fn run_session_tui(
             // changed nothing about the fleet, so it owes no re-fetch.
             Action::NewSession => match new_session::fetch_targets(client, url).await {
                 Ok(targets) => {
-                    state.open_new_session(new_session::NewSessionFlow::new(targets));
+                    // #7406: open on the project of the row the cursor is on.
+                    let cursor = sessions.get(state.selected());
+                    state.open_new_session(
+                        new_session::NewSessionFlow::new(targets).preselected_for(cursor),
+                    );
                     continue;
                 }
                 Err(e) => state.set_message(

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/new_session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/new_session.rs
@@ -21,14 +21,22 @@
 //! over the target list and the typed-path buffer, and [`perform_with`] is the
 //! driver that orders register-then-create.
 //!
+//! #7406 polished that choosing without touching either leg: the overlay opens
+//! on the cursor session's project ([`preselect_index`]), each row reads
+//! `owner/repo` rather than the stored URL or path ([`row_labels`]), and a
+//! registration nobody can work in is dropped by
+//! [`is_offerable_project`](crate::commands::projects::offerable::is_offerable_project).
+//!
 //! Test: `new_session_*` in `super::tests`.
 
 use std::future::Future;
 use std::path::Path;
 
 use anyhow::Context as _;
-use trusty_mpm::client::DaemonClient;
+use trusty_common::github_path::parse_remote_url;
+use trusty_mpm::client::{DaemonClient, ManagedSessionSummary};
 use trusty_mpm::project::Project;
+use trusty_mpm::project::record::repo_url_matches;
 
 use crate::commands::picker_launch_new::LaunchIsolation;
 use crate::commands::projects::registry::RegisterInput;
@@ -180,6 +188,19 @@ impl NewSessionFlow {
         }
     }
 
+    /// Highlight the project the list cursor was already on (#7406).
+    ///
+    /// Why: the operator opened this overlay from a row, and the project of
+    /// that row is overwhelmingly the project they want another session in.
+    /// Starting on row 0 instead made them scroll past it every time.
+    /// What: moves the highlight to [`preselect_index`]'s answer for `session`,
+    /// which falls back to the first row when nothing matches.
+    /// Test: `new_session_preselects_the_cursor_sessions_project`.
+    pub(crate) fn preselected_for(mut self, session: Option<&ManagedSessionSummary>) -> Self {
+        self.selected = preselect_index(&self.targets, session);
+        self
+    }
+
     /// The free-text buffer, while the path entry is open.
     pub(crate) fn typed(&self) -> Option<&str> {
         self.typed.as_deref()
@@ -191,21 +212,20 @@ impl NewSessionFlow {
     /// overlay taller than the terminal. The window scrolls only once the
     /// selection passes the bottom, so a short registry never moves.
     /// What: the marked rows, in registry order, starting at whichever offset
-    /// keeps the selection on screen.
-    /// Test: `new_session_rows_window_keeps_the_selection_visible`.
+    /// keeps the selection on screen. Each row is [`row_labels`]' short
+    /// `owner/repo` form (#7406), never the stored URL or path.
+    /// Test: `new_session_rows_window_keeps_the_selection_visible`,
+    /// `new_session_rows_show_owner_repo_only`.
     pub(crate) fn rows(&self) -> Vec<String> {
         let start = self.selected.saturating_sub(PICK_ROWS.saturating_sub(1));
-        self.targets
-            .iter()
+        row_labels(&self.targets)
+            .into_iter()
             .enumerate()
             .skip(start)
             .take(PICK_ROWS)
-            .map(|(i, t)| {
+            .map(|(i, label)| {
                 let marker = if i == self.selected { "▸" } else { " " };
-                match t {
-                    Target::Registered { name, repo } => format!("{marker} {name}  {repo}"),
-                    Target::Other => format!("{marker} other — type a project path…"),
-                }
+                format!("{marker} {label}")
             })
             .collect()
     }
@@ -372,15 +392,158 @@ pub(crate) async fn fetch_targets(
 }
 
 /// Pure half of [`fetch_targets`]: registry rows → targets, escape hatch last.
+///
+/// #7406: a row the operator must never be offered — a temp-directory or
+/// scratchpad registration, a path that is gone, a directory that is not a
+/// checkout — is dropped here, through the shared
+/// [`is_offerable_project`](crate::commands::projects::offerable::is_offerable_project)
+/// predicate.
+/// Test: `new_session_targets_from_drops_a_scratchpad_registration`.
 pub(crate) fn targets_from(projects: &[Project]) -> Vec<Target> {
     projects
         .iter()
+        .filter(|p| crate::commands::projects::offerable::is_offerable_project(p))
         .map(|p| Target::Registered {
             name: p.name.clone(),
             repo: p.repo_url.clone(),
         })
         .chain(std::iter::once(Target::Other))
         .collect()
+}
+
+/// One display label per target — `owner/repo`, never a URL or a path (#7406).
+///
+/// Why: the owner's screen showed a stored `repo_url` verbatim, which is either
+/// a full `https://github.com/owner/repo` or an absolute checkout path. Both are
+/// wider than the overlay, so the row wrapped and the list stopped being
+/// scannable. `owner/repo` is the identity, and everything else was noise.
+/// What: a parseable git remote becomes `owner/repo`, widened to
+/// `host/owner/repo` ONLY when another row on a different host spells the same
+/// `owner/repo`. An absolute path becomes `<basename> (local)`, as does a row
+/// with no `repo_url` at all. Anything else falls back to the registry name.
+/// Test: `new_session_rows_show_owner_repo_only`,
+/// `new_session_labels_disambiguate_by_host`.
+pub(crate) fn row_labels(targets: &[Target]) -> Vec<String> {
+    let labels: Vec<Option<Label>> = targets
+        .iter()
+        .map(|t| match t {
+            Target::Registered { name, repo } => Some(label_for(name, repo)),
+            Target::Other => None,
+        })
+        .collect();
+    labels
+        .iter()
+        .map(|label| match label {
+            Some(Label::Remote { host, owner, repo }) => {
+                if collides_across_hosts(&labels, host, owner, repo) {
+                    format!("{host}/{owner}/{repo}")
+                } else {
+                    format!("{owner}/{repo}")
+                }
+            }
+            Some(Label::Local(base)) => format!("{base} (local)"),
+            Some(Label::Plain(name)) => name.clone(),
+            None => "other — type a project path…".to_string(),
+        })
+        .collect()
+}
+
+/// What one registry row reduces to before the host is decided.
+enum Label {
+    /// A git remote: owner and repo as the remote spells them, plus its host.
+    Remote {
+        /// Remote host, kept only for the disambiguating form.
+        host: String,
+        /// Repository owner.
+        owner: String,
+        /// Repository name.
+        repo: String,
+    },
+    /// A checkout that exists only on this host; the directory's basename.
+    Local(String),
+    /// Neither a remote nor a path — the registry name is all there is.
+    Plain(String),
+}
+
+/// Reduce one registry row to its [`Label`].
+fn label_for(name: &str, repo: &str) -> Label {
+    if let Ok(remote) = parse_remote_url(repo) {
+        return Label::Remote {
+            host: remote.host,
+            owner: remote.owner,
+            repo: remote.repo,
+        };
+    }
+    let trimmed = repo.trim();
+    if trimmed.is_empty() {
+        return Label::Local(name.to_string());
+    }
+    if trimmed.starts_with('/') {
+        let base = Path::new(trimmed)
+            .file_name()
+            .map(|b| b.to_string_lossy().to_string())
+            .unwrap_or_else(|| name.to_string());
+        return Label::Local(base);
+    }
+    Label::Plain(name.to_string())
+}
+
+/// True when another row spells this `owner/repo` on a DIFFERENT host.
+///
+/// The host is width the row can rarely afford, so it is added only when
+/// leaving it out would make two rows read identically.
+fn collides_across_hosts(labels: &[Option<Label>], host: &str, owner: &str, repo: &str) -> bool {
+    labels.iter().flatten().any(|l| {
+        matches!(
+            l,
+            Label::Remote {
+                host: h,
+                owner: o,
+                repo: r,
+            } if o.eq_ignore_ascii_case(owner)
+                && r.eq_ignore_ascii_case(repo)
+                && !h.eq_ignore_ascii_case(host)
+        )
+    })
+}
+
+/// Which target row the overlay should open on, given the list cursor (#7406).
+///
+/// Why: "start where I already am" is the whole of the owner's first
+/// requirement, and the session under the cursor is the only thing that says
+/// where that is.
+/// What: the first target whose repo is the cursor session's — matched through
+/// [`repo_url_matches`], so an `https` row and an `ssh` session agree, and
+/// failing that against the session's `owner/repo` `source_id`. Falls back to
+/// row 0 when there is no cursor session, or its project is not in the list.
+/// Test: `new_session_preselects_the_cursor_sessions_project`,
+/// `new_session_preselect_falls_back_to_the_first_row`.
+pub(crate) fn preselect_index(
+    targets: &[Target],
+    session: Option<&ManagedSessionSummary>,
+) -> usize {
+    let Some(session) = session else { return 0 };
+    targets
+        .iter()
+        .position(|t| is_session_project(t, session))
+        .unwrap_or(0)
+}
+
+/// True when `target` is the project `session` runs in.
+fn is_session_project(target: &Target, session: &ManagedSessionSummary) -> bool {
+    let Target::Registered { repo, .. } = target else {
+        return false;
+    };
+    if let Some(url) = session.repo_url.as_deref()
+        && !url.trim().is_empty()
+        && repo_url_matches(url, repo)
+    {
+        return true;
+    }
+    let Some(source) = session.source_id.as_deref() else {
+        return false;
+    };
+    parse_remote_url(repo).is_ok_and(|r| r.owner_repo().eq_ignore_ascii_case(source.trim()))
 }
 
 /// Perform a confirmed request against the real daemon.

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/render.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/render.rs
@@ -90,7 +90,12 @@ pub(crate) fn render(frame: &mut Frame, sessions: &[ManagedSessionSummary], stat
             overlay(frame, area, "rename", rename_body(was, typed));
         }
         // #7395: the create flow — a project list, then optionally a path.
-        Mode::New(flow) => overlay(frame, area, "new session", new_session_body(flow)),
+        // #7406: built to the popup's INNER width (its rect less the two
+        // border columns), so no project row can wrap.
+        Mode::New(flow) => {
+            let inner = overlay_rect(area).width.saturating_sub(2) as usize;
+            overlay(frame, area, "new session", new_session_body(flow, inner));
+        }
     }
 }
 
@@ -211,6 +216,24 @@ fn row(columns: &[Column], session: &ManagedSessionSummary, selected: bool) -> R
 /// the parent, which is what keeps a 20x5 terminal from panicking), `Clear`ed
 /// then filled with a bordered paragraph.
 fn overlay(frame: &mut Frame, area: Rect, title: &str, body: Vec<Line<'static>>) {
+    let popup = overlay_rect(area);
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(body).wrap(Wrap { trim: false }).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" {title} ")),
+        ),
+        popup,
+    );
+}
+
+/// The centered modal's rect: 60% of the height, 80% of the width.
+///
+/// #7406: split out of [`overlay`] so a body can be built to the width it will
+/// actually be drawn at. Percentages cannot fall outside the parent, which is
+/// what keeps a 20x5 terminal from panicking.
+fn overlay_rect(area: Rect) -> Rect {
     let [_, middle, _] = Layout::vertical([
         Constraint::Percentage(20),
         Constraint::Percentage(60),
@@ -223,15 +246,27 @@ fn overlay(frame: &mut Frame, area: Rect, title: &str, body: Vec<Line<'static>>)
         Constraint::Percentage(10),
     ])
     .areas(middle);
-    frame.render_widget(Clear, popup);
-    frame.render_widget(
-        Paragraph::new(body).wrap(Wrap { trim: false }).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(format!(" {title} ")),
-        ),
-        popup,
-    );
+    popup
+}
+
+/// Text of `text` that fits `width` columns, ending in `…` when it was cut.
+///
+/// Why (#7406): the overlay wraps, so one row wider than the pane becomes two
+/// rows and the list stops lining up. Cutting is the lesser loss — the head of
+/// an `owner/repo` is what identifies it.
+/// What: counts CHARACTERS, not bytes, so a multi-byte name is never split
+/// mid-codepoint. A width under two leaves nothing to say and returns empty.
+/// Test: `render_new_session_overlay_truncates_a_long_row`.
+fn fit(text: &str, width: usize) -> String {
+    if text.chars().count() <= width {
+        return text.to_string();
+    }
+    if width < 2 {
+        return String::new();
+    }
+    let mut cut: String = text.chars().take(width - 1).collect();
+    cut.push('…');
+    cut
 }
 
 /// The delete confirmation's text — the word required, and what typing it does.
@@ -271,11 +306,13 @@ fn rename_body(was: &str, typed: &str) -> Vec<Line<'static>> {
 /// readable branch, and makes the free-text entry look exactly like the rename
 /// overlay's — the operator has already learned that shape.
 /// What: the picker step lists the windowed targets from
-/// [`super::new_session::NewSessionFlow::rows`]; the path step draws the typed
-/// buffer with the same cursor block. Both name Esc as the way out.
+/// [`super::new_session::NewSessionFlow::rows`], each cut to `width` (#7406);
+/// the path step draws the typed buffer with the same cursor block. Both name
+/// Esc as the way out.
 /// Test: `render_new_session_overlay_lists_the_registered_projects`,
-/// `render_new_session_overlay_shows_the_typed_path`.
-fn new_session_body(flow: &super::new_session::NewSessionFlow) -> Vec<Line<'static>> {
+/// `render_new_session_overlay_shows_the_typed_path`,
+/// `render_new_session_overlay_truncates_a_long_row`.
+fn new_session_body(flow: &super::new_session::NewSessionFlow, width: usize) -> Vec<Line<'static>> {
     if let Some(typed) = flow.typed() {
         return vec![
             Line::from("Path to a git checkout tm has not registered yet:"),
@@ -288,7 +325,7 @@ fn new_session_body(flow: &super::new_session::NewSessionFlow) -> Vec<Line<'stat
         Line::from("Start a new session in:"),
         Line::from(String::new()),
     ];
-    lines.extend(flow.rows().into_iter().map(Line::from));
+    lines.extend(flow.rows().iter().map(|r| Line::from(fit(r, width))));
     lines.push(Line::from(String::new()));
     lines.push(Line::from("Enter confirms, Esc cancels."));
     lines

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/tests.rs
@@ -1373,10 +1373,9 @@ fn render_new_session_overlay_lists_the_registered_projects() {
     let mut state = creating();
     let joined = draw(110, 30, &sessions, &mut state).join("\n");
     assert!(joined.contains("Start a new session in:"), "{joined}");
-    assert!(
-        joined.contains("https://github.com/duetto/apex"),
-        "{joined}"
-    );
+    // #7406: the row is the project's identity, not its stored URL.
+    assert!(joined.contains("duetto/apex"), "{joined}");
+    assert!(!joined.contains("https://"), "{joined}");
     assert!(joined.contains("other — type a project path"), "{joined}");
     assert!(joined.contains("Esc cancels"), "{joined}");
 }
@@ -1417,4 +1416,208 @@ fn render_footer_offers_the_new_session_key() {
     state.apply(Input::Char('?'), &sessions);
     let joined = draw(110, 30, &sessions, &mut state).join("\n");
     assert!(joined.contains("new session"), "{joined}");
+}
+
+// ── new-session picker polish (#7406) ───────────────────────────────────────
+
+/// The overlay's own rows, unwrapped from the border columns around them.
+fn overlay_rows(screen: &[String]) -> Vec<String> {
+    screen
+        .iter()
+        .filter_map(|line| {
+            let mut parts = line.split('│');
+            parts.next()?;
+            Some(parts.next()?.trim_end().to_string())
+        })
+        .collect()
+}
+
+/// A registered row built straight, bypassing the offerable filter.
+fn target(name: &str, repo: &str) -> Target {
+    Target::Registered {
+        name: name.to_string(),
+        repo: repo.to_string(),
+    }
+}
+
+/// A session whose project is the THIRD registered row.
+fn three_projects() -> Vec<Target> {
+    new_session::targets_from(&[
+        project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+        project("apex", "https://github.com/duetto/apex"),
+        project("widgets", "https://github.com/acme/widgets"),
+    ])
+}
+
+/// The overlay opens on the project of the row the cursor was on.
+///
+/// Why (#7406 requirement 1): opening on row 0 made the operator scroll past
+/// the project they were already looking at on every create. The fixture puts
+/// that project THIRD, so an implementation that keeps the old behaviour — or
+/// that matches on the first row by accident — fails here.
+#[test]
+fn new_session_preselects_the_cursor_sessions_project() {
+    let targets = three_projects();
+    // The session spells the remote differently from the registry row; the
+    // shared `repo_url_matches` is what makes the two agree.
+    let mut cursor = session("w1", "Active", 1);
+    cursor.repo_url = Some("git@github.com:acme/widgets.git".to_string());
+    assert_eq!(new_session::preselect_index(&targets, Some(&cursor)), 2);
+
+    let flow = NewSessionFlow::with_resolver(targets.clone(), stub_identity)
+        .preselected_for(Some(&cursor));
+    let rows = flow.rows();
+    assert_eq!(rows[2], "▸ acme/widgets", "{rows:?}");
+    assert!(!rows[0].starts_with('▸'), "{rows:?}");
+
+    // A session with no `repo_url` is matched on its `owner/repo` source id.
+    let mut by_source = session("a1", "Active", 2);
+    by_source.source_id = Some("duetto/apex".to_string());
+    assert_eq!(new_session::preselect_index(&targets, Some(&by_source)), 1);
+}
+
+#[test]
+fn new_session_preselect_falls_back_to_the_first_row() {
+    let targets = three_projects();
+    // No cursor session at all.
+    assert_eq!(new_session::preselect_index(&targets, None), 0);
+    // A cursor session whose project is not registered.
+    let mut stranger = session("s1", "Active", 1);
+    stranger.repo_url = Some("https://github.com/other/thing".to_string());
+    assert_eq!(new_session::preselect_index(&targets, Some(&stranger)), 0);
+    // A cursor session that names no project at all.
+    let bare = session("b1", "Active", 1);
+    assert_eq!(new_session::preselect_index(&targets, Some(&bare)), 0);
+}
+
+/// Every row is `owner/repo` or `<basename> (local)` — never a URL or a path.
+#[test]
+fn new_session_rows_show_owner_repo_only() {
+    let flow = NewSessionFlow::with_resolver(
+        vec![
+            target(
+                "trusty-tools",
+                "https://github.com/bobmatnyc/trusty-tools.git",
+            ),
+            target("widgets", "/Users/me/code/widgets"),
+            target("nameless", ""),
+            Target::Other,
+        ],
+        stub_identity,
+    );
+    assert_eq!(
+        flow.rows(),
+        vec![
+            "▸ bobmatnyc/trusty-tools".to_string(),
+            "  widgets (local)".to_string(),
+            "  nameless (local)".to_string(),
+            "  other — type a project path…".to_string(),
+        ]
+    );
+}
+
+/// The host appears only when two rows would otherwise read identically.
+#[test]
+fn new_session_labels_disambiguate_by_host() {
+    let labels = new_session::row_labels(&[
+        target("apex", "https://github.com/duetto/apex"),
+        target("apex-gl", "https://gitlab.com/duetto/apex"),
+        target("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+    ]);
+    assert_eq!(
+        labels,
+        vec![
+            "github.com/duetto/apex".to_string(),
+            "gitlab.com/duetto/apex".to_string(),
+            // Unique on its own, so it keeps the short form.
+            "bobmatnyc/trusty-tools".to_string(),
+        ]
+    );
+}
+
+/// A registration nobody can work in never reaches the picker.
+///
+/// Why (#7406 requirement 3): the owner's screen listed a probe registered at a
+/// `/private/tmp/…/scratchpad/…` path. The fixture carries that row, a row
+/// whose path is gone, and two rows that must survive.
+#[test]
+fn new_session_targets_from_drops_a_scratchpad_registration() {
+    let targets = new_session::targets_from(&[
+        project(
+            "mcp-probe-scratch-4181",
+            "/private/tmp/claude-502/abc/scratchpad/mcp-probe-scratch-4181",
+        ),
+        project("gone", "/nonexistent/7406/no-such-checkout"),
+        project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+        project("apex", "https://github.com/duetto/apex"),
+    ]);
+    assert_eq!(
+        targets,
+        vec![
+            target("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+            target("apex", "https://github.com/duetto/apex"),
+            Target::Other,
+        ]
+    );
+}
+
+/// At 80 columns the rows are short, exact, and never wrap.
+///
+/// Why (#7406 requirement 2): the owner's screen wrapped a path onto a second
+/// line, which is what made the list unreadable. Asserting the EXACT row text
+/// at the narrowest supported width is what catches a row that grows back.
+#[test]
+fn render_new_session_rows_at_eighty_columns() {
+    let sessions = fleet();
+    let mut state = browsing();
+    state.open_new_session(NewSessionFlow::with_resolver(
+        vec![
+            target("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+            target("widgets", "/Users/me/code/widgets"),
+            Target::Other,
+        ],
+        stub_identity,
+    ));
+    let screen = draw(80, 24, &sessions, &mut state);
+    let rows = overlay_rows(&screen);
+    // The popup is 80% of 80 columns; its inner width is what a row may use.
+    for row in &rows {
+        assert!(
+            row.chars().count() <= 62,
+            "row over the pane width: {row:?}"
+        );
+    }
+    assert!(
+        rows.contains(&"▸ bobmatnyc/trusty-tools".to_string()),
+        "{rows:?}"
+    );
+    assert!(rows.contains(&"  widgets (local)".to_string()), "{rows:?}");
+    let joined = screen.join("\n");
+    assert!(
+        !joined.contains("https://"),
+        "a full URL reached a row: {joined}"
+    );
+    assert!(
+        !joined.contains("/Users/me/code"),
+        "an absolute path reached a row: {joined}"
+    );
+}
+
+/// A row wider than the pane is cut with `…` rather than wrapped.
+#[test]
+fn render_new_session_overlay_truncates_a_long_row() {
+    let sessions = fleet();
+    let mut state = browsing();
+    let long = format!("https://github.com/{}/{}", "o".repeat(40), "r".repeat(40));
+    state.open_new_session(NewSessionFlow::with_resolver(
+        vec![target("long", &long), Target::Other],
+        stub_identity,
+    ));
+    let screen = draw(80, 24, &sessions, &mut state);
+    let joined = screen.join("\n");
+    assert!(joined.contains('…'), "the long row was not cut: {joined}");
+    assert!(
+        !joined.contains(&"r".repeat(40)),
+        "the long row wrapped instead of being cut: {joined}"
+    );
 }


### PR DESCRIPTION
## Outcome

Refs #7406. The new-session picker preselects the project of the session under the cursor instead of defaulting to the first row.

## Changes

Renders `owner/repo` (or `name (local)`) instead of raw URLs, fits the overlay to the terminal width, and filters temp, scratchpad, missing and non-git registrations through the new `is_offerable_project` in `commands/projects/offerable.rs`. `tm project list` stays unfiltered so an operator can still see and delete a bad row. Out of scope: no change to project registration itself.

## Risk

Low — confined to `trusty-mpm`'s `tm` bin, session_tui and projects commands. No change to daemon, IPC, or persisted state shapes.

## Tests

Rung 3. `cargo fmt --check`, `cargo check -p trusty-mpm --bin tm`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` all exit 0; 57 targets, 0 failed (lib 6646 passed / 8 ignored; bin tm 2635 passed / 1 ignored). 7 new session_tui tests plus 5 offerable tests, including an exact 80x24 render fixture.

## Baseline

No pre-existing red on this crate. `scripts/check_rustdoc_links.sh` initially failed on the pre-rebase head with an unrelated dangling `git_output_file` doc link already fixed on `origin/main` by #7408; rebasing onto `origin/main` picked up that fix and the gate now passes clean (26 crates examined, 0 broken links, baseline 0).

## Docs

Line cap 0 violations, test pointers 0 dangling, sld 0 errors, changelog fragment recorded at `crates/trusty-mpm/changelog.d/7406-new-session-picker-polish.md`, pr-version-bump clear, rustdoc links 0 broken.

## Review

No review findings yet raised against this PR.

Refs #7406

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
