### PR TITLE
fix(trusty-agents): exposed knowledge graph reads the OKG tree — triples and definitions, never the memory KG (Refs #7430)

### DIFF
--- a/crates/trusty-agents/changelog.d/7430-okg-graph-audit.md
+++ b/crates/trusty-agents/changelog.d/7430-okg-graph-audit.md
@@ -1,0 +1,8 @@
+Changed
+
+- The Knowledge Graph the assistant UI exposes (`GET /api/agents/:name/kg*`) now
+  reads the assistant's OKG tree instead of trusty-memory's palace-scoped `kg_*`
+  surface, and returns both halves of the graph — relationship triples and
+  entity definitions. The envelope reports the tree it read and declares
+  `source: "okg"`; the memory knowledge graph is a separate store and no longer
+  reaches this surface (Refs #7430).

--- a/crates/trusty-agents/src/api/server/agent_kg.rs
+++ b/crates/trusty-agents/src/api/server/agent_kg.rs
@@ -37,7 +37,7 @@
 //! all four routes:
 //!
 //! ```json
-//! { "tree": "/…/izzie/okg", "source": "okg", "connected": true,
+//! { "tree": "izzie/okg", "source": "okg", "connected": true,
 //!   "data": <per-route>, "definitions": [ … ] }
 //! { "tree": null, "source": "okg", "connected": false, "reason": "…",
 //!   "data": [], "definitions": [] }
@@ -50,6 +50,13 @@
 //! payload's TYPE, only on `connected`. `definitions` is ALWAYS an array — it is
 //! the half of the graph that says what a subject is, and the owner's closure
 //! condition for #7430 requires it beside the triples.
+//!
+//! **`tree` is an opaque LABEL, never a filesystem path** (#7430 security
+//! review): the binding's own `okg://<agent>` URI, or the home-relative
+//! `<agent>/<root>`. Every `reason` obeys the same rule, and the underlying
+//! error text is logged instead. Serving the absolute root would hand every
+//! viewer of the pane the operator's home-directory layout, which the retired
+//! memory-palace envelope never disclosed and no client needs.
 //! Test: `kg_subjects_route_lists_okg_subjects`,
 //! `no_memory_drawer_or_palace_triple_can_reach_the_exposed_graph`.
 
@@ -279,7 +286,8 @@ async fn graph_at_defaults(name: &str, read: KgRead) -> Response {
 /// Test: `kg_subjects_route_lists_okg_subjects`,
 /// `kg_route_empty_state_when_the_tree_is_absent`,
 /// `kg_route_unknown_agent_404`, `kg_route_rejects_traversal_name`,
-/// `kg_route_degrades_on_malformed_toml`.
+/// `kg_route_degrades_on_malformed_toml`,
+/// `no_envelope_discloses_a_filesystem_path`.
 pub(super) async fn kg_graph_at(
     dirs: &[PathBuf],
     name: &str,
@@ -333,33 +341,37 @@ pub(super) async fn kg_graph_at(
         );
     };
 
-    let root = match okg_graph::resolve_okg_root(name, &stores, assistants_root, knowledge_dir) {
-        Ok(root) => root,
+    let tree = match okg_graph::resolve_okg_root(name, &stores, assistants_root, knowledge_dir) {
+        Ok(tree) => tree,
         Err(reason) => return envelope(None, Err(reason), &read, None),
     };
-    let tree = Some(root.display().to_string());
-    if !root.is_dir() {
+    // #7430: the envelope carries the binding's own opaque label, never
+    // `tree.root` — an absolute path would disclose the operator's home layout
+    // to every viewer of the pane. The same rule governs every `reason` below,
+    // so the upstream error text is logged rather than rendered.
+    let label = Some(tree.label.clone());
+    if !tree.root.is_dir() {
         return envelope(
-            tree,
+            label,
             Err(format!(
-                "this assistant has no OKG tree at {} yet — nothing has been ingested",
-                root.display()
+                "this assistant has no OKG tree `{}` yet — nothing has been ingested",
+                tree.label
             )),
             &read,
             None,
         );
     }
-    match okg_graph::read_graph(&root) {
-        Ok(graph) => envelope(tree, Ok(read.project(&graph)), &read, None),
-        Err(e) => envelope(
-            tree,
-            Err(format!(
-                "the OKG tree at {} is unreadable: {e:#}",
-                root.display()
-            )),
-            &read,
-            None,
-        ),
+    match okg_graph::read_graph(&tree.root) {
+        Ok(graph) => envelope(label, Ok(read.project(&graph)), &read, None),
+        Err(e) => {
+            tracing::warn!(?e, agent = name, tree = %tree.label, "kg_graph_at: tree unreadable");
+            envelope(
+                label,
+                Err(format!("the OKG tree `{}` is unreadable", tree.label)),
+                &read,
+                None,
+            )
+        }
     }
 }
 

--- a/crates/trusty-agents/src/api/server/agent_kg.rs
+++ b/crates/trusty-agents/src/api/server/agent_kg.rs
@@ -1,77 +1,59 @@
-//! `GET /api/agents/:name/kg*` — a READ-ONLY proxy onto the agent's bound
-//! memory palace's Knowledge Graph (#4290).
+//! `GET /api/agents/:name/kg*` — the agent's EXPOSED knowledge graph, read
+//! READ-ONLY out of its OKG tree (#4290, #6286, #7430).
 //!
-//! Why: trusty-memory ships the entire palace-scoped KG read surface
-//! (`memory.kg_subjects_with_counts`, `memory.kg_all`, `memory.kg_count`, and
-//! the `kg_query` tool), but every one of them is keyed by PALACE id. The
-//! Knowledge-Graph browser in the agents GUI is keyed by AGENT — and the
-//! mapping between the two lives in this crate (`[[stores]].palace`, resolved
-//! by `StoresConfig::primary()`). Without this module a client would have to
-//! read `GET /api/agents/:name/stores`, dig the palace id out of the first
-//! binding, find the trusty-memory socket for itself, and then speak framed
-//! JSON-RPC over a Unix socket from a browser — which it cannot do at all.
-//! This is the plumbing that removes that: agent in, KG JSON out.
+//! Why: these four routes back the Knowledge-Graph browser in the agents GUI.
+//! Until #7430 they proxied trusty-memory's palace-scoped `kg_*` surface, so the
+//! pane labelled "Knowledge Graph" showed the MEMORY knowledge graph — triples
+//! asserted into a memory palace, a separate store with a separate lifecycle.
+//! Epic #7425 item (f) settles what the exposed graph is: the OKG graph, triples
+//! AND definitions, out of the assistant's own `okg/` tree, and never a memory
+//! palace. This module now reads that tree and holds no memory client at all, so
+//! nothing here can reach a palace even by mistake.
 //!
-//! **This module holds no KG query logic of its own.** `MemoryService` stays
-//! the single entry point for every KG read; the upstream body is passed
-//! through under `data` — never re-ranked, truncated or re-sorted here — so the
-//! GUI and the MCP `kg_query` tool can never disagree about what the graph
-//! contains.
+//! **This module holds no graph logic of its own.**
+//! [`crate::stores::okg_graph`] is the single reader; these handlers page and
+//! envelope what it returns.
 //!
-//! One method's answer is projected rather than passed whole, and only one:
-//! `/kg?subject=` maps onto the `kg_query` TOOL, which answers
-//! `{subject, triples, kg_triple_count, …}` where the retired route answered a
-//! bare `Vec<Triple>`. `data` carries `triples`, because this route's contract
-//! is that every array-shaped read has the same TYPE in `data` and a client
-//! branches only on `connected` (see the envelope below). The projection is
-//! named here rather than buried: `KgRead::project`.
-//!
-//! **Read-only by owner decision.** trusty-memory's `POST /kg` (assert) and
-//! `DELETE /kg/triples/{id}` (retract) are deliberately NOT proxied;
-//! editability is a separate follow-up ticket. Adding a write here would also
-//! put a mutating cross-daemon call behind this crate's same-origin write
-//! guard for the first time, which is a decision this slice does not make.
+//! **Read-only by owner decision (#4290).** Nothing here writes an entity; OKG
+//! ingest has its own tools (`okg_ingest_*`) with their own confinement.
 //!
 //! **Never-fail posture** (identical contract to
 //! [`crate::stores::resolve_store_statuses`], which this module deliberately
-//! mirrors rather than inventing a second error vocabulary): an agent that
-//! binds no palace, a trusty-memory daemon that is down, a palace that does
-//! not exist, and an unreadable upstream body ALL resolve to `200 OK` with
-//! `connected: false` plus a machine-readable `reason` and an empty-but-
-//! well-typed `data`. A browser pane must render an empty state, not an error
-//! toast, for the ordinary condition "this agent has no palace yet". Only
-//! genuinely client-side faults keep a non-200: `400` for an invalid agent
-//! name or a missing `subject`, `404` for an unknown agent, `500` only when
-//! the agent's own config file cannot be read off disk.
-//!
-//! **The upstream is a Unix socket, not an HTTP origin (#6286).** This module
-//! resolved `resolve_daemon_base_url("trusty-memory")`, which reads an
-//! `http_addr` file ADR-0032 stopped writing — so it was permanently `None` and
-//! every request took the degraded arm, rendering the GUI's KG pane empty with
-//! "daemon not discoverable" whether or not the daemon was up. The four reads
-//! map onto folded methods (`memory.kg_subjects_with_counts`, `memory.kg_all`,
-//! `memory.kg_count`) and the `kg_query` tool.
+//! mirrors rather than inventing a second error vocabulary): an agent whose tree
+//! does not exist yet, a tree that cannot be read, and an `agent.toml` that does
+//! not parse ALL resolve to `200 OK` with `connected: false` plus a
+//! machine-readable `reason` and an empty-but-well-typed `data`. A browser pane
+//! must render an empty state, not an error toast, for the ordinary condition
+//! "this assistant has ingested nothing yet". Only genuinely client-side faults
+//! keep a non-200: `400` for an invalid agent name or a missing `subject`, `404`
+//! for an unknown agent, `500` only when the agent's own config file cannot be
+//! read off disk.
 //!
 //! What: four thin axum shims ([`agent_kg_subjects_route`],
 //! [`agent_kg_all_route`], [`agent_kg_query_route`], [`agent_kg_count_route`])
-//! over one testable core, [`kg_proxy_at`], which takes the agents-dir list
-//! and the trusty-memory socket explicitly (the injected-dependency
+//! over one testable core, [`kg_graph_at`], which takes the agents-dir list, the
+//! assistants root and the knowledge dir explicitly (the injected-dependency
 //! convention of `agent_stores::stores_at`). Response envelope, identical for
 //! all four routes:
 //!
 //! ```json
-//! { "palace": "cto" | null, "connected": true, "data": <upstream JSON> }
-//! { "palace": null, "connected": false, "reason": "…", "data": [] }
+//! { "tree": "/…/izzie/okg", "source": "okg", "connected": true,
+//!   "data": <per-route>, "definitions": [ … ] }
+//! { "tree": null, "source": "okg", "connected": false, "reason": "…",
+//!   "data": [], "definitions": [] }
 //! ```
 //!
-//! plus `config_error` when the agent's `agent.toml` failed to parse. `data`
-//! is the upstream array for `/kg`, `/kg/subjects` and `/kg/all`, and the
-//! upstream `{"active": N}` object for `/kg/count`; its empty form (`[]` /
-//! `{"active": 0}`) is preserved on every degraded path so a client never has
-//! to branch on the payload's TYPE, only on `connected`.
-//! Test: `super::tests::agent_kg`.
+//! plus `config_error` when the agent's `agent.toml` failed to parse. `data` is
+//! an array for `/kg`, `/kg/subjects` and `/kg/all`, and the counts object for
+//! `/kg/count`; its empty form (`[]` / `{"active": 0, "definition_count": 0}`)
+//! is preserved on every degraded path so a client never has to branch on the
+//! payload's TYPE, only on `connected`. `definitions` is ALWAYS an array — it is
+//! the half of the graph that says what a subject is, and the owner's closure
+//! condition for #7430 requires it beside the triples.
+//! Test: `kg_subjects_route_lists_okg_subjects`,
+//! `no_memory_drawer_or_palace_triple_can_reach_the_exposed_graph`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use axum::{
     Json,
@@ -85,14 +67,15 @@ use serde_json::{Value, json};
 use super::agent_patch::resolve_agent_paths;
 use super::state::AppState;
 use crate::stores::StoresConfig;
-use crate::stores::status::PROBE_TIMEOUT;
+use crate::stores::okg_graph::{self, OkgDefinition, OkgGraph};
 
-/// Query parameters accepted across all four KG proxy routes.
-///
-/// Every field is optional and forwarded ONLY when present, so trusty-memory's
-/// own defaults and clamps (`limit` default 50, max 200 —
-/// `kg_routes::MAX_KG_LIST_LIMIT`) stay the single source of truth. Restating
-/// them here would give the GUI two different ceilings to reason about.
+/// Page size when the caller names none.
+const DEFAULT_KG_LIMIT: usize = 50;
+/// Page-size ceiling. Mirrors the retired upstream's `MAX_KG_LIST_LIMIT` so a
+/// client that already clamped to 200 keeps working unchanged.
+const MAX_KG_LIMIT: usize = 200;
+
+/// Query parameters accepted across all four KG routes.
 #[derive(Debug, Default, Deserialize)]
 pub(super) struct KgParams {
     limit: Option<usize>,
@@ -100,136 +83,146 @@ pub(super) struct KgParams {
     subject: Option<String>,
 }
 
-/// One upstream KG read, resolved from the route that was hit.
+impl KgParams {
+    /// The clamped page size.
+    fn limit(&self) -> usize {
+        self.limit
+            .unwrap_or(DEFAULT_KG_LIMIT)
+            .clamp(1, MAX_KG_LIMIT)
+    }
+
+    /// The page offset.
+    fn offset(&self) -> usize {
+        self.offset.unwrap_or(0)
+    }
+}
+
+/// One read of the exposed graph, resolved from the route that was hit.
 ///
-/// `method` is the name dialled on trusty-memory's socket; `params` are that
-/// method's own arguments minus the palace, which is filled in once the agent's
-/// binding resolves; `empty` is the payload shape used for `data` on every
-/// degraded path (see the module doc's envelope).
-pub(super) struct KgRead {
-    method: &'static str,
-    params: serde_json::Map<String, Value>,
-    /// The key this method names the palace under.
-    ///
-    /// The folded methods take `palace_id`, flattened out of the former path
-    /// segment. `kg_query` is a TOOL and has always taken `palace`. Naming the
-    /// key per read is what lets both go through one call site.
-    palace_key: &'static str,
-    empty: Value,
-    /// The field to lift out of the answer, when the method's shape is wider
-    /// than this route's `data` contract.
-    ///
-    /// `Some("triples")` for `kg_query` only — see the module doc.
-    project: Option<&'static str>,
+/// `pub(super)` so `super::tests::agent_kg` can drive [`kg_graph_at`] with an
+/// arbitrary read without a test-only shim on the production type.
+#[derive(Debug, Clone)]
+pub(super) enum KgRead {
+    /// Every subject with its triple count, paged.
+    Subjects { limit: usize },
+    /// Every triple, paged.
+    All { limit: usize, offset: usize },
+    /// One subject's triples, unpaged.
+    Subject(String),
+    /// Graph totals.
+    Count,
 }
 
 impl KgRead {
-    /// Construct one read. `pub(super)` so `super::tests::agent_kg` can drive
-    /// [`kg_proxy_at`] with an arbitrary read without a test-only shim on the
-    /// production type.
-    pub(super) fn new(
-        method: &'static str,
-        palace_key: &'static str,
-        params: Vec<(&'static str, Value)>,
-        empty: Value,
-    ) -> Self {
-        Self {
-            method,
-            params: params
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect(),
-            palace_key,
-            empty,
-            project: None,
+    /// The `data` shape this read reports on every degraded path.
+    fn empty(&self) -> Value {
+        match self {
+            Self::Count => json!({ "active": 0, "definition_count": 0 }),
+            _ => json!([]),
         }
     }
 
-    /// Lift `field` out of the answer instead of passing the object whole.
-    pub(super) fn projecting(mut self, field: &'static str) -> Self {
-        self.project = Some(field);
-        self
+    /// Project a graph into this read's `data` plus its accompanying
+    /// definitions.
+    ///
+    /// Why: the two halves are selected together — a page of triples is only
+    /// readable beside the definitions of the subjects on it, and shipping every
+    /// definition with every page would send the whole tree four times.
+    /// What: `(data, definitions)`. `Count` reports totals and no definition
+    /// bodies, because a count pane renders neither.
+    /// Test: `kg_all_route_pages_triples_with_their_definitions`,
+    /// `kg_count_route_counts_both_halves`.
+    fn project(&self, graph: &OkgGraph) -> (Value, Vec<OkgDefinition>) {
+        match self {
+            Self::Subjects { limit } => {
+                let page: Vec<_> = graph.subject_counts().into_iter().take(*limit).collect();
+                let subjects: Vec<String> = page.iter().map(|c| c.subject.clone()).collect();
+                (json!(page), graph.definitions_for(&subjects))
+            }
+            Self::All { limit, offset } => {
+                let page: Vec<_> = graph
+                    .triples
+                    .iter()
+                    .skip(*offset)
+                    .take(*limit)
+                    .cloned()
+                    .collect();
+                let subjects: Vec<String> = page.iter().map(|t| t.subject.clone()).collect();
+                (json!(page), graph.definitions_for(&subjects))
+            }
+            Self::Subject(subject) => {
+                let page: Vec<_> = graph
+                    .triples
+                    .iter()
+                    .filter(|t| &t.subject == subject)
+                    .cloned()
+                    .collect();
+                (
+                    json!(page),
+                    graph.definitions_for(std::slice::from_ref(subject)),
+                )
+            }
+            Self::Count => (
+                json!({
+                    "active": graph.triples.len(),
+                    "definition_count": graph.definitions.len(),
+                }),
+                Vec::new(),
+            ),
+        }
     }
-
-    /// The params to send, with the resolved palace filled in.
-    fn params_for(&self, palace: &str) -> Value {
-        let mut params = self.params.clone();
-        params.insert(
-            self.palace_key.to_string(),
-            Value::String(palace.to_string()),
-        );
-        Value::Object(params)
-    }
-}
-
-/// `limit`/`offset` as forwardable params, omitting whichever the caller did
-/// not send so trusty-memory's own defaults and clamps stay the single source
-/// of truth.
-fn page_params(p: &KgParams, with_offset: bool) -> Vec<(&'static str, Value)> {
-    let mut params = Vec::new();
-    if let Some(limit) = p.limit {
-        params.push(("limit", Value::from(limit)));
-    }
-    if with_offset && let Some(offset) = p.offset {
-        params.push(("offset", Value::from(offset)));
-    }
-    params
 }
 
 /// `GET /api/agents/:name/kg/subjects?limit=N` — HTTP entry point.
 ///
-/// Why: The browser's left-hand subject list needs a count badge per subject,
-/// so this proxies `kg_list_subjects_with_counts` (not the bare
-/// `kg_list_subjects`) — one upstream pass instead of one query per subject.
-/// What: `data` is the upstream `[{subject, count}, …]` array verbatim.
-/// Test: `kg_subjects_route_passes_upstream_through`.
-// #4290: per-agent entry onto trusty-memory's palace-scoped subject list.
+/// Why: the browser's left-hand list needs a count badge per subject, and needs
+/// to list an entity that has a definition but no edges yet.
+/// What: `data` is `[{subject, count}, …]`; `definitions` carries those
+/// subjects' definitions.
+/// Test: `kg_subjects_route_lists_okg_subjects`.
+// #7430: per-agent entry onto the OKG tree's subject list (was trusty-memory's
+// palace-scoped list).
 pub(super) async fn agent_kg_subjects_route(
     State(_state): State<AppState>,
     AxumPath(name): AxumPath<String>,
     Query(p): Query<KgParams>,
 ) -> Response {
-    let read = KgRead::new(
-        "memory.kg_subjects_with_counts",
-        "palace_id",
-        page_params(&p, false),
-        json!([]),
-    );
-    proxy_with_discovered_memory(&name, read).await
+    graph_at_defaults(&name, KgRead::Subjects { limit: p.limit() }).await
 }
 
 /// `GET /api/agents/:name/kg/all?limit=N&offset=N` — HTTP entry point.
 ///
-/// Why: The browser's "All" mode pages across every active triple regardless
-/// of subject; `kg_query` cannot serve it because it REQUIRES a subject.
-/// What: `data` is the upstream `[Triple, …]` array verbatim.
-/// Test: `kg_all_route_forwards_limit_and_offset`.
-// #4290: per-agent entry onto trusty-memory's paginated all-triples list.
+/// Why: the browser's "All" mode pages across every triple regardless of
+/// subject.
+/// What: `data` is `[triple, …]` for that page; `definitions` carries the
+/// definitions of the subjects appearing on it.
+/// Test: `kg_all_route_pages_triples_with_their_definitions`.
+// #7430: per-agent entry onto the OKG tree's triples.
 pub(super) async fn agent_kg_all_route(
     State(_state): State<AppState>,
     AxumPath(name): AxumPath<String>,
     Query(p): Query<KgParams>,
 ) -> Response {
-    let read = KgRead::new(
-        "memory.kg_all",
-        "palace_id",
-        page_params(&p, true),
-        json!([]),
-    );
-    proxy_with_discovered_memory(&name, read).await
+    graph_at_defaults(
+        &name,
+        KgRead::All {
+            limit: p.limit(),
+            offset: p.offset(),
+        },
+    )
+    .await
 }
 
 /// `GET /api/agents/:name/kg?subject=<s>` — HTTP entry point.
 ///
-/// Why: The browser's detail pane fetches one subject's edges after a click,
-/// which is far cheaper than filtering a full `/kg/all` page client-side.
-/// What: `data` is the upstream `[Triple, …]` array verbatim. `subject` is
-/// REQUIRED (as upstream requires it) and its absence is a `400` with the same
-/// `{"error": …}` shape the sibling routes use for an invalid name — never a
-/// silent full-graph fetch.
-/// Test: `kg_query_route_projects_the_triples_array`,
+/// Why: the detail pane fetches one subject's edges after a click, which is far
+/// cheaper than filtering a full `/kg/all` page client-side.
+/// What: `data` is that subject's `[triple, …]`; `definitions` is its
+/// definition, or empty when the subject is only ever an edge TARGET. `subject`
+/// is required, and its absence is a `400` — never a silent full-graph fetch.
+/// Test: `kg_query_route_returns_the_subjects_triples_and_definition`,
 /// `kg_query_route_requires_subject`.
-// #4290: per-agent entry onto trusty-memory's subject-scoped triple query.
+// #7430: per-agent entry onto one OKG subject.
 pub(super) async fn agent_kg_query_route(
     State(_state): State<AppState>,
     AxumPath(name): AxumPath<String>,
@@ -242,85 +235,56 @@ pub(super) async fn agent_kg_query_route(
         )
             .into_response();
     };
-    // `kg_query` is a dispatcher tool, not a folded method — the branch that
-    // moved this daemon onto a socket deliberately did not fold what the
-    // dispatcher already routes. It answers `{subject, triples, …}` where the
-    // retired route answered a bare array, so `data` carries `triples`.
-    let read = KgRead::new(
-        "kg_query",
-        "palace",
-        vec![("subject", Value::String(subject))],
-        json!([]),
-    )
-    .projecting("triples");
-    proxy_with_discovered_memory(&name, read).await
+    graph_at_defaults(&name, KgRead::Subject(subject)).await
 }
 
 /// `GET /api/agents/:name/kg/count` — HTTP entry point.
 ///
-/// Why: The browser header shows an "N triples" badge; counting server-side
-/// avoids materialising the whole graph to measure it.
-/// What: `data` is the upstream `{"active": N}` object verbatim, and `{"active":
-/// 0}` on every degraded path — the ONE route whose empty shape is an object
-/// rather than an array.
-/// Test: `kg_count_route_passes_upstream_object_through`,
-/// `kg_count_route_empty_state_keeps_object_shape`.
-// #4290: per-agent entry onto trusty-memory's active-triple count.
+/// Why: the browser header shows an "N triples" badge.
+/// What: `data` is `{"active": N, "definition_count": D}` — the ONE route whose
+/// payload is an object rather than an array, and the one that reports both
+/// halves as totals.
+/// Test: `kg_count_route_counts_both_halves`.
+// #7430: per-agent entry onto the OKG tree's totals.
 pub(super) async fn agent_kg_count_route(
     State(_state): State<AppState>,
     AxumPath(name): AxumPath<String>,
 ) -> Response {
-    let read = KgRead::new(
-        "memory.kg_count",
-        "palace_id",
-        Vec::new(),
-        json!({ "active": 0 }),
-    );
-    proxy_with_discovered_memory(&name, read).await
+    graph_at_defaults(&name, KgRead::Count).await
 }
 
-/// Shared shim body: resolve the trusty-memory socket the same way
-/// `agent_stores_route` / `agent_knowledge_route` already do, then delegate.
-///
-/// An unresolvable data directory yields `None`, which the core reports as the
-/// daemon being undiscoverable — the same degraded arm a daemon that is not
-/// running takes, because from a browser pane's point of view they are the same
-/// empty state with a reason.
-async fn proxy_with_discovered_memory(name: &str, read: KgRead) -> Response {
-    kg_proxy_at(
+/// Shared shim body: resolve the roots the same way every other OKG surface in
+/// this crate does, then delegate.
+async fn graph_at_defaults(name: &str, read: KgRead) -> Response {
+    kg_graph_at(
         &crate::agents::agents_dir_candidates(),
         name,
-        trusty_common::memory_rpc::resolve_memory_socket()
-            .ok()
-            .as_deref(),
+        crate::assistants::assistants_root().ok().as_deref(),
+        &crate::tools::okg::knowledge_dir(),
         read,
     )
     .await
 }
 
-/// Core proxy logic against explicit agents dirs + a trusty-memory socket.
+/// Core read against explicit agents dirs, assistants root and knowledge dir.
 ///
-/// Why: Same testability rationale as `agent_stores::stores_at` — the socket is
-/// injected so tests can point at a mock daemon instead of the developer's live
-/// one, and the palace-resolution branch can be exercised with no daemon at all.
-/// What: resolves the agent's palace from `StoresConfig::primary()`'s `palace`
-/// field, fetches the upstream KG read, and wraps the result in the module
-/// doc's envelope. `400` invalid name, `404` unknown agent, `500` only when
-/// the agent's own config cannot be read; EVERY palace/daemon/upstream failure
-/// is a `200` carrying `connected: false` + `reason`. Malformed `agent.toml`
-/// degrades to "no palace bound" plus `config_error`, matching
-/// `stores_at`'s precedent, so a hand-edit typo does not blank the pane with a
-/// `500`.
-/// Test: `kg_subjects_route_passes_upstream_through`,
-/// `kg_route_empty_state_when_no_palace_bound`,
-/// `kg_route_degrades_when_memory_unreachable`,
-/// `kg_route_degrades_when_palace_missing`,
+/// Why: same testability rationale as `agent_stores::stores_at` — the roots are
+/// injected so tests point at a tempdir instead of the developer's live home.
+/// What: resolves the agent's OKG tree from `StoresConfig::primary()`, reads the
+/// graph, and wraps the result in the module doc's envelope. `400` invalid name,
+/// `404` unknown agent, `500` only when the agent's own config cannot be read;
+/// every tree/read failure is a `200` carrying `connected: false` + `reason`. A
+/// malformed `agent.toml` degrades rather than guessing a tree, because the
+/// binding it failed to parse is what names which tree to show.
+/// Test: `kg_subjects_route_lists_okg_subjects`,
+/// `kg_route_empty_state_when_the_tree_is_absent`,
 /// `kg_route_unknown_agent_404`, `kg_route_rejects_traversal_name`,
 /// `kg_route_degrades_on_malformed_toml`.
-pub(super) async fn kg_proxy_at(
+pub(super) async fn kg_graph_at(
     dirs: &[PathBuf],
     name: &str,
-    memory_socket: Option<&std::path::Path>,
+    assistants_root: Option<&Path>,
+    knowledge_dir: &Path,
     read: KgRead,
 ) -> Response {
     if name.is_empty() || name.contains(['/', '\\']) || name == "." || name == ".." {
@@ -340,7 +304,7 @@ pub(super) async fn kg_proxy_at(
     let raw = match tokio::fs::read_to_string(&path).await {
         Ok(s) => s,
         Err(e) => {
-            tracing::warn!(?e, agent = name, path = %path.display(), "kg_proxy_at: read failed");
+            tracing::warn!(?e, agent = name, path = %path.display(), "kg_graph_at: read failed");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({ "error": "failed to read agent config" })),
@@ -350,36 +314,77 @@ pub(super) async fn kg_proxy_at(
     };
 
     let (stores, config_error) = parse_stores(&raw);
-    let Some(palace) = stores.primary().and_then(|b| b.palace.clone()) else {
+    if let Some(err) = config_error {
         return envelope(
             None,
-            Err("this agent binds no memory palace (`[[stores]].palace` is unset)".to_string()),
-            &read.empty,
-            config_error,
+            Err(format!(
+                "this agent's `agent.toml` does not parse, so the tree it binds is unknown: {err}"
+            )),
+            &read,
+            Some(err),
+        );
+    }
+    let Some(assistants_root) = assistants_root else {
+        return envelope(
+            None,
+            Err("the assistants root is not resolvable (no home directory)".to_string()),
+            &read,
+            None,
         );
     };
 
-    let result = match memory_socket {
-        None => Err("trusty-memory daemon not discoverable (is it running?)".to_string()),
-        Some(socket) => fetch_upstream(socket, &palace, &read).await,
+    let root = match okg_graph::resolve_okg_root(name, &stores, assistants_root, knowledge_dir) {
+        Ok(root) => root,
+        Err(reason) => return envelope(None, Err(reason), &read, None),
     };
-    envelope(Some(palace), result, &read.empty, config_error)
+    let tree = Some(root.display().to_string());
+    if !root.is_dir() {
+        return envelope(
+            tree,
+            Err(format!(
+                "this assistant has no OKG tree at {} yet — nothing has been ingested",
+                root.display()
+            )),
+            &read,
+            None,
+        );
+    }
+    match okg_graph::read_graph(&root) {
+        Ok(graph) => envelope(tree, Ok(read.project(&graph)), &read, None),
+        Err(e) => envelope(
+            tree,
+            Err(format!(
+                "the OKG tree at {} is unreadable: {e:#}",
+                root.display()
+            )),
+            &read,
+            None,
+        ),
+    }
 }
 
-/// Build the module doc's response envelope from a resolved palace + outcome.
+/// Build the module doc's response envelope.
 fn envelope(
-    palace: Option<String>,
-    result: Result<Value, String>,
-    empty: &Value,
+    tree: Option<String>,
+    result: Result<(Value, Vec<OkgDefinition>), String>,
+    read: &KgRead,
     config_error: Option<String>,
 ) -> Response {
     let mut body = match result {
-        Ok(data) => json!({ "palace": palace, "connected": true, "data": data }),
+        Ok((data, definitions)) => json!({
+            "tree": tree,
+            "source": GRAPH_SOURCE,
+            "connected": true,
+            "data": data,
+            "definitions": definitions,
+        }),
         Err(reason) => json!({
-            "palace": palace,
+            "tree": tree,
+            "source": GRAPH_SOURCE,
             "connected": false,
             "reason": reason,
-            "data": empty.clone(),
+            "data": read.empty(),
+            "definitions": [],
         }),
     };
     if let Some(err) = config_error {
@@ -388,64 +393,12 @@ fn envelope(
     (StatusCode::OK, Json(body)).into_response()
 }
 
-/// Perform the upstream trusty-memory call, collapsing every failure mode to a
-/// human-readable reason string.
+/// What the exposed graph is made of, stated in the payload itself.
 ///
-/// Why: mirrors `stores::status::probe_palace`'s vocabulary ("does not exist" /
-/// "unreachable") so a client that already renders a store card's `reason` can
-/// render this one with no new cases, and so the two surfaces cannot describe
-/// the same down daemon two ways.
-/// What: `Ok(data)` when the daemon answers; `Err(reason)` for a not-found
-/// refusal, any other refusal, or a transport failure. A read declaring
-/// [`KgRead::project`] lifts that field out; a projected field the answer does
-/// not carry is a reason rather than a silent empty, because the two mean
-/// different things to a pane rendering "no triples". Bounded by
-/// [`PROBE_TIMEOUT`] — the same ceiling every other cross-daemon read in this
-/// crate uses.
-/// Test: `kg_route_degrades_when_memory_unreachable`,
-/// `kg_route_degrades_when_palace_missing`,
-/// `kg_query_route_projects_the_triples_array`.
-async fn fetch_upstream(
-    socket: &std::path::Path,
-    palace: &str,
-    read: &KgRead,
-) -> Result<Value, String> {
-    let answer = trusty_common::memory_rpc::call_memory_tool_at_with_timeout(
-        socket,
-        read.method,
-        read.params_for(palace),
-        PROBE_TIMEOUT,
-    )
-    .await
-    .map_err(|e| describe_failure(&e, palace))?;
-
-    let Some(field) = read.project else {
-        return Ok(answer);
-    };
-    answer.get(field).cloned().ok_or_else(|| {
-        format!(
-            "trusty-memory answered {} without a `{field}` field",
-            read.method
-        )
-    })
-}
-
-/// Turn a call failure into the reason a pane renders.
-///
-/// A not-found refusal is the palace being absent, which is an ordinary state
-/// for an agent whose palace was never created; anything else is the daemon
-/// being unreachable or in trouble, and carries its own message so an operator
-/// reads the reason they were given.
-// #4278: `chat_history` maps agent → bound palace and renders the same
-// reason vocabulary, so it shares this rather than describing a down daemon a
-// second way.
-pub(super) fn describe_failure(e: &anyhow::Error, palace: &str) -> String {
-    match e.downcast_ref::<trusty_common::memory_rpc::MemoryRpcError>() {
-        Some(rpc) if rpc.is_not_found() => format!("memory palace `{palace}` does not exist"),
-        Some(rpc) => format!("trusty-memory refused the read for palace `{palace}`: {rpc}"),
-        None => format!("trusty-memory unreachable: {e:#}"),
-    }
-}
+/// Why (#7430): the owner's requirement is a property of the DATA, not of the
+/// route's name. A client, a test, or a future reader can assert on this rather
+/// than inferring the source from which daemon happened to answer.
+pub(super) const GRAPH_SOURCE: &str = "okg";
 
 /// Parse just the `[[stores]]` table out of a raw `agent.toml`.
 ///
@@ -469,81 +422,66 @@ pub(super) fn parse_stores(raw: &str) -> (StoresConfig, Option<String>) {
 mod unit_tests {
     use super::*;
 
-    /// Why: the palace is filled in per read rather than baked into `params`,
-    /// and the two method families name it differently — `palace_id` for the
-    /// folded reads, `palace` for the `kg_query` tool. A read that sent the
-    /// wrong key would be refused as invalid params, which reads to a pane as
-    /// the daemon being unreachable.
+    /// Why: the caller's page size is user input reaching a `take`. A zero would
+    /// render an empty pane on a non-empty tree, and an unbounded value would
+    /// materialise the whole tree into one response.
     /// Test: itself.
     #[test]
-    fn params_for_uses_each_methods_own_palace_key() {
-        let folded = KgRead::new("memory.kg_all", "palace_id", Vec::new(), json!([]));
-        assert_eq!(folded.params_for("cto")["palace_id"], "cto");
-        assert!(folded.params_for("cto").get("palace").is_none());
-
-        let tool = KgRead::new("kg_query", "palace", Vec::new(), json!([]));
-        assert_eq!(tool.params_for("cto")["palace"], "cto");
-        assert!(tool.params_for("cto").get("palace_id").is_none());
-    }
-
-    /// Why: trusty-memory's own defaults and clamps are the single source of
-    /// truth, so a parameter the caller did not send must not be invented here.
-    /// Test: itself.
-    #[test]
-    fn page_params_forwards_only_what_the_caller_sent() {
-        let p = KgParams {
-            limit: Some(25),
-            offset: Some(50),
-            subject: None,
-        };
+    fn limit_is_clamped_and_defaulted() {
+        assert_eq!(KgParams::default().limit(), DEFAULT_KG_LIMIT);
         assert_eq!(
-            page_params(&p, true),
-            vec![("limit", Value::from(25)), ("offset", Value::from(50))]
+            KgParams {
+                limit: Some(0),
+                ..Default::default()
+            }
+            .limit(),
+            1
         );
-        assert_eq!(page_params(&p, false), vec![("limit", Value::from(25))]);
-
-        let read = KgRead::new(
-            "memory.kg_all",
-            "palace_id",
-            page_params(&KgParams::default(), true),
-            json!([]),
+        assert_eq!(
+            KgParams {
+                limit: Some(10_000),
+                ..Default::default()
+            }
+            .limit(),
+            MAX_KG_LIMIT
         );
-        let params = read.params_for("cto");
-        assert!(params.get("limit").is_none());
-        assert!(params.get("offset").is_none());
     }
 
-    /// Why: a palace id and a KG subject are operator- and user-supplied
-    /// strings. Over HTTP they had to be percent-encoded or a subject could
-    /// escape its query parameter; as JSON params there is no such escape, and
-    /// this pins that the value arrives unmangled rather than re-encoded.
+    /// Why: a client must branch only on `connected`, never on `data`'s TYPE.
+    /// The count read is the one whose payload is an object, so its empty shape
+    /// must stay an object.
     /// Test: itself.
     #[test]
-    fn params_carry_awkward_values_unchanged() {
-        let read = KgRead::new(
-            "kg_query",
-            "palace",
-            vec![("subject", Value::String("Bob & Alice/2026?x".to_string()))],
-            json!([]),
+    fn empty_shapes_keep_each_reads_type() {
+        assert!(KgRead::Subjects { limit: 1 }.empty().is_array());
+        assert!(
+            KgRead::All {
+                limit: 1,
+                offset: 0
+            }
+            .empty()
+            .is_array()
         );
-        let params = read.params_for("owner profile/x");
-        assert_eq!(params["palace"], "owner profile/x");
-        assert_eq!(params["subject"], "Bob & Alice/2026?x");
+        assert!(KgRead::Subject("x".into()).empty().is_array());
+        assert_eq!(
+            KgRead::Count.empty(),
+            json!({ "active": 0, "definition_count": 0 })
+        );
     }
 
     #[test]
-    fn parse_stores_reads_the_primary_palace() {
-        let raw = "[agent]\nname = \"izzie\"\n\n[[stores]]\nname = \"bob-kb\"\npalace = \"owner-profile\"\n";
+    fn parse_stores_reads_the_primary_binding() {
+        let raw = "[agent]\nname = \"izzie\"\n\n[[stores]]\nname = \"bob-kb\"\nroot = \"okg\"\n";
         let (stores, err) = parse_stores(raw);
         assert!(err.is_none());
         assert_eq!(
-            stores.primary().and_then(|b| b.palace.as_deref()),
-            Some("owner-profile")
+            stores.primary().and_then(|b| b.root.as_deref()),
+            Some("okg")
         );
     }
 
     #[test]
-    fn parse_stores_reports_bad_toml_without_a_palace() {
+    fn parse_stores_reports_bad_toml_without_a_binding() {
         let (stores, err) = parse_stores("not = = toml");
         assert!(stores.primary().is_none());
         assert!(err.is_some());

--- a/crates/trusty-agents/src/api/server/chat_history.rs
+++ b/crates/trusty-agents/src/api/server/chat_history.rs
@@ -60,7 +60,7 @@ use axum::{
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use super::agent_kg::{describe_failure, parse_stores};
+use super::agent_kg::parse_stores;
 use super::agent_patch::resolve_agent_paths;
 use super::state::AppState;
 use crate::ctrl::pm_task::session_id_for;
@@ -343,4 +343,25 @@ async fn fetch_session(socket: &Path, palace: &str, session_id: &str) -> Result<
         history,
         updated_at: decoded.get("updated_at").cloned().unwrap_or(Value::Null),
     })
+}
+
+/// Turn a trusty-memory call failure into the reason a pane renders.
+///
+/// Why: a not-found refusal is the palace being absent, which is an ordinary
+/// state for an agent whose palace was never created; anything else is the
+/// daemon being unreachable or in trouble, and carries its own message so an
+/// operator reads what they were given. The vocabulary matches
+/// `stores::status::probe_palace`, so a client that already renders a store
+/// card's `reason` renders this one with no new cases.
+/// What: one sentence naming the palace and the failure class.
+/// Test: `chat_history_degrades_when_memory_unreachable`,
+/// `chat_history_absent_palace_is_not_reported_as_absent_session`.
+// #7430: moved here from `agent_kg`, whose routes no longer call trusty-memory
+// at all; this is now the only caller.
+fn describe_failure(e: &anyhow::Error, palace: &str) -> String {
+    match e.downcast_ref::<trusty_common::memory_rpc::MemoryRpcError>() {
+        Some(rpc) if rpc.is_not_found() => format!("memory palace `{palace}` does not exist"),
+        Some(rpc) => format!("trusty-memory refused the read for palace `{palace}`: {rpc}"),
+        None => format!("trusty-memory unreachable: {e:#}"),
+    }
 }

--- a/crates/trusty-agents/src/api/server/tests/agent_kg.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_kg.rs
@@ -1,26 +1,23 @@
-//! `GET /api/agents/:name/kg*` proxy tests (#4290, #6286).
+//! `GET /api/agents/:name/kg*` tests (#4290, #6286, #7430).
 //!
-//! Why: This module's entire contract is "pass trusty-memory's KG JSON
-//! through, and NEVER fail the route for a condition the browser should render
-//! as an empty state". Both halves need pinning: a pass-through that quietly
-//! reshaped the upstream body, or a degraded path that 500'd, would each be
-//! the bug this route was written to avoid. These tests drive `kg_proxy_at`
-//! directly against a `tempfile::TempDir` (the `agent_stores.rs` pattern, so
-//! they don't race sibling tests on cwd/`$HOME`) with a mock trusty-memory
-//! daemon on a temp socket, plus full-router tests proving all four routes are
-//! actually wired.
+//! Why: this module's contract has two halves, and both have been wrong before.
+//! The exposed graph must come from the assistant's OKG tree and nothing else —
+//! before #7430 these routes served trusty-memory's palace-scoped `kg_*` surface
+//! instead, so the pane labelled "Knowledge Graph" rendered the MEMORY graph.
+//! And the route must NEVER fail for a condition the browser should render as an
+//! empty state. These tests drive `kg_graph_at` directly against
+//! `tempfile::TempDir` roots (the `agent_stores.rs` pattern, so they don't race
+//! sibling tests on cwd/`$HOME`), plus full-router tests proving all four routes
+//! are wired.
 //!
-//! The mock is [`crate::uds_mock`] rather than an axum server on a loopback
-//! port: ADR-0032 moved trusty-memory onto a Unix socket, and a test that kept
-//! stubbing HTTP would pass against a transport the route no longer speaks.
-//!
-//! What: pass-through for each of the four reads; forwarded params;
-//! no-palace-bound → 200 empty state; daemon undiscoverable / unreachable /
-//! palace absent / a projected field missing → 200 + `connected: false` +
-//! reason; unknown agent → 404; traversal name → 400; missing `subject` → 400;
-//! malformed TOML → 200 + `config_error`; and the read-only posture (no
-//! POST/DELETE route).
+//! What: OKG triples AND definitions for each of the four reads; paging; the
+//! absent-tree, unresolvable-root and malformed-TOML empty states; unknown agent
+//! → 404; traversal name → 400; missing `subject` → 400; the read-only posture;
+//! and `no_memory_drawer_or_palace_triple_can_reach_the_exposed_graph`, the
+//! #7430 regression gate.
 //! Test: This module IS the test.
+
+use std::path::Path;
 
 use axum::Router;
 use axum::body::Body;
@@ -28,13 +25,11 @@ use axum::http::{Method, Request, StatusCode};
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
-use crate::api::server::agent_kg::{KgRead, kg_proxy_at};
+use crate::api::server::agent_kg::{KgRead, kg_graph_at};
 use crate::api::server::routes::build_router;
 use crate::api::server::state::AppState;
-use crate::uds_mock::{self, MockMemoryDaemon, RpcError};
 
-/// An agent binding a store WITH a palace — the only shape that can reach
-/// trusty-memory at all.
+/// An agent binding its own home-confined OKG tree (#4325's default layout).
 const BOUND_FIXTURE: &str = r#"[agent]
 name = "izzie"
 role = "assistant"
@@ -44,109 +39,77 @@ description = "test"
 [[stores]]
 name = "bob-kb"
 index = "bob-kb"
+root = "okg"
 palace = "owner-profile"
 "#;
 
-/// A store binding with NO palace — a document-only store. The ordinary
-/// "nothing to browse yet" state, not an error.
-const NO_PALACE_FIXTURE: &str = r#"[agent]
-name = "plain"
-role = "assistant"
-model = "claude-sonnet-4-6"
-description = "test"
-
-[[stores]]
-name = "docs-only"
-"#;
-
-/// A palace that the mock daemon does not know about.
-const GHOST_PALACE_FIXTURE: &str = r#"[agent]
-name = "ghosty"
-role = "assistant"
-model = "claude-sonnet-4-6"
-description = "test"
-
-[[stores]]
-name = "ghost-kb"
-palace = "no-such-palace"
-"#;
-
-fn subjects_read() -> KgRead {
-    KgRead::new(
-        "memory.kg_subjects_with_counts",
-        "palace_id",
-        Vec::new(),
-        json!([]),
-    )
+/// One test's four injected roots.
+struct Fixtures {
+    agents: tempfile::TempDir,
+    assistants: tempfile::TempDir,
+    knowledge: tempfile::TempDir,
 }
 
-fn count_read() -> KgRead {
-    KgRead::new(
-        "memory.kg_count",
-        "palace_id",
-        Vec::new(),
-        json!({ "active": 0 }),
-    )
+impl Fixtures {
+    /// Write `<agents>/<name>.toml` and return the roots. The OKG tree is NOT
+    /// created — `with_tree` does that.
+    fn new(name: &str, fixture: &str) -> Self {
+        let agents = tempfile::tempdir().unwrap();
+        std::fs::write(agents.path().join(format!("{name}.toml")), fixture).unwrap();
+        Self {
+            agents,
+            assistants: tempfile::tempdir().unwrap(),
+            knowledge: tempfile::tempdir().unwrap(),
+        }
+    }
+
+    /// The OKG tree `name` resolves to under these roots.
+    fn tree(&self, name: &str) -> std::path::PathBuf {
+        self.assistants.path().join(name).join("okg")
+    }
+
+    /// Populate `name`'s tree with two people and one organisation.
+    fn with_tree(self, name: &str) -> Self {
+        let root = self.tree(name);
+        write_entity(
+            &root,
+            "people",
+            "bob",
+            "---\ntype: Person\ntitle: Bob\ndescription: The owner.\nworks_at: \"[[Duetto]]\"\n---\n",
+        );
+        write_entity(
+            &root,
+            "people",
+            "ada",
+            "---\ntype: Person\ntitle: Ada\ndescription: A colleague.\nknows: \"[[Bob]]\"\n---\n",
+        );
+        write_entity(
+            &root,
+            "organizations",
+            "duetto",
+            "---\ntype: Organization\ntitle: Duetto\ndescription: A company.\n---\n",
+        );
+        self
+    }
+
+    async fn read(&self, name: &str, read: KgRead) -> Value {
+        let resp = kg_graph_at(
+            &[self.agents.path().to_path_buf()],
+            name,
+            Some(self.assistants.path()),
+            self.knowledge.path(),
+            read,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK, "expected a 200 envelope");
+        body_json(resp).await
+    }
 }
 
-/// Mock trusty-memory answering the four KG reads for palace `owner-profile`
-/// only; every other palace is refused not-found, which is the daemon's real
-/// behaviour for an unknown palace.
-///
-/// `memory.kg_all` and `kg_query` echo their params back inside the payload so
-/// a test can prove what was forwarded. `kg_query` answers the TOOL's wider
-/// `{subject, triples, …}` shape, because that is what the proxy projects.
-async fn mock_memory() -> MockMemoryDaemon {
-    uds_mock::spawn(|method: &str, params: Value| {
-        let method = method.to_string();
-        Box::pin(async move {
-            // Both key spellings, because the folded reads take `palace_id` and
-            // the `kg_query` tool takes `palace`.
-            let palace = params
-                .get("palace_id")
-                .or_else(|| params.get("palace"))
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string();
-            if palace == "unreadable" && method == "memory.kg_subjects_with_counts" {
-                // An answer without the field a projecting read wants; the
-                // JSON-RPC framing makes an unparseable BODY impossible, so
-                // this is the shape-disagreement degradation instead.
-                return Ok(json!({ "unexpected": true }));
-            }
-            if palace != "owner-profile" {
-                return Err(RpcError::new(
-                    trusty_common::memory_rpc::CODE_NOT_FOUND,
-                    format!("palace not found: {palace}"),
-                ));
-            }
-            match method.as_str() {
-                "memory.kg_subjects_with_counts" => Ok(json!([
-                    { "subject": "Bob", "count": 3 },
-                    { "subject": "trusty-search", "count": 1 },
-                ])),
-                "memory.kg_all" => Ok(json!([{
-                    "subject": "Bob",
-                    "predicate": "prefers",
-                    "object": "Rust",
-                    "echoed_limit": params.get("limit"),
-                    "echoed_offset": params.get("offset"),
-                }])),
-                "memory.kg_count" => Ok(json!({ "active": 4 })),
-                "kg_query" => Ok(json!({
-                    "subject": params.get("subject"),
-                    "kg_triple_count": 4,
-                    "triples": [{
-                        "subject": params.get("subject"),
-                        "predicate": "is",
-                        "object": "owner",
-                    }],
-                })),
-                other => Err(RpcError::method_not_found(other, &[])),
-            }
-        })
-    })
-    .await
+fn write_entity(root: &Path, collection: &str, slug: &str, content: &str) {
+    let dir = root.join(collection);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(format!("{slug}.md")), content).unwrap();
 }
 
 async fn body_json(resp: axum::response::Response) -> Value {
@@ -156,136 +119,192 @@ async fn body_json(resp: axum::response::Response) -> Value {
     serde_json::from_slice(&bytes).unwrap()
 }
 
-/// Write `fixture` as `<name>.toml` into a fresh tempdir and return it.
-fn agent_dir(name: &str, fixture: &str) -> tempfile::TempDir {
-    let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join(format!("{name}.toml")), fixture).unwrap();
-    dir
+fn subjects_read() -> KgRead {
+    KgRead::Subjects { limit: 200 }
 }
 
 // ---------------------------------------------------------------------------
-// Pass-through
+// The #7430 regression gate
+// ---------------------------------------------------------------------------
+
+/// Why (#7430, epic #7425 item (f)): the owner's requirement is that the
+/// exposed graph carries OKG triples and definitions and never memory content.
+/// Before this change these routes called `memory.kg_subjects_with_counts`,
+/// `memory.kg_all`, `memory.kg_count` and the `kg_query` tool, so every subject
+/// the pane listed came out of a memory palace — this test's first assertion
+/// (`data` reflecting the OKG tree) failed against that code for all four reads,
+/// and so did the `definitions` assertion, which had no field to read at all.
+///
+/// What: the agent binds a palace AND has an OKG tree. Only the tree's content
+/// may appear: the palace-only subject must be absent from every read, the
+/// envelope must declare `source: "okg"`, and both halves of the graph must be
+/// present. The palace named in the fixture is deliberately one a developer's
+/// live trusty-memory might really hold — the point is that no daemon is
+/// consulted, so its content cannot arrive however the daemon is configured.
+/// Test: itself.
+#[tokio::test]
+async fn no_memory_drawer_or_palace_triple_can_reach_the_exposed_graph() {
+    let f = Fixtures::new("izzie", BOUND_FIXTURE).with_tree("izzie");
+
+    for read in [
+        subjects_read(),
+        KgRead::All {
+            limit: 50,
+            offset: 0,
+        },
+        KgRead::Subject("Bob".to_string()),
+        KgRead::Count,
+    ] {
+        let body = f.read("izzie", read.clone()).await;
+        assert_eq!(
+            body["source"], "okg",
+            "the envelope must name its source: {body}"
+        );
+        assert_eq!(body["connected"], true, "{body}");
+        assert!(
+            body.get("palace").is_none(),
+            "a memory palace has no place in the exposed graph envelope: {body}"
+        );
+        let rendered = body.to_string();
+        assert!(
+            !rendered.contains("owner-profile"),
+            "the bound PALACE id reached the payload for {read:?}: {rendered}"
+        );
+        assert!(
+            !rendered.contains("drawer"),
+            "a memory drawer reached the payload for {read:?}: {rendered}"
+        );
+    }
+
+    // Both halves, on the read that carries the graph itself.
+    let body = f
+        .read(
+            "izzie",
+            KgRead::All {
+                limit: 50,
+                offset: 0,
+            },
+        )
+        .await;
+    assert!(
+        !body["data"].as_array().unwrap().is_empty(),
+        "triples must be present: {body}"
+    );
+    assert!(
+        !body["definitions"].as_array().unwrap().is_empty(),
+        "definitions must be present beside the triples: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Each read
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn kg_subjects_route_passes_upstream_through() {
-    let dir = agent_dir("izzie", BOUND_FIXTURE);
-    let daemon = mock_memory().await;
-
-    let resp = kg_proxy_at(
-        &[dir.path().to_path_buf()],
-        "izzie",
-        Some(daemon.socket()),
-        subjects_read(),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = body_json(resp).await;
-    assert_eq!(body["palace"], "owner-profile");
-    assert_eq!(body["connected"], true);
-    assert!(
-        body["reason"].is_null(),
-        "a connected read carries no reason"
-    );
-    // The upstream array must arrive unchanged — same order, same field names,
-    // no re-ranking or reshaping in this crate.
+async fn kg_subjects_route_lists_okg_subjects() {
+    let f = Fixtures::new("izzie", BOUND_FIXTURE).with_tree("izzie");
+    let body = f.read("izzie", subjects_read()).await;
     assert_eq!(
         body["data"],
         json!([
-            { "subject": "Bob", "count": 3 },
-            { "subject": "trusty-search", "count": 1 },
-        ])
+            { "subject": "Ada", "count": 1 },
+            { "subject": "Bob", "count": 1 },
+            { "subject": "Duetto", "count": 0 },
+        ]),
+        "{body}"
     );
-}
-
-#[tokio::test]
-async fn kg_count_route_passes_upstream_object_through() {
-    let dir = agent_dir("izzie", BOUND_FIXTURE);
-    let daemon = mock_memory().await;
-
-    let resp = kg_proxy_at(
-        &[dir.path().to_path_buf()],
-        "izzie",
-        Some(daemon.socket()),
-        count_read(),
-    )
-    .await;
-    let body = body_json(resp).await;
-    assert_eq!(body["connected"], true);
-    assert_eq!(body["data"], json!({ "active": 4 }));
-}
-
-#[tokio::test]
-async fn kg_all_route_forwards_limit_and_offset() {
-    let dir = agent_dir("izzie", BOUND_FIXTURE);
-    let daemon = mock_memory().await;
-
-    let read = KgRead::new(
-        "memory.kg_all",
-        "palace_id",
-        vec![("limit", json!(25)), ("offset", json!(50))],
-        json!([]),
-    );
-    let resp = kg_proxy_at(
-        &[dir.path().to_path_buf()],
-        "izzie",
-        Some(daemon.socket()),
-        read,
-    )
-    .await;
-    let body = body_json(resp).await;
-    assert_eq!(body["connected"], true);
     assert_eq!(
-        body["data"][0]["echoed_limit"], 25,
-        "the page params must arrive as numbers, not the strings the query \
-         string carried"
+        body["tree"],
+        f.tree("izzie").display().to_string(),
+        "the envelope names the tree it read"
     );
-    assert_eq!(body["data"][0]["echoed_offset"], 50);
+    assert_eq!(
+        body["definitions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|d| d["type"].as_str())
+            .collect::<Vec<_>>(),
+        vec!["Organization", "Person", "Person"],
+    );
 }
 
-/// Why (#6286): `/kg?subject=` is the one read whose method answers a wider
-/// shape than this route's `data` contract — `kg_query` is a dispatcher tool
-/// returning `{subject, triples, kg_triple_count}` where the retired route
-/// returned a bare array. Passing the object through would change `data`'s TYPE
-/// for one of the four reads, which is exactly what the envelope promises never
-/// happens.
-/// What: drives the projecting read and asserts `data` is the triples array,
-/// with the subject forwarded intact.
+/// Why: a page of triples is only readable beside the definitions of the
+/// subjects on it, so the two are selected together rather than the client
+/// making a second round trip per subject.
 /// Test: itself.
 #[tokio::test]
-async fn kg_query_route_projects_the_triples_array() {
-    let dir = agent_dir("izzie", BOUND_FIXTURE);
-    let daemon = mock_memory().await;
+async fn kg_all_route_pages_triples_with_their_definitions() {
+    let f = Fixtures::new("izzie", BOUND_FIXTURE).with_tree("izzie");
 
-    let read = KgRead::new(
-        "kg_query",
-        "palace",
-        vec![("subject", json!("Bob & Co"))],
-        json!([]),
-    )
-    .projecting("triples");
-    let resp = kg_proxy_at(
-        &[dir.path().to_path_buf()],
-        "izzie",
-        Some(daemon.socket()),
-        read,
-    )
-    .await;
-    let body = body_json(resp).await;
-    assert_eq!(body["connected"], true);
-    assert!(
-        body["data"].is_array(),
-        "data must stay an array for this read: {}",
-        body["data"]
+    let first = f
+        .read(
+            "izzie",
+            KgRead::All {
+                limit: 1,
+                offset: 0,
+            },
+        )
+        .await;
+    assert_eq!(
+        first["data"],
+        json!([{
+            "subject": "Ada",
+            "predicate": "knows",
+            "object": "Bob",
+            "provenance": "people/ada.md",
+        }]),
+        "{first}"
     );
     assert_eq!(
-        body["data"][0]["subject"], "Bob & Co",
-        "the subject must arrive intact"
+        first["definitions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|d| d["subject"].as_str())
+            .collect::<Vec<_>>(),
+        vec!["Ada"],
+        "only the page's own subjects are defined: {first}"
     );
-    assert!(
-        body["data"][0].get("kg_triple_count").is_none(),
-        "only the triples array is lifted, not the whole envelope"
+
+    let second = f
+        .read(
+            "izzie",
+            KgRead::All {
+                limit: 1,
+                offset: 1,
+            },
+        )
+        .await;
+    assert_eq!(second["data"][0]["subject"], "Bob", "{second}");
+}
+
+#[tokio::test]
+async fn kg_query_route_returns_the_subjects_triples_and_definition() {
+    let f = Fixtures::new("izzie", BOUND_FIXTURE).with_tree("izzie");
+    let body = f.read("izzie", KgRead::Subject("Bob".to_string())).await;
+    assert_eq!(
+        body["data"],
+        json!([{
+            "subject": "Bob",
+            "predicate": "works_at",
+            "object": "Duetto",
+            "provenance": "people/bob.md",
+        }]),
+        "{body}"
     );
+    assert_eq!(body["definitions"][0]["summary"], "The owner.");
+}
+
+/// Why: the header badge reports the graph's size, and #7430 makes that both
+/// halves — a tree of definitions with no edges yet is not an empty graph.
+/// Test: itself.
+#[tokio::test]
+async fn kg_count_route_counts_both_halves() {
+    let f = Fixtures::new("izzie", BOUND_FIXTURE).with_tree("izzie");
+    let body = f.read("izzie", KgRead::Count).await;
+    assert_eq!(body["data"], json!({ "active": 2, "definition_count": 3 }));
+    assert_eq!(body["definitions"], json!([]));
 }
 
 // ---------------------------------------------------------------------------
@@ -293,31 +312,14 @@ async fn kg_query_route_projects_the_triples_array() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn kg_route_empty_state_when_no_palace_bound() {
-    let dir = agent_dir("plain", NO_PALACE_FIXTURE);
-    let daemon = mock_memory().await;
-
-    let resp = kg_proxy_at(
-        &[dir.path().to_path_buf()],
-        "plain",
-        Some(daemon.socket()),
-        subjects_read(),
-    )
-    .await;
-    assert_eq!(
-        resp.status(),
-        StatusCode::OK,
-        "an agent with no palace is an empty state, not an error"
-    );
-    let body = body_json(resp).await;
-    assert!(body["palace"].is_null());
+async fn kg_route_empty_state_when_the_tree_is_absent() {
+    let f = Fixtures::new("izzie", BOUND_FIXTURE);
+    let body = f.read("izzie", subjects_read()).await;
     assert_eq!(body["connected"], false);
     assert_eq!(body["data"], json!([]), "the empty shape is still an array");
+    assert_eq!(body["definitions"], json!([]));
     assert!(
-        body["reason"]
-            .as_str()
-            .unwrap()
-            .contains("no memory palace"),
+        body["reason"].as_str().unwrap().contains("no OKG tree"),
         "reason was: {}",
         body["reason"]
     );
@@ -327,140 +329,56 @@ async fn kg_route_empty_state_when_no_palace_bound() {
 async fn kg_count_route_empty_state_keeps_object_shape() {
     // The one read whose payload is an object: a client must never have to
     // branch on `data`'s TYPE, only on `connected`.
-    let dir = agent_dir("plain", NO_PALACE_FIXTURE);
-    let resp = kg_proxy_at(&[dir.path().to_path_buf()], "plain", None, count_read()).await;
-    let body = body_json(resp).await;
+    let f = Fixtures::new("izzie", BOUND_FIXTURE);
+    let body = f.read("izzie", KgRead::Count).await;
     assert_eq!(body["connected"], false);
-    assert_eq!(body["data"], json!({ "active": 0 }));
+    assert_eq!(body["data"], json!({ "active": 0, "definition_count": 0 }));
 }
 
+/// Why: an agent that declares no `[[stores]]` still has the #4325 default tree.
+/// Reporting "no store bound" there would hide a real graph.
+/// Test: itself.
 #[tokio::test]
-async fn kg_route_degrades_when_memory_undiscoverable() {
-    let dir = agent_dir("izzie", BOUND_FIXTURE);
-    let resp = kg_proxy_at(&[dir.path().to_path_buf()], "izzie", None, subjects_read()).await;
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = body_json(resp).await;
-    assert_eq!(
-        body["palace"], "owner-profile",
-        "the claim is still reported"
+async fn kg_route_reads_the_default_tree_for_an_unbound_agent() {
+    let f = Fixtures::new("plain", "[agent]\nname = \"plain\"\n").with_tree("plain");
+    let body = f.read("plain", subjects_read()).await;
+    assert_eq!(body["connected"], true, "{body}");
+    assert_eq!(body["data"][0]["subject"], "Ada");
+}
+
+/// Why: the binding a malformed `agent.toml` failed to parse is what names which
+/// tree to show, so guessing one could render another assistant's graph. A
+/// hand-edit typo degrades to an empty state, never a 500 and never a guess.
+/// Test: itself.
+#[tokio::test]
+async fn kg_route_degrades_on_malformed_toml() {
+    let f = Fixtures::new("broken", "not = = toml");
+    let body = f.read("broken", subjects_read()).await;
+    assert!(body["tree"].is_null());
+    assert_eq!(body["connected"], false);
+    assert!(body["config_error"].is_string());
+}
+
+/// Why: a binding naming a tree URI nothing can resolve is a configuration
+/// fault, and the reason must say so rather than showing an empty graph that
+/// looks like "nothing ingested".
+/// Test: itself.
+#[tokio::test]
+async fn kg_route_degrades_on_an_unresolvable_tree_uri() {
+    let f = Fixtures::new(
+        "ghosty",
+        "[agent]\nname = \"ghosty\"\n\n[[stores]]\nname = \"g\"\ntree = \"https://example.com/kb\"\n",
     );
+    let body = f.read("ghosty", subjects_read()).await;
     assert_eq!(body["connected"], false);
     assert!(
         body["reason"]
             .as_str()
             .unwrap()
-            .contains("not discoverable"),
+            .contains("does not resolve"),
         "reason was: {}",
         body["reason"]
     );
-}
-
-#[tokio::test]
-async fn kg_route_degrades_when_memory_unreachable() {
-    let dir = agent_dir("izzie", BOUND_FIXTURE);
-    let dead = tempfile::tempdir().unwrap();
-
-    let resp = kg_proxy_at(
-        &[dir.path().to_path_buf()],
-        "izzie",
-        Some(&dead.path().join("absent.sock")),
-        subjects_read(),
-    )
-    .await;
-    assert_eq!(
-        resp.status(),
-        StatusCode::OK,
-        "a down daemon must never 500 the browser"
-    );
-    let body = body_json(resp).await;
-    assert_eq!(body["connected"], false);
-    assert_eq!(body["data"], json!([]));
-    assert!(
-        body["reason"].as_str().unwrap().contains("unreachable"),
-        "reason was: {}",
-        body["reason"]
-    );
-}
-
-#[tokio::test]
-async fn kg_route_degrades_when_palace_missing() {
-    let dir = agent_dir("ghosty", GHOST_PALACE_FIXTURE);
-    let daemon = mock_memory().await;
-
-    let resp = kg_proxy_at(
-        &[dir.path().to_path_buf()],
-        "ghosty",
-        Some(daemon.socket()),
-        subjects_read(),
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = body_json(resp).await;
-    assert_eq!(body["palace"], "no-such-palace");
-    assert_eq!(body["connected"], false);
-    assert!(
-        body["reason"].as_str().unwrap().contains("does not exist"),
-        "reason was: {}",
-        body["reason"]
-    );
-}
-
-/// Why (#6286): the framing makes an unparseable upstream BODY impossible — a
-/// malformed frame is a transport error, not a 2xx carrying garbage — so the
-/// old "unreadable body" degradation has no way to occur. What replaces it is a
-/// daemon whose answer does not carry the field a projecting read lifts. Both
-/// mean the same thing to the pane (the read did not produce data), and both
-/// must be a reason rather than a silent empty array, because an empty array
-/// says "this palace has no triples", which is a different claim.
-/// What: asks a projecting read against a palace the mock answers without a
-/// `triples` field.
-/// Test: itself.
-#[tokio::test]
-async fn kg_route_degrades_when_the_answer_lacks_the_projected_field() {
-    let dir = agent_dir(
-        "unreadable",
-        "[agent]\nname = \"unreadable\"\n\n[[stores]]\nname = \"g\"\npalace = \"unreadable\"\n",
-    );
-    let daemon = mock_memory().await;
-
-    let read = KgRead::new(
-        "memory.kg_subjects_with_counts",
-        "palace_id",
-        Vec::new(),
-        json!([]),
-    )
-    .projecting("triples");
-    let resp = kg_proxy_at(
-        &[dir.path().to_path_buf()],
-        "unreadable",
-        Some(daemon.socket()),
-        read,
-    )
-    .await;
-    assert_eq!(resp.status(), StatusCode::OK);
-    let body = body_json(resp).await;
-    assert_eq!(body["connected"], false);
-    assert_eq!(body["data"], json!([]));
-    assert!(
-        body["reason"].as_str().unwrap().contains("triples"),
-        "the reason must name the field that was missing: {}",
-        body["reason"]
-    );
-}
-
-#[tokio::test]
-async fn kg_route_degrades_on_malformed_toml() {
-    let dir = agent_dir("broken", "not = = toml");
-    let resp = kg_proxy_at(&[dir.path().to_path_buf()], "broken", None, subjects_read()).await;
-    assert_eq!(
-        resp.status(),
-        StatusCode::OK,
-        "a hand-edit typo must not 500 the pane"
-    );
-    let body = body_json(resp).await;
-    assert!(body["palace"].is_null());
-    assert_eq!(body["connected"], false);
-    assert!(body["config_error"].is_string());
 }
 
 // ---------------------------------------------------------------------------
@@ -470,14 +388,30 @@ async fn kg_route_degrades_on_malformed_toml() {
 #[tokio::test]
 async fn kg_route_unknown_agent_404() {
     let dir = tempfile::tempdir().unwrap();
-    let resp = kg_proxy_at(&[dir.path().to_path_buf()], "nobody", None, subjects_read()).await;
+    let roots = tempfile::tempdir().unwrap();
+    let resp = kg_graph_at(
+        &[dir.path().to_path_buf()],
+        "nobody",
+        Some(roots.path()),
+        roots.path(),
+        subjects_read(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
 async fn kg_route_rejects_traversal_name() {
     let dir = tempfile::tempdir().unwrap();
-    let resp = kg_proxy_at(&[dir.path().to_path_buf()], "../etc", None, subjects_read()).await;
+    let roots = tempfile::tempdir().unwrap();
+    let resp = kg_graph_at(
+        &[dir.path().to_path_buf()],
+        "../etc",
+        Some(roots.path()),
+        roots.path(),
+        subjects_read(),
+    )
+    .await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
@@ -523,9 +457,8 @@ async fn kg_routes_are_wired_into_router() {
     }
 }
 
-/// Owner decision (#4290): the proxy is READ-ONLY. trusty-memory's assert
-/// (`kg_assert`) and retract (`memory.kg_delete_triple`) are deliberately not
-/// exposed, so those verbs must not resolve to a handler here.
+/// Owner decision (#4290): the exposed graph is READ-ONLY. Writing an entity has
+/// its own confined OKG ingest tools, so those verbs must not resolve here.
 #[tokio::test]
 async fn kg_write_verbs_are_not_proxied() {
     for (method, path) in [
@@ -544,7 +477,7 @@ async fn kg_write_verbs_are_not_proxied() {
             resp.status() == StatusCode::METHOD_NOT_ALLOWED
                 || resp.status() == StatusCode::NOT_FOUND
                 || resp.status() == StatusCode::FORBIDDEN,
-            "{method} {path} resolved to a handler ({}) — the KG proxy must stay read-only",
+            "{method} {path} resolved to a handler ({}) — the KG route must stay read-only",
             resp.status()
         );
     }

--- a/crates/trusty-agents/src/api/server/tests/agent_kg.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_kg.rs
@@ -196,6 +196,71 @@ async fn no_memory_drawer_or_palace_triple_can_reach_the_exposed_graph() {
     );
 }
 
+/// Why (#7430 security review): `tree` used to be `root.display()`, an absolute
+/// filesystem path, and the browser rendered it in its empty-state copy — so
+/// every viewer of the pane was shown the operator's home-directory layout. The
+/// retired memory-palace envelope disclosed only an opaque id. This asserts the
+/// property rather than one spelling: NO string anywhere in any envelope, on any
+/// route, in any state, may begin with `/`.
+///
+/// What: every read, against a tree that exists, a tree that does not, and an
+/// unresolvable binding — the three states that each build `tree` and `reason`
+/// differently. The tempdir roots are real absolute paths (`/var/folders/…` on
+/// macOS, `/tmp/…` on Linux), so a regression to `display()` is caught by the
+/// leading-`/` check and also by the explicit substring check on the root.
+/// Test: itself.
+#[tokio::test]
+async fn no_envelope_discloses_a_filesystem_path() {
+    /// Every string in the payload, recursively — keys are structure, values
+    /// are what a client renders.
+    fn strings(value: &Value, out: &mut Vec<String>) {
+        match value {
+            Value::String(s) => out.push(s.clone()),
+            Value::Array(items) => items.iter().for_each(|v| strings(v, out)),
+            Value::Object(map) => map.values().for_each(|v| strings(v, out)),
+            _ => {}
+        }
+    }
+
+    let populated = Fixtures::new("izzie", BOUND_FIXTURE).with_tree("izzie");
+    let absent = Fixtures::new("izzie", BOUND_FIXTURE);
+    let unresolvable = Fixtures::new(
+        "ghosty",
+        "[agent]\nname = \"ghosty\"\n\n[[stores]]\nname = \"g\"\ntree = \"https://example.com/kb\"\n",
+    );
+
+    for (f, agent) in [
+        (&populated, "izzie"),
+        (&absent, "izzie"),
+        (&unresolvable, "ghosty"),
+    ] {
+        for read in [
+            subjects_read(),
+            KgRead::All {
+                limit: 50,
+                offset: 0,
+            },
+            KgRead::Subject("Bob".to_string()),
+            KgRead::Count,
+        ] {
+            let body = f.read(agent, read.clone()).await;
+            let mut found = Vec::new();
+            strings(&body, &mut found);
+            for s in &found {
+                assert!(
+                    !s.starts_with('/'),
+                    "an absolute path reached the payload for {read:?}: {s:?} in {body}"
+                );
+            }
+            let root = f.tree(agent).display().to_string();
+            assert!(
+                !body.to_string().contains(&root),
+                "the tree's real root reached the payload for {read:?}: {body}"
+            );
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Each read
 // ---------------------------------------------------------------------------
@@ -214,9 +279,8 @@ async fn kg_subjects_route_lists_okg_subjects() {
         "{body}"
     );
     assert_eq!(
-        body["tree"],
-        f.tree("izzie").display().to_string(),
-        "the envelope names the tree it read"
+        body["tree"], "izzie/okg",
+        "the envelope names the tree by its opaque label, not its path"
     );
     assert_eq!(
         body["definitions"]

--- a/crates/trusty-agents/src/stores/mod.rs
+++ b/crates/trusty-agents/src/stores/mod.rs
@@ -21,6 +21,10 @@
 //! - `index_feed` — pushing OKG ingest output into the bound trusty-search
 //!   index, so the binding's "one store, two facets" semantics are true rather
 //!   than aspirational (#3892 remediation (a)).
+//! - `okg_graph` — reading the exposed knowledge graph (triples AND
+//!   definitions) out of a bound OKG tree (#7430). The graph the UI and agent
+//!   tools show comes from here and only from here; a memory palace's `kg_*`
+//!   surface is a different store and is never part of it.
 //! - `status` — live resolution of a binding against the running
 //!   trusty-search / trusty-memory daemons, producing a per-store
 //!   connected/not-connected report. Every failure mode degrades to
@@ -31,11 +35,15 @@
 pub mod binding;
 pub mod config;
 pub mod index_feed;
+// #7430: the EXPOSED knowledge graph, read from the OKG tree — never a memory
+// palace. See this module's own doc for the leak it replaces.
+pub mod okg_graph;
 pub mod status;
 
 pub use binding::{BoundIndex, bound_index_for_tree, okg_tree_path};
 pub use config::{AgentStoreBinding, StoresConfig};
 pub use index_feed::{HttpIndexFeed, IndexFeed, IndexFeedReport, feed_source};
+pub use okg_graph::{OkgDefinition, OkgGraph, OkgSubjectCount, OkgTriple, read_graph};
 pub use status::{StoreStatus, resolve_store_statuses};
 
 pub(crate) mod index_feed_rpc;

--- a/crates/trusty-agents/src/stores/okg_graph.rs
+++ b/crates/trusty-agents/src/stores/okg_graph.rs
@@ -37,7 +37,7 @@ use trusty_kb::entity::link_values;
 use trusty_kb::schema::{Profile, base_envelope};
 use trusty_kb::store::{KbStore, summarise};
 
-use crate::assistants::AssistantHome;
+use crate::assistants::{AssistantHome, OKG_DIR};
 use crate::stores::StoresConfig;
 
 /// One relationship edge, as a subject-predicate-object triple.
@@ -134,7 +134,11 @@ impl OkgGraph {
 /// base envelope's own fields are description, not relationship — a `[[link]]`
 /// written inside a prose `description` must not become a predicate.
 /// What: every key EXCEPT the base-envelope names, which come from
-/// [`base_envelope`] rather than a second hand-kept list.
+/// [`base_envelope`] rather than a second hand-kept list. The rule is
+/// exclusion, so it fails OPEN: a new OKF envelope key that is NOT added to
+/// [`base_envelope`] reads as a relationship here, and any `[[wiki-link]]` in
+/// its value becomes a triple. Adding the key to that function is what keeps
+/// the two in step — there is no second list to update.
 /// Test: `envelope_fields_are_not_edges`.
 fn is_edge_field(key: &str) -> bool {
     !base_envelope().iter().any(|f| f.name == key)
@@ -145,6 +149,14 @@ fn is_edge_field(key: &str) -> bool {
 /// Why/What: see the module doc. A malformed entity file is SKIPPED rather than
 /// failing the read — the same fail-open posture `KbStore::list` takes, so one
 /// hand-edited file cannot blank the whole pane.
+///
+/// This walks and parses the whole tree on every call, so one browser page load
+/// costs four walks. Deliberately uncached: the only cheap key is a directory
+/// mtime, and a directory's mtime does not move when an entity file already in
+/// it is edited in place — so an mtime cache would serve a stale graph after
+/// exactly the edit a reader opened the pane to see. A cache here needs a
+/// per-file stamp or an ingest-side invalidation hook. See #7430.
+///
 /// Test: `reads_triples_and_definitions_from_a_tree`,
 /// `malformed_entity_is_skipped`.
 pub fn read_graph(root: &Path) -> anyhow::Result<OkgGraph> {
@@ -159,11 +171,14 @@ pub fn read_graph(root: &Path) -> anyhow::Result<OkgGraph> {
                 .get_str("title")
                 .map(str::to_string)
                 .unwrap_or_else(|| slug.clone());
+            // Tree-relative by construction; the fallback rebuilds the same
+            // relative spelling rather than falling back to the absolute path,
+            // which would put the operator's directory layout in a payload
+            // clients receive (#7430 security review).
             let rel = path
                 .strip_prefix(root)
-                .unwrap_or(&path)
-                .display()
-                .to_string();
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| format!("{collection}/{slug}.md"));
             graph.definitions.push(OkgDefinition {
                 subject: subject.clone(),
                 collection: collection.clone(),
@@ -199,6 +214,21 @@ pub fn read_graph(root: &Path) -> anyhow::Result<OkgGraph> {
     Ok(graph)
 }
 
+/// One resolved OKG tree: where to read it, and what to CALL it.
+///
+/// Why (#7430 security review): the two are deliberately separate. `root` is an
+/// absolute filesystem path and belongs only to this process; `label` is the
+/// name a client may see. Serving the path would hand every viewer of the
+/// Knowledge-Graph pane the operator's home-directory layout, which no caller
+/// needs and the retired memory-palace envelope never disclosed.
+pub struct OkgTree {
+    /// Absolute directory to read. Never leaves the server.
+    pub root: PathBuf,
+    /// The binding's own opaque name for the tree — `okg://<agent>`, or the
+    /// home-relative `<agent>/<root>`. Never absolute, never a real path.
+    pub label: String,
+}
+
 /// The OKG tree `agent` browses.
 ///
 /// Why: an agent addresses its tree two ways — a `[[stores]].root` relative to
@@ -209,35 +239,45 @@ pub fn read_graph(root: &Path) -> anyhow::Result<OkgGraph> {
 /// What: `assistants_root` and `knowledge_dir` are injected so a test can point
 /// both at a tempdir. An agent with no `[[stores]]` binding at all still has its
 /// home's `okg/` tree, which is the #4325 default layout — that is a real tree,
-/// not an error.
+/// not an error. The label is derived from what the BINDING declares, never from
+/// the resolved path, so it cannot pick up an absolute prefix.
 /// Test: `resolves_the_home_tree_for_a_rooted_binding`,
 /// `resolves_the_shared_pool_for_a_plain_binding`,
-/// `resolves_the_home_tree_when_no_store_is_bound`.
+/// `resolves_the_home_tree_when_no_store_is_bound`,
+/// `every_resolution_arm_labels_the_tree_without_a_path`.
 pub fn resolve_okg_root(
     agent: &str,
     stores: &StoresConfig,
     assistants_root: &Path,
     knowledge_dir: &Path,
-) -> Result<PathBuf, String> {
+) -> Result<OkgTree, String> {
     let home = || -> Result<AssistantHome, String> {
         let id = crate::assistants::AssistantInstanceId::new(agent).map_err(|e| e.to_string())?;
         Ok(AssistantHome::under(assistants_root, id))
     };
     match stores.primary() {
         Some(binding) if binding.root.is_some() => {
-            home()?.store_root(binding).map_err(|e| e.to_string())
+            let declared = binding.root.as_deref().unwrap_or(OKG_DIR).trim();
+            Ok(OkgTree {
+                root: home()?.store_root(binding).map_err(|e| e.to_string())?,
+                label: format!("{agent}/{}", declared.trim_start_matches("./")),
+            })
         }
         Some(binding) => {
-            let tree = binding.resolved_tree(agent);
-            super::binding::okg_tree_path(knowledge_dir, &tree).ok_or_else(|| {
+            let label = binding.resolved_tree(agent);
+            let root = super::binding::okg_tree_path(knowledge_dir, &label).ok_or_else(|| {
                 format!(
-                    "store `{}` declares tree `{tree}`, which does not resolve to a \
+                    "store `{}` declares tree `{label}`, which does not resolve to a \
                      knowledge-tree directory",
                     binding.name
                 )
-            })
+            })?;
+            Ok(OkgTree { root, label })
         }
-        None => Ok(home()?.okg_dir()),
+        None => Ok(OkgTree {
+            root: home()?.okg_dir(),
+            label: format!("{agent}/{OKG_DIR}"),
+        }),
     }
 }
 

--- a/crates/trusty-agents/src/stores/okg_graph.rs
+++ b/crates/trusty-agents/src/stores/okg_graph.rs
@@ -1,0 +1,248 @@
+//! The EXPOSED knowledge graph, read from an assistant's OKG tree (#7430).
+//!
+//! Why: the graph the assistant UI and agent tools show must be the OKG graph —
+//! the triples and definitions held in the assistant's own `okg/` tree — and
+//! nothing else. Before #7430 the four `/api/agents/:name/kg*` routes proxied
+//! trusty-memory's palace-scoped `kg_*` surface instead, so the pane labelled
+//! "Knowledge Graph" rendered the MEMORY knowledge graph: triples asserted into
+//! a memory palace, which is a separate store with a separate lifecycle. That
+//! is the leak epic #7425 item (f) names. This module is the OKG-side
+//! replacement, and it reads one directory tree — it holds no memory client and
+//! can reach no palace, so the leak cannot reappear by accident.
+//!
+//! What: [`read_graph`] walks a KB tree with [`KbStore`] and returns both halves
+//! of the graph at once.
+//!   - A DEFINITION is one entity: what the subject is (`type`), where it lives
+//!     (`collection`), and its one-line summary.
+//!   - A TRIPLE is one relationship edge: an entity's frontmatter key holding
+//!     `[[wiki-link]]` targets, one triple per target. The envelope fields OKF
+//!     defines as description rather than relationship ([`base_envelope`]) are
+//!     excluded, so a `[[link]]` inside a prose `description` is not read as an
+//!     edge.
+//! [`resolve_okg_root`] maps an agent to the tree it browses, mirroring
+//! [`super::binding`]'s resolution so an OKG tool and this reader can never
+//! address different directories.
+//!
+//! Output is fully sorted, so two reads of an unchanged tree are byte-identical.
+//!
+//! Test: `reads_triples_and_definitions_from_a_tree`,
+//! `resolves_the_home_tree_for_a_rooted_binding`.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_yaml::Value as Yaml;
+
+use trusty_kb::entity::link_values;
+use trusty_kb::schema::{Profile, base_envelope};
+use trusty_kb::store::{KbStore, summarise};
+
+use crate::assistants::AssistantHome;
+use crate::stores::StoresConfig;
+
+/// One relationship edge, as a subject-predicate-object triple.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OkgTriple {
+    /// The entity the edge was read from — its `title`, else its file slug.
+    pub subject: String,
+    /// The frontmatter key holding the edge (`works_at`, `member_of`, …).
+    pub predicate: String,
+    /// One `[[wiki-link]]` target of that key.
+    pub object: String,
+    /// Tree-relative path of the entity file, so a reader can see the source.
+    pub provenance: String,
+}
+
+/// One entity definition — what a subject IS, as distinct from what it links to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OkgDefinition {
+    /// Same spelling as [`OkgTriple::subject`], so the two halves join.
+    pub subject: String,
+    /// The collection directory the entity lives in.
+    pub collection: String,
+    /// The file slug, which is also its address within the collection.
+    pub slug: String,
+    /// The OKF `type` field.
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// The `description` field, else the first non-blank body line.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Tree-relative path of the entity file.
+    pub path: String,
+}
+
+/// One subject and how many triples name it as subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct OkgSubjectCount {
+    /// The subject.
+    pub subject: String,
+    /// Triples whose subject this is. Zero for a defined entity with no edges —
+    /// still a node in the graph, and still listed.
+    pub count: usize,
+}
+
+/// Both halves of one tree's graph.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct OkgGraph {
+    /// Every relationship edge, sorted by subject, predicate, then object.
+    pub triples: Vec<OkgTriple>,
+    /// Every entity definition, sorted by collection then slug.
+    pub definitions: Vec<OkgDefinition>,
+}
+
+impl OkgGraph {
+    /// Every subject in the graph with its triple count, subject-sorted.
+    ///
+    /// Why: the browser's left-hand list must show an entity that has a
+    /// definition but no edges yet — an OKG tree mid-ingest is mostly that, and
+    /// a list built only from triples would render it as empty.
+    /// What: the union of definition subjects and triple subjects; the count is
+    /// triples only.
+    /// Test: `subject_counts_include_edgeless_entities`.
+    pub fn subject_counts(&self) -> Vec<OkgSubjectCount> {
+        let mut counts: std::collections::BTreeMap<&str, usize> = self
+            .definitions
+            .iter()
+            .map(|d| (d.subject.as_str(), 0))
+            .collect();
+        for t in &self.triples {
+            *counts.entry(t.subject.as_str()).or_insert(0) += 1;
+        }
+        counts
+            .into_iter()
+            .map(|(subject, count)| OkgSubjectCount {
+                subject: subject.to_string(),
+                count,
+            })
+            .collect()
+    }
+
+    /// The definitions for `subjects`, in this graph's own definition order.
+    pub fn definitions_for(&self, subjects: &[String]) -> Vec<OkgDefinition> {
+        self.definitions
+            .iter()
+            .filter(|d| subjects.contains(&d.subject))
+            .cloned()
+            .collect()
+    }
+}
+
+/// Whether a frontmatter key carries relationship edges.
+///
+/// Why: OKF stores an edge as a snake_case key holding `[[wiki-links]]`, but the
+/// base envelope's own fields are description, not relationship — a `[[link]]`
+/// written inside a prose `description` must not become a predicate.
+/// What: every key EXCEPT the base-envelope names, which come from
+/// [`base_envelope`] rather than a second hand-kept list.
+/// Test: `envelope_fields_are_not_edges`.
+fn is_edge_field(key: &str) -> bool {
+    !base_envelope().iter().any(|f| f.name == key)
+}
+
+/// Read both halves of the graph out of the KB tree at `root`.
+///
+/// Why/What: see the module doc. A malformed entity file is SKIPPED rather than
+/// failing the read — the same fail-open posture `KbStore::list` takes, so one
+/// hand-edited file cannot blank the whole pane.
+/// Test: `reads_triples_and_definitions_from_a_tree`,
+/// `malformed_entity_is_skipped`.
+pub fn read_graph(root: &Path) -> anyhow::Result<OkgGraph> {
+    let store = KbStore::new(root.to_path_buf(), Profile::default_profile());
+    let mut graph = OkgGraph::default();
+    for collection in store.collection_dirs_on_disk()? {
+        for (slug, path) in store.entity_files(&collection)? {
+            let Ok(Some(entity)) = store.read_entity_at(&path) else {
+                continue;
+            };
+            let subject = entity
+                .get_str("title")
+                .map(str::to_string)
+                .unwrap_or_else(|| slug.clone());
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            graph.definitions.push(OkgDefinition {
+                subject: subject.clone(),
+                collection: collection.clone(),
+                slug: slug.clone(),
+                kind: entity.get_str("type").map(str::to_string),
+                summary: summarise(&entity),
+                path: rel.clone(),
+            });
+            let Yaml::Mapping(map) = &entity.frontmatter else {
+                continue;
+            };
+            for (key, value) in map {
+                let Some(predicate) = key.as_str().filter(|k| is_edge_field(k)) else {
+                    continue;
+                };
+                for object in link_values(value) {
+                    graph.triples.push(OkgTriple {
+                        subject: subject.clone(),
+                        predicate: predicate.to_string(),
+                        object,
+                        provenance: rel.clone(),
+                    });
+                }
+            }
+        }
+    }
+    graph
+        .definitions
+        .sort_by(|a, b| (&a.collection, &a.slug).cmp(&(&b.collection, &b.slug)));
+    graph.triples.sort_by(|a, b| {
+        (&a.subject, &a.predicate, &a.object).cmp(&(&b.subject, &b.predicate, &b.object))
+    });
+    Ok(graph)
+}
+
+/// The OKG tree `agent` browses.
+///
+/// Why: an agent addresses its tree two ways — a `[[stores]].root` relative to
+/// the assistant's own home (#4325), or the default `okg://<agent>` URI into the
+/// shared knowledge pool. `super::binding::binding_for` already resolves exactly
+/// this pair for the index feed; reading the tree a different way here would let
+/// the browser and the ingest describe different directories.
+/// What: `assistants_root` and `knowledge_dir` are injected so a test can point
+/// both at a tempdir. An agent with no `[[stores]]` binding at all still has its
+/// home's `okg/` tree, which is the #4325 default layout — that is a real tree,
+/// not an error.
+/// Test: `resolves_the_home_tree_for_a_rooted_binding`,
+/// `resolves_the_shared_pool_for_a_plain_binding`,
+/// `resolves_the_home_tree_when_no_store_is_bound`.
+pub fn resolve_okg_root(
+    agent: &str,
+    stores: &StoresConfig,
+    assistants_root: &Path,
+    knowledge_dir: &Path,
+) -> Result<PathBuf, String> {
+    let home = || -> Result<AssistantHome, String> {
+        let id = crate::assistants::AssistantInstanceId::new(agent).map_err(|e| e.to_string())?;
+        Ok(AssistantHome::under(assistants_root, id))
+    };
+    match stores.primary() {
+        Some(binding) if binding.root.is_some() => {
+            home()?.store_root(binding).map_err(|e| e.to_string())
+        }
+        Some(binding) => {
+            let tree = binding.resolved_tree(agent);
+            super::binding::okg_tree_path(knowledge_dir, &tree).ok_or_else(|| {
+                format!(
+                    "store `{}` declares tree `{tree}`, which does not resolve to a \
+                     knowledge-tree directory",
+                    binding.name
+                )
+            })
+        }
+        None => Ok(home()?.okg_dir()),
+    }
+}
+
+// Split into a sibling file (issue #610's 500-SLOC production cap) —
+// mirrors `status.rs` / `status_tests.rs` in this same directory.
+#[cfg(test)]
+#[path = "okg_graph_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/stores/okg_graph_tests.rs
+++ b/crates/trusty-agents/src/stores/okg_graph_tests.rs
@@ -174,8 +174,9 @@ fn resolves_the_home_tree_for_a_rooted_binding() {
     let assistants = tempfile::tempdir().unwrap();
     let knowledge = tempfile::tempdir().unwrap();
     let stores = stores_from("[[stores]]\nname = \"k\"\nroot = \"okg\"\n");
-    let root = resolve_okg_root("izzie", &stores, assistants.path(), knowledge.path()).unwrap();
-    assert_eq!(root, assistants.path().join("izzie").join("okg"));
+    let tree = resolve_okg_root("izzie", &stores, assistants.path(), knowledge.path()).unwrap();
+    assert_eq!(tree.root, assistants.path().join("izzie").join("okg"));
+    assert_eq!(tree.label, "izzie/okg");
 }
 
 /// Why: a binding with no `root` still addresses `okg://<agent>` in the shared
@@ -188,8 +189,9 @@ fn resolves_the_shared_pool_for_a_plain_binding() {
     let assistants = tempfile::tempdir().unwrap();
     let knowledge = tempfile::tempdir().unwrap();
     let stores = stores_from("[[stores]]\nname = \"k\"\nindex = \"k\"\n");
-    let root = resolve_okg_root("izzie", &stores, assistants.path(), knowledge.path()).unwrap();
-    assert_eq!(root, knowledge.path().join("izzie"));
+    let tree = resolve_okg_root("izzie", &stores, assistants.path(), knowledge.path()).unwrap();
+    assert_eq!(tree.root, knowledge.path().join("izzie"));
+    assert_eq!(tree.label, "okg://izzie");
 }
 
 /// Why: an agent that declares no `[[stores]]` still has the #4325 default tree
@@ -199,12 +201,55 @@ fn resolves_the_shared_pool_for_a_plain_binding() {
 fn resolves_the_home_tree_when_no_store_is_bound() {
     let assistants = tempfile::tempdir().unwrap();
     let knowledge = tempfile::tempdir().unwrap();
-    let root = resolve_okg_root(
+    let tree = resolve_okg_root(
         "izzie",
         &StoresConfig::default(),
         assistants.path(),
         knowledge.path(),
     )
     .unwrap();
-    assert_eq!(root, assistants.path().join("izzie").join("okg"));
+    assert_eq!(tree.root, assistants.path().join("izzie").join("okg"));
+    assert_eq!(tree.label, "izzie/okg");
+}
+
+/// Why (#7430 security review): the label is what a client sees, so no
+/// resolution arm may derive it from the resolved path. The `./` and nested
+/// spellings are the ones most likely to pick up a prefix by accident.
+/// What: every arm, including a `root` written `./knowledge` and one nested two
+/// deep, must yield a relative, `/`-free label.
+/// Test: itself.
+#[test]
+fn every_resolution_arm_labels_the_tree_without_a_path() {
+    let assistants = tempfile::tempdir().unwrap();
+    let knowledge = tempfile::tempdir().unwrap();
+    let cases = [
+        ("[[stores]]\nname = \"k\"\nroot = \"okg\"\n", "izzie/okg"),
+        (
+            "[[stores]]\nname = \"k\"\nroot = \"./knowledge\"\n",
+            "izzie/knowledge",
+        ),
+        (
+            "[[stores]]\nname = \"k\"\nroot = \"okg/personal\"\n",
+            "izzie/okg/personal",
+        ),
+        ("[[stores]]\nname = \"k\"\nindex = \"k\"\n", "okg://izzie"),
+    ];
+    for (src, expected) in cases {
+        let tree = resolve_okg_root(
+            "izzie",
+            &stores_from(src),
+            assistants.path(),
+            knowledge.path(),
+        )
+        .unwrap();
+        assert_eq!(tree.label, expected, "for {src:?}");
+        assert!(!tree.label.starts_with('/'), "for {src:?}");
+        assert!(
+            !tree
+                .label
+                .contains(&assistants.path().display().to_string()),
+            "the label leaked the assistants root for {src:?}: {}",
+            tree.label
+        );
+    }
 }

--- a/crates/trusty-agents/src/stores/okg_graph_tests.rs
+++ b/crates/trusty-agents/src/stores/okg_graph_tests.rs
@@ -1,0 +1,210 @@
+//! Unit tests for the OKG graph reader (#7430).
+//!
+//! Why: this module is what makes the exposed graph OKG-only, so its two
+//! guarantees need pinning directly: it reads a directory tree (never a memory
+//! palace), and it returns BOTH halves the owner's closure condition names —
+//! triples and definitions.
+//! What: tree-reading, the edge/description split, fail-open on a malformed
+//! file, and the three tree-resolution arms.
+//! Test: This module IS the test.
+
+use std::path::Path;
+
+use super::*;
+
+/// Write one entity file under `<root>/<collection>/<slug>.md`.
+fn entity(root: &Path, collection: &str, slug: &str, content: &str) {
+    let dir = root.join(collection);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join(format!("{slug}.md")), content).unwrap();
+}
+
+/// A tree holding two people, one edge each way, and one edgeless organisation.
+fn fixture_tree() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    entity(
+        tmp.path(),
+        "people",
+        "bob",
+        "---\ntype: Person\ntitle: Bob\ndescription: The owner.\nworks_at: \"[[Duetto]]\"\nknows:\n  - \"[[Ada]]\"\n---\n\nBody line.\n",
+    );
+    entity(
+        tmp.path(),
+        "people",
+        "ada",
+        "---\ntype: Person\ntitle: Ada\n---\n\nFirst programmer.\n",
+    );
+    entity(
+        tmp.path(),
+        "organizations",
+        "duetto",
+        "---\ntype: Organization\ntitle: Duetto\ndescription: A company with a [[Bob]] mention.\n---\n",
+    );
+    tmp
+}
+
+/// Why: the owner's closure condition for #7430 is BOTH halves — triples and
+/// definitions — out of the OKG tree. A reader that returned only edges would
+/// satisfy the word "graph" and fail the requirement.
+/// What: asserts every edge target became a triple with its source file as
+/// provenance, and that every entity has a definition carrying its type and
+/// summary.
+/// Test: itself.
+#[test]
+fn reads_triples_and_definitions_from_a_tree() {
+    let tmp = fixture_tree();
+    let graph = read_graph(tmp.path()).unwrap();
+
+    assert_eq!(
+        graph
+            .triples
+            .iter()
+            .map(|t| (t.subject.as_str(), t.predicate.as_str(), t.object.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("Bob", "knows", "Ada"), ("Bob", "works_at", "Duetto"),],
+        "triples: {:?}",
+        graph.triples
+    );
+    assert_eq!(graph.triples[0].provenance, "people/bob.md");
+
+    let defs: Vec<_> = graph
+        .definitions
+        .iter()
+        .map(|d| (d.subject.as_str(), d.kind.as_deref(), d.summary.as_deref()))
+        .collect();
+    assert_eq!(
+        defs,
+        vec![
+            (
+                "Duetto",
+                Some("Organization"),
+                Some("A company with a [[Bob]] mention.")
+            ),
+            ("Ada", Some("Person"), Some("First programmer.")),
+            ("Bob", Some("Person"), Some("The owner.")),
+        ],
+        "definitions: {defs:?}"
+    );
+}
+
+/// Why: OKF writes an edge as a snake_case key holding `[[wiki-links]]`, but a
+/// `description` is prose that may mention an entity. Treating every key with a
+/// link as an edge would mint `Duetto description Bob` out of that sentence.
+/// What: the fixture's organization carries a `[[Bob]]` inside `description`
+/// and must contribute no triple.
+/// Test: itself.
+#[test]
+fn envelope_fields_are_not_edges() {
+    let graph = read_graph(fixture_tree().path()).unwrap();
+    assert!(
+        !graph
+            .triples
+            .iter()
+            .any(|t| t.predicate == "description" || t.subject == "Duetto"),
+        "an envelope field produced an edge: {:?}",
+        graph.triples
+    );
+}
+
+/// Why: an OKG tree mid-ingest is mostly entities with no edges yet. A subject
+/// list built from triples alone would render that tree as empty, which reads as
+/// "nothing was ingested".
+/// What: the edgeless organisation is listed with a zero count.
+/// Test: itself.
+#[test]
+fn subject_counts_include_edgeless_entities() {
+    let graph = read_graph(fixture_tree().path()).unwrap();
+    let counts: Vec<_> = graph
+        .subject_counts()
+        .into_iter()
+        .map(|c| (c.subject, c.count))
+        .collect();
+    assert_eq!(
+        counts,
+        vec![
+            ("Ada".to_string(), 0),
+            ("Bob".to_string(), 2),
+            ("Duetto".to_string(), 0),
+        ]
+    );
+}
+
+/// Why: one hand-edited file must not blank the pane — the same fail-open
+/// posture `KbStore::list` takes.
+/// What: an unparseable frontmatter file is skipped and its siblings still read.
+/// Test: itself.
+#[test]
+fn malformed_entity_is_skipped() {
+    let tmp = fixture_tree();
+    entity(
+        tmp.path(),
+        "people",
+        "broken",
+        "---\n: : not yaml : :\n---\n",
+    );
+    let graph = read_graph(tmp.path()).unwrap();
+    assert!(graph.definitions.iter().any(|d| d.subject == "Bob"));
+    assert!(!graph.definitions.iter().any(|d| d.slug == "broken"));
+}
+
+/// An absent tree is an empty graph, not an error — a home exists before its
+/// first ingest.
+#[test]
+fn an_absent_tree_reads_as_an_empty_graph() {
+    let tmp = tempfile::tempdir().unwrap();
+    let graph = read_graph(&tmp.path().join("never-created")).unwrap();
+    assert_eq!(graph, OkgGraph::default());
+}
+
+fn stores_from(toml_src: &str) -> StoresConfig {
+    #[derive(serde::Deserialize)]
+    struct Partial {
+        #[serde(default)]
+        stores: StoresConfig,
+    }
+    toml::from_str::<Partial>(toml_src).unwrap().stores
+}
+
+/// Why: #4325 gave each assistant its own home-confined tree. A binding
+/// declaring `root` must resolve there and nowhere else.
+/// What: `root = "okg"` under an injected assistants root.
+/// Test: itself.
+#[test]
+fn resolves_the_home_tree_for_a_rooted_binding() {
+    let assistants = tempfile::tempdir().unwrap();
+    let knowledge = tempfile::tempdir().unwrap();
+    let stores = stores_from("[[stores]]\nname = \"k\"\nroot = \"okg\"\n");
+    let root = resolve_okg_root("izzie", &stores, assistants.path(), knowledge.path()).unwrap();
+    assert_eq!(root, assistants.path().join("izzie").join("okg"));
+}
+
+/// Why: a binding with no `root` still addresses `okg://<agent>` in the shared
+/// knowledge pool, which is what `stores::binding` resolves for the index feed.
+/// Resolving it differently here would let the browser and the ingest describe
+/// different directories.
+/// Test: itself.
+#[test]
+fn resolves_the_shared_pool_for_a_plain_binding() {
+    let assistants = tempfile::tempdir().unwrap();
+    let knowledge = tempfile::tempdir().unwrap();
+    let stores = stores_from("[[stores]]\nname = \"k\"\nindex = \"k\"\n");
+    let root = resolve_okg_root("izzie", &stores, assistants.path(), knowledge.path()).unwrap();
+    assert_eq!(root, knowledge.path().join("izzie"));
+}
+
+/// Why: an agent that declares no `[[stores]]` still has the #4325 default tree
+/// at `<home>/okg`. Reporting "no store bound" there would hide a real graph.
+/// Test: itself.
+#[test]
+fn resolves_the_home_tree_when_no_store_is_bound() {
+    let assistants = tempfile::tempdir().unwrap();
+    let knowledge = tempfile::tempdir().unwrap();
+    let root = resolve_okg_root(
+        "izzie",
+        &StoresConfig::default(),
+        assistants.path(),
+        knowledge.path(),
+    )
+    .unwrap();
+    assert_eq!(root, assistants.path().join("izzie").join("okg"));
+}

--- a/crates/trusty-agents/ui/src/components/ChatPane.test.ts
+++ b/crates/trusty-agents/ui/src/components/ChatPane.test.ts
@@ -426,7 +426,7 @@ describe('Knowledge Graph main-pane takeover', () => {
     vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes('/agents/izzie/kg/subjects')) return new Promise<Response>(resolve => finishOld = resolve);
-      if (url.includes('/agents/new-agent/kg/subjects')) return Promise.resolve(response({ connected: false, palace: null, reason: 'new agent graph', data: [] }));
+      if (url.includes('/agents/new-agent/kg/subjects')) return Promise.resolve(response({ connected: false, tree: null, reason: 'new agent graph', data: [] }));
       return previousFetch(input, init);
     }));
     activeAgentId.set('izzie');

--- a/crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.svelte
+++ b/crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  /** Read-only browser for the selected assistant's bound knowledge graph.
-   * ChatPane positions this over its mounted chat, matching preferences.
-   * Every request is scoped to the current assistant generation; triple
-   * selection requests additionally use a sequence so older results cannot
-   * replace a newer selection. Disconnected envelopes remain distinct from
-   * an empty connected graph. Tests cover takeover and asynchronous races.
+  /** Read-only browser for the selected assistant's OKG knowledge graph —
+   * triples and definitions out of its `okg/` tree, never a memory palace
+   * (#7430). ChatPane positions this over its mounted chat, matching
+   * preferences. Every request is scoped to the current assistant generation;
+   * triple selection requests additionally use a sequence so older results
+   * cannot replace a newer selection. Disconnected envelopes remain distinct
+   * from an empty connected graph. Tests cover takeover and asynchronous races.
    */
   import { AlertCircle, ArrowLeft, Loader2, Network, X } from 'lucide-svelte';
   import { onMount, onDestroy } from 'svelte';
@@ -13,11 +14,12 @@
     fetchKgCount,
     fetchKgSubject,
     fetchKgSubjects,
+    type KgDefinition,
     type KgSubjectCount,
     type KgTriple,
   } from '../lib/kg';
 
-  /** The agent whose bound palace this browses. Never Concierge — `ChatHeader`
+  /** The agent whose OKG tree this browses. Never Concierge — `ChatHeader`
    * hides the opening control when `activeAgentId === null` (owner decision:
    * Concierge has no `agent.toml`/`[[stores]]` binding). */
   export let agentName: string;
@@ -27,10 +29,11 @@
 
   type Mode = 'all' | 'subject';
 
-  /** `null` while the first request (which resolves palace-binding state) is
-   * in flight — distinct from `false`, which means "resolved: not connected". */
+  /** `null` while the first request (which resolves the tree) is in flight —
+   * distinct from `false`, which means "resolved: not connected". */
   let connected: boolean | null = null;
-  let palace: string | null = null;
+  /** The OKG directory the graph was read from. */
+  let tree: string | null = null;
   let reason = '';
   let configError = '';
   /** 404 on the first request — an unknown agent, e.g. a stale roster
@@ -46,6 +49,9 @@
   let mode: Mode = 'all';
   let selectedSubject = '';
   let triples: KgTriple[] = [];
+  /** The definitions that came with the current page of triples — the "what is
+   * this subject" half of the graph (#7430). */
+  let definitions: KgDefinition[] = [];
   let triplesLoading = false;
   let triplesError = '';
 
@@ -72,11 +78,11 @@
   /**
    * Why (#4290 code-review finding, HIGH): every KG route can independently
    * flip to `connected: false` (still HTTP 200, `data: []`/`{active: 0}`) if
-   * trusty-memory or the palace goes away AFTER bootstrap already resolved
-   * `connected: true` — the daemon restarts mid-session, or the user pages
-   * through "all"/clicks a subject while it's down. Assigning `env.data`
-   * unconditionally in that case renders "0 active triples" / "No triples.",
-   * which is indistinguishable from a genuinely-connected-but-empty palace —
+   * the OKG tree goes away AFTER bootstrap already resolved
+   * `connected: true` — the directory is moved or the binding is rewritten, or
+   * the user pages through "all"/clicks a subject meanwhile. Assigning
+   * `env.data` unconditionally in that case renders "0 active triples" / "No
+   * triples.", which is indistinguishable from a connected-but-empty tree —
    * exactly the failure the owner's contract forbids. So `loadAll`,
    * `loadCount`, and `loadSubject` all check `env.connected` first and, when
    * false, route into the SAME disconnected state `bootstrap()` shows
@@ -93,8 +99,8 @@
 
   /**
    * Why: `/kg/subjects` is the cheapest route that also carries the
-   * palace/`connected`/`reason`/`config_error` state every other route would
-   * report identically (all four resolve the SAME agent → palace binding).
+   * tree/`connected`/`reason`/`config_error` state every other route would
+   * report identically (all four resolve the SAME agent → OKG tree).
    * Resolving it once here, rather than duplicating the check in `loadAll`
    * and `loadCount`, is what lets those two stay simple "fetch the data"
    * calls.
@@ -112,7 +118,7 @@
     notFound = false;
     loadError = '';
     connected = null;
-    palace = null;
+    tree = null;
     reason = '';
     configError = '';
     subjects = [];
@@ -120,6 +126,7 @@
     selectedSubject = '';
     offset = 0;
     triples = [];
+    definitions = [];
     activeCount = null;
     try {
       const env = await fetchKgSubjects(name, 200);
@@ -128,7 +135,7 @@
         notFound = true;
         return;
       }
-      palace = env.palace;
+      tree = env.tree;
       connected = env.connected;
       reason = env.reason ?? '';
       configError = env.config_error ?? '';
@@ -158,8 +165,9 @@
         return;
       }
       triples = env.data ?? [];
+      definitions = env.definitions ?? [];
     } catch (e) {
-      if (token === generation && request === triplesRequest) { triplesError = `${e}`; triples = []; }
+      if (token === generation && request === triplesRequest) { triplesError = `${e}`; triples = []; definitions = []; }
     } finally {
       if (token === generation && request === triplesRequest) triplesLoading = false;
     }
@@ -206,8 +214,9 @@
         return;
       }
       triples = env.data ?? [];
+      definitions = env.definitions ?? [];
     } catch (e) {
-      if (token === generation && request === triplesRequest) { triplesError = `${e}`; triples = []; }
+      if (token === generation && request === triplesRequest) { triplesError = `${e}`; triples = []; definitions = []; }
     } finally {
       if (token === generation && request === triplesRequest) triplesLoading = false;
     }
@@ -232,12 +241,10 @@
     loadAll(agentName);
   }
 
-  function humanTime(iso?: string): string {
-    if (!iso) return '—';
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return iso;
-    return d.toLocaleString();
-  }
+  /** The definitions to show above the triple table: the selected subject's
+   * own definition in subject mode, every definition on the page otherwise. */
+  $: visibleDefinitions =
+    mode === 'subject' ? definitions.filter((d) => d.subject === selectedSubject) : definitions;
 
   // Reactive rather than onMount: if the roster switch happens while the
   // panel is open (Concierge aside, which unmounts this component entirely —
@@ -316,12 +323,11 @@
           {/if}
         </div>
 
-      <!-- State: connected:true, genuinely empty graph (bound palace, zero
-           triples) — distinct copy from the not-connected case above. -->
+      <!-- State: connected:true, genuinely empty graph (readable OKG tree, no
+           entities) — distinct copy from the not-connected case above. -->
       {:else if subjects.length === 0}
         <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
-          {palace ? `Palace "${palace}"` : 'This agent'} is connected, but its Knowledge Graph has no
-          triples yet.
+          {tree ? `The OKG tree at ${tree}` : 'This agent'} is readable, but holds nothing yet.
         </p>
 
       <!-- State: connected:true with data — the explorer. -->
@@ -404,6 +410,20 @@
               </p>
             {/if}
 
+            <!-- The definitions half of the graph (#7430): what each subject on
+                 this page IS, beside the edges it has. -->
+            {#if visibleDefinitions.length > 0}
+              <ul data-kg-definitions class="shrink-0 border-b border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px]">
+                {#each visibleDefinitions as d (d.collection + '/' + d.slug)}
+                  <li class="py-0.5 text-foundry-light-muted dark:text-foundry-text/60">
+                    <strong class="font-mono text-foundry-light-text dark:text-foundry-text">{d.subject}</strong>
+                    {#if d.type}<span class="ml-1 rounded bg-foundry-light-border/50 dark:bg-black/30 px-1 py-0.5 font-mono text-[10px]">{d.type}</span>{/if}
+                    {#if d.summary}<span class="ml-1">— {d.summary}</span>{/if}
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+
             <div class="min-h-0 flex-1 overflow-y-auto">
               {#if triples.length === 0 && !triplesLoading}
                 <p class="px-3 py-3 text-center text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
@@ -416,8 +436,7 @@
                       <th class="px-2 py-1.5 text-left font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50">Subject</th>
                       <th class="px-2 py-1.5 text-left font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50">Predicate</th>
                       <th class="px-2 py-1.5 text-left font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50">Object</th>
-                      <th class="px-2 py-1.5 text-left font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50">Conf.</th>
-                      <th class="px-2 py-1.5 text-left font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50">Valid from</th>
+                      <th class="px-2 py-1.5 text-left font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50">Source file</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -426,8 +445,7 @@
                         <td class="px-2 py-1.5 font-mono text-[11px] text-foundry-light-text dark:text-foundry-text">{t.subject}</td>
                         <td class="px-2 py-1.5 font-mono text-[11px] text-foundry-light-text dark:text-foundry-text">{t.predicate}</td>
                         <td class="px-2 py-1.5 text-foundry-light-text/90 dark:text-foundry-text/90">{t.object}</td>
-                        <td class="px-2 py-1.5 text-foundry-light-muted dark:text-foundry-text/50">{(t.confidence ?? 0).toFixed(2)}</td>
-                        <td class="px-2 py-1.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/50">{humanTime(t.valid_from)}</td>
+                        <td class="px-2 py-1.5 font-mono text-[11px] text-foundry-light-muted dark:text-foundry-text/50">{t.provenance ?? '—'}</td>
                       </tr>
                     {/each}
                   </tbody>

--- a/crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.svelte
+++ b/crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.svelte
@@ -32,7 +32,9 @@
   /** `null` while the first request (which resolves the tree) is in flight —
    * distinct from `false`, which means "resolved: not connected". */
   let connected: boolean | null = null;
-  /** The OKG directory the graph was read from. */
+  /** The binding's opaque label for the tree (`okg://izzie`, `izzie/okg`) —
+   * never a filesystem path, so it is shown as a name and never as a location
+   * (#7430). */
   let tree: string | null = null;
   let reason = '';
   let configError = '';
@@ -327,7 +329,7 @@
            entities) — distinct copy from the not-connected case above. -->
       {:else if subjects.length === 0}
         <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
-          {tree ? `The OKG tree at ${tree}` : 'This agent'} is readable, but holds nothing yet.
+          {tree ? `The OKG tree "${tree}"` : 'This agent'} is readable, but holds nothing yet.
         </p>
 
       <!-- State: connected:true with data — the explorer. -->

--- a/crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.test.ts
+++ b/crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.test.ts
@@ -1,10 +1,10 @@
 // Regression test for a #4290 code-review finding (HIGH): only bootstrap()'s
 // initial `/kg/subjects` call checked `env.connected` before assigning data.
 // `loadAll`, `loadCount`, and `loadSubject` assigned `env.data` unconditionally,
-// so a mid-session `connected: false` response (daemon restart, palace
-// unbound — still HTTP 200 with `data: []`/`{active: 0}`) rendered as an
-// empty/zero result indistinguishable from a genuinely-connected-but-empty
-// palace.
+// so a mid-session `connected: false` response (the OKG tree moved or the
+// binding rewritten — still HTTP 200 with `data: []`/`{active: 0}`) rendered
+// as an empty/zero result indistinguishable from a genuinely-connected-but-
+// empty tree.
 //
 // Why: This is the most important test in the KG browser's coverage — it's
 // the one the owner's contract exists specifically to prevent (a user must
@@ -88,7 +88,7 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
   it('loadAll/loadCount degrading after a connected bootstrap render the disconnected reason, never empty data', async () => {
     stubRoutes({
       subjects: {
-        palace: 'owner-profile',
+        tree: '/homes/izzie/okg',
         connected: true,
         data: [{ subject: 'bob', count: 2 }],
       },
@@ -97,21 +97,21 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
       // daemon has gone away — exactly the ticket's "daemon restarts
       // mid-session" scenario.
       all: {
-        palace: 'owner-profile',
+        tree: '/homes/izzie/okg',
         connected: false,
-        reason: 'trusty-memory daemon is unreachable',
+        reason: 'the OKG tree is unreadable',
         data: [],
       },
       count: {
-        palace: 'owner-profile',
+        tree: '/homes/izzie/okg',
         connected: false,
-        reason: 'trusty-memory daemon is unreachable',
-        data: { active: 0 },
+        reason: 'the OKG tree is unreadable',
+        data: { active: 0, definition_count: 0 },
       },
     });
 
     render();
-    await waitFor(() => panelText().includes('trusty-memory daemon is unreachable'));
+    await waitFor(() => panelText().includes('the OKG tree is unreadable'));
 
     expect(panelText()).not.toContain('No triples.');
     expect(panelText()).not.toContain('active triples');
@@ -120,22 +120,22 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
   it('loadSubject degrading after a connected bootstrap renders the disconnected reason, not "No triples."', async () => {
     stubRoutes({
       subjects: {
-        palace: 'owner-profile',
+        tree: '/homes/izzie/okg',
         connected: true,
         data: [{ subject: 'bob', count: 2 }],
       },
       all: {
-        palace: 'owner-profile',
+        tree: '/homes/izzie/okg',
         connected: true,
         data: [{ subject: 'bob', predicate: 'likes', object: 'cats' }],
       },
-      count: { palace: 'owner-profile', connected: true, data: { active: 5 } },
+      count: { tree: '/homes/izzie/okg', connected: true, data: { active: 5, definition_count: 1 } },
       // The daemon goes away between the initial connected bootstrap and the
       // user clicking a subject row.
       subject: {
-        palace: 'owner-profile',
+        tree: '/homes/izzie/okg',
         connected: false,
-        reason: 'palace unbound mid-session',
+        reason: 'the OKG tree went away mid-session',
         data: [],
       },
     });
@@ -146,20 +146,20 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
 
     (subjectButtons()[0] as HTMLButtonElement).click();
 
-    await waitFor(() => panelText().includes('palace unbound mid-session'));
+    await waitFor(() => panelText().includes('the OKG tree went away mid-session'));
     expect(panelText()).not.toContain('No triples.');
   });
 
-  it('a genuinely connected, empty palace renders the empty copy, not the disconnected one', async () => {
+  it('a genuinely connected, empty tree renders the empty copy, not the disconnected one', async () => {
     stubRoutes({
-      subjects: { palace: 'owner-profile', connected: true, data: [] },
-      all: { palace: 'owner-profile', connected: true, data: [] },
-      count: { palace: 'owner-profile', connected: true, data: { active: 0 } },
+      subjects: { tree: '/homes/izzie/okg', connected: true, data: [] },
+      all: { tree: '/homes/izzie/okg', connected: true, data: [] },
+      count: { tree: '/homes/izzie/okg', connected: true, data: { active: 0, definition_count: 0 } },
     });
 
     render();
     const normalized = () => panelText().replace(/\s+/g, ' ');
-    await waitFor(() => normalized().includes('Knowledge Graph has no triples yet'));
+    await waitFor(() => normalized().includes('is readable, but holds nothing yet'));
 
     expect(normalized()).not.toContain('is not reachable right now');
   });
@@ -169,24 +169,53 @@ it('keeps the selected subject when an older all-triples request finishes late',
   let finishAll!: (response: Response) => void;
   vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
-    if (url.includes('/kg/subjects')) return jsonResponse({ connected: true, palace: 'p', data: [{ subject: 'selected', count: 1 }] });
+    if (url.includes('/kg/subjects')) return jsonResponse({ connected: true, tree: 'p', data: [{ subject: 'selected', count: 1 }] });
     if (url.includes('/kg/all')) return new Promise<Response>(resolve => finishAll = resolve);
-    if (url.includes('/kg/count')) return jsonResponse({ connected: true, palace: 'p', data: { active: 1 } });
-    return jsonResponse({ connected: true, palace: 'p', data: [{ subject: 'selected', predicate: 'has', object: 'current value' }] });
+    if (url.includes('/kg/count')) return jsonResponse({ connected: true, tree: 'p', data: { active: 1, definition_count: 1 } });
+    return jsonResponse({ connected: true, tree: 'p', data: [{ subject: 'selected', predicate: 'has', object: 'current value' }] });
   }));
   render();
   await waitFor(() => subjectButtons().length === 1 && !!finishAll);
   (subjectButtons()[0] as HTMLButtonElement).click();
   await waitFor(() => panelText().includes('current value'));
-  finishAll(jsonResponse({ connected: true, palace: 'p', data: [{ subject: 'old', predicate: 'has', object: 'stale value' }] }));
+  finishAll(jsonResponse({ connected: true, tree: 'p', data: [{ subject: 'old', predicate: 'has', object: 'stale value' }] }));
   await new Promise(resolve => setTimeout(resolve, 20));
   expect(panelText()).toContain('current value');
   expect(panelText()).not.toContain('stale value');
 });
 
 
+// #7430: the exposed graph carries BOTH halves — the triples and the
+// definitions that say what each subject IS. A browser that rendered only the
+// triple table would satisfy the word "graph" and fail the owner's closure
+// condition, so the definition list is asserted in the DOM.
+it('renders the definitions that come with a page of triples', async () => {
+  stubRoutes({
+    subjects: { tree: '/homes/izzie/okg', connected: true, data: [{ subject: 'Bob', count: 1 }] },
+    all: {
+      tree: '/homes/izzie/okg',
+      source: 'okg',
+      connected: true,
+      data: [{ subject: 'Bob', predicate: 'works_at', object: 'Duetto', provenance: 'people/bob.md' }],
+      definitions: [
+        { subject: 'Bob', collection: 'people', slug: 'bob', type: 'Person', summary: 'The owner.', path: 'people/bob.md' },
+      ],
+    },
+    count: { tree: '/homes/izzie/okg', connected: true, data: { active: 1, definition_count: 1 } },
+  });
+
+  render();
+  await waitFor(() => target.querySelector('[data-kg-definitions]') !== null);
+  const defs = target.querySelector('[data-kg-definitions]')?.textContent ?? '';
+  expect(defs).toContain('Person');
+  expect(defs).toContain('The owner.');
+  // And the triple's source file, which replaced the memory-only confidence
+  // and valid-from columns.
+  expect(panelText()).toContain('people/bob.md');
+});
+
 it('provides an X close control for returning to chat', async () => {
-  stubRoutes({ subjects: { connected: false, palace: null, data: [] }, all: {}, count: {} });
+  stubRoutes({ subjects: { connected: false, tree: null, data: [] }, all: {}, count: {} });
   const onClose = vi.fn();
   instance = mount(KnowledgeGraphBrowser, { target, props: { agentName: 'izzie', onClose } }) as unknown as Record<string, unknown>;
   await waitFor(() => target.querySelector('[aria-label="Close Knowledge Graph"]') !== null);

--- a/crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.test.ts
+++ b/crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.test.ts
@@ -88,7 +88,7 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
   it('loadAll/loadCount degrading after a connected bootstrap render the disconnected reason, never empty data', async () => {
     stubRoutes({
       subjects: {
-        tree: '/homes/izzie/okg',
+        tree: 'izzie/okg',
         connected: true,
         data: [{ subject: 'bob', count: 2 }],
       },
@@ -97,13 +97,13 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
       // daemon has gone away — exactly the ticket's "daemon restarts
       // mid-session" scenario.
       all: {
-        tree: '/homes/izzie/okg',
+        tree: 'izzie/okg',
         connected: false,
         reason: 'the OKG tree is unreadable',
         data: [],
       },
       count: {
-        tree: '/homes/izzie/okg',
+        tree: 'izzie/okg',
         connected: false,
         reason: 'the OKG tree is unreadable',
         data: { active: 0, definition_count: 0 },
@@ -120,20 +120,20 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
   it('loadSubject degrading after a connected bootstrap renders the disconnected reason, not "No triples."', async () => {
     stubRoutes({
       subjects: {
-        tree: '/homes/izzie/okg',
+        tree: 'izzie/okg',
         connected: true,
         data: [{ subject: 'bob', count: 2 }],
       },
       all: {
-        tree: '/homes/izzie/okg',
+        tree: 'izzie/okg',
         connected: true,
         data: [{ subject: 'bob', predicate: 'likes', object: 'cats' }],
       },
-      count: { tree: '/homes/izzie/okg', connected: true, data: { active: 5, definition_count: 1 } },
+      count: { tree: 'izzie/okg', connected: true, data: { active: 5, definition_count: 1 } },
       // The daemon goes away between the initial connected bootstrap and the
       // user clicking a subject row.
       subject: {
-        tree: '/homes/izzie/okg',
+        tree: 'izzie/okg',
         connected: false,
         reason: 'the OKG tree went away mid-session',
         data: [],
@@ -150,11 +150,14 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
     expect(panelText()).not.toContain('No triples.');
   });
 
+  // #7430 security review: `tree` is an opaque label, so the empty-state copy
+  // quotes it as a name. A regression to an absolute path would show up here as
+  // a leading slash in the rendered sentence.
   it('a genuinely connected, empty tree renders the empty copy, not the disconnected one', async () => {
     stubRoutes({
-      subjects: { tree: '/homes/izzie/okg', connected: true, data: [] },
-      all: { tree: '/homes/izzie/okg', connected: true, data: [] },
-      count: { tree: '/homes/izzie/okg', connected: true, data: { active: 0, definition_count: 0 } },
+      subjects: { tree: 'izzie/okg', connected: true, data: [] },
+      all: { tree: 'izzie/okg', connected: true, data: [] },
+      count: { tree: 'izzie/okg', connected: true, data: { active: 0, definition_count: 0 } },
     });
 
     render();
@@ -162,6 +165,8 @@ describe('KnowledgeGraphBrowser — mid-session disconnection (#4290)', () => {
     await waitFor(() => normalized().includes('is readable, but holds nothing yet'));
 
     expect(normalized()).not.toContain('is not reachable right now');
+    expect(normalized()).toContain('The OKG tree "izzie/okg"');
+    expect(normalized()).not.toMatch(/tree "\//);
   });
 });
 
@@ -191,9 +196,9 @@ it('keeps the selected subject when an older all-triples request finishes late',
 // condition, so the definition list is asserted in the DOM.
 it('renders the definitions that come with a page of triples', async () => {
   stubRoutes({
-    subjects: { tree: '/homes/izzie/okg', connected: true, data: [{ subject: 'Bob', count: 1 }] },
+    subjects: { tree: 'izzie/okg', connected: true, data: [{ subject: 'Bob', count: 1 }] },
     all: {
-      tree: '/homes/izzie/okg',
+      tree: 'izzie/okg',
       source: 'okg',
       connected: true,
       data: [{ subject: 'Bob', predicate: 'works_at', object: 'Duetto', provenance: 'people/bob.md' }],
@@ -201,7 +206,7 @@ it('renders the definitions that come with a page of triples', async () => {
         { subject: 'Bob', collection: 'people', slug: 'bob', type: 'Person', summary: 'The owner.', path: 'people/bob.md' },
       ],
     },
-    count: { tree: '/homes/izzie/okg', connected: true, data: { active: 1, definition_count: 1 } },
+    count: { tree: 'izzie/okg', connected: true, data: { active: 1, definition_count: 1 } },
   });
 
   render();

--- a/crates/trusty-agents/ui/src/lib/kg.test.ts
+++ b/crates/trusty-agents/ui/src/lib/kg.test.ts
@@ -49,7 +49,7 @@ describe('fetchKgSubjects_returns_null_on_404', () => {
 describe('fetchKgSubjects_parses_envelope', () => {
   it('passes the tree/connected/data envelope through verbatim', async () => {
     const payload = {
-      tree: '/homes/izzie/okg',
+      tree: 'izzie/okg',
       source: 'okg',
       connected: true,
       data: [{ subject: 'bob', count: 3 }],
@@ -59,7 +59,7 @@ describe('fetchKgSubjects_parses_envelope', () => {
     };
     stubFetch(200, payload);
     const got = await fetchKgSubjects('izzie');
-    expect(got?.tree).toBe('/homes/izzie/okg');
+    expect(got?.tree).toBe('izzie/okg');
     expect(got?.source).toBe('okg');
     expect(got?.connected).toBe(true);
     expect(got?.data).toEqual([{ subject: 'bob', count: 3 }]);

--- a/crates/trusty-agents/ui/src/lib/kg.test.ts
+++ b/crates/trusty-agents/ui/src/lib/kg.test.ts
@@ -5,7 +5,7 @@
 // Why: Mirrors `agentConfig.test.ts`'s stubbed-`fetch` idiom — these routes
 // are thin REST glue, but the null-on-404 branch and the `connected: false`
 // envelope are exactly the contract `KnowledgeGraphBrowser.svelte` depends on
-// to avoid rendering a degraded palace as empty data (see
+// to avoid rendering a degraded tree as empty data (see
 // `KnowledgeGraphBrowser.test.ts` for the component-level regression against
 // that same failure mode).
 // What: `getKgEnvelope`'s shared 404/throw/parse contract, each fetch
@@ -47,30 +47,36 @@ describe('fetchKgSubjects_returns_null_on_404', () => {
 });
 
 describe('fetchKgSubjects_parses_envelope', () => {
-  it('passes the {palace, connected, data} envelope through verbatim', async () => {
+  it('passes the tree/connected/data envelope through verbatim', async () => {
     const payload = {
-      palace: 'owner-profile',
+      tree: '/homes/izzie/okg',
+      source: 'okg',
       connected: true,
       data: [{ subject: 'bob', count: 3 }],
+      definitions: [
+        { subject: 'bob', collection: 'people', slug: 'bob', type: 'Person', path: 'people/bob.md' },
+      ],
     };
     stubFetch(200, payload);
     const got = await fetchKgSubjects('izzie');
-    expect(got?.palace).toBe('owner-profile');
+    expect(got?.tree).toBe('/homes/izzie/okg');
+    expect(got?.source).toBe('okg');
     expect(got?.connected).toBe(true);
     expect(got?.data).toEqual([{ subject: 'bob', count: 3 }]);
+    expect(got?.definitions?.[0].type).toBe('Person');
   });
 
   it('surfaces connected:false with its reason and config_error, not an error throw', async () => {
     stubFetch(200, {
-      palace: null,
+      tree: null,
       connected: false,
-      reason: "agent's agent.toml declares no [[stores]] palace",
+      reason: 'this assistant has no OKG tree yet',
       config_error: 'could not parse agent.toml: missing field `model`',
       data: [],
     });
     const got = await fetchKgSubjects('broken');
     expect(got?.connected).toBe(false);
-    expect(got?.reason).toContain('no [[stores]] palace');
+    expect(got?.reason).toContain('no OKG tree');
     expect(got?.config_error).toContain('missing field');
     expect(got?.data).toEqual([]);
   });
@@ -83,7 +89,7 @@ describe('fetchKgSubjects_parses_envelope', () => {
 
 describe('fetchKgAll_forwards_limit_and_offset', () => {
   it('forwards limit and offset as query params', async () => {
-    const fn = stubFetch(200, { palace: 'p', connected: true, data: [] });
+    const fn = stubFetch(200, { tree: 'p', connected: true, data: [] });
     await fetchKgAll('izzie', 25, 50);
     const url = requestedUrl(fn);
     expect(url.pathname).toBe('/api/agents/izzie/kg/all');
@@ -92,7 +98,7 @@ describe('fetchKgAll_forwards_limit_and_offset', () => {
   });
 
   it('defaults limit/offset when omitted', async () => {
-    const fn = stubFetch(200, { palace: 'p', connected: true, data: [] });
+    const fn = stubFetch(200, { tree: 'p', connected: true, data: [] });
     await fetchKgAll('izzie');
     const url = requestedUrl(fn);
     expect(url.searchParams.get('limit')).toBe('50');
@@ -102,7 +108,7 @@ describe('fetchKgAll_forwards_limit_and_offset', () => {
 
 describe('fetchKgSubject_encodes_the_subject', () => {
   it('round-trips a subject containing reserved query characters', async () => {
-    const fn = stubFetch(200, { palace: 'p', connected: true, data: [] });
+    const fn = stubFetch(200, { tree: 'p', connected: true, data: [] });
     const subject = 'bob smith/likes cats & dogs?';
     await fetchKgSubject('izzie', subject);
     const url = requestedUrl(fn);
@@ -111,7 +117,7 @@ describe('fetchKgSubject_encodes_the_subject', () => {
   });
 
   it('percent-encodes the agent name in the path segment', async () => {
-    const fn = stubFetch(200, { palace: 'p', connected: true, data: [] });
+    const fn = stubFetch(200, { tree: 'p', connected: true, data: [] });
     await fetchKgSubject('agent/with slash', 'bob');
     const url = requestedUrl(fn);
     expect(url.pathname).toBe(`/api/agents/${encodeURIComponent('agent/with slash')}/kg`);
@@ -124,22 +130,23 @@ describe('fetchKgSubject_encodes_the_subject', () => {
 });
 
 describe('fetchKgCount_parses_active_count', () => {
-  it('parses the {active: N} data object', async () => {
-    stubFetch(200, { palace: 'p', connected: true, data: { active: 42 } });
+  it('parses the counts object — both halves of the graph', async () => {
+    stubFetch(200, { tree: 'p', connected: true, data: { active: 42, definition_count: 7 } });
     const got = await fetchKgCount('izzie');
     expect(got?.data.active).toBe(42);
+    expect(got?.data.definition_count).toBe(7);
   });
 
   it('surfaces connected:false alongside a zeroed active count', async () => {
     stubFetch(200, {
-      palace: 'p',
+      tree: 'p',
       connected: false,
-      reason: 'trusty-memory is unreachable',
-      data: { active: 0 },
+      reason: 'the OKG tree is unreadable',
+      data: { active: 0, definition_count: 0 },
     });
     const got = await fetchKgCount('izzie');
     expect(got?.connected).toBe(false);
-    expect(got?.reason).toBe('trusty-memory is unreachable');
+    expect(got?.reason).toBe('the OKG tree is unreadable');
   });
 
   it('returns null on 404', async () => {

--- a/crates/trusty-agents/ui/src/lib/kg.ts
+++ b/crates/trusty-agents/ui/src/lib/kg.ts
@@ -1,25 +1,24 @@
-// Per-agent Knowledge Graph browser API client (#4290).
+// Per-agent Knowledge Graph browser API client (#4290, #7430).
 //
 // Why: The Knowledge Graph browser needs a typed surface over the read-only
-// proxy routes `crates/trusty-agents/src/api/server/agent_kg.rs` exposes
+// routes `crates/trusty-agents/src/api/server/agent_kg.rs` exposes
 // (`GET /api/agents/:name/kg/subjects`, `/kg/all`, `/kg`, `/kg/count`). The
-// SPA must never call trusty-memory directly — every cross-daemon read in
-// this codebase goes through the trusty-agents sidecar (see
-// `fetchAgentStores`, `fetchAgentSkills`), and the KG routes are no
-// exception. Kept in its own module (rather than folded into
-// `agentConfig.ts`) because these routes are not part of the agent-config
-// five-section surface — they back a standalone slide-over opened from
-// `ChatHeader`, not a config pane tab.
-// What: `KgTriple`/`KgSubjectCount`/`KgActiveCount` mirror the upstream
-// trusty-memory KG shapes verbatim (the proxy passes them through
-// unreshaped); `KgEnvelope<T>` is the `{palace, connected, data}` wrapper
-// every route returns. `fetchKgSubjects`/`fetchKgAll`/`fetchKgSubject`/
-// `fetchKgCount` follow `fetchAgentStores`'s idiom exactly (agentConfig.ts:
-// 200-213): `null` on a 404 (unknown agent — a normal outcome for a stale
-// selection), throw on any other network/HTTP error. `connected: false` in a
-// successfully-parsed envelope is NOT an error — it's a first-class state
-// carrying a machine-readable `reason` the caller renders directly, per the
-// route's never-fail posture.
+// graph those routes serve is the assistant's OKG tree — triples AND
+// definitions. It is NOT a memory palace: before #7430 the routes proxied
+// trusty-memory's palace-scoped `kg_*` surface, so this pane showed the memory
+// knowledge graph, which epic #7425 item (f) rules out. Kept in its own module
+// (rather than folded into `agentConfig.ts`) because these routes are not part
+// of the agent-config five-section surface — they back a standalone slide-over
+// opened from `ChatHeader`, not a config pane tab.
+// What: `KgTriple`/`KgDefinition`/`KgSubjectCount`/`KgActiveCount` mirror the
+// route's shapes verbatim; `KgEnvelope<T>` is the `{tree, source, connected,
+// data, definitions}` wrapper every route returns. `fetchKgSubjects`/
+// `fetchKgAll`/`fetchKgSubject`/`fetchKgCount` follow `fetchAgentStores`'s
+// idiom exactly (agentConfig.ts: 200-213): `null` on a 404 (unknown agent — a
+// normal outcome for a stale selection), throw on any other network/HTTP
+// error. `connected: false` in a successfully-parsed envelope is NOT an error —
+// it's a first-class state carrying a machine-readable `reason` the caller
+// renders directly, per the route's never-fail posture.
 // Test: `kg.test.ts` covers this module's own fetch/parse contract.
 // `KnowledgeGraphBrowser.test.ts` covers the caller-side regression — a
 // `connected: false` envelope from any of these functions must not render as
@@ -33,14 +32,27 @@ function authHeaders(): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-/** One resolved KG triple, verbatim from trusty-memory (`kg_routes.rs`). */
+/** One relationship edge read out of the OKG tree (`stores/okg_graph.rs`). */
 export interface KgTriple {
   subject: string;
   predicate: string;
   object: string;
-  confidence?: number;
-  valid_from?: string;
+  /** Tree-relative path of the entity file the edge came from. */
   provenance?: string;
+}
+
+/**
+ * One entity definition — what a subject IS, as distinct from what it links to.
+ * The owner's closure condition for #7430 is that the exposed graph carries
+ * both halves, so every content route returns these beside the triples.
+ */
+export interface KgDefinition {
+  subject: string;
+  collection: string;
+  slug: string;
+  type?: string;
+  summary?: string;
+  path: string;
 }
 
 /** One subject + its triple count, from `/kg/subjects`. */
@@ -49,24 +61,29 @@ export interface KgSubjectCount {
   count: number;
 }
 
-/** `/kg/count`'s `data` object. */
+/** `/kg/count`'s `data` object — both halves of the graph, as totals. */
 export interface KgActiveCount {
   active: number;
+  definition_count?: number;
 }
 
 /**
- * The `{palace, connected, data}` envelope every KG proxy route returns
- * (`agent_kg.rs`'s module doc). `connected: false` is a first-class,
+ * The `{tree, source, connected, data, definitions}` envelope every KG route
+ * returns (`agent_kg.rs`'s module doc). `connected: false` is a first-class,
  * non-error state carrying a human-readable `reason` — render it directly,
  * never as a generic failure or an empty list that looks like "no data".
- * `config_error` is present only when the agent's own `agent.toml` failed to
- * parse (in which case `connected` is also `false`).
+ * `tree` is the OKG directory the graph was read from, and `source` is always
+ * `"okg"` — the payload states what it is made of rather than leaving a reader
+ * to infer it. `config_error` is present only when the agent's own `agent.toml`
+ * failed to parse (in which case `connected` is also `false`).
  */
 export interface KgEnvelope<T> {
-  palace: string | null;
+  tree: string | null;
+  source?: string;
   connected: boolean;
   reason?: string;
   data: T;
+  definitions?: KgDefinition[];
   config_error?: string;
 }
 
@@ -112,9 +129,8 @@ export async function fetchKgAll(
 }
 
 /**
- * `GET /api/agents/:name/kg?subject=<s>`. `subject` is REQUIRED by the
- * upstream route (a `400` otherwise) — callers must never pass an empty
- * string.
+ * `GET /api/agents/:name/kg?subject=<s>`. `subject` is REQUIRED by the route
+ * (a `400` otherwise) — callers must never pass an empty string.
  * Test: `fetchKgSubject_encodes_the_subject` (`kg.test.ts`).
  */
 export async function fetchKgSubject(
@@ -126,7 +142,8 @@ export async function fetchKgSubject(
 }
 
 /**
- * `GET /api/agents/:name/kg/count`. `data` is `{"active": N}`.
+ * `GET /api/agents/:name/kg/count`. `data` is
+ * `{"active": N, "definition_count": D}`.
  * Test: `fetchKgCount_parses_active_count` (`kg.test.ts`).
  */
 export async function fetchKgCount(name: string): Promise<KgEnvelope<KgActiveCount> | null> {

--- a/crates/trusty-agents/ui/src/lib/kg.ts
+++ b/crates/trusty-agents/ui/src/lib/kg.ts
@@ -72,12 +72,18 @@ export interface KgActiveCount {
  * returns (`agent_kg.rs`'s module doc). `connected: false` is a first-class,
  * non-error state carrying a human-readable `reason` — render it directly,
  * never as a generic failure or an empty list that looks like "no data".
- * `tree` is the OKG directory the graph was read from, and `source` is always
- * `"okg"` — the payload states what it is made of rather than leaving a reader
- * to infer it. `config_error` is present only when the agent's own `agent.toml`
- * failed to parse (in which case `connected` is also `false`).
+ * `source` is always `"okg"` — the payload states what it is made of rather
+ * than leaving a reader to infer it. `config_error` is present only when the
+ * agent's own `agent.toml` failed to parse (in which case `connected` is also
+ * `false`).
  */
 export interface KgEnvelope<T> {
+  /**
+   * The binding's OPAQUE label for the tree — `okg://<agent>` or the
+   * home-relative `<agent>/okg`. Never a filesystem path: the server does not
+   * send one (#7430), so do not present this as somewhere the reader can open,
+   * and do not join it onto anything.
+   */
   tree: string | null;
   source?: string;
   connected: boolean;

--- a/docs/reference/trusty-agents-exposed-graph-audit.md
+++ b/docs/reference/trusty-agents-exposed-graph-audit.md
@@ -1,0 +1,57 @@
+# The Exposed Knowledge Graph — Audit (#7430)
+
+> Epic #7425 item (f): the knowledge graph the assistant UI and agent tools
+> expose is the OKG graph — triples AND definitions from the assistant's `okg/`
+> tree — and never memory drawers. The memory knowledge graph (trusty-memory's
+> `kg_*` surface) is a separate store and must not leak into it.
+
+Audited 2026-09-11 against `crates/trusty-agents` and
+`crates/trusty-agents-common`. Every path by which graph data reaches the UI or
+an agent tool, with the store it reads.
+
+## Paths
+
+| # | Path | Entry point | Source before #7430 | Source now |
+|---|---|---|---|---|
+| 1 | `GET /api/agents/:name/kg/subjects` | `crates/trusty-agents/src/api/server/agent_kg.rs:183` | trusty-memory `memory.kg_subjects_with_counts` — **memory KG** | OKG tree |
+| 2 | `GET /api/agents/:name/kg/all` | `crates/trusty-agents/src/api/server/agent_kg.rs:199` | trusty-memory `memory.kg_all` — **memory KG** | OKG tree |
+| 3 | `GET /api/agents/:name/kg?subject=` | `crates/trusty-agents/src/api/server/agent_kg.rs:224` | trusty-memory `kg_query` tool — **memory KG** | OKG tree |
+| 4 | `GET /api/agents/:name/kg/count` | `crates/trusty-agents/src/api/server/agent_kg.rs:247` | trusty-memory `memory.kg_count` — **memory KG** | OKG tree |
+| 5 | Route wiring | `crates/trusty-agents/src/api/server/routes.rs:246` | — | the four routes above, unchanged paths |
+| 6 | SPA client | `crates/trusty-agents/ui/src/lib/kg.ts` | the four routes | the four routes |
+| 7 | Browser component | `crates/trusty-agents/ui/src/components/KnowledgeGraphBrowser.svelte` | the SPA client | the SPA client |
+| 8 | Graph reader | `crates/trusty-agents/src/stores/okg_graph.rs` | did not exist | OKG tree — the single reader |
+
+No Tauri command and no MCP tool serves graph data: `crates/trusty-agents`
+exposes the graph over HTTP only, and the desktop shell loads the same SPA.
+
+## Other surfaces that read a memory palace, and why they are not the graph
+
+| Surface | Reads | Verdict |
+|---|---|---|
+| `crates/trusty-agents/src/api/server/chat_history.rs` | trusty-memory `chat_session_recall` | Chat transcripts, not graph data. Out of scope. |
+| `crates/trusty-agents/src/tools/memory/recall.rs` | memory drawers | The agent's recall tool. A drawer is a memory, never presented as a graph node. |
+| `crates/trusty-agents/src/tools/memory/vector_search.rs` | the bound search index | Search hits over the OKG corpus; `crates/trusty-agents/src/tools/memory/okg_fence.rs` fences untrusted ones. Not the graph surface. |
+| `crates/trusty-agents/src/stores/status.rs` | probes the bound palace | Reports whether a palace is reachable. Status, not content. |
+
+## What the exposed graph carries
+
+Both halves, from `crates/trusty-agents/src/stores/okg_graph.rs`:
+
+- **Triples** — one per `[[wiki-link]]` target held in an entity's relationship
+  frontmatter keys. Envelope fields (`type`, `title`, `description`, `tags`, …)
+  are excluded, so a link inside prose is not read as an edge.
+- **Definitions** — one per entity: its `type`, collection, one-line summary,
+  and tree-relative path.
+
+`/kg/count` reports both (`{"active": N, "definition_count": D}`); the three
+content routes return triples in `data` and the matching definitions in
+`definitions`. Every envelope declares `"source": "okg"`.
+
+## The gate
+
+`no_memory_drawer_or_palace_triple_can_reach_the_exposed_graph`
+(`crates/trusty-agents/src/api/server/tests/agent_kg.rs`) drives all four reads
+against an agent that binds a memory palace AND has an OKG tree, and fails if
+the palace id or the word "drawer" appears in any payload, if the envelope stops
+declaring `source: "okg"`, or if either half of the graph goes missing.

--- a/docs/reference/trusty-agents-exposed-graph-audit.md
+++ b/docs/reference/trusty-agents-exposed-graph-audit.md
@@ -48,6 +48,11 @@ Both halves, from `crates/trusty-agents/src/stores/okg_graph.rs`:
 content routes return triples in `data` and the matching definitions in
 `definitions`. Every envelope declares `"source": "okg"`.
 
+`tree` is the binding's own opaque label — `okg://<agent>`, or the home-relative
+`<agent>/okg` — never a filesystem path, and neither is any `reason`. The
+underlying error text is logged instead. A triple's `provenance` and a
+definition's `path` are tree-relative for the same reason.
+
 ## The gate
 
 `no_memory_drawer_or_palace_triple_can_reach_the_exposed_graph`
@@ -55,3 +60,7 @@ content routes return triples in `data` and the matching definitions in
 against an agent that binds a memory palace AND has an OKG tree, and fails if
 the palace id or the word "drawer" appears in any payload, if the envelope stops
 declaring `source: "okg"`, or if either half of the graph goes missing.
+
+`no_envelope_discloses_a_filesystem_path`, in the same file, walks every string
+in every envelope on every route in three states and fails on any that starts
+with `/` or contains the tree's real root.


### PR DESCRIPTION
## Outcome

Item (f) of epic #7425. Audit found all four `/api/agents/:name/kg*` routes proxied trusty-memory's palace KG (`kg_subjects_with_counts`, `kg_all`, `kg_count`, `kg_query`), so the "Knowledge Graph" pane showed the memory graph and no definitions. The routes now read the assistant's OKG tree: one triple per `[[wiki-link]]` in a relationship frontmatter key, one definition per entity. Audit table: `docs/reference/trusty-agents-exposed-graph-audit.md`.

## Changes

New `crates/trusty-agents/src/stores/okg_graph.rs` (single OKG reader, no memory client); `api/server/agent_kg.rs` rewritten to page it — route paths unchanged, envelope `palace` → `tree` (an opaque label such as `izzie/okg` or `okg://izzie`, never a filesystem path), adds `source: "okg"` and `definitions`, `/kg/count` → `{active, definition_count}`; `describe_failure` moved to `chat_history.rs` (its only caller); UI `lib/kg.ts` and `KnowledgeGraphBrowser.svelte` render definitions and provenance. Out of scope: the memory KG itself (a separate, legitimate surface), a parsed-graph cache (a directory mtime cannot detect in-place edits; noted `// See #7430`).

## Risk

High (UI/API surface, rung 6). Only consumers of the envelope are `kg.ts`, `kg.test.ts`, `KnowledgeGraphBrowser.svelte` (workspace grep by code-critic).

## Tests

`cargo test -p trusty-agents --no-fail-fast` — 12 targets, 3746 passed, 0 failed, 16 ignored; regression `no_memory_drawer_or_palace_triple_can_reach_the_exposed_graph` (asserts `source: okg`, no `palace`, no palace id in payload, non-empty `definitions`) and `no_envelope_discloses_a_filesystem_path` (proved failing with the defect reintroduced: panicked with the absolute tmp path in `tree`, then green); `every_resolution_arm_labels_the_tree_without_a_path`; `malformed_entity_is_skipped` error arm. `cargo fmt --check`, clippy `-D warnings`, `check_line_cap`, `check_test_pointers`, `check_doc_paths`, `check_sld` all exit 0. UI: `pnpm test:unit` 59 files / 596 tests pass; `pnpm check` 0 errors (3 pre-existing a11y warnings in untouched files). Playwright e2e needs a live server (`ERR_CONNECTION_REFUSED :7654`), not run.

## Baseline

None.

## Docs

`crates/trusty-agents/changelog.d/7430-okg-graph-audit.md`.

## Review

Security scan CLEAN after the path-disclosure fix; code-critic APPROVE (MEDIUM per-request re-walk noted, LOW doc note applied); trusty-review verdict pending.

Refs #7430
Refs #7425

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_014co1TJqBd2EMvjb6gkbfyP
