### PR TITLE
chore(trusty-mpm): bump to 1.5.28 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11919,7 +11919,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.27"
+version = "1.5.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -41,7 +41,10 @@ name = "trusty-mpm"
 # #7275 #7237 #7325 #7319): patch, version-only — 1.5.23 is already
 # published and this bump exists solely so `tm --version` identifies the
 # reinstalled build (statusline savings percentage format).
-version = "1.5.27"
+# 1.5.28 (owner-authorized reinstall, refs #7418): patch, version-only —
+# 1.5.27 is already published and this bump exists solely so `tm --version`
+# identifies the reinstalled build.
+version = "1.5.28"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome

Bumps trusty-mpm to 1.5.28 for an owner-authorized reinstall so `tm --version` identifies the build.

## Changes

- `crates/trusty-mpm/Cargo.toml`: version bump 1.5.27 -> 1.5.28
- `Cargo.lock`: matching version update

## Risk

Low — version-only change, no source edits.

## Tests

Not applicable — no source changed.

## Baseline

- `bash scripts/check_workspace_dep_versions.sh`: OK (requirement 1.0.0 accepts 1.5.28)
- `bash scripts/check_changelog_fragment.sh --staged`: OK (no crate source changed)
- `bash scripts/check-pr-version-bump.sh`: OK

## Docs

Not applicable — no doc-bearing source changed.

## Review

Owner-authorized reinstall 2026-09-11 ("reinstall tm and close out the verified ones"). Includes everything merged through #7418.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01XQqfNN77rPGpfiLFmSEAbb
