### PR TITLE
docs(trusty-agents): align specs to the 1.0 assistant-platform model (Refs #7426)

### DIFF
--- a/docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md
+++ b/docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md
@@ -1,0 +1,451 @@
+# trusty-agents 1.0 Gap Analysis (2026-09-11)
+
+Scope: `crates/trusty-agents`, `crates/trusty-agents-common`, `crates/trusty-agents-local`.
+Supporting crates (out of scope for changes): `crates/trusty-kb`, `crates/trusty-channels`,
+`crates/trusty-gworkspace`.
+
+## Baseline facts
+
+- Crate versions: `trusty-agents` 0.39.1, `trusty-agents-common` 0.7.2,
+  `trusty-agents-local` 0.1.4 (all in `crates/<name>/Cargo.toml`).
+- `trusty-agents-local` (`crates/trusty-agents-local/src/main.rs`) is a 15-line
+  pass-through binary: `fn main() { trusty_agents::run_to_completion() }`. Its
+  Cargo.toml doc comment records that #3732 removed its only reason to exist
+  (a plugin-install edge for CTO-DB tools). No crate depends on
+  `trusty-agents-local` (`grep -rl trusty-agents-local crates/*/Cargo.toml`
+  returns only its own manifest) — it is a leaf, installed as a second binary
+  alongside `tagent`.
+- `trusty-agents-common` is consumed by `trusty-agents`, `trusty-code`,
+  `trusty-kb`, and `trusty-mpm` (`Cargo.toml` grep).
+- `trusty-kb` is consumed only by `trusty-agents`. `trusty-channels` is consumed
+  by `trusty-agents`, `trusty-code`, `trusty-gworkspace`. `trusty-gworkspace` is
+  consumed by `tc-services`, `trusty-agents`, `trusty-common`, `trusty-memory`.
+- GitHub milestones relevant here: `PAUSED · agents` (#53, 17 open),
+  `Backlog · agents` (#73, 37 open). No dedicated "1.0" milestone exists yet.
+
+## Recommended ordering (dependency-driven)
+
+1. **(a) Crate consolidation** first — it is nearly free (issue #7359's
+   assessment checklist is already done) and every other item's PR surface
+   (config structs, API routes) is cleaner to land against a settled two-crate
+   layout than a three-crate one mid-flight.
+2. **(d) Per-assistant/per-thread projects** next — §4.7 of
+   `agent-config-five-sections.md` already makes project attachment the
+   *source* feed for the assistant OKG pipeline in (c), so (d)'s attachment
+   API must exist before (c)'s "one index, multiple roots" can be built
+   against real inputs.
+3. **(c) Memory/search reconfiguration** — needs (d)'s project attachment
+   model, and is the largest architectural change (single index with
+   multiple roots contradicts the current two-index, fan-out design).
+4. **(f) Knowledge-graph cleanup** — depends on (c) settling what "the index"
+   even is; today's drawer/OKG separation is already directionally right
+   (§6.1 below) and mostly needs enforcement/audit, not a new store.
+5. **(b) Channels in/out (Slack/Telegram/Notion/gworkspace)** — largely
+   independent of (c)/(d), but Notion has no connector at all yet and should
+   ride on whatever credential/store model (c) settles, per DOC-63 §7.1b.
+6. **(e) Attachments in chat** — already has its own open issue (#7370) with
+   an owner-accepted API+UI plan; can land in parallel with (b), gated only by
+   (d) for the `<assistant>/attachments/<session>/` path convention, which
+   already exists on disk (see item e below).
+
+---
+
+## a) Consolidate to 2 crates
+
+**Current state**
+- `crates/trusty-agents-local/src/main.rs:1-24` — literally
+  `fn main() -> Result<()> { trusty_agents::run_to_completion() }`, no other
+  logic.
+- `crates/trusty-agents-local/Cargo.toml` records (in-file comment) that this
+  is a "Private launcher: thin pass-through to trusty-agents::run()",
+  `publish = false`.
+- `tagent` (in `trusty-agents`, per CLAUDE.md's abbreviation table) calls the
+  same `run_to_completion()` entry point.
+
+**Gap**: `trusty-agents-local` has no remaining behavioral reason to exist —
+confirmed by its own doc comment, not inferred. Folding it away is a pure
+build/packaging change (drop the crate, keep one binary target, or keep a
+thin cargo alias) with an installer/compatibility migration cost that issue
+#7359 explicitly scoped but has not yet decided in the affirmative.
+
+**Spec coverage**: none of the six specs scoped for this analysis mention
+crate topology; it is purely an owner directive, not documented anywhere in
+`docs/specs/`.
+
+**Existing issues**: **#7359** `chore(trusty-agents): assess the three-crate
+boundary`, OPEN, milestone `Backlog · agents`, labels include
+`status:in-progress`. All three checklist boxes are already checked
+("Record each crate's current consumers...", "Decide whether to retain common
+and retire the redundant local launcher...", "Record the recommendation...")
+but the issue itself is still open — the recommendation exists somewhere
+(comments/linked doc, not fetched here) but the retirement has not shipped.
+This issue already IS the ticket for item (a); a PM should read its comments
+rather than open a duplicate.
+
+**Cross-crate risk**: low. Deleting `trusty-agents-local` touches only its own
+`Cargo.toml`/`main.rs` plus the root workspace member glob and installer
+scripts that reference the second binary name — grep for
+`trusty-agents-local` in `scripts/` and installer manifests before removing.
+`trusty-agents-common`'s public API is untouched.
+
+---
+
+## b) Channels: native in/out connectors (gworkspace, Slack, Telegram, Notion)
+
+**Current state**
+- `crates/trusty-channels/src/lib.rs:23-24` — only `pub mod slack;` and
+  `pub mod telegram;`. No Notion or gworkspace module lives in this crate.
+- `crates/trusty-agents/src/tools/channel.rs:1-64` — the `ChannelTool` MCP
+  tool (`name() = "channel"`), actions `list`/`read`/`send`, backed by
+  `crate::api::server::agent_channels::{read,messages,send}`.
+- `crates/trusty-agents/src/tools/channel.rs:66-73` — the `context()` help
+  string states outright: **"Automatic Slack updates require the configured
+  bot listener and existing pairing and sender permissions; Telegram is
+  send-only."** Telegram has no inbound path today.
+- `crates/trusty-agents/src/slack/{mod.rs,pairing.rs,handlers.rs,tests.rs}` —
+  Slack has both directions (pairing + inbound handlers + outbound send).
+- gworkspace (Gmail/Drive/Calendar) is wired as an MCP endpoint
+  (`gworkspace`, `enabled = true` per
+  `agent-config-five-sections.md` §4.4) but through the generic MCP knowledge
+  surface, not the `channel` tool's saved-destination model — it is a
+  read/compose tool set, not a "bound channel with inbound listener."
+- Notion: `grep -rn "notion" crates/trusty-agents/src crates/trusty-channels/src
+  crates/trusty-kb/src` returns only comments about Slack/Notion/Granola being
+  *untrusted-by-construction sources* for search results
+  (`crates/trusty-agents/src/untrusted.rs:11`,
+  `crates/trusty-agents/src/tools/memory/vector_search.rs:37,514`). There is
+  no Notion client, connector module, or store type anywhere in the three
+  in-scope crates.
+
+**Gap**
+- Notion has zero connector code — not even a read-only one. The nearest
+  planned surface is an OKG *source* (read-only ingestion), not a two-way
+  channel.
+- Telegram is send-only by design comment; the owner's item (b) explicitly
+  wants messages "IN and OUT" for every listed channel.
+- gworkspace is not modeled as a `channel` binding (list/read/send), so it is
+  inconsistent with how Slack/Telegram are exposed to the agent and to the
+  chat UI's channel picker.
+
+**Spec coverage**
+- `DOC-60-bus-based-agent-messaging.md` (not read in full here — 934 lines;
+  scoped by title to the messaging bus, not connector build-out) and
+  `agent-config-five-sections.md` §4.4's K-c MCP table are the closest specs;
+  neither states a target of two-way Slack/Telegram/Notion/gworkspace parity.
+- DOC-63 §7.1b (`docs/specs/DOC-63-okg-sources.md:914`) treats Gmail/Drive/
+  Slack/Calendar explicitly as **read-only OKG source kinds**, not send
+  channels: *"Gmail, Google Drive, Slack, and Google Calendar are channel
+  source kinds"* (§4.7 of `agent-config-five-sections.md`, echoing DOC-63).
+  This is a real disagreement with item (b): the current spec line treats
+  these as one-directional ingestion sources feeding the OKG pipeline, while
+  the owner's item (b) wants bidirectional messaging channels. The two models
+  (channel-as-source vs. channel-as-conversation-endpoint) are not reconciled
+  in either spec.
+
+**Existing issues**
+- **#2811** `epic(trusty-agents): declarative channels over trusty-channels and
+  SessionProxy` — CLOSED, milestone `1.3.8`. Delivered the `[channels]`
+  manifest section (**#3212**, CLOSED) that `channel.rs` implements today.
+- **#2641** `Telegram support: telegram module in trusty-channels` — CLOSED.
+- **#2636** `EPIC: native Slack/Telegram MCP servers (chat-as-tools)` —
+  CLOSED, `1.3.8`.
+- **#4853** `Slack pairing is not persisted...` — CLOSED, milestone
+  `trusty-agents 0.39 — internal beta`.
+- **#7389** `chore: verify Trusty Slack and Notion connector read access` —
+  OPEN, `Backlog · agents`. Read-only verification, not connector build-out.
+- **#4547** `[BLOCKED on #4040] OKG store type: Notion directory` — OPEN,
+  `PAUSED · agents`. This is the closest existing ticket to "Notion", and it
+  is scoped as a read-only OKG source, not a chat channel. Its blocker
+  (#4040, credential authority) is CLOSED, so #4547 is unblocked but still
+  open.
+- **#4546** `[BLOCKED on #4040] OKG store type: Slack — sent messages and
+  channels` — OPEN, `PAUSED · agents`. Same shape, for Slack-as-source.
+- No open issue proposes Telegram-inbound or a gworkspace `channel` binding.
+
+**Cross-crate risk**: adding Notion means a new module in `trusty-channels`
+(low risk, additive) plus a new `ChannelKind`/binding variant surfaced through
+`trusty-agents::tools::channel` and `agent_channels` API — touches
+`trusty-agents-common` only if channel binding types are promoted there for
+reuse by `trusty-code` (which already depends on `trusty-channels` directly,
+per `crates/trusty-code/Cargo.toml`). Telegram-inbound requires a new listener
+path in `trusty-channels::telegram`, consumed by `trusty-agents`,
+`trusty-code`, and `trusty-gworkspace` (all three depend on
+`trusty-channels`) — a wire-format change there is a 3-consumer, rung-4 change
+per CLAUDE.md's test ladder.
+
+---
+
+## c) Memory and search properly configured
+
+**Current state**
+- Memory: `crates/trusty-agents/src/memory/store.rs:20-37` defines
+  `enum Segment { AgentMemory, CodeIndex, Context, Brief, History }` — palace
+  segmentation today is by **content type**, not by assistant identity, and
+  there is no per-assistant palace concept in this enum.
+- `crates/trusty-agents/src/memory/trusty_backed.rs:70-266` — `TrustyBacked`
+  holds one palace per `Segment` under a shared `data_root`
+  (`palace_id_for(segment)`), confirming palaces are keyed by segment, not by
+  assistant instance.
+- Search: `crates/trusty-agents/src/agents/config.rs:315-450` — `ToolsConfig`
+  carries `search_indexes: Option<Vec<String>>` and
+  `enforce_search_indexes: Option<bool>`, resolved via
+  `resolved_search_indexes()`. This is a **list of named indexes an agent may
+  query**, not "one index per assistant with multiple roots."
+- `DOC-63-okg-sources.md` §3.4 / §10.5
+  (`docs/specs/DOC-63-okg-sources.md:1254-1313`) formalizes the opposite
+  design from the owner's ask: *"S-14.3 Tiers are queried **concurrently**...
+  there is **no fan-out** — a call reaches one index"* per tier, and
+  §4.7 of `agent-config-five-sections.md` states plainly: **"The two indexes
+  serve different purposes: a project's index covers its eligible current
+  files; the Assistant's index covers its derived OKG business entities."**
+  This is a direct, quotable disagreement with owner item (c), which wants
+  **one** trusty-search index per assistant with the OKG tree as one root and
+  each used project as another root — not two (or N) separate indexes reached
+  by concurrent fan-out.
+
+**Gap**
+- No memory concept of "one palace per assistant, fan-out to other
+  assistants' palaces if selected in settings" exists anywhere in
+  `crates/trusty-agents/src/memory/`. `Segment` has no `Assistant(id)`
+  variant, and there is no settings surface for cross-assistant palace
+  selection.
+- Search is architected as N separate indexes (project index(es) + the
+  Assistant's own OKG index) queried via concurrent fan-out, not a single
+  index with multiple roots. Multi-root single-index search would be a
+  different trusty-search-side capability (out of scope for changes here, but
+  the owner's ask implies trusty-search itself would need a multi-root index
+  primitive that does not appear to exist — worth flagging to trusty-search's
+  own backlog).
+
+**Spec coverage**
+- `agent-config-five-sections.md` §4.7 is the current normative design and
+  actively contradicts the owner's single-index-multi-root model (quoted
+  above).
+- `DOC-63-okg-sources.md` §10.5 (`SPEC-OKGSRC-14~draft`) is the fan-out design
+  that would need to be superseded, not extended, if item (c) is accepted
+  verbatim.
+- Memory's per-assistant-palace-with-fan-out model is not documented in any
+  of the six scoped specs; `trusty-agents-product-spec.md` §SPEC-AGENTS-08
+  (`docs/specs/trusty-agents-product-spec.md:385`) discusses memory
+  classification but predates the Assistant-instance model entirely (no
+  mention of "Assistant" as a first-class identity).
+
+**Existing issues**
+- **#4282** `Cap attached search indexes at 10 per assistant, and ship the
+  selection GUI` — OPEN, `PAUSED · agents`. Closest existing ticket to a
+  per-assistant index cap, but caps *multiple* indexes rather than unifying
+  to one multi-root index.
+- **#4283** `OKG entity extraction: pull entities from attached search
+  indexes into the canonical per-assistant OKG store` — OPEN, `Backlog ·
+  agents`.
+- **#4531** `epic: OKG Sources — per-assistant knowledge sources, scheduled
+  refresh, and the untrusted-content boundary` — OPEN, `Backlog · agents`.
+  This is the active epic implementing §4.7 above; it inherits the
+  two-index-plus-fan-out disagreement.
+- **#4539** `OKG Sources: create and register the assistant store's own
+  trusty-search index` — OPEN, `Backlog · agents` — literally creates a
+  *second* index, the opposite of the owner's one-index model.
+- **#4325** `Assistant store model: app-generated per-assistant home
+  directory with explicit OKG entity extraction` — CLOSED, milestone `M2 —
+  trusty-agents internal driver beta`. Delivered the `AssistantHome`
+  scaffolding item (d)/(e) build on.
+- No open issue proposes cross-assistant memory palace fan-out or a
+  single-index multi-root search model. This is a genuine spec-and-backlog
+  gap, not just an implementation gap.
+
+**Cross-crate risk**: high if pursued as "one multi-root index." trusty-search
+itself (out of scope crate, not one of the three named `trusty-kb`/
+`trusty-channels`/`trusty-gworkspace` either — it's a fourth dependency) would
+need a multi-root index primitive; `trusty-agents-common`'s public API is not
+obviously implicated since index/palace types live in `trusty-agents` and
+`trusty-common`/`trusty-memory`, not in `trusty-agents-common`.
+
+---
+
+## d) Projects configured per assistant or per chat thread
+
+**Current state**
+- `crates/trusty-agents/src/assistants/home.rs:75-104` (`AssistantHome`
+  module doc) already establishes the target model: *"Sources are the union of
+  registered project folders attached to the Assistant's chats"* (§4.7,
+  `agent-config-five-sections.md:296-403`).
+- `crates/trusty-agents/src/api/server/projects.rs:1-60` — existing
+  `GET /api/projects`, `POST /api/projects`, `GET /api/projects/:name`
+  handlers back a project navigator, but per the file's own doc comment this
+  is a general project-registry surface (`ProjectRegistry`,
+  `discover_active_projects`), not yet the per-assistant/per-thread
+  attachment API that §4.7 specifies (`PUT
+  /api/agents/{name}/knowledge/pipeline/projects`, "Revisioned per-chat
+  registered project selection").
+- UI: `crates/trusty-agents/ui/src/components/KnowledgeProjectSync.svelte`,
+  `crates/trusty-agents/ui/src/lib/knowledgeProjects.ts`,
+  `crates/trusty-agents/ui/src/lib/knowledgeProjectSync.ts` exist and (by
+  name) implement project-to-knowledge syncing already.
+- `InputArea.svelte:389` references a `chatFolderError` / "Remove attachment"
+  affordance for a per-chat folder attachment, suggesting per-thread project
+  attachment UI is at least partially built.
+
+**Gap**: the `PUT .../pipeline/projects` endpoint §4.7 specifies is not
+confirmed live in `projects.rs` (that file predates §4.7's revision and is
+described as the general project listing/registration surface, #341/#405/
+#407/#451/#465). Whether project paths are *auto-added to the assistant's
+index* on attachment (owner's exact wording) versus requiring a separate
+extraction trigger is unresolved without reading the pipeline route
+implementation directly — flag as needing direct verification before
+ticketing, since §4.7 text says "Registration alone never authorizes
+extraction," which is a **narrower** behavior than the owner's "project paths
+auto-added to the assistant's index."
+
+**Spec coverage**: `agent-config-five-sections.md` §4.7 is the live, current
+spec and is broadly aligned with item (d) — the disagreement is the one
+sentence just quoted: *"Registration alone never authorizes extraction"*
+versus the owner's "project paths auto-added to the assistant's index,"
+which implies attachment should be sufficient by itself.
+
+**Existing issues**
+- **#4358** `feat(trusty-agents): add per-chat project workspaces` — OPEN,
+  `Backlog · agents`. This is the primary ticket for item (d).
+- **#4355** `Epic: Projects surface + tasks-by-assistant in trusty-agents
+  GUI` — OPEN, `PAUSED · agents`.
+- **#4289** `Index a new directory from the agent config UI, with an overlap
+  guard against existing index roots` — OPEN, `Backlog · agents`.
+- **#3899** `Platform: tagent-native sync of agent config to
+  bobmatnyc/trusty-agents-agents monorepo` — OPEN, tangential.
+
+**Cross-crate risk**: low-to-moderate. Project attachment lives entirely in
+`trusty-agents`; touches `trusty-kb`'s ingest/registry API
+(`crates/trusty-kb/src/okg/{registry.rs,ingest.rs}`) if project roots feed the
+OKG pipeline, which is a single-consumer (`trusty-agents`) relationship today.
+
+---
+
+## e) Chat attachments (text/binary/CSV), shown as objects, saved under assistant home
+
+**Current state**
+- `crates/trusty-agents/src/assistants/home.rs:83-84,96` already defines and
+  documents the exact path convention the owner asked for: *"Binary files
+  attached to this instance's chat"* — `pub const ATTACHMENTS_DIR: &str =
+  "attachments";"*, sibling to `OKG_DIR`, both under `AssistantHome`. The
+  module doc explicitly says the layout matches `<assistant>/attachments/...`
+  beside `<assistant>/okg` (`home.rs:17-21`).
+- `grep -rln ATTACHMENTS_DIR crates/trusty-agents/src` shows it used in
+  `home.rs`, `health.rs`, `mod.rs`, and `tests/home_tests.rs` — i.e., the
+  directory constant exists and is health-checked, but is not yet referenced
+  from any API route or UI component (no hits in `api/server/` or `ui/src/`).
+- UI: `crates/trusty-agents/ui/src/components/InputArea.svelte` has drag/drop
+  ("drop" comment at line 164) and a `chatFolderError` affordance, but that is
+  the *project-folder* attachment from item (d), not binary file attachments
+  with thumbnails.
+
+**Gap**: the on-disk convention item (e) asks for already exists
+(`AssistantHome::ATTACHMENTS_DIR`), but nothing populates it yet, and there is
+no thumbnail/click-expand UI, no CSV/XLSX parsing, and no persisted
+association between an attachment and a chat message.
+
+**Spec coverage**: none of the six scoped specs describe attachment UI or the
+CSV/binary parsing pipeline. `home.rs`'s doc comments are the closest thing to
+a spec and are already aligned with the owner's exact path structure.
+
+**Existing issues**
+- **#7370** `feat(trusty-agents): paste images and tables into chat` — OPEN,
+  `Backlog · agents`, created 2026-09-10 (one day before this analysis).
+  Its checklist is essentially item (e) verbatim: "raw images, CSV/XLSX files,
+  and pasted HTML/TSV through an API with authoritative bounded validation,"
+  "readable removable previews," "persist attachments with conversation
+  history, expose authorized asset retrieval." This issue **is** the ticket
+  for item (e); no new issue is needed, only confirmation the
+  `<assistant>/attachments/<session>/<file>` path from `home.rs` is the
+  target persistence layout in its implementation.
+- **#4358** (per-chat project workspaces) is explicitly noted in #7370's body
+  as owning "project browsing," distinguishing it from file attachments.
+
+**Cross-crate risk**: low. Entirely within `trusty-agents` (API + UI); no
+changes to `trusty-agents-common`, `trusty-kb`, `trusty-channels`, or
+`trusty-gworkspace` anticipated.
+
+---
+
+## f) Clean up the knowledge graph: exclude memory drawers, expose only OKG (triples + definitions)
+
+**Current state**
+- `DOC-63-okg-sources.md:774` (table row) already records the separation as
+  **BUILT**: *"Prompt-level fencing — recalled content is delimited and
+  preambled as DATA, not instruction | BUILT, for memory drawers |
+  `crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_memory.rs:420-533`;
+  `UNTRUSTED_PREAMBLE` at `:502`... 'drawer content is UNTRUSTED. It arrives
+  from Gmail/Drive ingestion'"*.
+- `DOC-63-okg-sources.md:783-786`: *"memory-drawer path, not the search
+  path... assistant's memory drawers are fenced; the OKG store this document
+  fills from"* — i.e., the spec already models memory drawers and the OKG
+  store as two separate things.
+- `crates/trusty-kb/src/okg/{docstore.rs,ledger.rs,trust.rs,ingest.rs,
+  registry.rs,jsonl.rs}` is the OKG-store implementation — triples/definitions
+  live here, structurally separate from `trusty-agents/src/memory/` (palace
+  drawers).
+- UI: `crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.svelte`
+  exists as a dedicated OKG viewer, separate from any memory/drawer viewer
+  component (no drawer references found in that file:
+  `grep -n "drawer" KnowledgeGraphBrowser.svelte` returns nothing).
+- **#4406** `[trusty-agents] Two unconnected systems are both called "OKG" —
+  trusty-kb entity tree vs trusty-memory KG` — CLOSED, milestone `trusty-agents
+  0.42 — Knowledge (OKG)`. This issue's title names exactly the confusion item
+  (f) warns against, and it is already closed/resolved.
+
+**Gap**: structurally, the separation the owner wants (exposed graph = OKG
+triples/definitions only, memory drawers excluded) already exists in both the
+data model (`trusty-kb::okg` vs `trusty-agents::memory`) and the UI
+(`KnowledgeGraphBrowser.svelte` has no drawer content). The residual gap is
+**audit/enforcement**, not architecture: confirm no code path feeds drawer
+content into `KnowledgeGraphBrowser`'s API response, and confirm the "OKG"
+naming is now unambiguous across UI copy, API field names, and MCP tool
+descriptions (the historical confusion #4406 fixed could recur if a new
+surface reintroduces a "knowledge" label that mixes both).
+
+**Spec coverage**: `DOC-63-okg-sources.md` is well-aligned with item (f); no
+quoted disagreement found. `DOC-58-knowledge-kd-attached-indexes.md` (not
+fully read — 317 lines, title suggests it covers attached-index knowledge
+surfaces) should be checked for any residual "knowledge" terminology that
+blends drawers and OKG before closing this item out.
+
+**Existing issues**
+- **#4406** (above) — CLOSED, the historical fix.
+- **#4363** `[trusty-agents] Extract/update-entities button: wire OKG tools to
+  UI trigger` — OPEN, `PAUSED · agents` — UI-side follow-up, still relevant to
+  confirming the KG browser only shows OKG content.
+- **#4990** `roadmap: adopt four design ideas from omnigraph.dev for
+  memory-core KG and search fusion` — OPEN, `Backlog · memory (triaged)` —
+  touches trusty-memory's own KG, worth checking it does not reintroduce a
+  merged surface.
+- No open issue proposes a fresh audit of drawer/OKG separation as item (f)
+  implies is still needed; recommend a small verification-only ticket rather
+  than a new epic.
+
+**Cross-crate risk**: low. Verification-only; if a leak is found, the fix is
+localized to whichever API handler feeds `KnowledgeGraphBrowser.svelte` or to
+`persona_memory.rs`'s fencing boundary.
+
+---
+
+## Summary table
+
+| Item | Code exists today | Spec alignment | Open issue(s) | Effort class |
+|---|---|---|---|---|
+| a) 2-crate consolidation | `trusty-agents-local` is a dead pass-through | No spec; owner directive only | #7359 (assessment done, action pending) | Small, mechanical |
+| b) Channels in/out | Slack (in+out), Telegram (out only), gworkspace (read/compose, not a bound channel), Notion (none) | DOC-63/§4.7 model these as one-way OKG sources, not 2-way channels — contradicts item (b) | #4547, #4546 (Notion/Slack as sources), #7389 (verify access) — none for Telegram-inbound or gworkspace-as-channel | Large |
+| c) Memory/search per-assistant | Memory palaces keyed by `Segment`, not assistant; search is N named indexes, not 1 multi-root index | §4.7 explicitly designs 2 separate indexes + fan-out — contradicts item (c) | #4282, #4283, #4531, #4539 (build the 2-index model) | Large, needs spec revision first |
+| d) Per-assistant/per-thread projects | `AssistantHome` + `KnowledgeProjectSync.svelte` scaffolding exists; pipeline route status unconfirmed | §4.7 mostly aligned; "registration alone never authorizes extraction" is narrower than owner's "auto-added" | #4358, #4355, #4289 | Medium |
+| e) Chat attachments | `ATTACHMENTS_DIR` constant + path convention already correct; no upload/thumbnail/persistence code | No spec; `home.rs` doc comments match owner's path exactly | #7370 (already scoped to spec) | Medium, well-scoped |
+| f) KG cleanup | Structurally already separated (`trusty-kb::okg` vs `trusty-agents::memory`); UI has no drawer leakage found | DOC-63 aligned | #4406 (closed, historical), #4363 | Small, audit-only |
+
+## Notes on data not verified
+
+- Did not read `DOC-58-knowledge-kd-attached-indexes.md` or `DOC-60-bus-based-
+  agent-messaging.md` in full (317 and 934 lines respectively) — only grepped
+  for `drawer`. A full pass may surface additional disagreements, especially
+  in DOC-60 for item (b)'s bus-based message routing.
+- Did not fetch #7359's issue comments (only the issue body), which likely
+  contain the actual crate-consolidation recommendation referenced by its
+  checked-off checklist.
+- Did not verify live behavior of `PUT /api/agents/{name}/knowledge/pipeline/
+  projects` (§4.7) against `projects.rs` — recommend a direct code read before
+  ticketing item (d) to confirm current vs. spec'd behavior.

--- a/docs/specs/DOC-58-knowledge-kd-attached-indexes.md
+++ b/docs/specs/DOC-58-knowledge-kd-attached-indexes.md
@@ -10,7 +10,7 @@ spec_refs:
 **Status:** Draft
 **Subsystem:** trusty-agents — agent configuration model (Knowledge section, DOC-57 §4); `tools.search_indexes` config surface; trusty-search — index attachment
 **Owner:** Engineering (trusty-agents) / Bob Matsuoka
-**Last-updated:** 2026-07-26
+**Last-updated:** 2026-09-11
 **Spec ID:** `SPEC-KDIDX-01~draft` … `SPEC-KDIDX-06~draft` (DOC-58)
 **Epic:** #4007 (Two-tier knowledge architecture: curated OKG stores vs arbitrary attached search indexes)
 **Builds on:** DOC-57 [Five-Section Agent Configuration](./agent-config-five-sections.md) §4 `SPEC-AGENTCFG-03~draft` (the Knowledge section this addendum extends with a fourth sub-surface, K-d, alongside K-a/K-b/K-c); the backend ticket #3935 (`GET /api/agents/:name/knowledge`), whose scope this addendum amends rather than forks (§1)
@@ -18,6 +18,21 @@ spec_refs:
 **Related issues:** #4007 (epic), #4008 (this ticket), #3232 (`tools.search_indexes` primitive — depended on), #3935 (Knowledge backend — amended, not reopened), #3890 (store-PATCH pattern, referenced for its read-only-until posture), #3936 (permissions backend, referenced not duplicated), #4009 (vector_search schema enrichment + optional allowlist enforcement), #4010 (Knowledge pane GUI: K-d sub-surface), #4011 (ops runbook + guardrail for `create_index` over an external/cross-org directory), #4012 (memory↔search M1), #4013/#4014 (memory↔search stretch tiers — out of scope here), #4015 (concrete driver: attach APEX to `cto-assistant`)
 
 ---
+
+> **SUPERSEDED IN PART (2026-09-11) by the one-index-multiple-roots model
+> (epic #7425, tracked for search in #7429).** The owner's 1.0
+> assistant-platform revision replaces this document's two-tier principle —
+> curated OKG stores (K-a) plus arbitrary attached indexes (K-d) as a
+> *second, separately-queried index* — with one trusty-search index per
+> Assistant, where an attached project is a **root** of that single index
+> rather than a second index reached through `tools.search_indexes`. This
+> document is retained below for historical record of the pre-1.0
+> architecture and continues to govern the current implementation until
+> #7429 lands and a K-d successor spec is written. See
+> `agent-config-five-sections.md` §4.7 and `DOC-63-okg-sources.md` §10.2/§10.5
+> for the corresponding supersession notes, and
+> `docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md` for the
+> evidence.
 
 ## 1. Why this is a new document, not an edit to DOC-57 or #3935
 
@@ -312,6 +327,14 @@ This walks the two-tier principle (§2) and K-d (§3–§7) through epic #4007's
 
 ## 12. Change Log
 
+- **2026-09-11** — Added a superseded-in-part notice for the owner's 1.0
+  assistant-platform scope (epic #7425): the K-a/K-d two-tier attached-index
+  architecture this document specifies is replaced by the one-index-
+  multiple-roots model (#7429), where an attached project becomes a root of
+  the Assistant's one search index rather than a second index reached
+  through `tools.search_indexes`. No normative section text changed; this
+  document continues to govern the current implementation until #7429 lands.
+  Evidence: `docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md`.
 - **2026-07-26 (second revision)** — Amended per code-critic review of PR #4019: §5.3's source table said `/stores.search_indexes` sources verbatim from `ToolsConfig::resolved_search_indexes()`, which the critic ruled wrong and self-contradictory — KD-21 requires an id that is both bound (K-a) and attached (K-d) to be deduped and presented once under its bound role, and KD-18/C-KD.8 require this route's id set to match `/knowledge.attached_indexes[]` exactly, so a verbatim list would carry an id absent from the future `attached_indexes[]`. Changed the `search_indexes` source column to `attached_indexes_deduped()` — the resolved attached list with any id whose resolved index matches a store binding filtered out, dedupe keyed on `resolved_index()` per KD-21 — and added a one-sentence rationale citing KD-18/KD-21/C-KD.8 so the derivation is not "fixed" back to the verbatim resolver. Also fixed §5.3's citations: commit `7dc401dd` is superseded and no longer reachable on `feat-3232-4009-attached-search-indexes` (PR #4019 is the current implementation), and `agent_stores.rs:115-116` had drifted to the `"search_indexes"`/`"enforce_search_indexes"` insertion at lines 127-128 in `stores_at` and `attached_indexes_deduped` at line 151 — now cited by symbol name first, with line numbers as a secondary, degrading pointer, since the branch is still in-flight.
 - **2026-07-26 (revision)** — Amended per code-critic review of PR #4017 (WARN, one HIGH): the concurrent `feat-3232-4009-attached-search-indexes` implementation branch (commit `7dc401dd`) already adds `search_indexes`/`enforce_search_indexes` to `GET /api/agents/:name/stores`, which contradicted the original KD-8/C-KD.7 "byte-identical" wording. Added §5.3 ("Interim raw surface on `/stores`") licensing those two fields as an interim, non-authoritative-for-UI raw surface, and defining the id-set consistency relationship to the future `/knowledge.attached_indexes[]` (KD-17…KD-20, C-KD.8). Reworded KD-8 and C-KD.7 to scope the "unchanged" guarantee to *pre-existing* fields rather than to the whole route, so they no longer contradict the licensed addition. Added KD-21 resolving the reviewer's minor note: an id legally overlapping both `[[stores]]` (K-a) and `tools.search_indexes` (K-d) MUST be deduped and presented once, under its bound (K-a) role.
 - **2026-07-26** — Initial addendum (DOC-58, `SPEC-KDIDX-01~draft` … `-06~draft`). Introduces K-d (attached search indexes) as a fourth Knowledge sub-surface alongside DOC-57 §4's K-a/K-b/K-c, backed by `tools.search_indexes` (#3232) with union-extends merge semantics. Specifies the `attached_indexes[]` addition to #3935's `/knowledge` route (declarative, degrade-never-fail, read-only), an M1 enforcement posture of opt-in-allowlist-declared-but-not-enforced, GUI expectations for #4010 (attach/detach existing indexes only, creation stays CLI-only per #4011), and the permissions interaction with `search.read` (category-level, unchanged). Records the APEX/`cto-assistant` driver (#4015) as a worked example and lists explicit non-goals, including the #4013/#4014 stretch tiers. Amends #3935's scope per #4008's acceptance criteria; does not edit DOC-57's or #3935's existing text.

--- a/docs/specs/DOC-63-okg-sources.md
+++ b/docs/specs/DOC-63-okg-sources.md
@@ -18,7 +18,7 @@ spec_refs:
 **Spec ID:** `SPEC-OKGSRC-01~draft` … `SPEC-OKGSRC-14~draft` (DOC-63)
 **Subsystem:** trusty-agents — assistant home / OKG store, source catalog, scheduled refresh, credentials consumption, Knowledge config pane; trusty-kb — `okg` engine (ledger, registry, entity tree); trusty-search — index over the store
 **Owner:** Engineering (trusty-agents) / Bob Matsuoka
-**Last-updated:** 2026-08-01
+**Last-updated:** 2026-09-11
 **DOC-N claim:** `DOC-63`, scan-before-claim per DOC-38 §4.1. **This document originally claimed `DOC-62` and was renumbered.** Two concurrent spec passes both claimed DOC-62 — this one and PR #4529 (Style Modes for Coding Delegation) — because each correctly scanned `origin/main` and found `DOC-61` as the highest claimed number, and neither could see the other's unmerged branch. #4529 keeps `DOC-62` as the earlier and further-advanced PR; this is a mechanical tie-break. `DOC-63` was verified free three ways: no filename claim or header self-label under `docs/specs/**` or `docs/trusty-installer/research/02-design/**` on `origin/main`; no claim on any remote branch; and **no claim in any open PR** — the last check being precisely the gap that produced the original collision, since `scripts/check_doc_numbers.sh` scans the tree and cannot see an unmerged reservation (its own header states this limitation explicitly). Note also that `DOC-55` is claimed by `okg-universal-importer.md` via self-label only, its filename carrying no number, so a filename scan alone is insufficient in either direction.
 **Builds on:** DOC-55 [Universal OKG Importer](./okg-universal-importer.md) `SPEC-OKGIMPORT-03~draft`/`-04~draft` (the extraction layer and the `Connector` contract this document does **not** re-specify); DOC-57 [Five-Section Agent Configuration](./agent-config-five-sections.md) `SPEC-AGENTCFG-03~draft` (the Knowledge section this document adds a sub-surface to) and `SPEC-AGENTCFG-05~draft` (Listeners, the existing poll machinery); DOC-58 [K-d Attached Search Indexes](./DOC-58-knowledge-kd-attached-indexes.md) `SPEC-KDIDX-01~draft` (the two-tier curated-vs-attached principle this document depends on)
 **Related issues:** #4325 (per-assistant home directory — **in flight, PR #4523**); #3904 (epic: universal assistant-driven OKG importer); #4283 (index→OKG entity extraction); #4007 (epic: curated stores vs attached indexes); #4289 (index a new directory from the config UI); #4363 (extract-entities UI trigger); #4590 (concierge offers to build an assistant — the build path, §2.1a); #4591 (templates excluded from provisioning only incidentally); #4406 (which store is canonical — superseded in framing by §2 here); #4040 (epic: unified credential authority — this document is a **consumer**, never a parallel mechanism)
@@ -914,7 +914,16 @@ or URL query string that could carry one.
 ### 7.1b What OKG Sources needs from #4040
 
 Offered as concrete input to an epic that currently carries no child checklist.
-OKG Sources needs exactly five things, and nothing beyond them:
+OKG Sources needs exactly five things, and nothing beyond them.
+
+**Clarification, 2026-09-11 (#7425).** The read-scoped credential this section
+specifies is for the OKG entity-extraction pipeline (this document), not for
+the connector's own chat channel. Gmail, Drive, Slack, and Notion are, as of
+the owner's 1.0 assistant-platform revision, two-way channel connectors with
+independent inbound and outbound bindings (#7427; `agent-config-five-sections.md`
+§4.7). A channel's send/receive credential and an OKG source's read-scoped
+credential are two separate grants against the same provider, both routed
+through #4040, and neither implies the other.
 
 1. **A durable, opaque reference** a store row can hold in plain text under the
    home without that text being a secret.
@@ -1200,6 +1209,13 @@ and the push feed never assumes the watcher ran.
 
 ### 10.2 Index cardinality
 
+**Superseded 2026-09-11 by the one-index-multiple-roots model (#7425, tracked
+for search in #7429).** §10.5 below no longer holds: an attached project is a
+root of the assistant's one index, not a second, separately-queried K-d index.
+The K-a/K-d two-tier distinction this subsection and DOC-58 build on is
+retained below for historical record of the pre-1.0 architecture; it governs
+the current implementation until #7429 lands.
+
 **S-8.2** **One index per assistant store**, not one per source. The store is one
 tree; sources are rows within it; a search over "what this assistant knows" is
 one query. Per-source indexes would multiply index count by source count, fragment
@@ -1252,6 +1268,17 @@ the store's index is registered against the stable assistant home — never agai
 a worktree or temporary path.
 
 ### 10.5 Search tiering: OKG first, attached stores as fan-out {#SPEC-OKGSRC-14~draft}
+
+**Superseded 2026-09-11 by the one-index-multiple-roots model (#7425, tracked
+for search in #7429).** The owner's 2026-08-01 two-tier fan-out requirement
+below is replaced: there is one trusty-search index per Assistant, the OKG
+tree is one root of it, and each attached project is another root of the
+*same* index, so a query reaches one index, not two tiers reached
+concurrently. The tier/origin provenance requirement (§10.6, S-14.7/S-14.8)
+becomes root/origin provenance under the new model — which root within the one
+index produced a result — and needs its own normative pass under #7429. S-14.1
+through S-14.6 are retained below for historical record of the pre-1.0
+architecture; they govern the current implementation until #7429 lands.
 
 **Owner requirement (2026-08-01):** *"the internal OKG has priority for search,
 then attached stores for fan out."*
@@ -1706,3 +1733,4 @@ Phase B's runner ticket.
 | 2026-08-01 | Restructured around the owner's canonical model — one built OKG per agent, populated by many stores of two kinds (`SPEC-OKGSRC-12~draft`); "store" adopted as the single canonical noun with "OKG Source" recorded as an earlier synonym; bound-store extraction split into its own section (`SPEC-OKGSRC-13~draft`). |
 | 2026-08-01 | §3.4 added: searchable-corpus and OKG-contributor capacities are orthogonal, and search-only is a complete end state, never pending. §10.5–§10.6 added: OKG-first search tiering with attached-store fan-out, and per-result tier/origin provenance (`SPEC-OKGSRC-14~draft`), verified absent today. |
 | 2026-08-01 | §2.4–§2.7 added: `stores/<store-identifier>/` extraction targets for remote stores with the local/remote asymmetry made explicit (`SPEC-OKGSRC-11~draft`); `${TRUSTY_AGENTS_HOME}` recorded as one system value with migration deferred; config-format, dotless, and not-access-controlled recorded as settled. |
+| 2026-09-11 | Amended for the owner's 1.0 assistant-platform scope (epic #7425). Marked §10.2 (`S-8.2`/`S-8.3`, index cardinality) and §10.5 (`SPEC-OKGSRC-14~draft`, OKG-first tiering with attached-store fan-out) superseded by the one-index-multiple-roots model (#7429): one trusty-search index per Assistant, with the OKG tree and each attached project as roots of that single index, not separate K-a/K-d indexes queried by fan-out. Pre-1.0 tier/fan-out text is retained for historical record; it governs the current implementation until #7429 lands. Clarified §7.1b that an OKG source's read-scoped credential and a two-way channel's send/receive credential (#7427) are separate grants against the same provider. Evidence: `docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md`. |

--- a/docs/specs/agent-config-five-sections.md
+++ b/docs/specs/agent-config-five-sections.md
@@ -16,7 +16,7 @@ spec_refs:
 **Status:** Draft
 **Subsystem:** trusty-agents — agent configuration model, capability declaration, permissions surface, GUI config pane
 **Owner:** Engineering (trusty-agents) / Bob Matsuoka
-**Last-updated:** 2026-09-09
+**Last-updated:** 2026-09-11
 **Spec ID:** `SPEC-AGENTCFG-01~draft` … `SPEC-AGENTCFG-09~draft` (DOC-57)
 **Epic:** #3052 (Assistant M1)
 **Builds on:** DOC-54 [Trusty Agents Product Specification](./trusty-agents-product-spec.md) §5 (the config triple this spec supersedes) and §8.4 (the in-pane config sections); DOC-41 [Eve-Style Agent Framework](./trusty-agents-eve-style-agents-spec.md) §2.3/§2.6/§5.5 (manifest schema, no-code enforcement, user-authority singleton); DOC-42 [Agent-Bundled Skills](./agent-bundled-skills.md) (the `skills:` declaration + co-deployment model on the trusty-mpm side); DOC-23 [Learned-Autonomy Auto-Answer](./learned-autonomy-auto-answer.md) (the only designed approval/undo/audit model in the repo)
@@ -316,17 +316,29 @@ follows a symlink. Interrupted manifest binding is recoverable on retry.
 
 Sources are the union of registered project folders attached to the Assistant's
 chats and its effective, enabled incoming-channel bindings. Registration alone
-never authorizes extraction. The API persists chat-to-project attachments;
-canonical directory identity deduplicates them. Missing directories are omitted
-from the eligible catalogue without erasing attachment history. Channel source
-identity includes the configured account, target, and deterministic filters.
-Gmail, Google Drive, Slack, and Google Calendar are channel source kinds.
-Disabled, removed, or retargeted bindings invalidate pending work. No job may
-broaden the connector's configured authorization or filters.
+never authorizes extraction; it does auto-add the project's path as a root of
+the Assistant's one search index (below), which is immediate and does not wait
+for entity extraction. The API persists chat-to-project attachments; canonical
+directory identity deduplicates them. Missing directories are omitted from the
+eligible catalogue without erasing attachment history. Channel source identity
+includes the configured account, target, and deterministic filters. **Superseded
+2026-09-11:** gworkspace (Gmail, Drive, Calendar), Slack, Telegram, and Notion
+were previously described here as one-way "channel source kinds." They are
+two-way channel connectors — independent inbound and outbound bindings,
+configured per Assistant (#7425, tracked in #7427; see
+`crates/trusty-agents/src/tools/channel.rs`'s `context()` string for today's
+per-connector direction gaps). Each connector separately backs a read-only
+OKG entity-extraction source, specified in DOC-63 §5.1 — that pipeline's
+direction is independent of the channel's own send/receive bindings. Disabled,
+removed, or retargeted bindings invalidate pending work. No job may broaden the
+connector's configured authorization or filters.
 
-The two indexes serve different purposes: a project's index covers its eligible
-current files; the Assistant's index covers its derived **OKG business
-entities**. A copied source document alone does not count as entity extraction.
+**Superseded 2026-09-11 by the one-index-multiple-roots model (#7425, tracked
+for search in #7429).** The Assistant has **one** trusty-search index, not two:
+the OKG tree is one root of that index, and each attached project is an
+additional root. A copied source document alone does not count as entity
+extraction.
+
 The pipeline is source collection → NLP entity candidates → bounded batches of
 inexpensive inference for normalization/deduplication → validated OKG entities
 with provenance → trusty-search publication. People, organizations, projects,
@@ -1383,3 +1395,12 @@ tools *and* MCP connections. Users may read "Knowledge" as documents only.
   permissive behavior; §5.8 will be revisited when the review gate lands to make
   enforcement normative. Harmonizes this spec with the stated intent that security
   review gates implementation.
+- **2026-09-11** — Amended §4.7 for the owner's 1.0 assistant-platform scope
+  (epic #7425). Superseded the two-index-per-Assistant description with the
+  one-index-multiple-roots model (#7429): one trusty-search index per
+  Assistant, the OKG tree as one root, each attached project as another root.
+  Superseded the "channel source kinds" framing of gworkspace/Slack/Telegram/
+  Notion with the two-way channel connector model (#7427): each connector
+  carries independent inbound and outbound bindings, and separately backs a
+  read-only OKG entity-extraction source (DOC-63 §5.1). Evidence:
+  `docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md`.

--- a/docs/specs/trusty-agents-product-spec.md
+++ b/docs/specs/trusty-agents-product-spec.md
@@ -3,7 +3,7 @@
 **Status:** Draft  
 **Subsystem:** trusty-agents — product vision / agent model / eventstream processing  
 **Owner:** Engineering (trusty-agents) / Bob Matsuoka  
-**Last-updated:** 2026-07-24  
+**Last-updated:** 2026-09-11  
 **Spec ID:** `SPEC-AGENTS-01~draft` … `SPEC-AGENTS-08~draft` (DOC-54)
 
 ---
@@ -11,6 +11,50 @@
 ## 1. Executive Summary
 
 Trusty Agents is a personal-productivity agent platform focused on three things: **tasks** (user-facing workstreams), **workstreams** (resumable, agent-tagged memory history), and **eventstream processing** (the primary capability). The product is NOT a general coding/project-work agent — that domain belongs to Co-work. Instead, Trusty Agents connects assistants to event sources (Gmail, Google Calendar, Slack, etc.), delivers events as they arrive, asks how to respond, learns preferences in trusty-memory, and adapts over time. All agents are declarative-only, instantiated from templates into local configuration packages, never coded.
+
+---
+
+## 1a. 1.0 Scope — the Assistant Platform (owner, 2026-09-11)
+
+The owner set six items as the 1.0 assistant-platform scope for `trusty-agents`
+and `trusty-agents-common`, reviewed 2026-09-11 (epic #7425). Evidence for the
+current-state gap against each item:
+`docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md`.
+
+1. **Two crates, not three.** `trusty-agents` and `trusty-agents-common` are
+   the only agents crates; `trusty-agents-local` folds away — it is a
+   15-line pass-through binary with no remaining reason to exist. (#7359)
+2. **Two-way channel connectors.** gworkspace, Slack, Telegram, and Notion are
+   native connectors with messages IN and OUT, configured per Assistant — not
+   one-way ingestion sources. Today Telegram is send-only and gworkspace is
+   not modeled as a bound channel (`crates/trusty-agents/src/tools/channel.rs`
+   `context()`). (#7427)
+3. **One memory palace per Assistant, opt-in fan-out.** Each Assistant has one
+   trusty-memory palace. Reading another Assistant's palace requires that
+   Assistant to be selected in settings — it is never automatic. §5.1 above
+   amends the prior "no shared stores" framing. (#7428)
+4. **One search index per Assistant, multiple roots.** Each Assistant has one
+   trusty-search index, not one index per source. The OKG tree is one root;
+   each attached project is another root. No concurrent fan-out across
+   separate named indexes. Supersedes DOC-63 §10.2/§10.5 and the two-index
+   framing in `agent-config-five-sections.md` §4.7. (#7429)
+5. **Projects per Assistant or per chat thread.** A project's path is
+   auto-added as a root of the Assistant's index on attachment. Assistant
+   projects are configured in settings. (#4358)
+6. **Chat attachments as objects.** Text, binary, and CSV attachments on a
+   chat thread render as thumbnail, click-expandable objects, stored at
+   `<assistant home>/attachments/<session>/<file>`
+   (`AssistantHome::attachments_dir`, sibling to `AssistantHome::okg_dir` —
+   `crates/trusty-agents/src/assistants/home.rs`). (#7370)
+7. **OKG-only exposed knowledge graph.** The graph a user or agent can browse
+   carries only OKG triples and definitions. Memory drawers are never exposed
+   through it; they stay fenced behind the untrusted-content boundary
+   (DOC-63 §6). (#7430)
+
+Scope boundary: changes for these items land in `trusty-agents`,
+`trusty-agents-common`, and (for item 1) the retirement of
+`trusty-agents-local`. `trusty-kb`, `trusty-channels`, and `trusty-gworkspace`
+are consumed as dependencies, not modified as part of this epic.
 
 ---
 
@@ -119,8 +163,18 @@ specialist and delegated agents do not receive independent stores.
 [DOC-57 §4.7](./agent-config-five-sections.md#SPEC-AGENTCFG-03~draft) governs
 project/channel business-entity extraction, monthly history, and ongoing updates.
 
-- **Contents:** The agent's OKF knowledge tree (structured markdown KG) + search index over that tree.
-- **Cross-agent knowledge:** Flows via agent-to-agent communication (via MCP tools or chat), NOT via shared stores.
+- **Contents:** The agent's OKF knowledge tree (structured markdown KG) + one
+  trusty-search index over that tree, with an additional root per attached
+  project (**superseded 2026-09-11** from a two-index design — one for the
+  tree, one per project — by the one-index-multiple-roots model; #7425,
+  tracked for search in #7429).
+- **Cross-agent knowledge:** **Superseded 2026-09-11** ("flows via
+  agent-to-agent communication, NOT via shared stores") by the owner's
+  one-memory-palace-per-assistant model: each Assistant has one trusty-memory
+  palace, and cross-assistant reads happen only as an opt-in fan-out to
+  another Assistant's palace, selected in that Assistant's settings (#7425,
+  tracked in #7428). Agent-to-agent communication (MCP tools or chat) remains
+  a separate path and is not replaced by palace fan-out.
 - **Configuration:** `agent.toml` lists the store name; the harness initializes/attaches it on agent startup.
 
 ### 5.2 Tools (Actions): MCP allow-list
@@ -486,9 +540,10 @@ Focused context is a **starting point, not a wall**. The agent has full agency:
 | Listeners as inbound API bindings, NOT MCP tools; two-stage filtering (listener-level + per-agent) | 2026-07-24 | #3820 |
 | Gmail: Pub/Sub pull + history.list fallback; Calendar: syncToken polling | 2026-07-24 | #3820 |
 | Eventstream processing is primary product focus | 2026-07-24 | #3798 |
-| One OKG store per agent; cross-agent knowledge via agent-to-agent communication | 2026-07-24 | 3820 (config triple discussion) |
+| One OKG store per agent; cross-agent knowledge via agent-to-agent communication (superseded 2026-09-11 — see below) | 2026-07-24 | 3820 (config triple discussion) |
 | Demo three agents: Izzie (personal), CTO Assistant (work), Concierge (fixed/ctrl) | 2026-07-24 | #3818, #3816 |
 | Declarative-only agents (no coded agents) | 2026-07-16 | #2791, reaffirmed 2026-07-24 |
+| 1.0 assistant-platform scope: 2 crates; two-way channels; one memory palace per Assistant with opt-in fan-out; one search index per Assistant with multiple roots; projects per Assistant/thread; chat attachments as objects; OKG-only exposed graph | 2026-09-11 | #7425 (epic), #7359/#7427/#7428/#7429/#4358/#7370/#7430 |
 
 ---
 
@@ -519,15 +574,32 @@ Focused context is a **starting point, not a wall**. The agent has full agency:
 - #3790 — Personal Assistant onboarding epic
 - #3795 — Multi-tenancy foundations (gworkspace named identities)
 - #2791 — Declarative-only agents (standing rule)
+- #7425 — Epic: 1.0 assistant platform (owner scope, 2026-09-11)
+- #7359 — (a) two-crate consolidation
+- #7427 — (b) two-way channel connectors
+- #7428 — (c1) one memory palace per Assistant, opt-in fan-out
+- #7429 — (c2) one search index per Assistant, multiple roots
+- #4358 — (d) per-chat/per-Assistant project workspaces
+- #7370 — (e) chat attachments as objects
+- #7430 — (f) knowledge-graph cleanup, OKG-only exposed graph
 
 **Related Specs:**
 - DOC-41 (SPEC-AGENTFW-01~draft …) — Eve-Style Agent Framework (agent definition format, runtime)
 - DOC-47 (SPEC-EVTING-01~draft …) — External Event Ingestion (webhooks & connector push)
 - DOC-48 (SPEC-WS-01~draft …) — tcode Workstreams (durable work aggregation)
 - DOC-38 (SPEC-SLD-01~draft …) — Spec-Linked Documentation standard
+- [DOC-57 — Five-Section Agent Configuration](./agent-config-five-sections.md) §4.7 — the one-index-multiple-roots and two-way-channel model
+- [DOC-63 — OKG Sources](./DOC-63-okg-sources.md) §10.2, §10.5 — the superseded two-tier fan-out design
 
 ---
 
 ## 13. Change Log
 
 - **2026-07-24** — Initial spec (DOC-54, SPEC-AGENTS-01~draft … 08~draft), consolidating Bob's product vision decisions from 2026-07-24 demo and morning directives. Eight sections covering product vision, agent model, config triple, persona/instructions, listeners (Gmail/Calendar detail), GUI structure, memory/workstreams, and open questions. Demo roster (Izzie, CTO Assistant, Concierge) established. User-facing terminology (Tasks = Workstreams) recorded.
+- **2026-09-11** — Added §1a, the owner's 1.0 assistant-platform scope (epic
+  #7425): two-crate consolidation, two-way channel connectors, one memory
+  palace per Assistant with opt-in fan-out, one search index per Assistant
+  with multiple roots, projects per Assistant/thread, chat attachments as
+  objects, and an OKG-only exposed knowledge graph. Amended §5.1's
+  cross-agent-knowledge line, superseded by the opt-in palace fan-out model.
+  Evidence: `docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md`.


### PR DESCRIPTION
## Outcome
The agents specs now state the owner's 2026-09-11 1.0 model — one index per assistant with an OKG root plus one root per project, two-way channels, one palace per assistant with opt-in fan-out, attachments under `<assistant home>/attachments/<session>/`, OKG-only exposed graph. Epic #7425.

## Changes
`docs/specs/agent-config-five-sections.md` §4.7; `docs/specs/DOC-63-okg-sources.md` §7.1b/§10.2/§10.5 superseded notices; `docs/specs/trusty-agents-product-spec.md` new §1a and §5.1; `docs/specs/DOC-58-knowledge-kd-attached-indexes.md` superseded-in-part notice; new evidence record `docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md`. Out of scope: any code change; the implementation issues #7427/#7428/#7429/#4358 are blocked on this PR.

## Risk
Low, rung 1 (docs only).

## Tests
`./scripts/check_sld.sh` exit 0, `./scripts/check_doc_paths.sh` exit 0, run before and after rebase onto origin/main 7a8a391cd. Not in `docs/public-manifest.tsv`, so no public-docs gate.

## Baseline failures
None known.

## Changelog
None owed (docs-only).

## Review findings
Security credential scan CLEAN.

Refs #7426

Refs #7425

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_014co1TJqBd2EMvjb6gkbfyP
