### PR TITLE
fix(trusty-mpm): claim stranded instruction-compression savings rows at the next hook (Refs #7411)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7411-claim-stranded-savings-rows.md
+++ b/crates/trusty-mpm/changelog.d/7411-claim-stranded-savings-rows.md
@@ -1,0 +1,11 @@
+Fixed
+
+- A staged instruction-compression savings row is no longer stranded when the
+  hook resolves a different session scope than the compile did. `tm hook` now
+  sweeps `~/.trusty-mpm/usage/pending-savings/` instead of probing the one file
+  name it could rebuild: every row whose compiled prompt still exists is claimed
+  and appended to the ledger, and only a row whose compiled prompt is gone is
+  discarded — after 12 hours, with its measurement logged. A hook that finds
+  nothing staged re-measures the fold from the compiled prompt on disk, so the
+  `💸` statusline segment is no longer blank for a session whose row was never
+  staged (#7411).

--- a/crates/trusty-mpm/src/core/savings.rs
+++ b/crates/trusty-mpm/src/core/savings.rs
@@ -335,6 +335,27 @@ pub fn fold_session(ledger: &Path, session_id: &str) -> SavingsTotal {
     fold(ledger, Some(session_id))
 }
 
+/// Does the ledger already hold an accepted `technique` row for `session_id`?
+///
+/// Why (#7411): the hook re-derives an instruction-compression row from the
+/// compiled prompt when nothing was staged for the session, and a Claude
+/// session raises `SessionStart` more than once — a resume and a compact each
+/// raise it again. Without a "this session already has one" read, every one of
+/// those would append a second copy of the same measurement and double the
+/// `💸` figure. [`fold_session`] cannot answer it: it sums across every
+/// technique, so a session that had only a `divert` row would read as already
+/// covered.
+/// What: scans the accepted rows for `session_id` and reports whether any
+/// carries `technique`. A missing or unreadable ledger reads as `false`.
+/// Test: `has_row_sees_only_the_named_technique`.
+pub fn has_row(ledger: &Path, session_id: &str, technique: &str) -> bool {
+    let mut found = false;
+    for_each_accepted_row(ledger, Some(session_id), |row| {
+        found |= row.technique == technique;
+    });
+    found
+}
+
 /// Fold every accepted row, whatever session wrote it.
 ///
 /// Why: a machine-wide figure is what a future `tm usage`/console surface wants,

--- a/crates/trusty-mpm/src/core/savings_instructions.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions.rs
@@ -161,6 +161,48 @@ fn record_instruction_compression_to(
     }
 }
 
+/// Re-measure the fold from a compiled prompt already on disk and append the
+/// row under a known Claude session id.
+///
+/// Why (#7411): staging is the only way this producer's row reaches the ledger
+/// for a normal launch, so a staged file that is lost — an unwritable
+/// `pending-savings/`, a compile whose row was discarded, a `tm` upgraded
+/// between the compile and the hook — leaves the session with no row at all and
+/// the `💸` segment blank for the rest of it. The compiled prompt itself
+/// survives on disk, and it is the same input the producer measured, so the
+/// hook can redo the measurement instead of inventing a second staging
+/// mechanism to protect the first.
+/// What: reads `compiled_prompt`, then runs the ordinary producer against it
+/// with `claude_session_id` supplied, which makes it append rather than stage.
+/// Reports whether a row landed, read back off the ledger — the producer
+/// declines silently for an unpriceable model or a prompt that folded nothing,
+/// and a caller must not report those as a row. Callers guard against the
+/// double-append themselves with [`crate::core::savings::has_row`].
+/// Test: `rederiving_from_the_compiled_prompt_appends_under_the_session_id`,
+/// `rederiving_a_prompt_that_folds_nothing_appends_nothing`.
+pub(crate) fn rederive_from_compiled_prompt(
+    framework_root: &Path,
+    compiled_prompt: &Path,
+    claude_session_id: &str,
+) -> bool {
+    let Ok(prompt) = std::fs::read_to_string(compiled_prompt) else {
+        return false;
+    };
+    let ledger = savings_log_in(framework_root);
+    record_instruction_compression_to(
+        framework_root,
+        compiled_prompt,
+        &prompt,
+        Some(claude_session_id.to_string()),
+        resolve_pm_price,
+    );
+    crate::core::savings::has_row(
+        &ledger,
+        claude_session_id,
+        TECHNIQUE_INSTRUCTION_COMPRESSION,
+    )
+}
+
 /// Split `<harness-root>/.trusty-mpm/sessions/<id>/INSTRUCTIONS-COMPILED.md`
 /// into its session id and its harness root.
 ///

--- a/crates/trusty-mpm/src/core/savings_instructions_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions_tests.rs
@@ -349,6 +349,55 @@ fn a_prompt_that_folds_nothing_warns_once_and_writes_no_row() {
     );
 }
 
+/// Why (#7411): staging is the producer's only route to the ledger for a normal
+/// launch, so a staged row that was never written leaves the session with a
+/// blank `💸` segment for its whole life. The compiled prompt on disk is the
+/// same input the producer measured, so the hook can redo the measurement
+/// rather than depend on a file that may not be there.
+/// Test: itself.
+#[test]
+fn rederiving_from_the_compiled_prompt_appends_under_the_session_id() {
+    let project = tempfile::tempdir().expect("temp project");
+    let framework_root = tempfile::tempdir().expect("temp framework root");
+    let dest = compiled_prompt_dest(project.path(), "local");
+    std::fs::write(&dest, "tiny").expect("compiled prompt");
+    let ledger = crate::core::savings::savings_log_in(framework_root.path());
+
+    assert!(
+        rederive_from_compiled_prompt(framework_root.path(), &dest, "c1"),
+        "the compiled prompt on disk must be enough to produce the row"
+    );
+    let folded = crate::core::savings::fold_session(&ledger, "c1");
+    assert!(
+        !folded.is_zero(),
+        "the re-derived row must fold under the Claude session id: {folded:?}"
+    );
+    assert!(
+        !crate::core::savings_sidecar::pending_row_path_in(framework_root.path(), &dest).exists(),
+        "a re-derivation appends; it must never stage a second copy"
+    );
+}
+
+/// Why (#7411): the re-derivation runs the ordinary producer, so it inherits the
+/// decline for a project that folds nothing. Reporting a row there would put a
+/// fabricated figure on the status bar.
+/// Test: itself.
+#[test]
+fn rederiving_a_prompt_that_folds_nothing_appends_nothing() {
+    let project = tempfile::tempdir().expect("temp project");
+    let framework_root = tempfile::tempdir().expect("temp framework root");
+    let dest = compiled_prompt_dest(project.path(), "local");
+    let bulky = "x".repeat(folded_source_bytes(project.path()) + 1);
+    std::fs::write(&dest, &bulky).expect("compiled prompt");
+    let ledger = crate::core::savings::savings_log_in(framework_root.path());
+
+    assert!(
+        !rederive_from_compiled_prompt(framework_root.path(), &dest, "c1"),
+        "a prompt that folded nothing must report no row"
+    );
+    assert!(crate::core::savings::fold_session(&ledger, "c1").is_zero());
+}
+
 /// Why (#7209): the producers must read one variable name. A rename on one side
 /// only would silently unmatch every row the other writes.
 /// Test: itself.

--- a/crates/trusty-mpm/src/core/savings_sidecar.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar.rs
@@ -42,6 +42,23 @@
 //! machine-wide [`crate::core::savings::fold_all`] — a contribution no
 //! per-session surface could ever have read.
 //!
+//! **Why "in the same scope" was not good enough (#7411).** The compiling
+//! process exports `TM_MANAGED_SESSION_ID`; the hook Claude Code spawns does
+//! not. The two therefore derive different compiled-prompt paths, different
+//! digests, and different staging file names, and the claim — which only ever
+//! tried the one digest the hook could rebuild — matched nothing. Rows sat in
+//! `pending-savings/` indefinitely and the `💸` segment under-reported by
+//! exactly them. Three changes close it:
+//!
+//! - the staged file records the compiled prompt it measures, so a claimer that
+//!   derives a different path can still tell what the file is for;
+//! - [`sweep_pending_rows`] walks the whole directory instead of probing one
+//!   name, claiming every row whose compiled prompt still exists and deleting —
+//!   with the measurement logged — only the ones whose prompt is gone and which
+//!   have passed [`STRANDED_AFTER`];
+//! - a hook that finds nothing staged re-measures the fold from the compiled
+//!   prompt on disk, so the ledger is not left empty for the session.
+//!
 //! Everything here is best-effort, like the producer it serves: an unwritable
 //! directory, an unparseable staged row, or a lost claim each skip silently. A
 //! missing savings row must never cost a session its launch.
@@ -55,14 +72,45 @@
 //! `two_compiled_prompts_stage_to_different_files`,
 //! `the_no_fold_warning_fires_once_per_project`,
 //! `the_no_fold_warning_fires_again_when_the_byte_pair_moves`,
-//! `the_no_fold_warning_is_emitted_at_warn_level`.
+//! `the_no_fold_warning_is_emitted_at_warn_level`,
+//! `a_staged_row_remembers_its_compiled_prompt` — plus the #7411 suite in
+//! `savings_sidecar_sweep_tests.rs`:
+//! `a_stranded_row_for_another_project_is_adopted_rather_than_stranded`,
+//! `a_second_session_start_does_not_append_a_second_rederived_row`,
+//! `the_sweep_claims_a_row_staged_under_another_session_scope`,
+//! `a_hook_with_nothing_staged_rederives_from_the_compiled_prompt`,
+//! `a_stranded_orphan_is_discarded_with_its_measurement_logged`,
+//! `a_fresh_row_for_another_project_is_left_for_its_own_hook`,
+//! `a_row_staged_without_a_path_is_still_claimed_by_digest`,
+//! `two_racing_sweeps_append_exactly_one_row`.
 
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use crate::core::savings::{SavingsRow, append_row};
 
 /// Directory holding staged rows, under the framework root's `usage/`.
 const PENDING_DIR: &str = "pending-savings";
+
+/// How long a staged row whose compiled prompt is gone waits before the next
+/// hook discards it (#7411).
+///
+/// Why: two failure shapes need separating, and only time separates them. A
+/// staged row is normally claimed seconds later — the compile stages it and the
+/// launch it is part of raises `SessionStart` immediately — so anything still
+/// unclaimed after half a day belongs to a launch that never happened, or to a
+/// compiled prompt that has since been deleted. Twelve hours is long enough to
+/// cover a machine suspended mid-launch and an overnight gap between a compile
+/// and the session it was for, and short enough that the ledger does not carry
+/// a growing tail of files nothing will ever attribute. Days would defeat the
+/// point: the whole defect is a file that outlives every hook that could have
+/// claimed it.
+///
+/// It never causes a row to be LOST while its compiled prompt still exists —
+/// such a row is claimed at any age. Age only decides two things: when an
+/// orphan is discarded, and when a row staged for another project's compiled
+/// prompt may be adopted rather than left forever.
+const STRANDED_AFTER: Duration = Duration::from_secs(12 * 60 * 60);
 
 /// Directory holding the per-project "nothing folded" warning markers.
 const NO_FOLD_WARNED_DIR: &str = "no-fold-warned";
@@ -106,6 +154,32 @@ pub fn pending_row_path_in(root: &Path, compiled_prompt: &Path) -> PathBuf {
     keyed_path(root, PENDING_DIR, compiled_prompt, ".json")
 }
 
+/// A staged row plus the compiled prompt it measures (#7411).
+///
+/// Why: the file name is a digest, which is one-way — a sweeping hook can see
+/// that a staged file exists and cannot tell which compiled prompt it belongs
+/// to, whether that prompt still exists, or whether it is this project's. That
+/// is the whole defect: the claim only ever matched a path the hook happened to
+/// reconstruct identically, and a row staged under a managed session scope the
+/// hook process does not export sat unclaimed forever.
+/// What: `#[serde(flatten)]` keeps the on-disk object exactly the row's own
+/// fields plus `compiled_prompt`, so a file staged before this field existed
+/// still parses (the path reads back empty and the sweep falls back to matching
+/// the digest), and a file staged now still deserialises as a bare
+/// [`SavingsRow`] for anything that reads it that way.
+/// Test: `a_staged_row_remembers_its_compiled_prompt`,
+/// `a_row_staged_without_a_path_is_still_claimed_by_digest`.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct StagedRow {
+    /// The compiled prompt whose fold this row measures; empty in a file
+    /// staged before #7411.
+    #[serde(default)]
+    compiled_prompt: String,
+    /// The row itself, inlined as the object's own fields.
+    #[serde(flatten)]
+    row: SavingsRow,
+}
+
 /// Stage `row` for the hook that will learn this session's Claude id.
 ///
 /// Why: see the module header — the compiling process has the measurement and
@@ -123,7 +197,14 @@ pub fn stage_row(root: &Path, compiled_prompt: &Path, row: &SavingsRow) {
     let staged = (|| -> Option<()> {
         let dir = path.parent()?;
         std::fs::create_dir_all(dir).ok()?;
-        let line = serde_json::to_string(row).ok()?;
+        // #7411: record which compiled prompt this measures, so a hook that
+        // reconstructs a different path can still claim it and a sweep can tell
+        // an orphan from a row still waiting for its own launch.
+        let line = serde_json::to_string(&StagedRow {
+            compiled_prompt: compiled_prompt.to_string_lossy().into_owned(),
+            row: row.clone(),
+        })
+        .ok()?;
         let mut tmp = tempfile::NamedTempFile::new_in(dir).ok()?;
         tmp.write_all(line.as_bytes()).ok()?;
         // On failure `PersistError::Drop` removes the temp file.
@@ -185,11 +266,31 @@ pub fn emit_staged_row(
     compiled_prompt: &Path,
     claude_session_id: &str,
 ) -> bool {
+    claim_staged_row(
+        ledger,
+        &pending_row_path_in(root, compiled_prompt),
+        claude_session_id,
+    )
+}
+
+/// Claim the staged row at `path` and append it under `claude_session_id`.
+///
+/// Why (#7411): the claim used to be reachable only through the digest of a
+/// compiled-prompt path the caller had reconstructed, which is exactly the
+/// reconstruction that fails when the hook resolves a different session scope
+/// than the compile did. The sweep needs to claim a file it found by reading
+/// the directory, so the atomic rename lives here — one claim primitive, still
+/// the only writer, so two hooks racing on one staged file still produce one
+/// ledger row.
+/// What: see [`emit_staged_row`], which is this against a digested path.
+/// Test: `two_racing_claims_append_exactly_one_row`,
+/// `a_failed_append_leaves_the_row_staged_for_the_next_hook`.
+fn claim_staged_row(ledger: &Path, path: &Path, claude_session_id: &str) -> bool {
     let session_id = claude_session_id.trim();
     if session_id.is_empty() {
         return false;
     }
-    let path = pending_row_path_in(root, compiled_prompt);
+    let path = path.to_path_buf();
     // #7245: the rename IS the claim. A second hook — or a concurrent one —
     // finds nothing to rename and appends nothing, which is what makes this
     // idempotent, and the claimed file still exists until the append lands.
@@ -210,8 +311,8 @@ pub fn emit_staged_row(
             return false;
         }
     };
-    let mut row: SavingsRow = match serde_json::from_str(&text) {
-        Ok(row) => row,
+    let mut row: SavingsRow = match serde_json::from_str::<StagedRow>(&text) {
+        Ok(staged) => staged.row,
         Err(source) => {
             tracing::warn!(
                 path = %path.display(),
@@ -239,40 +340,242 @@ pub fn emit_staged_row(
     true
 }
 
-/// [`emit_staged_row`] against the ambient framework root, working directory
-/// and managed session scope.
+/// Every compiled prompt that exists under `project_dir`, newest first.
+///
+/// Why (#7411): the hook cannot reconstruct the session scope the compiling
+/// process used. `TM_MANAGED_SESSION_ID` is set for the compile and absent in
+/// the hook Claude Code spawns, so the two derive different paths, different
+/// digests, and different staging file names — which is how a row is staged
+/// that no hook ever claims. Reading the sessions directory answers the same
+/// question without guessing at the scope, and a file found this way is by
+/// construction a compiled prompt that still exists.
+/// What: the `INSTRUCTIONS-COMPILED.md` under each
+/// `<project>/.trusty-mpm/sessions/<scope>/`, ordered by modification time with
+/// the most recent first, so a caller wanting this launch's prompt takes the
+/// head. Empty when the directory is absent.
+/// Test: `the_sweep_claims_a_row_staged_under_another_session_scope`,
+/// `a_hook_with_nothing_staged_rederives_from_the_compiled_prompt`.
+fn compiled_prompts_in(project_dir: &Path) -> Vec<PathBuf> {
+    let sessions = crate::core::harness_root::harness_dir(project_dir)
+        .join(crate::core::harness_root::SESSIONS_DIR);
+    let Ok(entries) = std::fs::read_dir(&sessions) else {
+        return Vec::new();
+    };
+    let mut found: Vec<(SystemTime, PathBuf)> = entries
+        .flatten()
+        .map(|entry| {
+            entry
+                .path()
+                .join(crate::core::instruction_pipeline::COMPILED_PROMPT_FILE)
+        })
+        .filter_map(|path| {
+            let modified = std::fs::metadata(&path).ok()?.modified().ok()?;
+            Some((modified, path))
+        })
+        .collect();
+    found.sort_by(|left, right| right.0.cmp(&left.0));
+    found.into_iter().map(|(_, path)| path).collect()
+}
+
+/// How long ago `path` was last written.
+///
+/// Why: the staging file's own modification time is the moment the compile
+/// staged it, which is the age the sweep's discard bound is measured against.
+/// Reading it rather than the row's `ts` field means an unparseable file — the
+/// one shape with no readable timestamp — still ages out.
+/// What: `None` when the file is gone or the clock ran backwards, which both
+/// read as "not stranded" and leave the file alone.
+/// Test: `a_stranded_orphan_is_discarded_with_its_measurement_logged`.
+fn age_of(path: &Path) -> Option<Duration> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    SystemTime::now().duration_since(modified).ok()
+}
+
+/// The compiled prompt the file staged at `staged` measures, if it still
+/// exists.
+///
+/// Why (#7411): the sweep's three-way decision — claim, leave, discard — turns
+/// entirely on this. A staged row whose prompt exists is live and must never be
+/// dropped; one whose prompt is gone can never be attributed to a session and
+/// is the only thing the sweep is allowed to discard.
+/// What: the path the file recorded, when that file is still there. A file
+/// staged before #7411 records none, so it falls back to the digest match the
+/// pre-#7411 claim used — no row is lost across the upgrade.
+/// Test: `a_row_staged_without_a_path_is_still_claimed_by_digest`,
+/// `a_stranded_orphan_is_discarded_with_its_measurement_logged`.
+fn live_compiled_prompt(
+    root: &Path,
+    staged: &Path,
+    project_prompts: &[PathBuf],
+) -> Option<PathBuf> {
+    let recorded = std::fs::read_to_string(staged)
+        .ok()
+        .and_then(|text| serde_json::from_str::<StagedRow>(&text).ok())
+        .map(|parsed| parsed.compiled_prompt)
+        .filter(|recorded| !recorded.is_empty())
+        .map(PathBuf::from);
+    if let Some(recorded) = recorded {
+        return recorded.is_file().then_some(recorded);
+    }
+    project_prompts
+        .iter()
+        .find(|compiled| pending_row_path_in(root, compiled) == staged)
+        .cloned()
+}
+
+/// Claim, discard, or leave every row staged under `root`, on behalf of
+/// `project_dir`.
+///
+/// Why (#7411): claiming only the one digest the hook could reconstruct left
+/// every other staged row on disk forever, under-reporting the `💸` segment by
+/// exactly the rows it stranded. A sweep reaches them all, and gives each file
+/// one of two terminal outcomes — appended to the ledger, or deleted with its
+/// measurement in the log — so no file can outlive the hooks that could have
+/// resolved it.
+/// What: for each `*.json` under `usage/pending-savings/`, resolves the
+/// compiled prompt it measures and then:
+///
+/// - prompt exists and is this project's → claim it, at any age;
+/// - prompt exists and is another project's → leave it, until it passes
+///   [`STRANDED_AFTER`], after which this hook adopts it rather than let it sit
+///   forever;
+/// - prompt is gone (or the file is unreadable) and it has passed
+///   [`STRANDED_AFTER`] → delete it and log the row's JSON at `warn`;
+/// - otherwise → leave it for a hook that can do better.
+///
+/// Claiming goes through [`claim_staged_row`], so the rename-then-append still
+/// makes two racing sweeps append exactly one row. Returns how many rows
+/// reached the ledger.
+/// Test: `the_sweep_claims_a_row_staged_under_another_session_scope`,
+/// `a_stranded_orphan_is_discarded_with_its_measurement_logged`,
+/// `a_fresh_row_for_another_project_is_left_for_its_own_hook`,
+/// `a_stranded_row_for_another_project_is_adopted_rather_than_stranded`,
+/// `a_row_staged_without_a_path_is_still_claimed_by_digest`,
+/// `two_racing_sweeps_append_exactly_one_row`.
+pub fn sweep_pending_rows(
+    ledger: &Path,
+    root: &Path,
+    project_dir: &Path,
+    claude_session_id: &str,
+) -> usize {
+    let Ok(entries) = std::fs::read_dir(root.join("usage").join(PENDING_DIR)) else {
+        return 0;
+    };
+    let prompts = compiled_prompts_in(project_dir);
+    let harness = crate::core::harness_root::harness_dir(project_dir);
+    let mut appended = 0;
+    for staged in entries.flatten().map(|entry| entry.path()) {
+        // Skip the `.claim-<pid>-<n>` files a concurrent claim is holding.
+        if staged.extension().is_none_or(|ext| ext != "json") {
+            continue;
+        }
+        let stranded = age_of(&staged).is_some_and(|age| age >= STRANDED_AFTER);
+        match live_compiled_prompt(root, &staged, &prompts) {
+            Some(compiled) if compiled.starts_with(&harness) || stranded => {
+                if claim_staged_row(ledger, &staged, claude_session_id) {
+                    appended += 1;
+                }
+            }
+            Some(_) => {}
+            None if stranded => {
+                let row = std::fs::read_to_string(&staged).unwrap_or_default();
+                if std::fs::remove_file(&staged).is_ok() {
+                    tracing::warn!(
+                        path = %staged.display(),
+                        row = %row.trim(),
+                        stranded_hours = STRANDED_AFTER.as_secs() / 3600,
+                        "discarding a staged instruction-compression savings row whose \
+                         compiled prompt no longer exists; no session can be attributed \
+                         it, and this line preserves the measurement"
+                    );
+                }
+            }
+            None => {}
+        }
+    }
+    appended
+}
+
+/// Put an instruction-compression row in the ledger for `claude_session_id`,
+/// from whatever this machine has on disk.
 ///
 /// Why: the `tm hook` handler knows only the Claude session id Claude Code sent
-/// it on stdin. Every other input — which ledger, which project, which session
-/// scope — is ambient, and resolving it here keeps the handler's addition to
+/// it on stdin. Every other input — which ledger, which project, which compiled
+/// prompt — is ambient, and resolving it here keeps the handler's addition to
 /// one call. The framework root is
 /// [`crate::core::paths::FrameworkPaths::default`], the same root the producer
-/// staged under, so the two cannot disagree about where the file is.
-/// What: rebuilds the compiled-prompt path from the session scope
-/// ([`crate::core::harness_root::session_scope`], i.e. `TM_MANAGED_SESSION_ID`
-/// or `local`) and tries it against two project directories — the checkout that
-/// owns this working directory's harness state, then the working directory
-/// itself, which differ when the session runs in a worktree. Returns whether a
-/// row was appended.
-/// Test: `a_staged_row_emits_once_under_the_claude_session_id` covers the
-/// resolved-path form this delegates to; the ambient reads themselves are
+/// staged under, so the two cannot disagree about where the files are.
+/// What: sweeps the staged rows ([`sweep_pending_rows`]) for two project
+/// directories — the checkout that owns this working directory's harness state,
+/// then the working directory itself, which differ when the session runs in a
+/// worktree. When that appends nothing and the ledger holds no
+/// instruction-compression row for this session yet, re-measures the fold from
+/// the newest compiled prompt on disk (#7411), so a session whose staged row
+/// was never written still gets its figure. Returns whether a row was appended.
+/// Test: `the_sweep_claims_a_row_staged_under_another_session_scope` and
+/// `a_hook_with_nothing_staged_rederives_from_the_compiled_prompt` cover the
+/// two resolved-path forms this delegates to; the ambient reads themselves are
 /// exercised by the `tm hook` SessionStart path.
 pub fn emit_staged_row_for_session(claude_session_id: &str) -> bool {
     let root = crate::core::paths::FrameworkPaths::default().root;
-    let ledger = crate::core::savings::savings_log_in(&root);
-    let scope = crate::core::harness_root::session_scope(None);
     let Ok(cwd) = std::env::current_dir() else {
         return false;
     };
-    let owner = crate::core::harness_root::harness_root(&cwd);
-    let mut candidates = vec![owner.clone()];
-    if owner != cwd {
-        candidates.push(cwd);
+    emit_staged_row_for_session_in(&root, &cwd, claude_session_id)
+}
+
+/// [`emit_staged_row_for_session`] against an explicit framework root and
+/// working directory.
+///
+/// Why: the two ambient reads the entry point makes — the framework root under
+/// the operator's home and the process working directory — are the whole reason
+/// the sweep and the re-derivation were untestable in place. Passing them in
+/// keeps every test on a tempdir with no process-env or working-directory
+/// mutation, which parallel test binaries require. Same split as
+/// [`crate::core::harness_root::session_scope_from`] and
+/// `savings_instructions::record_instruction_compression_to`.
+/// What: see [`emit_staged_row_for_session`]; this is its body.
+/// Test: `the_sweep_claims_a_row_staged_under_another_session_scope`,
+/// `a_hook_with_nothing_staged_rederives_from_the_compiled_prompt`,
+/// `a_second_session_start_does_not_append_a_second_rederived_row`.
+pub fn emit_staged_row_for_session_in(root: &Path, cwd: &Path, claude_session_id: &str) -> bool {
+    let session_id = claude_session_id.trim();
+    if session_id.is_empty() {
+        return false;
     }
-    candidates.iter().any(|project_dir| {
-        let compiled = crate::core::instruction_pipeline::compiled_prompt_path(project_dir, &scope);
-        emit_staged_row(&ledger, &root, &compiled, claude_session_id)
-    })
+    let ledger = crate::core::savings::savings_log_in(root);
+    let cwd = cwd.to_path_buf();
+    let owner = crate::core::harness_root::harness_root(&cwd);
+    let mut projects = vec![owner.clone()];
+    if owner != cwd {
+        projects.push(cwd);
+    }
+    let appended: usize = projects
+        .iter()
+        .map(|project| sweep_pending_rows(&ledger, root, project, session_id))
+        .sum();
+    if appended > 0 {
+        return true;
+    }
+    // #7411: nothing was staged for this session, so re-measure the fold from
+    // the compiled prompt this launch is actually running on. Guarded by the
+    // ledger read because a Claude session raises SessionStart again on every
+    // resume and compact.
+    if crate::core::savings::has_row(
+        &ledger,
+        session_id,
+        crate::core::savings::TECHNIQUE_INSTRUCTION_COMPRESSION,
+    ) {
+        return false;
+    }
+    projects
+        .iter()
+        .filter_map(|project| compiled_prompts_in(project).into_iter().next())
+        .any(|compiled| {
+            crate::core::savings_instructions::rederive_from_compiled_prompt(
+                root, &compiled, session_id,
+            )
+        })
 }
 
 /// Where the "nothing folded" warning marker for `project_dir` lives.
@@ -332,3 +635,7 @@ pub fn warn_no_fold_once(
 #[cfg(test)]
 #[path = "savings_sidecar_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "savings_sidecar_sweep_tests.rs"]
+mod sweep_tests;

--- a/crates/trusty-mpm/src/core/savings_sidecar.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar.rs
@@ -373,7 +373,7 @@ fn compiled_prompts_in(project_dir: &Path) -> Vec<PathBuf> {
             Some((modified, path))
         })
         .collect();
-    found.sort_by(|left, right| right.0.cmp(&left.0));
+    found.sort_by_key(|left| std::cmp::Reverse(left.0));
     found.into_iter().map(|(_, path)| path).collect()
 }
 

--- a/crates/trusty-mpm/src/core/savings_sidecar_sweep_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar_sweep_tests.rs
@@ -1,0 +1,345 @@
+//! Tests for the staged-row sweep that stops a savings row being stranded
+//! (#7411).
+//!
+//! Why: #7245's claim only ever probed the one staging file name the hook could
+//! rebuild, and the compiling process and the hook do not agree on that name —
+//! the compile exports `TM_MANAGED_SESSION_ID` and the hook Claude Code spawns
+//! does not, so they derive different session scopes, different compiled-prompt
+//! paths and different digests. Rows sat in `pending-savings/` forever and the
+//! `💸` segment under-reported by exactly them. The properties below are the
+//! ones a probe-one-name implementation gets wrong.
+//! What: drives the sweep and the ambient emit against temp directories, with
+//! no process-environment or working-directory mutation — every input the
+//! production path reads from the ambient is passed in.
+//! Test: this file.
+
+use super::*;
+
+use std::sync::{Arc, Mutex};
+
+/// A row with a known, foldable measurement.
+///
+/// What: `session_id` is the compile-time placeholder the claim replaces.
+fn a_row(session_id: &str) -> SavingsRow {
+    SavingsRow {
+        ts: "2026-09-10T21:08:49Z".to_string(),
+        session_id: session_id.to_string(),
+        technique: crate::core::savings::TECHNIQUE_INSTRUCTION_COMPRESSION.to_string(),
+        tokens_saved: 6_699,
+        tokens_before: 6_702,
+        cost_saved_usd: 0.020_097,
+        basis: "hand-built".to_string(),
+        model_source: crate::core::session_model::MODEL_SOURCE_LAUNCH_CONFIG.to_string(),
+    }
+}
+
+/// A project directory holding a compiled prompt at `scope`, written to disk.
+///
+/// What: returns the compiled prompt's path. The body is deliberately tiny so
+/// the producer's fold measurement comes out positive when a test re-derives.
+fn project_with_compiled_prompt(under: &Path, name: &str, scope: &str) -> PathBuf {
+    let project = under.join(name);
+    let compiled = crate::core::instruction_pipeline::compiled_prompt_path(&project, scope);
+    std::fs::create_dir_all(compiled.parent().expect("session dir")).expect("session dir");
+    std::fs::write(&compiled, "tiny").expect("compiled prompt");
+    compiled
+}
+
+/// How many rows the ledger holds.
+fn rows_in(ledger: &Path) -> usize {
+    std::fs::read_to_string(ledger)
+        .map(|text| text.lines().filter(|line| !line.trim().is_empty()).count())
+        .unwrap_or(0)
+}
+
+/// Move `path`'s modification time `hours` into the past.
+///
+/// Why: the sweep ages a staged file by its mtime, so a test of the discard
+/// bound has to be able to write an old file. Backdating beats waiting.
+fn backdate(path: &Path, hours: u64) {
+    let when = SystemTime::now() - Duration::from_secs(hours * 60 * 60);
+    std::fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("staged file")
+        .set_modified(when)
+        .expect("backdate the staged file");
+}
+
+/// Why (#7411): this is the live defect. The compile stages under the managed
+/// session scope it exports; the hook resolves `local` because Claude Code does
+/// not pass that variable on, probes one name, finds nothing, and the row is
+/// stranded. The hook must claim the row that is actually there.
+/// Test: itself.
+#[test]
+fn the_sweep_claims_a_row_staged_under_another_session_scope() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let compiled = project_with_compiled_prompt(tmp.path(), "project", "managed-7411");
+    let project = tmp.path().join("project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+
+    stage_row(&root, &compiled, &a_row("managed-7411"));
+
+    assert!(
+        emit_staged_row_for_session_in(&root, &project, "claude-1"),
+        "a hook that resolves a different session scope must still claim the staged row"
+    );
+    assert!(
+        !crate::core::savings::fold_session(&ledger, "claude-1").is_zero(),
+        "the statusline fold under the Claude session id must find the row"
+    );
+    assert!(
+        !pending_row_path_in(&root, &compiled).exists(),
+        "a claimed row must not stay staged"
+    );
+
+    assert!(
+        !emit_staged_row_for_session_in(&root, &project, "claude-1"),
+        "a second SessionStart must append nothing"
+    );
+    assert_eq!(rows_in(&ledger), 1, "the row must land exactly once");
+}
+
+/// Why (#7411): staging is the only route this producer has to the ledger, so a
+/// staged file that was never written — an unwritable directory, a `tm`
+/// upgraded between the compile and the hook — left the session with a blank
+/// `💸` segment for its whole life. The compiled prompt is still on disk and is
+/// the same input the producer measured, so the hook can redo the measurement.
+/// Test: itself.
+#[test]
+fn a_hook_with_nothing_staged_rederives_from_the_compiled_prompt() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    project_with_compiled_prompt(tmp.path(), "project", "local");
+    let project = tmp.path().join("project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+
+    assert!(
+        emit_staged_row_for_session_in(&root, &project, "claude-2"),
+        "with nothing staged the hook must re-measure the fold from the compiled prompt"
+    );
+    let folded = crate::core::savings::fold_session(&ledger, "claude-2");
+    assert!(
+        !folded.is_zero(),
+        "the re-derived row must be foldable under the Claude session id: {folded:?}"
+    );
+}
+
+/// Why (#7411): a Claude session raises `SessionStart` again on every resume and
+/// compact. Re-deriving on each one would append the same measurement several
+/// times and inflate the segment.
+/// Test: itself.
+#[test]
+fn a_second_session_start_does_not_append_a_second_rederived_row() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    project_with_compiled_prompt(tmp.path(), "project", "local");
+    let project = tmp.path().join("project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+
+    emit_staged_row_for_session_in(&root, &project, "claude-3");
+    emit_staged_row_for_session_in(&root, &project, "claude-3");
+
+    assert_eq!(
+        rows_in(&ledger),
+        1,
+        "two SessionStart events for one session must leave one row"
+    );
+}
+
+/// Why (#7411): the defect is a file that outlives every hook that could have
+/// resolved it. A row whose compiled prompt is gone can never be attributed to
+/// a session, so leaving it is a permanent leak — it has to go, and the
+/// measurement has to survive somewhere an operator can read.
+/// Test: itself.
+#[test]
+fn a_stranded_orphan_is_discarded_with_its_measurement_logged() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let project = tmp.path().join("project");
+    // Staged for a compiled prompt that does not exist — the shape the two live
+    // rows on the owner's host had.
+    let vanished = project.join(".trusty-mpm/sessions/gone/INSTRUCTIONS-COMPILED.md");
+    let staged = pending_row_path_in(&root, &vanished);
+    let ledger = crate::core::savings::savings_log_in(&root);
+    stage_row(&root, &vanished, &a_row("gone"));
+
+    assert_eq!(
+        sweep_pending_rows(&ledger, &root, &project, "claude-4"),
+        0,
+        "a fresh orphan is not yet the sweep's to judge"
+    );
+    assert!(staged.exists(), "a fresh orphan must be left alone");
+
+    backdate(&staged, 13);
+    let capture = CaptureWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
+        .finish();
+    tracing::subscriber::with_default(subscriber, || {
+        sweep_pending_rows(&ledger, &root, &project, "claude-4");
+    });
+
+    assert!(
+        !staged.exists(),
+        "a stranded orphan must not survive the next hook"
+    );
+    assert_eq!(rows_in(&ledger), 0, "a discarded row is not a ledger row");
+    let logged = String::from_utf8(capture.0.lock().expect("capture lock").clone())
+        .expect("the captured log must be utf-8");
+    assert!(
+        logged.contains("compiled prompt no longer exists"),
+        "the discard must state its reason: {logged}"
+    );
+    assert!(
+        logged.contains("6699"),
+        "the discard must preserve the measurement: {logged}"
+    );
+}
+
+/// Why (#7411): the sweep reads one shared directory, so a hook for project A
+/// sees project B's staged rows. Claiming one while B's own launch is still
+/// coming would attribute B's saving to A's session.
+/// Test: itself.
+#[test]
+fn a_fresh_row_for_another_project_is_left_for_its_own_hook() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let theirs = project_with_compiled_prompt(tmp.path(), "theirs", "local");
+    let ours = tmp.path().join("ours");
+    std::fs::create_dir_all(&ours).expect("our project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+
+    stage_row(&root, &theirs, &a_row("local"));
+
+    assert_eq!(
+        sweep_pending_rows(&ledger, &root, &ours, "claude-5"),
+        0,
+        "another project's fresh row is not ours to claim"
+    );
+    assert!(
+        pending_row_path_in(&root, &theirs).exists(),
+        "it must still be there for its own hook"
+    );
+    assert_eq!(
+        sweep_pending_rows(&ledger, &root, &tmp.path().join("theirs"), "claude-6"),
+        1,
+        "its own project's hook must claim it"
+    );
+}
+
+/// Why (#7411): a row whose project never launches again would otherwise sit
+/// forever behind the ownership check above. Once it has outlived
+/// [`STRANDED_AFTER`] the next hook adopts it — a row attributed to a nearby
+/// session beats a row attributed to none.
+/// Test: itself.
+#[test]
+fn a_stranded_row_for_another_project_is_adopted_rather_than_stranded() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let theirs = project_with_compiled_prompt(tmp.path(), "theirs", "local");
+    let ours = tmp.path().join("ours");
+    std::fs::create_dir_all(&ours).expect("our project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+
+    stage_row(&root, &theirs, &a_row("local"));
+    backdate(&pending_row_path_in(&root, &theirs), 13);
+
+    assert_eq!(
+        sweep_pending_rows(&ledger, &root, &ours, "claude-7"),
+        1,
+        "a row nobody has claimed in half a day must be adopted, not stranded"
+    );
+    assert!(
+        !crate::core::savings::fold_session(&ledger, "claude-7").is_zero(),
+        "the adopted row must reach the ledger"
+    );
+}
+
+/// Why (#7411): rows staged by a `tm` from before this fix record no compiled
+/// prompt, and an upgrade must not strand the very rows it exists to rescue.
+/// Test: itself.
+#[test]
+fn a_row_staged_without_a_path_is_still_claimed_by_digest() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let compiled = project_with_compiled_prompt(tmp.path(), "project", "local");
+    let project = tmp.path().join("project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+
+    // The pre-#7411 on-disk shape: the bare row, no `compiled_prompt` field.
+    let staged = pending_row_path_in(&root, &compiled);
+    std::fs::create_dir_all(staged.parent().expect("pending dir")).expect("pending dir");
+    std::fs::write(
+        &staged,
+        serde_json::to_string(&a_row("local")).expect("serialise"),
+    )
+    .expect("write the pre-#7411 staged row");
+
+    assert_eq!(
+        sweep_pending_rows(&ledger, &root, &project, "claude-8"),
+        1,
+        "a row staged by an older tm must still be claimed"
+    );
+    assert!(!crate::core::savings::fold_session(&ledger, "claude-8").is_zero());
+}
+
+/// Why (#7411): the sweep widened what a hook touches, and two hooks can run at
+/// once — a `SessionStart` and a resume land together often enough. The rename
+/// has to stay the claim, or the widened reach doubles rows instead of
+/// recovering them.
+/// Test: itself.
+#[test]
+fn two_racing_sweeps_append_exactly_one_row() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let compiled = project_with_compiled_prompt(tmp.path(), "project", "local");
+    let project = tmp.path().join("project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+
+    stage_row(&root, &compiled, &a_row("local"));
+
+    let claimed: usize = std::thread::scope(|scope| {
+        let racers: Vec<_> = (0..2)
+            .map(|_| scope.spawn(|| sweep_pending_rows(&ledger, &root, &project, "claude-9")))
+            .collect();
+        racers
+            .into_iter()
+            .map(|racer| racer.join().expect("racer"))
+            .sum()
+    });
+
+    assert_eq!(claimed, 1, "exactly one racer may claim the staged row");
+    assert_eq!(rows_in(&ledger), 1, "the ledger must hold exactly one row");
+}
+
+/// Collects a subscriber's output so a test can read back what was logged.
+///
+/// Why: the discard's contract is that the measurement survives in the log, so
+/// the test has to read the log rather than trust the return value.
+/// What: an `io::Write` over a shared buffer, and the `MakeWriter` that hands it
+/// to `tracing_subscriber::fmt`.
+#[derive(Clone, Default)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}

--- a/crates/trusty-mpm/src/core/savings_sidecar_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar_tests.rs
@@ -232,6 +232,36 @@ fn two_compiled_prompts_stage_to_different_files() {
     );
 }
 
+/// Why (#7411): the staging file's name is a one-way digest, so a hook that
+/// derives a different compiled-prompt path than the compile did cannot tell
+/// what the file is for, whether its prompt still exists, or whose project it
+/// belongs to. That is why rows staged under a managed session scope sat
+/// unclaimed forever. The path has to be IN the file — and the file has to stay
+/// readable as a bare row, so nothing that reads it that way breaks.
+/// Test: itself.
+#[test]
+fn a_staged_row_remembers_its_compiled_prompt() {
+    let root = tempfile::tempdir().expect("temp root");
+    let compiled = root
+        .path()
+        .join("project/.trusty-mpm/sessions/m1/INSTRUCTIONS-COMPILED.md");
+
+    stage_row(root.path(), &compiled, &staged_row("m1"));
+
+    let text = std::fs::read_to_string(pending_row_path_in(root.path(), &compiled))
+        .expect("the staged file must be readable");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&text).expect("the staged file must be one JSON object");
+    assert_eq!(
+        parsed.get("compiled_prompt").and_then(|v| v.as_str()),
+        Some(compiled.to_string_lossy().as_ref()),
+        "the staged row must name the compiled prompt it measures: {text}"
+    );
+    let row: SavingsRow =
+        serde_json::from_str(&text).expect("a staged file must still read back as a bare row");
+    assert_eq!(row.tokens_saved, 600, "the measurement must survive intact");
+}
+
 /// Why (#7245): the decline is permanent for a project that overrides no
 /// instruction section, so a warning on every launch is one an operator stops
 /// reading. It has to be visible once and then quiet.

--- a/crates/trusty-mpm/src/core/savings_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_tests.rs
@@ -382,6 +382,37 @@ fn fold_ignores_other_sessions() {
     assert!(fold_session(&ledger, "sess-c").is_zero());
 }
 
+/// Why (#7411): the hook re-derives an instruction-compression row when nothing
+/// was staged, and guards that on "this session has one already". A guard built
+/// on [`fold_session`] would read a session that has only a `divert` row as
+/// already covered and never write the row the segment is missing.
+/// Test: itself.
+#[test]
+fn has_row_sees_only_the_named_technique() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let ledger = savings_log_in(dir.path());
+    let mut diverted = row("sess-a", 4_000, 0.012);
+    diverted.technique = TECHNIQUE_DIVERT.to_string();
+    append_row(&ledger, &diverted).expect("append");
+
+    assert!(
+        !has_row(&ledger, "sess-a", TECHNIQUE_INSTRUCTION_COMPRESSION),
+        "a divert row must not mask a missing instruction-compression row"
+    );
+    assert!(has_row(&ledger, "sess-a", TECHNIQUE_DIVERT));
+
+    append_row(&ledger, &row("sess-a", 6_000, 0.018)).expect("append");
+    assert!(has_row(
+        &ledger,
+        "sess-a",
+        TECHNIQUE_INSTRUCTION_COMPRESSION
+    ));
+    assert!(
+        !has_row(&ledger, "sess-b", TECHNIQUE_INSTRUCTION_COMPRESSION),
+        "another session's row must not answer for this one"
+    );
+}
+
 /// Why: the machine-wide fold must use the identical skip rules, or a future
 /// `tm usage` surface and the status bar would disagree about a total.
 /// Test: itself.


### PR DESCRIPTION
## Outcome

Refs #7411.

## Changes

The compiling `tm` exports the managed session id and the hook Claude Code spawns does not, so the two derived different session scopes, different compiled-prompt paths and different staging digests; the SessionStart claim probe never matched and staged rows stayed in pending-savings forever. The staged file now records its compiled prompt path; every hook sweeps pending-savings, claims this project's rows, adopts another project's after 12h, and discards a row whose prompt is gone with its measurement logged. A hook with nothing staged re-derives from the compiled prompt on disk, double-append guarded. Two racing sweeps append exactly one row.

## Risk

Low-normal, confined to `trusty-mpm`'s instruction-compression savings pipeline. Rows staged before this change carry no path and are discarded with their measurement logged at the first hook after install; they cannot be recovered as ledger rows.

## Tests

Rung 3. `cargo fmt --check`, `cargo check -p trusty-mpm --all-targets`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` all exit 0; 57 targets, 0 failed (lib 6658 passed / 8 ignored).

## Baseline

Regression tests red pre-fix: `a_staged_row_remembers_its_compiled_prompt` (assertion), plus the sweep suite, which does not compile against origin/main.

## Docs

Line cap 0 violations, test pointers 0 dangling, changelog fragment recorded (`crates/trusty-mpm/changelog.d/7411-claim-stranded-savings-rows.md`), rustdoc links 0 broken.

## Review

Rung 3 gates all green; ready for review.

Refs #7411

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
