### PR TITLE
fix(trusty-mpm): tm ls new-session picker sorts live-session projects first, shows scroll position, filters by typing (Refs #7421)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7421-picker-ordering-filter.md
+++ b/crates/trusty-mpm/changelog.d/7421-picker-ordering-filter.md
@@ -1,0 +1,3 @@
+Fixed
+
+- The `tm ls` new-session picker (`n`) no longer lists registered projects in the registry's `HashMap` iteration order, which varied run to run and could push the projects you have sessions in below the eight-row window. Projects with a managed session come first — best session state first, most recently active within that — and the rest follow alphabetically by their `owner/repo` label. The overlay now says where the window sits (`3–10 of 27`), and typing narrows the rows by case-insensitive substring on that label; Backspace edits the filter and Esc clears it before it cancels the flow. Arrow keys move the highlight, since `j`/`k` now type into the filter (#7421).

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_order.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_order.rs
@@ -154,7 +154,9 @@ pub(crate) fn prepare_menu(sessions: Vec<ManagedSessionSummary>, scope: &PickerS
 /// other state. Lower sorts first.
 /// Test: `sort_sessions_recent_groups_attached_before_active_before_stopped`,
 /// `sort_sessions_alpha_groups_attached_before_active_before_stopped`.
-fn group_rank(s: &ManagedSessionSummary) -> u8 {
+// #7421: also ranks a PROJECT for the `tm ls` new-session picker, through
+// `session_tui::new_session_order`, so both surfaces share one precedence.
+pub(crate) fn group_rank(s: &ManagedSessionSummary) -> u8 {
     if s.attached {
         0
     } else if s.state == "active" {
@@ -211,7 +213,9 @@ pub(crate) fn sort_sessions(sessions: &mut [ManagedSessionSummary], sort: Sessio
 /// form.
 /// Test: covered indirectly by `sort_sessions_recent_orders_by_last_activity`
 /// and `sort_sessions_recent_falls_back_to_created_at`.
-fn recency_key(s: &ManagedSessionSummary) -> &str {
+// #7421: shared with `session_tui::new_session_order`, which ranks a project by
+// the newest key among its sessions.
+pub(crate) fn recency_key(s: &ManagedSessionSummary) -> &str {
     s.last_activity_at
         .as_deref()
         .or(s.created_at.as_deref())

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui.rs
@@ -50,6 +50,7 @@
 
 pub(crate) mod layout;
 pub(crate) mod new_session;
+pub(crate) mod new_session_order;
 pub(crate) mod render;
 pub(crate) mod state;
 
@@ -163,7 +164,9 @@ pub(crate) async fn run_session_tui(
             // #7395: read the project registry, then open the create flow over
             // it. `continue` rather than falling through — opening an overlay
             // changed nothing about the fleet, so it owes no re-fetch.
-            Action::NewSession => match new_session::fetch_targets(client, url).await {
+            // #7421: the session list this loop already holds is what orders
+            // the picker's rows, so no second daemon read is made for it.
+            Action::NewSession => match new_session::fetch_targets(client, url, &sessions).await {
                 Ok(targets) => {
                     // #7406: open on the project of the row the cursor is on.
                     let cursor = sessions.get(state.selected());

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/new_session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/new_session.rs
@@ -27,6 +27,12 @@
 //! registration nobody can work in is dropped by
 //! [`is_offerable_project`](crate::commands::projects::offerable::is_offerable_project).
 //!
+//! #7421 made the choosing usable past eight registrations: the rows come in a
+//! deterministic order ([`super::new_session_order::ordered_targets`]), the
+//! overlay says where in the list the window sits
+//! ([`NewSessionFlow::position`]), and typing narrows it
+//! ([`NewSessionFlow::filter`]).
+//!
 //! Test: `new_session_*` in `super::tests`.
 
 use std::future::Future;
@@ -153,6 +159,8 @@ pub(crate) struct NewSessionFlow {
     targets: Vec<Target>,
     selected: usize,
     typed: Option<String>,
+    /// #7421: the substring the operator has typed to narrow the rows.
+    filter: String,
     resolve: Resolver,
 }
 
@@ -167,6 +175,7 @@ impl PartialEq for NewSessionFlow {
         self.targets == other.targets
             && self.selected == other.selected
             && self.typed == other.typed
+            && self.filter == other.filter
     }
 }
 
@@ -184,6 +193,7 @@ impl NewSessionFlow {
             targets,
             selected: 0,
             typed: None,
+            filter: String::new(),
             resolve,
         }
     }
@@ -206,28 +216,92 @@ impl NewSessionFlow {
         self.typed.as_deref()
     }
 
+    /// The substring the operator has typed to narrow the rows (#7421).
+    pub(crate) fn filter(&self) -> &str {
+        &self.filter
+    }
+
+    /// Which targets the current filter shows, as indices into `targets`.
+    ///
+    /// Why (#7421): the filter changes what the operator can move over, so the
+    /// window, the highlight and the position indicator all have to read the
+    /// same answer rather than each deriving one.
+    /// What: every row whose [`row_labels`] label contains the filter, compared
+    /// case-insensitively. [`Target::Other`] always survives — filtering the
+    /// typed-path escape away would leave a non-matching filter with no way
+    /// forward and no way to reach a checkout the registry lacks.
+    /// Test: `new_session_typing_filters_the_rows`.
+    fn visible(&self) -> Vec<usize> {
+        let needle = self.filter.to_lowercase();
+        row_labels(&self.targets)
+            .into_iter()
+            .enumerate()
+            .filter(|(i, label)| {
+                needle.is_empty()
+                    || matches!(self.targets.get(*i), Some(Target::Other))
+                    || label.to_lowercase().contains(&needle)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Where the highlight sits within [`Self::visible`].
+    fn cursor(&self, visible: &[usize]) -> usize {
+        visible
+            .iter()
+            .position(|i| *i == self.selected)
+            .unwrap_or(0)
+    }
+
+    /// First visible row the window draws, given where the highlight is.
+    fn window_start(&self, visible: &[usize]) -> usize {
+        self.cursor(visible)
+            .saturating_sub(PICK_ROWS.saturating_sub(1))
+    }
+
     /// The overlay's visible target rows, at most [`PICK_ROWS`] of them.
     ///
     /// Why: a host with forty registered projects would otherwise draw an
     /// overlay taller than the terminal. The window scrolls only once the
     /// selection passes the bottom, so a short registry never moves.
-    /// What: the marked rows, in registry order, starting at whichever offset
+    /// What: the marked rows, in [`super::new_session_order::ordered_targets`]'
+    /// order and narrowed by the filter (#7421), starting at whichever offset
     /// keeps the selection on screen. Each row is [`row_labels`]' short
     /// `owner/repo` form (#7406), never the stored URL or path.
     /// Test: `new_session_rows_window_keeps_the_selection_visible`,
-    /// `new_session_rows_show_owner_repo_only`.
+    /// `new_session_rows_show_owner_repo_only`, `new_session_typing_filters_the_rows`.
     pub(crate) fn rows(&self) -> Vec<String> {
-        let start = self.selected.saturating_sub(PICK_ROWS.saturating_sub(1));
-        row_labels(&self.targets)
-            .into_iter()
-            .enumerate()
-            .skip(start)
+        let labels = row_labels(&self.targets);
+        let visible = self.visible();
+        visible
+            .iter()
+            .skip(self.window_start(&visible))
             .take(PICK_ROWS)
-            .map(|(i, label)| {
-                let marker = if i == self.selected { "▸" } else { " " };
+            .map(|i| {
+                let marker = if *i == self.selected { "▸" } else { " " };
+                let label = labels.get(*i).map_or("", String::as_str);
                 format!("{marker} {label}")
             })
             .collect()
+    }
+
+    /// Where the window sits in the list, when the list is longer than it
+    /// (#7421).
+    ///
+    /// Why: the owner could not tell that rows existed past the eighth, so a
+    /// project that scrolled out of the window simply looked absent.
+    /// What: `Some("3–10 of 27")` — the one-based span the window draws and the
+    /// filtered row count. `None` when everything fits, because a count that
+    /// never changes is noise.
+    /// Test: `new_session_position_indicator_reports_the_window`.
+    pub(crate) fn position(&self) -> Option<String> {
+        let visible = self.visible();
+        if visible.len() <= PICK_ROWS {
+            return None;
+        }
+        let start = self.window_start(&visible);
+        let end = (start + PICK_ROWS).min(visible.len());
+        Some(format!("{}–{} of {}", start + 1, end, visible.len()))
     }
 
     /// Route one keystroke through whichever step is open.
@@ -236,24 +310,51 @@ impl NewSessionFlow {
     /// matched once, ahead of the per-step handlers, rather than repeated in
     /// each of them where one could be forgotten.
     /// What: the path entry takes over as soon as it is open; before that the
-    /// keys move over the target list.
-    /// Test: `new_session_escape_cancels_from_both_steps`.
+    /// keys move over the target list. #7421 gives Esc one job first — a
+    /// non-empty filter is cleared, and only an Esc with nothing left to clear
+    /// cancels the flow.
+    /// Test: `new_session_escape_cancels_from_both_steps`,
+    /// `new_session_typing_filters_the_rows`.
     pub(crate) fn apply(&mut self, input: Input) -> Step {
         match input {
+            // #7421: clear the filter before cancelling, so a mistyped filter
+            // costs one key rather than the whole flow.
+            Input::Escape if self.typed.is_none() && !self.filter.is_empty() => {
+                self.filter.clear();
+                Step::Redraw
+            }
             Input::Escape => Step::Cancel,
             _ if self.typed.is_some() => self.apply_path(input),
             _ => self.apply_pick(input),
         }
     }
 
-    /// Target-list keys: move, then Enter to confirm or open the path entry.
+    /// Target-list keys: move or filter, then Enter to confirm or type a path.
     fn apply_pick(&mut self, input: Input) -> Step {
-        let last = self.targets.len().saturating_sub(1);
+        let visible = self.visible();
+        let cursor = self.cursor(&visible);
+        let last = visible.len().saturating_sub(1);
         match input {
-            Input::Up | Input::Char('k') => self.move_to(self.selected.saturating_sub(1)),
-            Input::Down | Input::Char('j') => self.move_to((self.selected + 1).min(last)),
-            Input::Home => self.move_to(0),
-            Input::End => self.move_to(last),
+            Input::Up => self.move_within(&visible, cursor.saturating_sub(1)),
+            Input::Down => self.move_within(&visible, (cursor + 1).min(last)),
+            Input::PageUp => self.move_within(&visible, cursor.saturating_sub(PICK_ROWS)),
+            Input::PageDown => self.move_within(&visible, (cursor + PICK_ROWS).min(last)),
+            Input::Home => self.move_within(&visible, 0),
+            Input::End => self.move_within(&visible, last),
+            // #7421: a printable key narrows the list rather than moving over
+            // it, so `j`/`k` are no longer movement here — the arrows are.
+            Input::Char(c) => {
+                self.filter.push(c);
+                self.keep_selection_visible();
+                Step::Redraw
+            }
+            Input::Backspace => {
+                if self.filter.pop().is_none() {
+                    return Step::Ignore;
+                }
+                self.keep_selection_visible();
+                Step::Redraw
+            }
             Input::Enter => match self.targets.get(self.selected) {
                 Some(Target::Registered { name, repo }) => Step::Create(NewSessionRequest {
                     register: None,
@@ -270,6 +371,14 @@ impl NewSessionFlow {
         }
     }
 
+    /// Move the highlight to a position within the filtered rows.
+    fn move_within(&mut self, visible: &[usize], position: usize) -> Step {
+        match visible.get(position) {
+            Some(index) => self.move_to(*index),
+            None => Step::Ignore,
+        }
+    }
+
     /// Move the highlight, reporting whether anything changed.
     fn move_to(&mut self, index: usize) -> Step {
         if self.targets.is_empty() || index == self.selected {
@@ -277,6 +386,15 @@ impl NewSessionFlow {
         }
         self.selected = index;
         Step::Redraw
+    }
+
+    /// Re-seat the highlight when the filter just hid the row it was on (#7421).
+    fn keep_selection_visible(&mut self) {
+        let visible = self.visible();
+        if visible.contains(&self.selected) {
+            return;
+        }
+        self.selected = visible.first().copied().unwrap_or(0);
     }
 
     /// Path-entry keys: edit the buffer, then Enter to resolve and confirm.
@@ -378,37 +496,39 @@ pub(crate) fn derive_identity(typed: &str) -> Option<ProjectIdentity> {
 /// being a third opinion.
 /// What: every registry row becomes a [`Target::Registered`], with
 /// [`Target::Other`] appended so an unregistered checkout is always reachable
-/// even when the registry is empty.
+/// even when the registry is empty. `sessions` is the list the `tm ls` TUI has
+/// already fetched — it decides the order (#7421), so no second read is made
+/// for it.
 /// Test: the pure half is `new_session_targets_from_puts_the_path_escape_last`;
 /// the read itself is the one `list_rows` already covers.
 pub(crate) async fn fetch_targets(
     client: &reqwest::Client,
     url: &str,
+    sessions: &[ManagedSessionSummary],
 ) -> anyhow::Result<Vec<Target>> {
     let projects = DaemonClient::with_client(client.clone(), url.to_string())
         .registry_list_projects(None)
         .await?;
-    Ok(targets_from(&projects))
+    Ok(targets_from(&projects, sessions))
 }
 
 /// Pure half of [`fetch_targets`]: registry rows → targets, escape hatch last.
 ///
 /// #7406: a row the operator must never be offered — a temp-directory or
 /// scratchpad registration, a path that is gone, a directory that is not a
-/// checkout — is dropped here, through the shared
+/// checkout — is dropped, through the shared
 /// [`is_offerable_project`](crate::commands::projects::offerable::is_offerable_project)
 /// predicate.
-/// Test: `new_session_targets_from_drops_a_scratchpad_registration`.
-pub(crate) fn targets_from(projects: &[Project]) -> Vec<Target> {
-    projects
-        .iter()
-        .filter(|p| crate::commands::projects::offerable::is_offerable_project(p))
-        .map(|p| Target::Registered {
-            name: p.name.clone(),
-            repo: p.repo_url.clone(),
-        })
-        .chain(std::iter::once(Target::Other))
-        .collect()
+/// #7421: the surviving rows are ordered by
+/// [`super::new_session_order::ordered_targets`] rather than left in the
+/// registry's `HashMap` iteration order.
+/// Test: `new_session_targets_from_drops_a_scratchpad_registration`,
+/// `new_session_order_is_independent_of_registry_iteration_order`.
+pub(crate) fn targets_from(
+    projects: &[Project],
+    sessions: &[ManagedSessionSummary],
+) -> Vec<Target> {
+    super::new_session_order::ordered_targets(projects, sessions)
 }
 
 /// One display label per target — `owner/repo`, never a URL or a path (#7406).
@@ -534,6 +654,21 @@ fn is_session_project(target: &Target, session: &ManagedSessionSummary) -> bool 
     let Target::Registered { repo, .. } = target else {
         return false;
     };
+    repo_is_session_project(repo, session)
+}
+
+/// True when `session` runs in the project a registry row's `repo_url` names.
+///
+/// Why: #7421's ordering asks the same question [`preselect_index`] does — "is
+/// this session's project THIS row" — so both route through one predicate
+/// rather than each spelling the URL comparison out.
+/// What: matches the session's `repo_url` through
+/// [`repo_url_matches`] (so an `https` row and an `ssh`
+/// session agree), and failing that the session's `owner/repo` `source_id`
+/// against the row's parsed remote.
+/// Test: `new_session_preselects_the_cursor_sessions_project`,
+/// `new_session_order_puts_a_live_session_project_first`.
+pub(crate) fn repo_is_session_project(repo: &str, session: &ManagedSessionSummary) -> bool {
     if let Some(url) = session.repo_url.as_deref()
         && !url.trim().is_empty()
         && repo_url_matches(url, repo)

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/new_session_order.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/new_session_order.rs
@@ -1,0 +1,119 @@
+//! What order the `tm ls` new-session picker lists registered projects in
+//! (#7421).
+//!
+//! Why: the registry read returns `HashMap::values()` with no sort, so the
+//! picker's rows arrived in whatever order the map iterated that run. The
+//! overlay shows eight rows, and the owner had over twenty registrations, so
+//! the handful of projects they actually had sessions in could sit below the
+//! fold — in a different place on every run.
+//!
+//! What: [`ordered_targets`] is the one place that order is decided. Projects
+//! with a managed session come first, best session state first and most
+//! recently active within that, through the SAME
+//! [`group_rank`](crate::commands::session_picker_order::group_rank) /
+//! [`recency_key`](crate::commands::session_picker_order::recency_key) the
+//! numbered picker orders its own rows by. Everything else follows
+//! alphabetically by the `owner/repo` label the row displays: the registry
+//! record carries no timestamp of its own, so alphabetical is the only stable
+//! order left for it.
+//!
+//! Test: `new_session_order_*` in `super::tests`.
+
+use std::cmp::Reverse;
+
+use trusty_mpm::client::ManagedSessionSummary;
+use trusty_mpm::project::Project;
+
+use crate::commands::session_picker_order::{group_rank, recency_key};
+
+use super::new_session::{Target, repo_is_session_project, row_labels};
+
+/// Sort tier for a project no session in the list belongs to.
+///
+/// One past [`group_rank`]'s widest answer, so any session at all outranks no
+/// session at all.
+const NO_SESSION: u8 = 3;
+
+/// Registry rows → picker targets, in an order the registry cannot change
+/// (#7421).
+///
+/// Why: see the module doc — the same registry contents must render the same
+/// rows, and the projects the operator is already working in must be the ones
+/// the eight-row window shows.
+/// What: drops every row
+/// [`is_offerable_project`](crate::commands::projects::offerable::is_offerable_project)
+/// rejects (#7406, unchanged), sorts the rest by [`Rank`], and appends
+/// [`Target::Other`] so the typed-path escape is always the last row.
+/// Test: `new_session_order_is_independent_of_registry_iteration_order`,
+/// `new_session_order_puts_a_live_session_project_first`.
+pub(crate) fn ordered_targets(
+    projects: &[Project],
+    sessions: &[ManagedSessionSummary],
+) -> Vec<Target> {
+    let registered: Vec<Target> = projects
+        .iter()
+        .filter(|p| crate::commands::projects::offerable::is_offerable_project(p))
+        .map(|p| Target::Registered {
+            name: p.name.clone(),
+            repo: p.repo_url.clone(),
+        })
+        .collect();
+    // The label is what the operator reads, so it is also what the alphabetical
+    // tie-break sorts on — `row_labels` answers for the whole set at once.
+    let labels = row_labels(&registered);
+    let mut ranked: Vec<(Rank, Target)> = registered
+        .into_iter()
+        .zip(labels)
+        .map(|(target, label)| (rank(&target, &label, sessions), target))
+        .collect();
+    ranked.sort_by(|a, b| a.0.cmp(&b.0));
+    ranked
+        .into_iter()
+        .map(|(_, target)| target)
+        .chain(std::iter::once(Target::Other))
+        .collect()
+}
+
+/// One row's sort position, in the order the fields are compared.
+///
+/// Why: a derived `Ord` over four named fields states the whole precedence in
+/// one place, and `name` last makes the order TOTAL — two registrations that
+/// spell the same label still come out in a fixed sequence.
+/// What: `session` is the best [`group_rank`] among the project's sessions
+/// ([`NO_SESSION`] when it has none); `recency` is the newest [`recency_key`]
+/// among them, reversed so later sorts first; `label` is the displayed
+/// `owner/repo`, lowercased.
+/// Test: `new_session_order_is_independent_of_registry_iteration_order`,
+/// `new_session_order_puts_a_live_session_project_first`.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Rank {
+    /// Best session tier for this project; lower sorts first.
+    session: u8,
+    /// Newest activity timestamp among its sessions, descending.
+    recency: Reverse<String>,
+    /// The displayed label, lowercased.
+    label: String,
+    /// Registry key, so equal labels still order deterministically.
+    name: String,
+}
+
+/// Rank one target against the session list the `tm ls` TUI already holds.
+fn rank(target: &Target, label: &str, sessions: &[ManagedSessionSummary]) -> Rank {
+    let (name, repo) = match target {
+        Target::Registered { name, repo } => (name.as_str(), repo.as_str()),
+        // Never ranked: `ordered_targets` appends the escape row after sorting.
+        Target::Other => ("", ""),
+    };
+    let mut session = NO_SESSION;
+    let mut recency = "";
+    for summary in sessions.iter().filter(|s| repo_is_session_project(repo, s)) {
+        session = session.min(group_rank(summary));
+        recency = recency.max(recency_key(summary));
+    }
+    Rank {
+        session,
+        recency: Reverse(recency.to_string()),
+        label: label.to_lowercase(),
+        name: name.to_string(),
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/render.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/render.rs
@@ -306,12 +306,14 @@ fn rename_body(was: &str, typed: &str) -> Vec<Line<'static>> {
 /// readable branch, and makes the free-text entry look exactly like the rename
 /// overlay's — the operator has already learned that shape.
 /// What: the picker step lists the windowed targets from
-/// [`super::new_session::NewSessionFlow::rows`], each cut to `width` (#7406);
-/// the path step draws the typed buffer with the same cursor block. Both name
-/// Esc as the way out.
+/// [`super::new_session::NewSessionFlow::rows`], each cut to `width` (#7406),
+/// under a hint line carrying the window's position in the list and the typed
+/// filter (#7421); the path step draws the typed buffer with the same cursor
+/// block. Both name Esc as the way out.
 /// Test: `render_new_session_overlay_lists_the_registered_projects`,
 /// `render_new_session_overlay_shows_the_typed_path`,
-/// `render_new_session_overlay_truncates_a_long_row`.
+/// `render_new_session_overlay_truncates_a_long_row`,
+/// `render_new_session_overlay_shows_the_position_and_filter`.
 fn new_session_body(flow: &super::new_session::NewSessionFlow, width: usize) -> Vec<Line<'static>> {
     if let Some(typed) = flow.typed() {
         return vec![
@@ -326,9 +328,26 @@ fn new_session_body(flow: &super::new_session::NewSessionFlow, width: usize) -> 
         Line::from(String::new()),
     ];
     lines.extend(flow.rows().iter().map(|r| Line::from(fit(r, width))));
+    // #7421: without this the rows past the eighth simply looked absent.
+    let hint = new_session_hint(flow);
+    if !hint.is_empty() {
+        lines.push(Line::from(fit(&hint, width)));
+    }
     lines.push(Line::from(String::new()));
-    lines.push(Line::from("Enter confirms, Esc cancels."));
+    lines.push(Line::from("Type to filter. Enter confirms, Esc cancels."));
     lines
+}
+
+/// The picker's position-and-filter hint, empty when it would say nothing.
+///
+/// A short list that has not been filtered has neither a position worth stating
+/// nor a filter to echo, so it gets no line at all rather than a blank one.
+fn new_session_hint(flow: &super::new_session::NewSessionFlow) -> String {
+    let mut parts: Vec<String> = flow.position().into_iter().collect();
+    if !flow.filter().is_empty() {
+        parts.push(format!("filter: {}", flow.filter()));
+    }
+    parts.join("  ·  ")
 }
 
 /// The `?` key reference.

--- a/crates/trusty-mpm/src/bin/tm/commands/session_tui/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_tui/tests.rs
@@ -17,7 +17,7 @@ use trusty_mpm::session_manager::rename::validate_session_name;
 
 use super::layout::{self, Column};
 use super::new_session::{
-    self, NewProject, NewSessionFlow, NewSessionRequest, ProjectIdentity, Target,
+    self, NewProject, NewSessionFlow, NewSessionRequest, ProjectIdentity, Step, Target,
 };
 use super::render;
 use super::state::{Action, Input, Mode, Severity, TuiState, is_self_session};
@@ -1048,10 +1048,13 @@ fn project(name: &str, repo_url: &str) -> Project {
 
 /// Two registered projects, plus the typed-path escape `targets_from` appends.
 fn targets() -> Vec<Target> {
-    new_session::targets_from(&[
-        project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
-        project("apex", "https://github.com/duetto/apex"),
-    ])
+    new_session::targets_from(
+        &[
+            project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+            project("apex", "https://github.com/duetto/apex"),
+        ],
+        &[],
+    )
 }
 
 /// Stand-in for the real git resolution, so the unregistered-path branch is
@@ -1093,7 +1096,7 @@ fn new_session_targets_from_puts_the_path_escape_last() {
     assert_eq!(targets.last(), Some(&Target::Other));
     // An empty registry still offers the escape, or a fresh host could never
     // create anything from this surface.
-    assert_eq!(new_session::targets_from(&[]), vec![Target::Other]);
+    assert_eq!(new_session::targets_from(&[], &[]), vec![Target::Other]);
 }
 
 #[test]
@@ -1343,10 +1346,18 @@ fn new_session_escape_leaves_the_state_identical() {
 
 #[test]
 fn new_session_rows_window_keeps_the_selection_visible() {
+    // #7421: zero-padded so the alphabetical order the picker now applies is
+    // also the numeric one, and the window arithmetic stays readable.
     let many: Vec<Project> = (0..12)
-        .map(|i| project(&format!("p{i}"), &format!("https://example.test/p{i}")))
+        .map(|i| {
+            project(
+                &format!("p{i:02}"),
+                &format!("https://example.test/p{i:02}"),
+            )
+        })
         .collect();
-    let mut flow = NewSessionFlow::with_resolver(new_session::targets_from(&many), stub_identity);
+    let mut flow =
+        NewSessionFlow::with_resolver(new_session::targets_from(&many, &[]), stub_identity);
     // Eight rows is the whole window, so a short registry never scrolls.
     assert_eq!(flow.rows().len(), 8);
     assert!(flow.rows()[0].starts_with('▸'));
@@ -1362,7 +1373,7 @@ fn new_session_rows_window_keeps_the_selection_visible() {
         "the selection scrolled off the window: {rows:?}"
     );
     assert!(
-        rows[0].contains("p5"),
+        rows[0].contains("p05"),
         "the window did not follow the selection down: {rows:?}"
     );
 }
@@ -1440,13 +1451,17 @@ fn target(name: &str, repo: &str) -> Target {
     }
 }
 
-/// A session whose project is the THIRD registered row.
+/// Three registered rows, in the alphabetical order #7421 renders them:
+/// `acme/widgets`, `bobmatnyc/trusty-tools`, `duetto/apex`.
 fn three_projects() -> Vec<Target> {
-    new_session::targets_from(&[
-        project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
-        project("apex", "https://github.com/duetto/apex"),
-        project("widgets", "https://github.com/acme/widgets"),
-    ])
+    new_session::targets_from(
+        &[
+            project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+            project("apex", "https://github.com/duetto/apex"),
+            project("widgets", "https://github.com/acme/widgets"),
+        ],
+        &[],
+    )
 }
 
 /// The overlay opens on the project of the row the cursor was on.
@@ -1460,19 +1475,19 @@ fn new_session_preselects_the_cursor_sessions_project() {
     let targets = three_projects();
     // The session spells the remote differently from the registry row; the
     // shared `repo_url_matches` is what makes the two agree.
-    let mut cursor = session("w1", "Active", 1);
-    cursor.repo_url = Some("git@github.com:acme/widgets.git".to_string());
+    let mut cursor = session("a1", "Active", 1);
+    cursor.repo_url = Some("git@github.com:duetto/apex.git".to_string());
     assert_eq!(new_session::preselect_index(&targets, Some(&cursor)), 2);
 
     let flow = NewSessionFlow::with_resolver(targets.clone(), stub_identity)
         .preselected_for(Some(&cursor));
     let rows = flow.rows();
-    assert_eq!(rows[2], "▸ acme/widgets", "{rows:?}");
+    assert_eq!(rows[2], "▸ duetto/apex", "{rows:?}");
     assert!(!rows[0].starts_with('▸'), "{rows:?}");
 
     // A session with no `repo_url` is matched on its `owner/repo` source id.
-    let mut by_source = session("a1", "Active", 2);
-    by_source.source_id = Some("duetto/apex".to_string());
+    let mut by_source = session("t1", "Active", 2);
+    by_source.source_id = Some("bobmatnyc/trusty-tools".to_string());
     assert_eq!(new_session::preselect_index(&targets, Some(&by_source)), 1);
 }
 
@@ -1542,15 +1557,18 @@ fn new_session_labels_disambiguate_by_host() {
 /// whose path is gone, and two rows that must survive.
 #[test]
 fn new_session_targets_from_drops_a_scratchpad_registration() {
-    let targets = new_session::targets_from(&[
-        project(
-            "mcp-probe-scratch-4181",
-            "/private/tmp/claude-502/abc/scratchpad/mcp-probe-scratch-4181",
-        ),
-        project("gone", "/nonexistent/7406/no-such-checkout"),
-        project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
-        project("apex", "https://github.com/duetto/apex"),
-    ]);
+    let targets = new_session::targets_from(
+        &[
+            project(
+                "mcp-probe-scratch-4181",
+                "/private/tmp/claude-502/abc/scratchpad/mcp-probe-scratch-4181",
+            ),
+            project("gone", "/nonexistent/7406/no-such-checkout"),
+            project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+            project("apex", "https://github.com/duetto/apex"),
+        ],
+        &[],
+    );
     assert_eq!(
         targets,
         vec![
@@ -1601,6 +1619,206 @@ fn render_new_session_rows_at_eighty_columns() {
         !joined.contains("/Users/me/code"),
         "an absolute path reached a row: {joined}"
     );
+}
+
+// ── new-session picker order, position and filter (#7421) ───────────────────
+
+/// Six registrations, spelled in one order; the caller may reshuffle them.
+fn six_projects() -> Vec<Project> {
+    vec![
+        project("apex", "https://github.com/duetto/apex"),
+        project("widgets", "https://github.com/acme/widgets"),
+        project("trusty-tools", "https://github.com/bobmatnyc/trusty-tools"),
+        project("zeta", "https://github.com/zed/zeta"),
+        project("mid", "https://github.com/mid/mid"),
+        project("early", "https://github.com/early/early"),
+    ]
+}
+
+/// The same registry contents render the same rows, whatever order they arrive
+/// in.
+///
+/// Why (#7421 acceptance 1 and 5): the registry is a `HashMap`, so
+/// `registry_list_projects` hands back `values()` in an order that varies run to
+/// run. Against the pre-#7421 `targets_from` — which mapped the input straight
+/// through — a permuted input produced a permuted row list, so this fails there.
+#[test]
+fn new_session_order_is_independent_of_registry_iteration_order() {
+    let forward = new_session::targets_from(&six_projects(), &[]);
+    let mut shuffled = six_projects();
+    shuffled.reverse();
+    shuffled.swap(0, 3);
+    let reversed = new_session::targets_from(&shuffled, &[]);
+    assert_eq!(forward, reversed, "the row order followed the input order");
+    // And the order is the alphabetical one the labels spell, escape hatch last.
+    assert_eq!(
+        new_session::row_labels(&forward),
+        vec![
+            "acme/widgets".to_string(),
+            "bobmatnyc/trusty-tools".to_string(),
+            "duetto/apex".to_string(),
+            "early/early".to_string(),
+            "mid/mid".to_string(),
+            "zed/zeta".to_string(),
+            "other — type a project path…".to_string(),
+        ]
+    );
+}
+
+/// A project with a live session outranks every project without one.
+///
+/// Why (#7421 acceptance 1 and 5): the owner's four projects with running
+/// sessions were the ones scrolling out of the eight-row window. `zed/zeta`
+/// sorts LAST alphabetically, so an implementation that only sorts by label —
+/// the pre-#7421 behaviour plus a plain sort — fails here.
+#[test]
+fn new_session_order_puts_a_live_session_project_first() {
+    let mut live = session("z1", "active", 1);
+    live.repo_url = Some("git@github.com:zed/zeta.git".to_string());
+    live.last_activity_at = Some("2026-09-11T10:00:00Z".to_string());
+    // A second session, older and merely stopped, in a project that would
+    // otherwise sort first.
+    let mut older = session("w1", "stopped", 2);
+    older.source_id = Some("acme/widgets".to_string());
+    older.last_activity_at = Some("2026-09-01T10:00:00Z".to_string());
+
+    let rows = new_session::targets_from(&six_projects(), &[live, older]);
+    let labels = new_session::row_labels(&rows);
+    assert_eq!(
+        labels.first().map(String::as_str),
+        Some("zed/zeta"),
+        "the live-session project did not sort first: {labels:?}"
+    );
+    assert_eq!(
+        labels.get(1).map(String::as_str),
+        Some("acme/widgets"),
+        "the stopped-session project did not outrank the session-less ones: {labels:?}"
+    );
+    assert_eq!(
+        labels.get(2).map(String::as_str),
+        Some("bobmatnyc/trusty-tools"),
+        "the session-less rows lost their alphabetical order: {labels:?}"
+    );
+}
+
+/// Typing narrows the rows; Esc clears the filter before it cancels the flow.
+///
+/// Why (#7421 acceptance 3): a twenty-project registry is unusable by arrow key
+/// alone, and an Esc that threw the whole flow away on a mistyped filter would
+/// make typing more expensive than scrolling.
+#[test]
+fn new_session_typing_filters_the_rows() {
+    let mut flow = NewSessionFlow::with_resolver(
+        new_session::targets_from(&six_projects(), &[]),
+        stub_identity,
+    );
+    assert_eq!(flow.rows().len(), 7);
+
+    assert_eq!(flow.apply(Input::Char('z')), Step::Redraw);
+    assert_eq!(flow.filter(), "z");
+    // The matching row, plus the typed-path escape, which never filters away.
+    assert_eq!(
+        flow.rows(),
+        vec![
+            "▸ zed/zeta".to_string(),
+            "  other — type a project path…".to_string(),
+        ],
+        "the filter did not narrow the rows"
+    );
+
+    // Matching is case-insensitive and runs over the whole label.
+    assert_eq!(flow.apply(Input::Backspace), Step::Redraw);
+    assert_eq!(flow.apply(Input::Char('A')), Step::Redraw);
+    assert_eq!(flow.apply(Input::Char('C')), Step::Redraw);
+    assert_eq!(flow.rows().len(), 2, "{:?}", flow.rows());
+    assert!(flow.rows()[0].contains("acme/widgets"), "{:?}", flow.rows());
+
+    // Esc clears the filter; a second Esc, with nothing left to clear, cancels.
+    assert_eq!(flow.apply(Input::Escape), Step::Redraw);
+    assert_eq!(flow.filter(), "");
+    assert_eq!(flow.rows().len(), 7);
+    assert_eq!(flow.apply(Input::Escape), Step::Cancel);
+}
+
+/// A filter that hides the highlighted row re-seats it on the first match.
+#[test]
+fn new_session_filter_keeps_the_selection_valid() {
+    let mut flow = NewSessionFlow::with_resolver(
+        new_session::targets_from(&six_projects(), &[]),
+        stub_identity,
+    );
+    // Move onto `bobmatnyc/trusty-tools`, then filter it away.
+    assert_eq!(flow.apply(Input::Down), Step::Redraw);
+    assert_eq!(flow.apply(Input::Char('z')), Step::Redraw);
+    let rows = flow.rows();
+    assert!(
+        rows[0].starts_with("▸ zed/zeta"),
+        "the highlight stayed on a hidden row: {rows:?}"
+    );
+    // And Enter confirms the row the highlight is actually on.
+    assert_eq!(
+        flow.apply(Input::Enter),
+        Step::Create(NewSessionRequest {
+            register: None,
+            repo: "https://github.com/zed/zeta".to_string(),
+            label: "zeta".to_string(),
+        })
+    );
+}
+
+/// The overlay says where in the list the eight-row window sits.
+///
+/// Why (#7421 acceptance 2): with twenty-seven registrations and no indicator,
+/// a project below the fold was indistinguishable from one that is not
+/// registered at all.
+#[test]
+fn new_session_position_indicator_reports_the_window() {
+    let many: Vec<Project> = (0..26)
+        .map(|i| {
+            project(
+                &format!("p{i:02}"),
+                &format!("https://ex.test/o{i:02}/p{i:02}"),
+            )
+        })
+        .collect();
+    let mut flow =
+        NewSessionFlow::with_resolver(new_session::targets_from(&many, &[]), stub_identity);
+    // Twenty-six projects plus the typed-path escape.
+    assert_eq!(flow.position(), Some("1–8 of 27".to_string()));
+    for _ in 0..9 {
+        flow.apply(Input::Down);
+    }
+    assert_eq!(flow.position(), Some("3–10 of 27".to_string()));
+    // A short list needs no indicator at all.
+    let short = NewSessionFlow::with_resolver(new_session::targets_from(&[], &[]), stub_identity);
+    assert_eq!(short.position(), None);
+}
+
+/// The rendered overlay carries both the position and the typed filter.
+#[test]
+fn render_new_session_overlay_shows_the_position_and_filter() {
+    let sessions = fleet();
+    let many: Vec<Project> = (0..26)
+        .map(|i| {
+            project(
+                &format!("p{i:02}"),
+                &format!("https://ex.test/o{i:02}/p{i:02}"),
+            )
+        })
+        .collect();
+    let mut state = browsing();
+    state.open_new_session(NewSessionFlow::with_resolver(
+        new_session::targets_from(&many, &[]),
+        stub_identity,
+    ));
+    let joined = draw(110, 30, &sessions, &mut state).join("\n");
+    assert!(joined.contains("1–8 of 27"), "{joined}");
+    assert!(joined.contains("Type to filter"), "{joined}");
+
+    state.apply(Input::Char('o'), &sessions);
+    state.apply(Input::Char('1'), &sessions);
+    let joined = draw(110, 30, &sessions, &mut state).join("\n");
+    assert!(joined.contains("filter: o1"), "{joined}");
 }
 
 /// A row wider than the pane is cut with `…` rather than wrapped.


### PR DESCRIPTION
## Outcome

Refs [#7421](https://github.com/bobmatnyc/trusty-tools/issues/7421); follows
[#7412](https://github.com/bobmatnyc/trusty-tools/pull/7412) (#7406).

`tm ls` new-session picker sorts live-session projects first, shows a scroll
position, and filters by typing.

## Changes

Registry rows were in raw HashMap order with no scroll indicator; now ordered
live-session projects first (most recent first), then alphabetical
owner/repo, with a `1–8 of 27` position line and type-to-filter (Backspace
edits, Esc clears the filter before cancelling).

Behaviour change: `j`/`k` no longer move the highlight in the picker (they
type into the filter); arrows, Home/End, PageUp/PageDown move. Out of scope:
no change to the registry's own storage order or to any other TUI screen.

## Risk

Localized to the `tm ls` new-session picker in `trusty-mpm`. No public API,
schema, or cross-crate surface change.

## Tests

Rung 3 (Normal, localized to trusty-mpm).

Gates run (raw output in the worktree run):
- `cargo fmt --check`
- `cargo check -p trusty-mpm --all-targets`
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- `cargo test -p trusty-mpm --no-fail-fast` — 6684 + 2662 + 2662 passed in the
  first three targets, 54 further targets ok, 0 failed
- `check_line_cap.sh`, `check_changelog_fragment.sh --staged`,
  `check_test_pointers.sh`, `check_sld.sh` — all OK

Regression tests `new_session_order_is_independent_of_registry_iteration_order`
and `new_session_order_puts_a_live_session_project_first` fail with the sort
removed.

## Baseline

No pre-existing red observed in this crate's gates.

## Docs

Changelog fragment added:
`crates/trusty-mpm/changelog.d/7421-picker-ordering-filter.md`.

## Review

No review round yet; nothing to disposition.

Refs #7421

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_015VfmMuEFGdvG7qvijiqYLk
