### PR TITLE
fix(scripts): check-pr-changelog-assembled tolerates a deleted CHANGELOG.md and fails closed on tool errors (Refs #7359)

### DIFF
--- a/scripts/check-pr-changelog-assembled.sh
+++ b/scripts/check-pr-changelog-assembled.sh
@@ -109,21 +109,31 @@ while IFS= read -r path; do
   # merge-base file. A heading that already existed at the merge base (a
   # --merge run folding fragments into a stale section, #5298) is not "new"
   # even if the diff happens to touch nearby lines.
-  # #7359: `|| true` — a PR that DELETES a crate's CHANGELOG.md produces a
-  # pure-deletion diff with no `+## [` lines, so grep exits 1, pipefail
-  # propagates it, and `set -e` killed this assignment before the `-z` guard
-  # below could skip the crate — the job failed with NO output. Same guard the
-  # `base_headings` pipeline below already carries.
+  # #7359: the `|| true` guards GREP ALONE, never the whole pipeline. A PR that
+  # DELETES a crate's CHANGELOG.md produces a pure-deletion diff with no
+  # `+## [` lines, so grep exits 1, pipefail propagates it, and `set -e` killed
+  # this assignment before the `-z` guard below could skip the crate — the job
+  # failed with NO output. Guarding the pipeline END instead would also swallow
+  # a git or sed failure: the result would be empty, the `-z` guard would read
+  # that as "no new headings", and the gate would go green on tool trouble.
+  # Grep's no-match is the ONE nonzero exit that means "nothing to check here".
   new_headings="$(
     git diff --unified=0 --no-renames "${MERGE_BASE}" HEAD -- "$path" \
-      | grep -E '^\+## \[' \
+      | { grep -E '^\+## \[' || true; } \
       | sed -E 's/^\+## \[([^]]+)\].*/\1/' \
-      | LC_ALL=C sort -u || true
+      | LC_ALL=C sort -u
   )"
   [[ -z "$new_headings" ]] && continue
 
-  base_headings="$(git show "${MERGE_BASE}:${path}" 2>/dev/null \
-    | grep -oE '^## \[[^]]+\]' | sed -E 's/^## \[([^]]+)\].*/\1/' || true)"
+  # #7359: same narrowing here. `git show` gets its own guard because a path
+  # that does not exist at the merge base is expected, not an error — that is
+  # a crate whose CHANGELOG.md this PR ADDS, and it means "no prior headings".
+  # sed stays unguarded, so a genuine sed failure still fails the gate.
+  base_headings="$(
+    { git show "${MERGE_BASE}:${path}" 2>/dev/null || true; } \
+      | { grep -oE '^## \[[^]]+\]' || true; } \
+      | sed -E 's/^## \[([^]]+)\].*/\1/'
+  )"
 
   while IFS= read -r version; do
     [[ -z "$version" ]] && continue

--- a/scripts/check-pr-changelog-assembled.sh
+++ b/scripts/check-pr-changelog-assembled.sh
@@ -109,11 +109,16 @@ while IFS= read -r path; do
   # merge-base file. A heading that already existed at the merge base (a
   # --merge run folding fragments into a stale section, #5298) is not "new"
   # even if the diff happens to touch nearby lines.
+  # #7359: `|| true` — a PR that DELETES a crate's CHANGELOG.md produces a
+  # pure-deletion diff with no `+## [` lines, so grep exits 1, pipefail
+  # propagates it, and `set -e` killed this assignment before the `-z` guard
+  # below could skip the crate — the job failed with NO output. Same guard the
+  # `base_headings` pipeline below already carries.
   new_headings="$(
     git diff --unified=0 --no-renames "${MERGE_BASE}" HEAD -- "$path" \
       | grep -E '^\+## \[' \
       | sed -E 's/^\+## \[([^]]+)\].*/\1/' \
-      | LC_ALL=C sort -u
+      | LC_ALL=C sort -u || true
   )"
   [[ -z "$new_headings" ]] && continue
 


### PR DESCRIPTION
## Outcome

The PR-time changelog gate no longer fails silently when a PR deletes a
crate's `CHANGELOG.md` (first hit: #7433, which removed
`crates/trusty-agents-local`), and no longer swallows a failing
`git diff`/`sed` as "no headings".

Refs #7359

## Changes

`scripts/check-pr-changelog-assembled.sh` only — both heading pipelines guard
grep's no-match exit alone (`| { grep … || true; } |`); `git show` in the base
pipeline keeps its own guard, because an absent path at the merge base is the
expected "new crate CHANGELOG.md" case, not a tool failure.

Out of scope: the missing self-test the header's `Test:` line names — ticketed
separately.

## Risk

Low. CI-script only; not a required context.

## Tests

```
$ bash scripts/check-pr-changelog-assembled.sh
no crates/*/CHANGELOG.md changed - OK
$ echo $?
0

$ # synthetic deletion of crates/tc-services/CHANGELOG.md
$ bash scripts/check-pr-changelog-assembled.sh
every new CHANGELOG.md section in this PR is assembled cleanly
$ echo $?
0

$ # stranded-fragment negative (unchanged behavior)
$ bash scripts/check-pr-changelog-assembled.sh
FAIL: crates/<crate>/CHANGELOG.md ...
$ echo $?
1

$ # injected failing `git diff` under set -e -o pipefail, same input on both shapes
$ # old shape (grep-guard on the whole pipeline): empty result, exit 0 (bug)
$ # new shape (grep-guard on grep alone): exit 128, propagated (fixed)

$ # newly-added crate CHANGELOG.md path: base pipeline resolves via the
$ # `git show` guard (absent path at merge base); gate reports the fixture's
$ # missing Cargo.toml as an unexpected failure rather than swallowing it

$ bash -n scripts/check-pr-changelog-assembled.sh
$ echo $?
0
```

Escapes verified byte-exact against the source diff.

## Baseline

None.

## Docs

None owed — scripts-only change, no crate `src/**` touched.

## Review

Below (trusty-review to run after this PR opens).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_014co1TJqBd2EMvjb6gkbfyP
