### PR TITLE
docs(trusty-agents-common): close five agent-instruction gaps — unbuilt worktrees, cache false-greens, merge from a worktree, control-byte edits (Refs #7118 #7381 #7117 #7104 #7229)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7118-agent-instruction-gaps.md
+++ b/crates/trusty-agents-common/changelog.d/7118-agent-instruction-gaps.md
@@ -1,0 +1,7 @@
+Fixed
+
+- `BASE-ENGINEER.md`'s "Dependency Verification" section now names a fresh or unbuilt monorepo worktree's `Cannot find module '@scope/…'` wall as a missing-build precondition, not a type error (#7118).
+- The same "Dependency Verification" section now states the once-before-first-gate install/build sequence, and that `isolation: "worktree"` provisions no dependencies (#7381).
+- `BASE-AGENT.md`'s silent-skip verification bullet now names the Turborepo/Nx cache-hit false green — a `Cached: N cached` summary with N>0 re-ran nothing — and requires `Cached: 0 cached` or a forced (`--force`) run before trusting test counts (#7117).
+- `version-control.md`'s merge section now covers the worktree/base-branch collision where `gh pr merge --delete-branch` fails post-merge with `fatal: '<branch>' is already used by worktree at <path>`, and gives the `tm pr merge --no-delete-branch` / confirm-then-`gh api -X DELETE` sequence (#7104).
+- `BASE-ENGINEER.md`'s "Escape-Sensitive Edits" byte-exact-verification bullet now applies to every Write/Edit call, not only shell-routed ones, and names the git binary-reclassification failure signature (#7229).

--- a/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-AGENT.md
@@ -338,7 +338,10 @@ Run the code and observe it succeed.
 2. Verify in the target environment where the code will actually run.
 3. Confirm the build is clean before declaring any module complete.
 4. Catch silent skips. "0 tests ran" or "7 ignored" is NOT passing — investigate
-   before declaring done.
+   before declaring done. In a monorepo with a shared Turborepo/Nx-style task
+   cache, a test summary showing cache hits (`Cached: N cached`, N>0) re-ran
+   nothing against the changed code (See #7117). Trust the counts only when
+   the raw output shows `Cached: 0 cached`, or the run was forced (`--force`).
 5. Test the entry point — the binary starts, the CLI runs — not just isolated
    functions.
 

--- a/crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md
@@ -48,8 +48,15 @@ against the file (issue #7121).
   compounds it — one such command turned 20 correct lines into a broken
   triple-`super` form (#7287). Use Edit for this shape: it matches one exact
   string and fails instead of reapplying.
-- After the edit, verify byte-for-byte over the affected region —
-  `od -c <file>` or `xxd` — not just a visual diff.
+- **Verify byte-for-byte after every Write or Edit call, not only a
+  shell-routed one** (See #7229). Check that the file gained no control byte
+  outside tab and newline: `od -c <file>` or `xxd` over the affected region, or
+  `git diff --stat` reporting `Bin` instead of a line count. The failure
+  signature is git reclassifying the text file as binary and `grep` returning
+  nothing against it, silently — which reads like an output-capture bug, not a
+  corrupted file. This does not mean Write or Edit itself refuses control
+  bytes; any such refusal belongs to the Claude Code harness, not this
+  repository.
 
 ## Proving a Regression Test Fails First
 
@@ -149,6 +156,14 @@ verify the build resolves clean.
   unconditional dependencies.
 - After writing code, run the build/verify command and confirm imports/paths
   resolve before returning.
+- **In a fresh or unbuilt worktree of a workspace monorepo, a wall of
+  `Cannot find module '@scope/…'` errors is a missing-build precondition, not
+  a type error** (See #7118, #7381). The harness's `isolation: "worktree"`
+  provisions the checkout only — it installs no dependencies and builds
+  nothing. Run the project's install and workspace-build command once —
+  illustrative pair: `pnpm install --frozen-lockfile`, then `npx turbo run
+  build --filter=<app>^...` — before the first per-package typecheck or gate,
+  not before every gate.
 
 ## No Mock Data or Silent Fallbacks
 

--- a/crates/trusty-agents-common/src/assets/agents/version-control.md
+++ b/crates/trusty-agents-common/src/assets/agents/version-control.md
@@ -126,6 +126,17 @@ branch's raw commit messages (#6808). On a host without `tm`, fall back to
 `gh pr merge --squash --delete-branch --auto`. Never merge on your own
 initiative.
 
+<!-- #7104: gh pr merge --delete-branch collides with a checked-out base branch elsewhere -->
+When the PR's base branch is checked out elsewhere — the main checkout, per
+this project's worktree discipline — `gh pr merge --delete-branch` fails
+post-merge with `fatal: '<branch>' is already used by worktree at <path>`,
+even though the squash already landed. Use `tm pr merge <n> --auto
+--no-delete-branch` (the flag exists:
+`crates/trusty-mpm/src/bin/tm/commands/pr/merge.rs:201-202`), or `gh pr merge
+--squash --auto` with no `--delete-branch`. Confirm `gh pr view <n> --json
+state` reports `MERGED`, then delete the remote branch yourself: `gh api -X
+DELETE repos/<owner>/<repo>/git/refs/heads/<branch>`.
+
 When the PM relays operator authorization to merge directly (e.g. an
 admin-merge), that IS operator authority — comply. Do not demand the user
 confirm it directly or treat the dispatching PM as a third party (see BASE-AGENT
@@ -260,7 +271,9 @@ path refuses and you believe the tree is reclaimable, fall back to the sweep,
 which reports what it spared and why.
 
 `gh pr merge --delete-branch` removes the remote branch at merge time; the local
-branch goes with the prune pass.
+branch goes with the prune pass. From a worktree whose base branch is checked
+out elsewhere, that flag fails post-merge instead (See #7104) — use the
+confirm-then-delete sequence above.
 
 ## Memory Management for Git Operations
 


### PR DESCRIPTION
## Outcome

Refs #7118 #7381 #7117 #7104 #7229. Addresses five agent-instruction gaps found in prior sessions.

## Changes

- BASE-ENGINEER Dependency Verification names the unbuilt-monorepo "Cannot find module" symptom and the install-and-build-once-before-first-gate rule (#7118, #7381).
- BASE-AGENT's silent-skip bullet names the Turborepo/Nx cache-hit false green and `--force` (#7117).
- version-control.md documents the `gh pr merge --delete-branch` worktree collision, `tm pr merge --no-delete-branch`, and confirm-then-delete (#7104).
- BASE-ENGINEER byte-exact bullet now applies to every Write/Edit and names git's binary reclassification (#7229) — instruction half only; Write/Edit refusing control bytes is a Claude Code harness change outside this repo.

## Risk

Low. Doc-only changes to three agent-asset `.md` files under `crates/trusty-agents-common/src/assets/agents/`; no code paths change.

## Tests

Rung 1 doc gates plus the asset crate's own tests, since the `.md` files ship inside it.
- `cargo test -p trusty-agents-common --no-fail-fast`: 573 passed, 0 failed
- `cargo test -p trusty-mpm golden`: 3 ok
- check_changelog_fragment: OK
- check_line_cap: 0 violations
- check_sld: 0 errors
- check_rustdoc_links: 0 broken

## Baseline

No pre-existing red encountered.

## Docs

Changelog fragment added: `crates/trusty-agents-common/changelog.d/7118-agent-instruction-gaps.md`.

## Review

No review findings outstanding.

Refs #7118

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
