### PR TITLE
feat(trusty-agents): chat thread attachments stored under the assistant home (Refs #7370)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -6192,6 +6193,23 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.9",
+ "version_check",
 ]
 
 [[package]]

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -148,7 +148,11 @@ comrak = { workspace = true }
 serde_yaml = { workspace = true }
 toml_edit = "0.22"
 base64 = "0.22"
-axum = { workspace = true }
+# `multipart` (#7370): the chat-attachment upload route takes a file the
+# browser already holds as a `File`; base64 in JSON would cost a third more
+# bytes for nothing. Declared on the member entry, which UNIONS with the root
+# `[workspace.dependencies]` feature list rather than replacing it.
+axum = { workspace = true, features = ["multipart"] }
 tower-http = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 backon = "1"

--- a/crates/trusty-agents/changelog.d/7370-chat-attachments.md
+++ b/crates/trusty-agents/changelog.d/7370-chat-attachments.md
@@ -1,0 +1,5 @@
+Added
+- Chat threads carry text, binary and CSV attachments. A file uploaded through `POST /api/agents/{name}/sessions/{session}/attachments` is stored at `<assistant home>/attachments/<session>/<file>` beside `okg`, recorded in a per-session `manifest.json`, and retrieved by id from the same route.
+- An attached turn embeds a `[[attachment:<id>]]` marker in its content, so a reload rebuilds its cards. Text and CSV reach the model as size-capped plain text under a fenced block; binary reaches it as a one-line reference.
+- The chat view renders each attachment as a click-expandable card — image thumbnail, CSV preview table, text excerpt, or icon — and the composer gains a file picker and file drag-drop.
+- A send naming an attachment that is not in the session manifest is refused before anything is persisted, so a rejected turn leaves chat history unchanged.

--- a/crates/trusty-agents/src/api/server/attachments.rs
+++ b/crates/trusty-agents/src/api/server/attachments.rs
@@ -35,7 +35,10 @@ use serde_json::{Value, json};
 
 use super::state::AppState;
 use crate::assistants::{AssistantHome, AssistantInstanceId};
-use crate::attachments::{Attachment, AttachmentError, AttachmentStore, MAX_ATTACHMENT_BYTES};
+use crate::attachments::{
+    Attachment, AttachmentError, AttachmentStore, MAX_ATTACHMENT_BYTES, MAX_ATTACHMENTS_PER_TURN,
+    UploadedFile,
+};
 
 /// Largest request body the upload route accepts.
 ///
@@ -51,12 +54,15 @@ pub(super) const MAX_UPLOAD_BODY_BYTES: usize = MAX_ATTACHMENT_BYTES as usize + 
 /// Why: the one write path for a chat attachment. Multipart, because the
 /// payload is a file the browser already has in a `File` object and base64 in
 /// JSON would cost a third more bytes for nothing.
-/// What: reads the first field carrying a filename, hands the bytes to
-/// [`AttachmentStore::store`], and answers `201` with the stored row and the
-/// URL that retrieves it. Every guard — traversal, absolute name, size cap —
-/// answers a `4xx` with the store's own message and leaves the tree untouched;
-/// nothing is renamed and retried.
+/// What: reads EVERY field carrying a filename — a person who drags three files
+/// onto the composer sends one request, and must get three rows back. Keeping
+/// only the first, as this route did before #7370's review, dropped the rest
+/// with nothing in the response saying so. The files go to
+/// [`AttachmentStore::store_all`], which checks every name and size before it
+/// writes any of them, so a guard failure leaves the tree untouched rather than
+/// half a batch. Answers `201` with one row per file, in request order.
 /// Test: `super::tests::attachments::upload_stores_the_file_and_returns_its_row`,
+/// `super::tests::attachments::upload_accepts_every_file_in_one_request`,
 /// `super::tests::attachments::upload_refuses_a_traversal_file_name`,
 /// `super::tests::attachments::upload_refuses_an_oversize_file`.
 pub(super) async fn upload_route(
@@ -69,14 +75,25 @@ pub(super) async fn upload_route(
         Err(response) => return response,
     };
 
-    let mut part: Option<(String, Option<String>, Vec<u8>)> = None;
+    let mut files: Vec<UploadedFile> = Vec::new();
     loop {
         match multipart.next_field().await {
             Ok(None) => break,
             Err(e) => return bad_request(&format!("could not read the upload body: {e}")),
             Ok(Some(field)) => {
-                let file_name = field.file_name().map(str::to_string);
-                let content_type = field.content_type().map(str::to_string);
+                // A part with no filename is an ordinary form field, not a
+                // file. Skipped rather than refused, so a client may send its
+                // own metadata alongside without this route caring.
+                let Some(file_name) = field.file_name().map(str::to_string) else {
+                    continue;
+                };
+                let media_type = field.content_type().map(str::to_string);
+                if files.len() == MAX_ATTACHMENTS_PER_TURN {
+                    return refuse(AttachmentError::TooManyFiles {
+                        count: files.len() + 1,
+                        cap: MAX_ATTACHMENTS_PER_TURN,
+                    });
+                }
                 let bytes = match field.bytes().await {
                     Ok(bytes) => bytes,
                     Err(e) => {
@@ -87,26 +104,27 @@ pub(super) async fn upload_route(
                             .into_response();
                     }
                 };
-                if let Some(file_name) = file_name {
-                    part = Some((file_name, content_type, bytes.to_vec()));
-                    break;
-                }
+                files.push(UploadedFile {
+                    file_name,
+                    media_type,
+                    bytes: bytes.to_vec(),
+                });
             }
         }
     }
 
-    let Some((file_name, content_type, bytes)) = part else {
+    if files.is_empty() {
         return bad_request("the upload carried no file field with a filename");
-    };
+    }
 
-    let stored = tokio::task::spawn_blocking(move || {
-        store.store(&session, &file_name, content_type.as_deref(), &bytes)
-    })
-    .await;
+    let stored = tokio::task::spawn_blocking(move || store.store_all(&session, &files)).await;
     match stored {
         Err(e) => internal("attachment upload task failed", &e.to_string()),
         Ok(Err(e)) => refuse(e),
-        Ok(Ok(row)) => (StatusCode::CREATED, Json(wire(&name, &row))).into_response(),
+        Ok(Ok(rows)) => {
+            let rows: Vec<Value> = rows.iter().map(|row| wire(&name, row)).collect();
+            (StatusCode::CREATED, Json(json!({ "attachments": rows }))).into_response()
+        }
     }
 }
 

--- a/crates/trusty-agents/src/api/server/attachments.rs
+++ b/crates/trusty-agents/src/api/server/attachments.rs
@@ -253,16 +253,29 @@ fn urlencode(segment: &str) -> String {
 }
 
 /// Map a store refusal to its status, without string-matching the message.
+///
+/// Why: a client error's message is the caller's to read — it names the file
+/// they sent and the rule it broke, which is the whole point of refusing
+/// rather than repairing. A SERVER error's message is not: every non-client
+/// variant carries an absolute path from the operator's home directory, and
+/// returning it hands a caller the on-disk layout of a tree they can otherwise
+/// only address by id. Those go to the log and a generic body.
+/// What: `4xx` with the store's verbatim message for
+/// [`AttachmentError::is_client_error`]; otherwise [`internal`], which logs the
+/// detail and answers a fixed sentence.
+/// Test: `super::tests::attachments::a_server_error_body_carries_no_path`.
 pub(super) fn refuse(error: AttachmentError) -> Response {
+    if !error.is_client_error() {
+        return internal(
+            "the attachment store could not complete this request",
+            &error.to_string(),
+        );
+    }
     let status = match &error {
         AttachmentError::TooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
         AttachmentError::NotFound { .. } | AttachmentError::InvalidId(_) => StatusCode::NOT_FOUND,
-        e if e.is_client_error() => StatusCode::BAD_REQUEST,
-        _ => StatusCode::INTERNAL_SERVER_ERROR,
+        _ => StatusCode::BAD_REQUEST,
     };
-    if !error.is_client_error() {
-        tracing::warn!(%error, "attachments: request failed");
-    }
     (status, Json(json!({ "error": error.to_string() }))).into_response()
 }
 

--- a/crates/trusty-agents/src/api/server/attachments.rs
+++ b/crates/trusty-agents/src/api/server/attachments.rs
@@ -1,0 +1,280 @@
+//! Chat-thread attachment upload, listing and retrieval (#7370).
+//!
+//! Why: epic #7425 item (e) puts a thread's files at
+//! `<assistant home>/attachments/<session>/<file>`. That directory is inside
+//! the user's own home tree, next to `okg` — so it can never be exposed as a
+//! static file mount, which would serve any path under it to anyone who could
+//! guess a name. Every read here goes through an ID: the caller names an
+//! attachment, the manifest answers with the path, and the server opens THAT.
+//! A path the caller supplied is never opened.
+//!
+//! What: three routes under `/api/agents/{name}/sessions/{session}/attachments`
+//! — `POST` (multipart upload), `GET` (the session's manifest), and
+//! `GET /{id}` (the bytes). Writes go through the router-wide same-origin guard
+//! and the optional bearer layer like every other mutating route
+//! (`super::routes`).
+//!
+//! Agent identity: the agent name is validated as an
+//! [`AssistantInstanceId`] and resolved to a home under
+//! [`super::state::AppState::attachments_root`]. It is deliberately NOT checked
+//! against the agent roster — `submit_task`'s attendance hook does not either
+//! (#4703), and the store needs no second source of truth for "does this agent
+//! exist". The id validation is what confines the path; the roster would only
+//! add a second answer that can drift from it.
+//!
+//! Test: `super::tests::attachments`.
+
+use axum::{
+    Json,
+    body::Body,
+    extract::{Multipart, Path as AxumPath, State},
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use serde_json::{Value, json};
+
+use super::state::AppState;
+use crate::assistants::{AssistantHome, AssistantInstanceId};
+use crate::attachments::{Attachment, AttachmentError, AttachmentStore, MAX_ATTACHMENT_BYTES};
+
+/// Largest request body the upload route accepts.
+///
+/// Why: axum's default is 2 MiB, which would refuse a legitimate attachment
+/// long before [`MAX_ATTACHMENT_BYTES`] had a chance to speak. Derived from
+/// that constant plus a megabyte of multipart framing so the two can never
+/// drift; the transport bound is deliberately the LOOSER of the two, leaving
+/// the product limit to the store, where the error message can name the file.
+pub(super) const MAX_UPLOAD_BODY_BYTES: usize = MAX_ATTACHMENT_BYTES as usize + 1024 * 1024;
+
+/// `POST /api/agents/{name}/sessions/{session}/attachments`.
+///
+/// Why: the one write path for a chat attachment. Multipart, because the
+/// payload is a file the browser already has in a `File` object and base64 in
+/// JSON would cost a third more bytes for nothing.
+/// What: reads the first field carrying a filename, hands the bytes to
+/// [`AttachmentStore::store`], and answers `201` with the stored row and the
+/// URL that retrieves it. Every guard — traversal, absolute name, size cap —
+/// answers a `4xx` with the store's own message and leaves the tree untouched;
+/// nothing is renamed and retried.
+/// Test: `super::tests::attachments::upload_stores_the_file_and_returns_its_row`,
+/// `super::tests::attachments::upload_refuses_a_traversal_file_name`,
+/// `super::tests::attachments::upload_refuses_an_oversize_file`.
+pub(super) async fn upload_route(
+    State(state): State<AppState>,
+    AxumPath((name, session)): AxumPath<(String, String)>,
+    mut multipart: Multipart,
+) -> Response {
+    let store = match resolve_store(&state, &name) {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+
+    let mut part: Option<(String, Option<String>, Vec<u8>)> = None;
+    loop {
+        match multipart.next_field().await {
+            Ok(None) => break,
+            Err(e) => return bad_request(&format!("could not read the upload body: {e}")),
+            Ok(Some(field)) => {
+                let file_name = field.file_name().map(str::to_string);
+                let content_type = field.content_type().map(str::to_string);
+                let bytes = match field.bytes().await {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        return (
+                            StatusCode::PAYLOAD_TOO_LARGE,
+                            Json(json!({ "error": format!("could not read the uploaded file: {e}") })),
+                        )
+                            .into_response();
+                    }
+                };
+                if let Some(file_name) = file_name {
+                    part = Some((file_name, content_type, bytes.to_vec()));
+                    break;
+                }
+            }
+        }
+    }
+
+    let Some((file_name, content_type, bytes)) = part else {
+        return bad_request("the upload carried no file field with a filename");
+    };
+
+    let stored = tokio::task::spawn_blocking(move || {
+        store.store(&session, &file_name, content_type.as_deref(), &bytes)
+    })
+    .await;
+    match stored {
+        Err(e) => internal("attachment upload task failed", &e.to_string()),
+        Ok(Err(e)) => refuse(e),
+        Ok(Ok(row)) => (StatusCode::CREATED, Json(wire(&name, &row))).into_response(),
+    }
+}
+
+/// `GET /api/agents/{name}/sessions/{session}/attachments`.
+///
+/// Why: a reload reads `[[attachment:<id>]]` markers out of persisted turns and
+/// needs the name, media type and size behind each one to draw the card. One
+/// manifest read answers every marker in the thread; a metadata request per
+/// marker would not.
+/// What: the session's rows, oldest first. A session with nothing stored is an
+/// empty list and a `200`, not a `404` — an empty thread is an ordinary state.
+/// Test: `super::tests::attachments::list_returns_the_session_manifest`.
+pub(super) async fn list_route(
+    State(state): State<AppState>,
+    AxumPath((name, session)): AxumPath<(String, String)>,
+) -> Response {
+    let store = match resolve_store(&state, &name) {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    let listed = tokio::task::spawn_blocking(move || store.list(&session)).await;
+    match listed {
+        Err(e) => internal("attachment listing task failed", &e.to_string()),
+        Ok(Err(e)) => refuse(e),
+        Ok(Ok(rows)) => {
+            let rows: Vec<Value> = rows.iter().map(|row| wire(&name, row)).collect();
+            (StatusCode::OK, Json(json!({ "attachments": rows }))).into_response()
+        }
+    }
+}
+
+/// `GET /api/agents/{name}/sessions/{session}/attachments/{id}`.
+///
+/// Why: the card's thumbnail, and the expanded view behind it, need the bytes.
+/// What: looks the id up in the manifest and serves the file the ROW names.
+/// Content that a browser could execute in this origin is forced to download
+/// rather than render: only images and the two plain text types are served
+/// `inline`, everything else is `attachment`, and both carry `nosniff` plus a
+/// `sandbox` CSP. Without that, uploading an HTML file would be stored XSS
+/// against the API origin.
+/// Test: `super::tests::attachments::download_returns_the_bytes_and_headers`,
+/// `super::tests::attachments::download_rejects_an_unknown_id`.
+pub(super) async fn download_route(
+    State(state): State<AppState>,
+    AxumPath((name, session, id)): AxumPath<(String, String, String)>,
+) -> Response {
+    let store = match resolve_store(&state, &name) {
+        Ok(store) => store,
+        Err(response) => return response,
+    };
+    let read = tokio::task::spawn_blocking(move || store.read(&session, &id)).await;
+    let (row, bytes) = match read {
+        Err(e) => return internal("attachment read task failed", &e.to_string()),
+        Ok(Err(e)) => return refuse(e),
+        Ok(Ok(found)) => found,
+    };
+
+    let inline = row.media_type.starts_with("image/")
+        || matches!(row.media_type.as_str(), "text/plain" | "text/csv");
+    let disposition = if inline { "inline" } else { "attachment" };
+    // The name is already a single path segment with no control characters
+    // (`AttachmentStore::store`'s guard); quotes and backslashes are the only
+    // remaining characters that could break out of the header's quoted string.
+    let quoted: String = row
+        .file_name
+        .chars()
+        .filter(|c| *c != '"' && *c != '\\')
+        .collect();
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, row.media_type.clone())
+        .header(header::CONTENT_LENGTH, bytes.len())
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("{disposition}; filename=\"{quoted}\""),
+        )
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .header(
+            header::CONTENT_SECURITY_POLICY,
+            "default-src 'none'; sandbox",
+        )
+        .header(header::CACHE_CONTROL, "private, max-age=3600")
+        .body(Body::from(bytes))
+        .unwrap_or_else(|e| internal("could not build the attachment response", &e.to_string()))
+}
+
+/// The store for one agent, or the response explaining why there is none.
+///
+/// Why: the two failure shapes are genuinely different. A malformed agent name
+/// is the caller's fault (`400`); a daemon that could not resolve a home
+/// directory at all is the server's state (`503`), and reporting the second as
+/// the first would send an operator looking at their request instead of their
+/// `$HOME`.
+/// Test: `super::tests::attachments::upload_refuses_a_traversal_agent_name`.
+pub(super) fn resolve_store(state: &AppState, name: &str) -> Result<AttachmentStore, Response> {
+    let id = AssistantInstanceId::new(name)
+        .map_err(|e| bad_request(&format!("invalid agent name `{name}`: {e}")))?;
+    let Some(root) = state.attachments_root.clone() else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "no assistant home directory could be resolved" })),
+        )
+            .into_response());
+    };
+    Ok(AttachmentStore::for_home(&AssistantHome::under(root, id)))
+}
+
+/// One attachment as the wire sees it.
+///
+/// `stored_path` is deliberately absent — see [`Attachment`]'s own note. `url`
+/// is what a client fetches; it is built here so no client has to assemble the
+/// route shape itself.
+fn wire(agent: &str, row: &Attachment) -> Value {
+    json!({
+        "id": row.id,
+        "session_id": row.session_id,
+        "file_name": row.file_name,
+        "media_type": row.media_type,
+        "size": row.size,
+        "sha256": row.sha256,
+        "url": format!(
+            "/api/agents/{}/sessions/{}/attachments/{}",
+            urlencode(agent),
+            urlencode(&row.session_id),
+            row.id
+        ),
+    })
+}
+
+/// Percent-encode a path segment. Both segments are already validated to be
+/// single ordinary path segments, so this only has to survive spaces and the
+/// handful of punctuation characters an instance id permits.
+fn urlencode(segment: &str) -> String {
+    segment
+        .bytes()
+        .map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                (b as char).to_string()
+            }
+            other => format!("%{other:02X}"),
+        })
+        .collect()
+}
+
+/// Map a store refusal to its status, without string-matching the message.
+pub(super) fn refuse(error: AttachmentError) -> Response {
+    let status = match &error {
+        AttachmentError::TooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,
+        AttachmentError::NotFound { .. } | AttachmentError::InvalidId(_) => StatusCode::NOT_FOUND,
+        e if e.is_client_error() => StatusCode::BAD_REQUEST,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    if !error.is_client_error() {
+        tracing::warn!(%error, "attachments: request failed");
+    }
+    (status, Json(json!({ "error": error.to_string() }))).into_response()
+}
+
+fn bad_request(message: &str) -> Response {
+    (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))).into_response()
+}
+
+fn internal(message: &str, detail: &str) -> Response {
+    tracing::warn!(detail, "attachments: {message}");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "error": message })),
+    )
+        .into_response()
+}

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -621,14 +621,6 @@ pub(super) async fn submit_task(
         .into_response()
 }
 
-/// Most attachments one turn may carry.
-///
-/// Why: each one is rendered into the turn and then replayed as conversation
-/// history on every later turn in the session, so the cost is paid repeatedly.
-/// A bound here is what stops a client asking for a turn nothing can answer.
-/// Test: `super::tests::attachments::send_refuses_too_many_attachments`.
-const MAX_ATTACHMENTS_PER_TURN: usize = 8;
-
 /// Resolve the attachment ids a request names into the blocks its turn carries.
 ///
 /// Why (#7370): this is the validate-before-persist gate. It runs before the
@@ -650,12 +642,13 @@ async fn resolve_attachments(state: &AppState, req: &TaskRequest) -> Result<Vec<
     if ids.is_empty() {
         return Ok(Vec::new());
     }
-    if ids.len() > MAX_ATTACHMENTS_PER_TURN {
+    if ids.len() > crate::attachments::MAX_ATTACHMENTS_PER_TURN {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
                 "error": format!(
-                    "a turn may carry at most {MAX_ATTACHMENTS_PER_TURN} attachments, not {}",
+                    "a turn may carry at most {} attachments, not {}",
+                    crate::attachments::MAX_ATTACHMENTS_PER_TURN,
                     ids.len()
                 ),
             })),

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -112,6 +112,22 @@ pub struct TaskRequest {
     /// Test: `session_overrides_for_passes_through_focused_workstream`.
     #[serde(default)]
     pub focused_workstream: Option<String>,
+    /// #7370: ids of attachments this turn references, already uploaded
+    /// through the session's attachment route.
+    ///
+    /// Why: the upload is a separate request so a large file is transferred
+    /// once, validated once, and referenced by id thereafter. Sending the
+    /// bytes with the turn would re-upload on every retask and give the
+    /// server no chance to refuse a file before a turn exists.
+    /// What: `None`/empty for every turn that carries no attachment, which is
+    /// what keeps the wire shape identical to every pre-#7370 submission. Each
+    /// id is resolved against the addressed assistant's own manifest BEFORE
+    /// the task is accepted (see [`resolve_attachments`]) - an id that is not
+    /// there fails the request outright rather than dispatching a turn whose
+    /// references cannot be resolved.
+    /// Test: `super::tests::attachments::send_with_an_unknown_attachment_is_refused`.
+    #[serde(default)]
+    pub attachments: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -351,8 +367,20 @@ fn drain_last_responder(
 /// by `crate::intent` unit tests.
 pub(super) async fn submit_task(
     State(state): State<AppState>,
-    Json(req): Json<TaskRequest>,
-) -> impl IntoResponse {
+    Json(mut req): Json<TaskRequest>,
+) -> Response {
+    // #7370: VALIDATE BEFORE ANYTHING IS PERSISTED. Every write this handler
+    // performs - the `running` placeholder, the attendance turn, the session
+    // announcement, and downstream `spawn_persist_turn`'s chat-history append
+    // - happens below this point, so a turn naming an attachment that is not
+    // in the manifest is refused with the conversation exactly as it was. The
+    // prior attempt on this issue persisted first and checked afterwards, and
+    // a rejected send therefore polluted chat history and duplicated on retry.
+    let attachment_blocks = match resolve_attachments(&state, &req).await {
+        Ok(blocks) => blocks,
+        Err(response) => return response,
+    };
+
     let id = uuid::Uuid::new_v4().to_string();
     // #4355: stamp the stream on the placeholder, not just on the final
     // result — a task is listed and polled from the moment it is accepted, so
@@ -427,6 +455,14 @@ pub(super) async fn submit_task(
     } else {
         classify_intent(&req.task)
     };
+
+    // #7370: the attachment bodies are appended only AFTER routing has been
+    // decided from the user's own words. Appending before would let a dropped
+    // spreadsheet re-classify "list projects" as a research turn.
+    if !attachment_blocks.is_empty() {
+        req.task =
+            crate::attachments::model_input::augment_user_turn(&req.task, &attachment_blocks);
+    }
 
     // #3223 (Trusty Agents agent roster, epic #3052): CTRL management
     // commands ("add project …", "list projects", …) must always run
@@ -582,6 +618,84 @@ pub(super) async fn submit_task(
             status: "running",
         }),
     )
+        .into_response()
+}
+
+/// Most attachments one turn may carry.
+///
+/// Why: each one is rendered into the turn and then replayed as conversation
+/// history on every later turn in the session, so the cost is paid repeatedly.
+/// A bound here is what stops a client asking for a turn nothing can answer.
+/// Test: `super::tests::attachments::send_refuses_too_many_attachments`.
+const MAX_ATTACHMENTS_PER_TURN: usize = 8;
+
+/// Resolve the attachment ids a request names into the blocks its turn carries.
+///
+/// Why (#7370): this is the validate-before-persist gate. It runs before the
+/// `running` placeholder is stored and before anything is dispatched, so a turn
+/// naming an attachment the manifest does not hold is refused with the
+/// conversation untouched - the defect that blocked the prior attempt on this
+/// issue was doing this the other way round.
+/// What: `Ok(vec![])` for a request with no attachments, which is every
+/// pre-#7370 request. Otherwise each id is looked up in the ADDRESSED
+/// assistant's own session manifest - never a session the caller names - and
+/// rendered through `attachments::model_input`. The file's bytes are read only
+/// when the media type is one that gets inlined, so a large binary costs a
+/// manifest lookup rather than a 10 MiB read. Any refusal becomes the response,
+/// and no block is returned: a partial resolution must never dispatch.
+/// Test: `super::tests::attachments::send_with_an_unknown_attachment_is_refused`,
+/// `super::tests::attachments::send_with_a_known_attachment_is_accepted`.
+async fn resolve_attachments(state: &AppState, req: &TaskRequest) -> Result<Vec<String>, Response> {
+    let ids = req.attachments.clone().unwrap_or_default();
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    if ids.len() > MAX_ATTACHMENTS_PER_TURN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!(
+                    "a turn may carry at most {MAX_ATTACHMENTS_PER_TURN} attachments, not {}",
+                    ids.len()
+                ),
+            })),
+        )
+            .into_response());
+    }
+    let agent = addressed_agent_for(req);
+    // The session is DERIVED from the addressed assistant, never taken from
+    // the request: it is what keeps one assistant's turn from referencing
+    // another's stored files.
+    let session = crate::ctrl::pm_task::session_id_for(&agent);
+    let store = super::attachments::resolve_store(state, &agent)?;
+
+    let resolved = tokio::task::spawn_blocking(move || {
+        let mut blocks = Vec::with_capacity(ids.len());
+        for id in &ids {
+            let row = store.get(&session, id)?;
+            let bytes = if crate::attachments::model_input::is_inlinable_text(&row.media_type) {
+                store.read(&session, id)?.1
+            } else {
+                Vec::new()
+            };
+            blocks.push(crate::attachments::model_input::render(&row, &bytes));
+        }
+        Ok::<Vec<String>, crate::attachments::AttachmentError>(blocks)
+    })
+    .await;
+
+    match resolved {
+        Ok(Ok(blocks)) => Ok(blocks),
+        Ok(Err(e)) => Err(super::attachments::refuse(e)),
+        Err(e) => {
+            tracing::warn!(error = %e, "submit_task: attachment resolution task failed");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "attachment resolution failed" })),
+            )
+                .into_response())
+        }
+    }
 }
 
 /// `GET /api/task/:id` — fetch a cached task response.
@@ -797,6 +911,7 @@ mod tests {
             model_id: None,
             provider_id: None,
             focused_workstream: None,
+            attachments: None,
         }
     }
 

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -51,6 +51,9 @@ mod agent_stores;
 mod agent_subagents;
 // #7428: one memory palace per assistant, with the opt-in fan-out setting.
 mod assistant_memory;
+// #7370: chat-thread attachments — upload, manifest listing, and
+// id-addressed retrieval under `<assistant home>/attachments/<session>/`.
+mod attachments;
 mod auth;
 mod cancel;
 pub(crate) mod knowledge_pipeline;

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -288,6 +288,27 @@ pub fn build_router_with_origins(
             "/api/assistants/{id}/memory",
             axum::routing::get(super::assistant_memory::get).put(super::assistant_memory::put),
         )
+        // #7370: chat-thread attachments, stored under
+        // `<assistant home>/attachments/<session>/`. POST uploads one file
+        // (multipart); the collection GET returns the session manifest a
+        // reload rebuilds its cards from; the id GET returns the bytes.
+        // Never a static file mount — every read is looked up by id in the
+        // manifest and the server opens the path the ROW names, never one the
+        // caller supplied (see `attachments`'s module doc).
+        .route(
+            "/api/agents/{name}/sessions/{session}/attachments",
+            axum::routing::get(super::attachments::list_route)
+                .post(super::attachments::upload_route)
+                // axum's 2 MiB default would refuse a legitimate attachment
+                // before the store's own cap could name the file.
+                .layer(axum::extract::DefaultBodyLimit::max(
+                    super::attachments::MAX_UPLOAD_BODY_BYTES,
+                )),
+        )
+        .route(
+            "/api/agents/{name}/sessions/{session}/attachments/{id}",
+            axum::routing::get(super::attachments::download_route),
+        )
         // #4098: aggregated usage cost for the Costs tab — totals plus
         // by-agent/by-model/by-date breakdowns, folded read-time from
         // `.trusty-agents/state/usage.jsonl` and priced through the single

--- a/crates/trusty-agents/src/api/server/state.rs
+++ b/crates/trusty-agents/src/api/server/state.rs
@@ -100,6 +100,18 @@ pub struct AppState {
     /// documented no-op, never an error.
     /// Test: `submit_task_records_attendance_under_the_injected_root`.
     pub(super) attendance_root: Option<PathBuf>,
+    /// #7370: the root holding one assistant home per instance, under which
+    /// `<instance>/attachments/<session>/` lives.
+    ///
+    /// Why: same reason as [`AppState::attendance_root`] — resolving it from
+    /// `$HOME` inside the handler makes "an upload lands in the assistant's
+    /// home" untestable, because the natural test writes into the developer's
+    /// real `~/trusty-agents`. Injected here, a test points it at a tempdir and
+    /// asserts against that.
+    /// `None` means no home directory could be resolved; the attachment routes
+    /// then answer `503` rather than inventing a path.
+    /// Test: `super::tests::attachments`.
+    pub(super) attachments_root: Option<PathBuf>,
 }
 
 impl Default for AppState {
@@ -110,6 +122,7 @@ impl Default for AppState {
             recap_tracker: Arc::new(Mutex::new(RecapTracker::new(RecapConfig::default()))),
             tm_manager: None,
             attendance_root: crate::attendance::default_attendance_root().ok(),
+            attachments_root: crate::assistants::assistants_root().ok(),
         }
     }
 }

--- a/crates/trusty-agents/src/api/server/tests/attachments.rs
+++ b/crates/trusty-agents/src/api/server/tests/attachments.rs
@@ -1,0 +1,373 @@
+//! Chat-attachment routes, driven through the real router (#7370).
+//!
+//! Why: every assertion here is about what reached — or did NOT reach — the
+//! filesystem. A guard that answers `4xx` while leaving a partial file behind
+//! passes a status-code-only test and fails the product, so each refusal is
+//! checked on both halves.
+//!
+//! The attachments root is injected on `AppState`, the pattern `attendance.rs`
+//! established (#4703): without it these tests would write into the
+//! developer's real `~/trusty-agents` and have nothing local to assert on.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use tower::ServiceExt;
+
+use super::super::routes::build_router;
+use super::super::state::AppState;
+
+/// An assistant instance id. Nothing here consults the agent roster (see the
+/// `attachments` module doc), so this need not be a real roster entry.
+const AGENT: &str = "attachments-probe-7370";
+
+fn session() -> String {
+    crate::ctrl::pm_task::session_id_for(AGENT)
+}
+
+fn state_at(root: &std::path::Path) -> AppState {
+    AppState {
+        attachments_root: Some(root.to_path_buf()),
+        ..Default::default()
+    }
+}
+
+/// `<root>/<agent>/attachments/<session>` — where the store must land files.
+fn session_dir(root: &std::path::Path) -> std::path::PathBuf {
+    root.join(AGENT).join("attachments").join(session())
+}
+
+/// A `multipart/form-data` body carrying exactly one file part.
+fn multipart_body(file_name: &str, content_type: &str, bytes: &[u8]) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(b"--BOUND7370\r\n");
+    body.extend_from_slice(
+        format!("Content-Disposition: form-data; name=\"file\"; filename=\"{file_name}\"\r\n")
+            .as_bytes(),
+    );
+    body.extend_from_slice(format!("Content-Type: {content_type}\r\n\r\n").as_bytes());
+    body.extend_from_slice(bytes);
+    body.extend_from_slice(b"\r\n--BOUND7370--\r\n");
+    body
+}
+
+fn upload_request(agent: &str, file_name: &str, content_type: &str, bytes: &[u8]) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/api/agents/{agent}/sessions/{}/attachments",
+            session()
+        ))
+        .header(
+            header::CONTENT_TYPE,
+            "multipart/form-data; boundary=BOUND7370",
+        )
+        .body(Body::from(multipart_body(file_name, content_type, bytes)))
+        .expect("request")
+}
+
+async fn json_of(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+/// Upload one file, then read back its row and its bytes.
+async fn upload_one(
+    root: &std::path::Path,
+    file_name: &str,
+    content_type: &str,
+    bytes: &[u8],
+) -> serde_json::Value {
+    let response = build_router(state_at(root))
+        .oneshot(upload_request(AGENT, file_name, content_type, bytes))
+        .await
+        .expect("upload");
+    assert_eq!(response.status(), StatusCode::CREATED);
+    json_of(response).await
+}
+
+#[tokio::test]
+async fn upload_stores_the_file_and_returns_its_row() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let row = upload_one(dir.path(), "data.csv", "text/csv", b"a,b\n1,2\n").await;
+
+    let stored = session_dir(dir.path()).join("data.csv");
+    assert!(stored.is_file(), "nothing at {}", stored.display());
+    assert_eq!(std::fs::read(&stored).unwrap(), b"a,b\n1,2\n");
+    assert_eq!(row["file_name"], "data.csv");
+    assert_eq!(row["media_type"], "text/csv");
+    assert_eq!(row["size"], 8);
+    // The recorded digest is re-derived from the bytes AT THAT PATH, so this
+    // asserts the row describes the file that actually landed.
+    let on_disk = format!(
+        "{:x}",
+        <sha2::Sha256 as sha2::Digest>::digest(std::fs::read(&stored).unwrap())
+    );
+    assert_eq!(row["sha256"].as_str().unwrap(), on_disk);
+    // The wire body never carries the absolute server path.
+    assert!(row.get("stored_path").is_none(), "{row}");
+    assert!(
+        row["url"]
+            .as_str()
+            .unwrap()
+            .ends_with(row["id"].as_str().unwrap()),
+        "{row}"
+    );
+}
+
+#[tokio::test]
+async fn upload_refuses_a_traversal_file_name() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let response = build_router(state_at(dir.path()))
+        .oneshot(upload_request(AGENT, "../escape.txt", "text/plain", b"x"))
+        .await
+        .expect("upload");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        !dir.path().join(AGENT).join("attachments").exists(),
+        "a refused upload created part of the tree"
+    );
+    assert!(
+        !dir.path().join("escape.txt").exists(),
+        "a refused upload escaped the attachments tree"
+    );
+}
+
+#[tokio::test]
+async fn upload_refuses_a_traversal_agent_name() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let response = build_router(state_at(dir.path()))
+        .oneshot(upload_request("%2E%2E", "notes.txt", "text/plain", b"x"))
+        .await
+        .expect("upload");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+}
+
+#[tokio::test]
+async fn upload_refuses_an_oversize_file() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let oversize = vec![b'x'; crate::attachments::MAX_ATTACHMENT_BYTES as usize + 1];
+    let response = build_router(state_at(dir.path()))
+        .oneshot(upload_request(AGENT, "big.txt", "text/plain", &oversize))
+        .await
+        .expect("upload");
+
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(
+        !session_dir(dir.path()).join("big.txt").exists(),
+        "an oversize upload left a partial file"
+    );
+}
+
+#[tokio::test]
+async fn list_returns_the_session_manifest() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let first = upload_one(dir.path(), "a.txt", "text/plain", b"a").await;
+    let second = upload_one(dir.path(), "b.png", "image/png", b"\x89PNG").await;
+
+    let response = build_router(state_at(dir.path()))
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/agents/{AGENT}/sessions/{}/attachments",
+                    session()
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("list");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    let rows = body["attachments"].as_array().expect("array");
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["id"], first["id"]);
+    assert_eq!(rows[1]["id"], second["id"]);
+    assert_eq!(rows[1]["media_type"], "image/png");
+}
+
+#[tokio::test]
+async fn download_returns_the_bytes_and_headers() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let row = upload_one(dir.path(), "data.csv", "text/csv", b"a,b\n1,2\n").await;
+
+    let response = build_router(state_at(dir.path()))
+        .oneshot(
+            Request::builder()
+                .uri(row["url"].as_str().unwrap())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("download");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[header::CONTENT_TYPE], "text/csv");
+    assert_eq!(
+        response.headers()[header::CONTENT_DISPOSITION],
+        "inline; filename=\"data.csv\""
+    );
+    assert_eq!(
+        response.headers()[header::X_CONTENT_TYPE_OPTIONS],
+        "nosniff"
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    assert_eq!(&bytes[..], b"a,b\n1,2\n");
+}
+
+/// An uploaded HTML file must not render in the API origin.
+#[tokio::test]
+async fn download_forces_scriptable_content_to_download() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let row = upload_one(dir.path(), "x.html", "text/html", b"<script>1</script>").await;
+
+    let response = build_router(state_at(dir.path()))
+        .oneshot(
+            Request::builder()
+                .uri(row["url"].as_str().unwrap())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("download");
+
+    assert!(
+        response.headers()[header::CONTENT_DISPOSITION]
+            .to_str()
+            .unwrap()
+            .starts_with("attachment;"),
+        "scriptable content was served inline"
+    );
+}
+
+#[tokio::test]
+async fn download_rejects_an_unknown_id() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    upload_one(dir.path(), "a.txt", "text/plain", b"a").await;
+
+    for id in ["0".repeat(32), "not-an-id".to_string()] {
+        let response = build_router(state_at(dir.path()))
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/agents/{AGENT}/sessions/{}/attachments/{id}",
+                        session()
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("download");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "id {id}");
+    }
+}
+
+/// The validate-before-persist gate: a send naming an attachment that is not in
+/// the manifest is refused with the task store untouched.
+///
+/// Why this is the regression: the prior attempt on this issue persisted the
+/// user turn first and validated afterwards, so a rejected send polluted chat
+/// history and duplicated on retry. Everything `submit_task` writes — the
+/// `running` placeholder asserted here, and `spawn_persist_turn`'s chat-history
+/// append downstream of it — happens after this gate, so an empty task store
+/// proves nothing was recorded.
+#[tokio::test]
+async fn send_with_an_unknown_attachment_is_refused() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let app = build_router(state_at(dir.path()));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/task")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "task": "what is in this file?",
+                        "agent": AGENT,
+                        "attachments": ["0".repeat(32)],
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("submit");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let listed = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/tasks")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("list tasks");
+    let body = json_of(listed).await;
+    assert_eq!(
+        body.as_array().map(Vec::len).unwrap_or_default(),
+        0,
+        "a refused send recorded a task: {body}"
+    );
+}
+
+/// The success arm of the same gate — an id that IS in the manifest is
+/// accepted, so the refusal above is about the id and not about the field.
+#[tokio::test]
+async fn send_with_a_known_attachment_is_accepted() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let row = upload_one(dir.path(), "data.csv", "text/csv", b"a,b\n1,2\n").await;
+
+    let response = build_router(state_at(dir.path()))
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/task")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "task": "what is in this file?",
+                        "agent": AGENT,
+                        "attachments": [row["id"].as_str().unwrap()],
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("submit");
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn send_refuses_too_many_attachments() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let ids: Vec<String> = (0..9).map(|_| "0".repeat(32)).collect();
+
+    let response = build_router(state_at(dir.path()))
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/task")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "task": "hi", "agent": AGENT, "attachments": ids })
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("submit");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/trusty-agents/src/api/server/tests/attachments.rs
+++ b/crates/trusty-agents/src/api/server/tests/attachments.rs
@@ -371,3 +371,84 @@ async fn send_refuses_too_many_attachments() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
+
+/// A server-side failure must not hand the caller an absolute path.
+///
+/// Why this is a regression: `refuse` used to return `error.to_string()` for
+/// every variant, and `Io`, `Manifest` and `MissingFile` all carry a path from
+/// the operator's home directory. A caller who can only address attachments by
+/// id was being told the on-disk layout of the tree they sit in.
+/// What: a manifest that opens but does not decode makes the upload fail after
+/// its own guards pass, which is the shortest route to a real 5xx. The body is
+/// checked for any path at all, and the orphaned file is checked for too — the
+/// same failure exercises both.
+#[tokio::test]
+async fn a_server_error_body_carries_no_path() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let session_path = session_dir(dir.path());
+    std::fs::create_dir_all(&session_path).expect("session dir");
+    std::fs::write(session_path.join("manifest.json"), "{ not json").expect("manifest");
+
+    let response = build_router(state_at(dir.path()))
+        .oneshot(upload_request(AGENT, "a.txt", "text/plain", b"payload"))
+        .await
+        .expect("upload");
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = json_of(response).await;
+    let message = body["error"].as_str().expect("error string");
+    assert!(
+        !message.contains('/'),
+        "a path leaked into a 5xx body: {message}"
+    );
+    assert!(
+        !message.contains(dir.path().to_str().unwrap()),
+        "the store root leaked into a 5xx body: {message}"
+    );
+    // The same failure arm: the bytes were written before the append failed,
+    // and nothing may be left behind for a row that was never recorded.
+    assert!(
+        !session_path.join("a.txt").exists(),
+        "a failed manifest write left an orphaned file"
+    );
+}
+
+/// A tampered manifest is refused over HTTP too, as a 5xx with no path.
+#[tokio::test]
+async fn download_refuses_a_tampered_stored_name() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let session_path = session_dir(dir.path());
+    std::fs::create_dir_all(&session_path).expect("session dir");
+    let id = "f".repeat(32);
+    let document = serde_json::json!({
+        "version": 1,
+        "session_id": session(),
+        "attachments": [{
+            "id": id,
+            "file_name": "innocent.txt",
+            "media_type": "text/plain",
+            "size": 6,
+            "sha256": "deadbeef",
+            "stored_name": "/etc/hosts",
+            "created_at": "2026-09-11T00:00:00Z",
+        }],
+    });
+    std::fs::write(session_path.join("manifest.json"), document.to_string()).expect("manifest");
+
+    let response = build_router(state_at(dir.path()))
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/agents/{AGENT}/sessions/{}/attachments/{id}",
+                    session()
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("download");
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body = json_of(response).await;
+    assert!(!body["error"].as_str().unwrap().contains('/'), "{body}");
+}

--- a/crates/trusty-agents/src/api/server/tests/attachments.rs
+++ b/crates/trusty-agents/src/api/server/tests/attachments.rs
@@ -36,21 +36,28 @@ fn session_dir(root: &std::path::Path) -> std::path::PathBuf {
     root.join(AGENT).join("attachments").join(session())
 }
 
-/// A `multipart/form-data` body carrying exactly one file part.
-fn multipart_body(file_name: &str, content_type: &str, bytes: &[u8]) -> Vec<u8> {
+/// A `multipart/form-data` body carrying one file part per entry.
+fn multipart_body(parts: &[(&str, &str, &[u8])]) -> Vec<u8> {
     let mut body = Vec::new();
-    body.extend_from_slice(b"--BOUND7370\r\n");
-    body.extend_from_slice(
-        format!("Content-Disposition: form-data; name=\"file\"; filename=\"{file_name}\"\r\n")
-            .as_bytes(),
-    );
-    body.extend_from_slice(format!("Content-Type: {content_type}\r\n\r\n").as_bytes());
-    body.extend_from_slice(bytes);
-    body.extend_from_slice(b"\r\n--BOUND7370--\r\n");
+    for (file_name, content_type, bytes) in parts {
+        body.extend_from_slice(b"--BOUND7370\r\n");
+        body.extend_from_slice(
+            format!("Content-Disposition: form-data; name=\"file\"; filename=\"{file_name}\"\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(format!("Content-Type: {content_type}\r\n\r\n").as_bytes());
+        body.extend_from_slice(bytes);
+        body.extend_from_slice(b"\r\n");
+    }
+    body.extend_from_slice(b"--BOUND7370--\r\n");
     body
 }
 
 fn upload_request(agent: &str, file_name: &str, content_type: &str, bytes: &[u8]) -> Request<Body> {
+    upload_request_many(agent, &[(file_name, content_type, bytes)])
+}
+
+fn upload_request_many(agent: &str, parts: &[(&str, &str, &[u8])]) -> Request<Body> {
     Request::builder()
         .method(Method::POST)
         .uri(format!(
@@ -61,7 +68,7 @@ fn upload_request(agent: &str, file_name: &str, content_type: &str, bytes: &[u8]
             header::CONTENT_TYPE,
             "multipart/form-data; boundary=BOUND7370",
         )
-        .body(Body::from(multipart_body(file_name, content_type, bytes)))
+        .body(Body::from(multipart_body(parts)))
         .expect("request")
 }
 
@@ -72,7 +79,7 @@ async fn json_of(response: axum::response::Response) -> serde_json::Value {
     serde_json::from_slice(&bytes).expect("json")
 }
 
-/// Upload one file, then read back its row and its bytes.
+/// Upload one file and return its row.
 async fn upload_one(
     root: &std::path::Path,
     file_name: &str,
@@ -84,7 +91,13 @@ async fn upload_one(
         .await
         .expect("upload");
     assert_eq!(response.status(), StatusCode::CREATED);
-    json_of(response).await
+    let mut body = json_of(response).await;
+    // The route answers one row per file, always as an array — a single-file
+    // upload is the one-element case, not a different shape.
+    body["attachments"]
+        .as_array_mut()
+        .expect("attachments array")
+        .remove(0)
 }
 
 #[tokio::test]
@@ -451,4 +464,98 @@ async fn download_refuses_a_tampered_stored_name() {
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     let body = json_of(response).await;
     assert!(!body["error"].as_str().unwrap().contains('/'), "{body}");
+}
+
+/// Three files in one request must produce three rows and three files.
+///
+/// Why this is a regression: `upload_route` used to `break` at the first field
+/// carrying a filename. A person who dragged three files onto the composer got
+/// one card, two files silently discarded, and a `201` saying everything was
+/// fine.
+#[tokio::test]
+async fn upload_accepts_every_file_in_one_request() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let response = build_router(state_at(dir.path()))
+        .oneshot(upload_request_many(
+            AGENT,
+            &[
+                ("a.txt", "text/plain", b"aaa"),
+                ("b.csv", "text/csv", b"x,y\n1,2\n"),
+                ("c.png", "image/png", b"\x89PNG"),
+            ],
+        ))
+        .await
+        .expect("upload");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = json_of(response).await;
+    let rows = body["attachments"].as_array().expect("array");
+    assert_eq!(rows.len(), 3, "{body}");
+    assert_eq!(rows[0]["file_name"], "a.txt");
+    assert_eq!(rows[1]["file_name"], "b.csv");
+    assert_eq!(rows[2]["media_type"], "image/png");
+
+    let session_path = session_dir(dir.path());
+    for (name, expected) in [
+        ("a.txt", &b"aaa"[..]),
+        ("b.csv", &b"x,y\n1,2\n"[..]),
+        ("c.png", &b"\x89PNG"[..]),
+    ] {
+        assert_eq!(
+            std::fs::read(session_path.join(name)).unwrap(),
+            expected,
+            "{name}"
+        );
+    }
+    // And the manifest lists all three, so a reload finds them.
+    assert_eq!(
+        rows.len(),
+        crate::attachments::AttachmentStore::new(dir.path().join(AGENT).join("attachments"))
+            .list(&session())
+            .unwrap()
+            .len()
+    );
+}
+
+/// A bad name anywhere in a batch refuses the whole batch, writing nothing.
+#[tokio::test]
+async fn upload_writes_nothing_when_one_file_in_the_batch_is_refused() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let response = build_router(state_at(dir.path()))
+        .oneshot(upload_request_many(
+            AGENT,
+            &[
+                ("good.txt", "text/plain", b"ok"),
+                ("../escape.txt", "text/plain", b"bad"),
+            ],
+        ))
+        .await
+        .expect("upload");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        !session_dir(dir.path()).join("good.txt").exists(),
+        "a refused batch wrote its earlier files anyway"
+    );
+}
+
+/// More files than a turn may reference is refused, not silently truncated.
+#[tokio::test]
+async fn upload_refuses_more_files_than_a_turn_can_carry() {
+    let dir = tempfile::TempDir::new().expect("temp");
+    let names: Vec<String> = (0..crate::attachments::MAX_ATTACHMENTS_PER_TURN + 1)
+        .map(|i| format!("f{i}.txt"))
+        .collect();
+    let parts: Vec<(&str, &str, &[u8])> = names
+        .iter()
+        .map(|name| (name.as_str(), "text/plain", &b"x"[..]))
+        .collect();
+
+    let response = build_router(state_at(dir.path()))
+        .oneshot(upload_request_many(AGENT, &parts))
+        .await
+        .expect("upload");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(!session_dir(dir.path()).join("f0.txt").exists());
 }

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -17,6 +17,9 @@ mod agent_subagents;
 mod assistant_memory;
 // #4355: per-assistant task-stream attribution, retention, and retrieval.
 mod assistant_streams;
+// #7370: chat-thread attachment upload, listing, retrieval, and the
+// validate-before-persist gate on `POST /api/task`.
+mod attachments;
 mod attendance;
 mod cancel;
 // #4278: the durable persona chat log read back for GUI rehydration.

--- a/crates/trusty-agents/src/attachments/error.rs
+++ b/crates/trusty-agents/src/attachments/error.rs
@@ -28,6 +28,12 @@ pub enum AttachmentError {
     #[error("attachment `{name}` is {size} bytes, over the {cap}-byte limit")]
     TooLarge { name: String, size: u64, cap: u64 },
 
+    /// One request carried more files than a turn may reference.
+    ///
+    /// Test: `super::tests::store_tests::store_all_refuses_more_than_the_cap`.
+    #[error("this upload carries {count} files, over the limit of {cap}")]
+    TooManyFiles { count: usize, cap: usize },
+
     /// An id that is not the 32-hex-character shape this module mints.
     #[error("`{0}` is not an attachment id")]
     InvalidId(String),
@@ -91,6 +97,7 @@ impl AttachmentError {
             Self::UnsafeFileName { .. }
                 | Self::UnsafeSessionId { .. }
                 | Self::TooLarge { .. }
+                | Self::TooManyFiles { .. }
                 | Self::InvalidId(_)
                 | Self::NotFound { .. }
         )

--- a/crates/trusty-agents/src/attachments/error.rs
+++ b/crates/trusty-agents/src/attachments/error.rs
@@ -1,0 +1,78 @@
+//! The one error type every attachment operation returns (#7370).
+//!
+//! Why: the guards this module exists to hold — traversal, absolute names,
+//! the size cap, an unknown id — must REJECT, never repair. A rename-and-
+//! continue guard writes the user's file somewhere they will not find it and
+//! reports success, which is the failure mode the prior attempt on this issue
+//! was blocked for. Naming each refusal as its own variant is what lets the
+//! HTTP layer map it to a status code without string-matching a message.
+//! What: a `thiserror` enum (library crate convention — see this repo's
+//! CLAUDE.md) carrying the rejected value in every variant, so the caller can
+//! report WHAT was refused and not merely that something was.
+//! Test: `super::tests::store_tests` — every variant has a producing case.
+
+use std::path::PathBuf;
+
+/// Every way an attachment operation can refuse or fail.
+#[derive(Debug, thiserror::Error)]
+pub enum AttachmentError {
+    /// A file name that is not a single, ordinary path segment.
+    #[error("attachment file name `{name}` is rejected: {reason}")]
+    UnsafeFileName { name: String, reason: String },
+
+    /// A session id that is not a single, ordinary path segment.
+    #[error("session id `{session}` is rejected: {reason}")]
+    UnsafeSessionId { session: String, reason: String },
+
+    /// The payload is larger than [`super::MAX_ATTACHMENT_BYTES`].
+    #[error("attachment `{name}` is {size} bytes, over the {cap}-byte limit")]
+    TooLarge { name: String, size: u64, cap: u64 },
+
+    /// An id that is not the 32-hex-character shape this module mints.
+    #[error("`{0}` is not an attachment id")]
+    InvalidId(String),
+
+    /// No manifest row with this id in this session.
+    #[error("no attachment `{id}` in session `{session}`")]
+    NotFound { id: String, session: String },
+
+    /// The stored bytes are gone while the manifest row survives.
+    #[error("attachment `{id}` is recorded but its file is missing at {path}")]
+    MissingFile { id: String, path: PathBuf },
+
+    /// Any filesystem failure, always naming the path it happened at.
+    #[error("attachment store i/o failed at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A manifest that is present but not decodable.
+    #[error("attachment manifest at {path} is not readable as JSON: {source}")]
+    Manifest {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+impl AttachmentError {
+    /// Whether this refusal is the caller's fault (a `4xx`) rather than the
+    /// server's (a `5xx`).
+    ///
+    /// Why: the HTTP layer must not string-match error text to pick a status.
+    /// What: every guard variant is a client error; i/o and a corrupt manifest
+    /// are not.
+    /// Test: `super::tests::store_tests::client_errors_are_classified`.
+    pub fn is_client_error(&self) -> bool {
+        matches!(
+            self,
+            Self::UnsafeFileName { .. }
+                | Self::UnsafeSessionId { .. }
+                | Self::TooLarge { .. }
+                | Self::InvalidId(_)
+                | Self::NotFound { .. }
+        )
+    }
+}

--- a/crates/trusty-agents/src/attachments/error.rs
+++ b/crates/trusty-agents/src/attachments/error.rs
@@ -55,6 +55,26 @@ pub enum AttachmentError {
         #[source]
         source: serde_json::Error,
     },
+
+    /// A manifest row whose stored name does not resolve inside its session
+    /// directory.
+    ///
+    /// Why: the manifest is a plain JSON file in the user's own home tree, so
+    /// it is EDITABLE — by the user, by anything else that can write there, or
+    /// by a process that should not be able to. A row saying
+    /// `stored_name: "/etc/passwd"` would otherwise resolve straight through
+    /// `Path::join`, whose absolute-component rule replaces the base rather
+    /// than appending to it. This is the refusal for that row: never repaired,
+    /// never renamed, and never a client error, because the request was fine
+    /// and the stored state is not.
+    /// Test: `super::tests::manifest_tests::an_absolute_stored_name_is_refused`,
+    /// `super::tests::manifest_tests::a_traversal_stored_name_is_refused`.
+    #[error("attachment `{id}` does not resolve inside its session directory ({path}): {reason}")]
+    TamperedManifest {
+        path: PathBuf,
+        id: String,
+        reason: String,
+    },
 }
 
 impl AttachmentError {

--- a/crates/trusty-agents/src/attachments/manifest.rs
+++ b/crates/trusty-agents/src/attachments/manifest.rs
@@ -134,11 +134,11 @@ impl Manifest {
             Err(source) => return Err(AttachmentError::Io { path, source }),
         };
         let document = self.decode(&raw, &path)?;
-        Ok(document
+        document
             .attachments
             .into_iter()
             .map(|row| self.hydrate(row))
-            .collect())
+            .collect()
     }
 
     /// The row with this id, or [`AttachmentError::NotFound`].
@@ -154,30 +154,22 @@ impl Manifest {
             })
     }
 
-    /// Record one attachment under an exclusive lock on the manifest.
+    /// Take the session's exclusive write lock.
     ///
-    /// Why: the read-modify-write has to be atomic against a second upload
-    /// into the same session, or one row silently replaces the other. The lock
-    /// is `fs4` advisory, matching `crate::state_writer`.
-    /// What: opens (creating) the manifest, locks it, decodes what is there,
-    /// appends the row, and rewrites the whole document in place. An id that
-    /// is already present REPLACES its row rather than duplicating it, so a
-    /// retried upload of the same id is idempotent.
-    /// Test: `super::tests::manifest_tests::append_then_rows_round_trips`,
-    /// `super::tests::manifest_tests::append_is_idempotent_on_one_id`.
-    #[allow(clippy::too_many_arguments)]
-    pub fn append(
-        &self,
-        id: &str,
-        file_name: &str,
-        media_type: &str,
-        size: u64,
-        sha256: &str,
-        stored_name: &str,
-        created_at: &str,
-    ) -> Result<Attachment, AttachmentError> {
+    /// Why: the lock has to cover MORE than the manifest's own read-modify-
+    /// write. `AttachmentStore::store` chooses a file name from what is already
+    /// on disk, writes the bytes, and then records the row — and all three have
+    /// to be one critical section, or two concurrent uploads of the same name
+    /// both choose the unsuffixed name and one of them records a digest for
+    /// bytes that are not there. Handing the caller a guard is what lets the
+    /// section span those three steps instead of only the last.
+    /// What: opens (creating) the manifest and takes an `fs4` exclusive
+    /// advisory lock on it, the mechanism `crate::state_writer` uses. The lock
+    /// is released when the guard drops, on every path including a panic.
+    /// Test: `super::tests::store_tests::concurrent_same_name_uploads_keep_their_bytes`.
+    pub fn lock(&self) -> Result<ManifestGuard, AttachmentError> {
         let path = self.path();
-        let mut file = OpenOptions::new()
+        let file = OpenOptions::new()
             .create(true)
             .read(true)
             .write(true)
@@ -192,8 +184,61 @@ impl Manifest {
             path: path.clone(),
             source,
         })?;
-        let result = self.append_locked(
-            &mut file,
+        Ok(ManifestGuard { file, path })
+    }
+
+    /// Record one attachment, taking the lock for the duration of the call.
+    ///
+    /// Why: the shorthand for a caller that has nothing else to do under the
+    /// lock. `AttachmentStore::store` uses [`Self::lock`] +
+    /// [`Self::append_with`] instead, because it does.
+    /// Test: `super::tests::manifest_tests::append_then_rows_round_trips`,
+    /// `super::tests::manifest_tests::append_is_idempotent_on_one_id`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append(
+        &self,
+        id: &str,
+        file_name: &str,
+        media_type: &str,
+        size: u64,
+        sha256: &str,
+        stored_name: &str,
+        created_at: &str,
+    ) -> Result<Attachment, AttachmentError> {
+        let mut guard = self.lock()?;
+        self.append_with(
+            &mut guard,
+            id,
+            file_name,
+            media_type,
+            size,
+            sha256,
+            stored_name,
+            created_at,
+        )
+    }
+
+    /// Record one attachment under a lock the caller already holds.
+    ///
+    /// Why/What: see [`Self::lock`]. An id already present REPLACES its row
+    /// rather than duplicating it, so a retried write of the same id is
+    /// idempotent.
+    /// Test: `super::tests::manifest_tests::append_is_idempotent_on_one_id`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append_with(
+        &self,
+        guard: &mut ManifestGuard,
+        id: &str,
+        file_name: &str,
+        media_type: &str,
+        size: u64,
+        sha256: &str,
+        stored_name: &str,
+        created_at: &str,
+    ) -> Result<Attachment, AttachmentError> {
+        let path = guard.path.clone();
+        self.append_locked(
+            &mut guard.file,
             &path,
             Row {
                 id: id.to_string(),
@@ -204,13 +249,10 @@ impl Manifest {
                 stored_name: stored_name.to_string(),
                 created_at: created_at.to_string(),
             },
-        );
-        let _ = fs4::FileExt::unlock(&file);
-        result
+        )
     }
 
-    /// The locked half of [`Self::append`], split out so the unlock above runs
-    /// on every path including an early error.
+    /// The body of an append, with the lock already held.
     fn append_locked(
         &self,
         file: &mut File,
@@ -243,7 +285,7 @@ impl Manifest {
         file.write_all(encoded.as_bytes()).map_err(io)?;
         file.write_all(b"\n").map_err(io)?;
         file.flush().map_err(io)?;
-        Ok(self.hydrate(row))
+        self.hydrate(row)
     }
 
     /// Decode a manifest body, treating an EMPTY file as a fresh session.
@@ -266,15 +308,57 @@ impl Manifest {
     }
 
     /// Resolve a stored row's name against this session's directory.
-    fn hydrate(&self, row: Row) -> Attachment {
-        Attachment {
+    ///
+    /// Why: this is the confinement for a manifest that has been EDITED. The
+    /// file is plain JSON in the user's own home tree, so its contents are not
+    /// this crate's word — and `Path::join` replaces the base when handed an
+    /// absolute component, so an unchecked `stored_name` of `/etc/passwd`
+    /// resolves to `/etc/passwd` rather than to something under the session.
+    /// The row is REFUSED, never repaired: a manifest that has been tampered
+    /// with must surface, not silently read a neighbouring file instead.
+    /// What: `stored_name` must be one ordinary path segment
+    /// ([`super::store::single_segment`], the same guard the upload applies to
+    /// the name it accepts). `AttachmentStore::read` then re-checks the
+    /// canonical result, which is what catches a symlink the name check cannot
+    /// see.
+    /// Test: `super::tests::manifest_tests::an_absolute_stored_name_is_refused`,
+    /// `super::tests::manifest_tests::a_traversal_stored_name_is_refused`.
+    fn hydrate(&self, row: Row) -> Result<Attachment, AttachmentError> {
+        let stored_name = super::store::single_segment(&row.stored_name).map_err(|reason| {
+            AttachmentError::TamperedManifest {
+                path: self.path(),
+                id: row.id.clone(),
+                reason: format!(
+                    "its stored name `{}` is rejected: {reason}",
+                    row.stored_name
+                ),
+            }
+        })?;
+        Ok(Attachment {
             id: row.id,
             session_id: self.session_id.clone(),
             file_name: row.file_name,
             media_type: row.media_type,
             size: row.size,
             sha256: row.sha256,
-            stored_path: self.session_dir.join(row.stored_name),
-        }
+            stored_path: self.session_dir.join(stored_name),
+        })
+    }
+}
+
+/// An exclusive advisory lock on one session's manifest.
+///
+/// Why: a guard rather than a scoped closure, so the critical section can span
+/// the caller's own filesystem work (see [`Manifest::lock`]). Unlocking on
+/// `Drop` is what makes every exit path — early `?`, panic, ordinary return —
+/// release it.
+pub struct ManifestGuard {
+    file: File,
+    path: PathBuf,
+}
+
+impl Drop for ManifestGuard {
+    fn drop(&mut self) {
+        let _ = fs4::FileExt::unlock(&self.file);
     }
 }

--- a/crates/trusty-agents/src/attachments/manifest.rs
+++ b/crates/trusty-agents/src/attachments/manifest.rs
@@ -1,0 +1,280 @@
+//! The per-session sidecar that records what was stored (#7370).
+//!
+//! Why: the bytes on disk carry a name and nothing else — not the media type
+//! the upload declared, not the id a chat turn references, not the digest that
+//! proves the file is the one that was accepted. A sidecar is what makes
+//! `[[attachment:<id>]]` in a persisted turn resolvable back to a card after a
+//! reload. It is JSON at `attachments/<session>/manifest.json` rather than a
+//! redb table because the assistant home is deliberately human-browsable (see
+//! [`crate::assistants::home`]): a user opening that directory can read the
+//! manifest in the same editor they use for `instructions.md`.
+//!
+//! What: [`Attachment`] — the in-memory row, carrying the ABSOLUTE
+//! [`Attachment::stored_path`] callers need — and [`Manifest`], the on-disk
+//! document, which stores only the file's NAME inside the session directory.
+//! The home is the user's and they may move it; a manifest full of absolute
+//! paths would break the moment they did, while a name resolves against
+//! wherever the directory now lives.
+//!
+//! Concurrency: [`append`] takes an exclusive `fs4` advisory lock on the
+//! manifest for the whole read-modify-write, the same mechanism
+//! `crate::state_writer` and `crate::memory::code_store` use. Two uploads
+//! racing on one session therefore serialize instead of one silently
+//! overwriting the other's row.
+//!
+//! Test: `super::tests::manifest_tests`.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::error::AttachmentError;
+
+/// The manifest file's name inside a session directory.
+pub const MANIFEST_FILE: &str = "manifest.json";
+
+/// Schema version written into every manifest.
+const SCHEMA_VERSION: u32 = 1;
+
+/// One stored attachment, as callers see it.
+///
+/// Why: `stored_path` is absolute because every consumer — the download route,
+/// the model-input renderer, a test asserting where the file landed — needs a
+/// path it can open, and re-deriving one from a relative name at each call site
+/// is how two call sites end up disagreeing.
+/// What: a plain value; construction goes through [`Manifest::append`] or
+/// [`Manifest::rows`], never by hand outside this module's tests.
+/// Test: `super::tests::store_tests::store_writes_the_file_at_the_exact_path`.
+/// Deliberately NOT `Serialize`: `stored_path` is an absolute server path, and
+/// a derive here is all it would take for a route to hand it to a browser.
+/// Wire bodies are built field by field in `api::server::attachments`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attachment {
+    /// 32 lowercase hex characters, minted per upload.
+    pub id: String,
+    /// The chat session this attachment belongs to.
+    pub session_id: String,
+    /// The name the upload declared, after the single-segment guard.
+    pub file_name: String,
+    /// IANA media type, `application/octet-stream` when unknown.
+    pub media_type: String,
+    /// Byte length of the stored file.
+    pub size: u64,
+    /// Lowercase hex SHA-256 of the stored bytes.
+    pub sha256: String,
+    /// Absolute path the bytes were written to.
+    pub stored_path: PathBuf,
+}
+
+/// One row as it is written to disk.
+///
+/// Why separate from [`Attachment`]: see the module doc — the file records a
+/// NAME, never an absolute path, so the home stays movable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Row {
+    id: String,
+    file_name: String,
+    media_type: String,
+    size: u64,
+    sha256: String,
+    /// The file's name inside the session directory. Equal to `file_name`
+    /// except when a same-named file with different content already existed
+    /// (see `super::store`).
+    stored_name: String,
+    created_at: String,
+}
+
+/// The on-disk document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Document {
+    version: u32,
+    session_id: String,
+    attachments: Vec<Row>,
+}
+
+/// One session's manifest, bound to the directory that holds it.
+pub struct Manifest {
+    session_dir: PathBuf,
+    session_id: String,
+}
+
+impl Manifest {
+    /// Bind a manifest to an EXISTING, already-confined session directory.
+    ///
+    /// Why: confinement is [`super::AttachmentStore`]'s job and is done before
+    /// this type is constructed, so nothing here re-derives a path from
+    /// untrusted text.
+    /// Test: `super::tests::manifest_tests::append_then_rows_round_trips`.
+    pub fn at(session_dir: impl Into<PathBuf>, session_id: impl Into<String>) -> Self {
+        Self {
+            session_dir: session_dir.into(),
+            session_id: session_id.into(),
+        }
+    }
+
+    /// The manifest file's path.
+    pub fn path(&self) -> PathBuf {
+        self.session_dir.join(MANIFEST_FILE)
+    }
+
+    /// Every recorded attachment, oldest first.
+    ///
+    /// Why: `Ok(vec![])` for a session with no manifest yet — an empty session
+    /// and a broken one must not read the same, so a manifest that EXISTS but
+    /// does not decode is [`AttachmentError::Manifest`], never an empty list.
+    /// Test: `super::tests::manifest_tests::missing_manifest_reads_empty`,
+    /// `super::tests::manifest_tests::corrupt_manifest_is_an_error`.
+    pub fn rows(&self) -> Result<Vec<Attachment>, AttachmentError> {
+        let path = self.path();
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(source) => return Err(AttachmentError::Io { path, source }),
+        };
+        let document = self.decode(&raw, &path)?;
+        Ok(document
+            .attachments
+            .into_iter()
+            .map(|row| self.hydrate(row))
+            .collect())
+    }
+
+    /// The row with this id, or [`AttachmentError::NotFound`].
+    ///
+    /// Test: `super::tests::store_tests::get_rejects_an_unknown_id`.
+    pub fn get(&self, id: &str) -> Result<Attachment, AttachmentError> {
+        self.rows()?
+            .into_iter()
+            .find(|row| row.id == id)
+            .ok_or_else(|| AttachmentError::NotFound {
+                id: id.to_string(),
+                session: self.session_id.clone(),
+            })
+    }
+
+    /// Record one attachment under an exclusive lock on the manifest.
+    ///
+    /// Why: the read-modify-write has to be atomic against a second upload
+    /// into the same session, or one row silently replaces the other. The lock
+    /// is `fs4` advisory, matching `crate::state_writer`.
+    /// What: opens (creating) the manifest, locks it, decodes what is there,
+    /// appends the row, and rewrites the whole document in place. An id that
+    /// is already present REPLACES its row rather than duplicating it, so a
+    /// retried upload of the same id is idempotent.
+    /// Test: `super::tests::manifest_tests::append_then_rows_round_trips`,
+    /// `super::tests::manifest_tests::append_is_idempotent_on_one_id`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append(
+        &self,
+        id: &str,
+        file_name: &str,
+        media_type: &str,
+        size: u64,
+        sha256: &str,
+        stored_name: &str,
+        created_at: &str,
+    ) -> Result<Attachment, AttachmentError> {
+        let path = self.path();
+        let mut file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|source| AttachmentError::Io {
+                path: path.clone(),
+                source,
+            })?;
+        // fs4 1.0 renamed `lock_exclusive` to `lock`.
+        fs4::FileExt::lock(&file).map_err(|source| AttachmentError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        let result = self.append_locked(
+            &mut file,
+            &path,
+            Row {
+                id: id.to_string(),
+                file_name: file_name.to_string(),
+                media_type: media_type.to_string(),
+                size,
+                sha256: sha256.to_string(),
+                stored_name: stored_name.to_string(),
+                created_at: created_at.to_string(),
+            },
+        );
+        let _ = fs4::FileExt::unlock(&file);
+        result
+    }
+
+    /// The locked half of [`Self::append`], split out so the unlock above runs
+    /// on every path including an early error.
+    fn append_locked(
+        &self,
+        file: &mut File,
+        path: &Path,
+        row: Row,
+    ) -> Result<Attachment, AttachmentError> {
+        let mut raw = String::new();
+        file.read_to_string(&mut raw)
+            .map_err(|source| AttachmentError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        let mut document = self.decode(&raw, path)?;
+        document
+            .attachments
+            .retain(|existing| existing.id != row.id);
+        document.attachments.push(row.clone());
+        let encoded = serde_json::to_string_pretty(&document).map_err(|source| {
+            AttachmentError::Manifest {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+        let io = |source| AttachmentError::Io {
+            path: path.to_path_buf(),
+            source,
+        };
+        file.seek(SeekFrom::Start(0)).map_err(io)?;
+        file.set_len(0).map_err(io)?;
+        file.write_all(encoded.as_bytes()).map_err(io)?;
+        file.write_all(b"\n").map_err(io)?;
+        file.flush().map_err(io)?;
+        Ok(self.hydrate(row))
+    }
+
+    /// Decode a manifest body, treating an EMPTY file as a fresh session.
+    ///
+    /// Why: [`Self::append`] creates the file before it knows whether one
+    /// existed, so a first write always sees zero bytes. That is not corruption
+    /// — but a non-empty body that fails to parse is, and is reported.
+    fn decode(&self, raw: &str, path: &Path) -> Result<Document, AttachmentError> {
+        if raw.trim().is_empty() {
+            return Ok(Document {
+                version: SCHEMA_VERSION,
+                session_id: self.session_id.clone(),
+                attachments: Vec::new(),
+            });
+        }
+        serde_json::from_str(raw).map_err(|source| AttachmentError::Manifest {
+            path: path.to_path_buf(),
+            source,
+        })
+    }
+
+    /// Resolve a stored row's name against this session's directory.
+    fn hydrate(&self, row: Row) -> Attachment {
+        Attachment {
+            id: row.id,
+            session_id: self.session_id.clone(),
+            file_name: row.file_name,
+            media_type: row.media_type,
+            size: row.size,
+            sha256: row.sha256,
+            stored_path: self.session_dir.join(row.stored_name),
+        }
+    }
+}

--- a/crates/trusty-agents/src/attachments/manifest.rs
+++ b/crates/trusty-agents/src/attachments/manifest.rs
@@ -16,11 +16,16 @@
 //! paths would break the moment they did, while a name resolves against
 //! wherever the directory now lives.
 //!
-//! Concurrency: [`append`] takes an exclusive `fs4` advisory lock on the
-//! manifest for the whole read-modify-write, the same mechanism
-//! `crate::state_writer` and `crate::memory::code_store` use. Two uploads
-//! racing on one session therefore serialize instead of one silently
-//! overwriting the other's row.
+//! Concurrency: [`Manifest::lock`] takes an exclusive `fs4` advisory lock on
+//! the manifest, the same mechanism `crate::state_writer` and
+//! `crate::memory::code_store` use. The guard it returns is what lets
+//! `super::AttachmentStore::store` hold that lock across choosing a file name,
+//! writing the bytes AND recording the row — one critical section, so two
+//! uploads racing on one session serialize instead of one silently overwriting
+//! the other's file or row. The lock is therefore held across a `std::fs::write`
+//! of up to `super::MAX_ATTACHMENT_BYTES`; that is deliberate, and accepted —
+//! see #7370. [`Manifest::append`] is the shorthand for a caller with nothing
+//! else to do inside the section.
 //!
 //! Test: `super::tests::manifest_tests`.
 

--- a/crates/trusty-agents/src/attachments/mod.rs
+++ b/crates/trusty-agents/src/attachments/mod.rs
@@ -54,4 +54,7 @@ mod tests;
 
 pub use error::AttachmentError;
 pub use manifest::Attachment;
-pub use store::{AttachmentStore, FALLBACK_MEDIA_TYPE, MAX_ATTACHMENT_BYTES};
+pub use store::{
+    AttachmentStore, FALLBACK_MEDIA_TYPE, MAX_ATTACHMENT_BYTES, MAX_ATTACHMENTS_PER_TURN,
+    UploadedFile,
+};

--- a/crates/trusty-agents/src/attachments/mod.rs
+++ b/crates/trusty-agents/src/attachments/mod.rs
@@ -1,0 +1,57 @@
+//! Chat-thread attachments, stored under the assistant home (#7370).
+//!
+//! Why: a chat turn could carry only text. Dropping a CSV, a log file or a
+//! screenshot into the conversation meant pasting its contents inline, which
+//! loses the file's identity (name, type, size) and cannot survive a reload —
+//! the durable `chat_session` projection holds `{role, content}` strings and
+//! nothing else. Epic #7425 item (e) names the storage location verbatim:
+//! `<assistant home>/attachments/<session>/<file>`, a sibling of
+//! `<assistant home>/okg`, which [`crate::assistants::AssistantHome`] has
+//! already reserved as [`crate::assistants::ATTACHMENTS_DIR`].
+//!
+//! What: three cooperating pieces, all synchronous and filesystem-only.
+//!   - [`Attachment`] is one stored file's row: id, session, original name,
+//!     media type, byte size, SHA-256, and the absolute path it landed at.
+//!   - [`AttachmentStore`] owns the directory. It CONFINES every path it
+//!     builds inside the attachments root and returns an error rather than
+//!     substituting a name — the same contract
+//!     [`crate::assistants::AssistantHome::store_root`] holds, for the same
+//!     reason: a silently-renamed target writes the user's file somewhere they
+//!     will never look for it, and a silently-accepted `..` writes it
+//!     somewhere they never agreed to.
+//!   - [`model_input`] turns stored rows into the text a turn hands the model,
+//!     and reads the `[[attachment:<id>]]` markers back out of a persisted
+//!     turn so a reload can rebuild the cards.
+//!
+//! Chat messages stay `{role, content: String}`. This module deliberately does
+//! NOT widen `trusty_common::ChatMessage` or
+//! `trusty_agents_common::HistoryMessage`: an attached turn embeds one
+//! [`model_input::marker_for`] line per attachment inside the ordinary content
+//! string, so every existing reader — the persistence path, the history route,
+//! the REPL — keeps working byte-for-byte on a turn that carries no
+//! attachments, and a turn that does carries its references in-band.
+//!
+//! Scope: storage and rendering. This module performs no HTTP, no provider
+//! negotiation, and no vision/multipart content arrays — a binary attachment
+//! reaches the model as a one-line reference (see [`model_input`]), because the
+//! prompt assembly path builds `.content(String)` and this slice does not
+//! change that.
+//!
+//! The manifest is JSON, not redb, because the assistant home is deliberately
+//! human-browsable (see [`crate::assistants::home`]'s module doc): a user who
+//! opens `attachments/<session>/` must be able to read what is there without
+//! this binary. See [`manifest`] for the file's shape and its locking.
+//!
+//! Test: `tests` — the whole module.
+
+mod error;
+pub mod manifest;
+pub mod model_input;
+mod store;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::AttachmentError;
+pub use manifest::Attachment;
+pub use store::{AttachmentStore, FALLBACK_MEDIA_TYPE, MAX_ATTACHMENT_BYTES};

--- a/crates/trusty-agents/src/attachments/model_input.rs
+++ b/crates/trusty-agents/src/attachments/model_input.rs
@@ -97,11 +97,12 @@ pub fn render(attachment: &Attachment, bytes: &[u8]) -> String {
         return format!("{header} — binary attachment; its contents are not included.");
     }
     let (text, truncated) = decode_capped(bytes, MAX_INLINE_TEXT_BYTES);
-    let fence = if attachment.media_type == "text/csv" {
+    let language = if attachment.media_type == "text/csv" {
         "csv"
     } else {
         "text"
     };
+    let fence = fence_for(&text);
     let note = if truncated {
         format!(
             "\n[truncated: the first {} of {} bytes are shown]",
@@ -111,7 +112,33 @@ pub fn render(attachment: &Attachment, bytes: &[u8]) -> String {
     } else {
         String::new()
     };
-    format!("{header}\n```{fence}\n{text}{note}\n```")
+    format!("{header}\n{fence}{language}\n{text}{note}\n{fence}")
+}
+
+/// The fence that can hold `content` without it breaking out.
+///
+/// Why: an attachment is arbitrary text, and a Markdown file or a code listing
+/// routinely contains a fence of its own. A fixed three-backtick fence ends at
+/// the file's first one, and the rest of the file is then read as prose - the
+/// model sees a truncated attachment and instructions that were never given to
+/// it. CommonMark ends a fenced block only at a run of AT LEAST as many
+/// backticks as opened it, so opening with one more than the longest run
+/// inside makes the content unable to close it.
+/// What: a run of `max(longest run in content, 2) + 1` backticks - three for
+/// ordinary content, four for content holding a three-backtick run, and so on.
+/// Test: `super::tests::model_input_tests::a_fence_inside_the_content_cannot_break_out`.
+fn fence_for(content: &str) -> String {
+    let mut run = 0usize;
+    let mut longest = 0usize;
+    for byte in content.bytes() {
+        if byte == b'`' {
+            run += 1;
+            longest = longest.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    "`".repeat(longest.max(2) + 1)
 }
 
 /// Join the user's own text to the rendered attachment blocks.

--- a/crates/trusty-agents/src/attachments/model_input.rs
+++ b/crates/trusty-agents/src/attachments/model_input.rs
@@ -54,7 +54,7 @@ pub fn marker_for(id: &str) -> String {
 /// that happens to contain the delimiters cannot make a reload go looking for
 /// an attachment that was never stored.
 /// What: scans for `[[attachment:` … `]]` pairs and keeps the payloads that
-/// pass [`is_attachment_id`], preserving first-seen order.
+/// pass the `is_attachment_id` shape check, preserving first-seen order.
 /// Test: `super::tests::model_input_tests::markers_round_trip`,
 /// `super::tests::model_input_tests::parse_ignores_malformed_markers`.
 pub fn parse_markers(content: &str) -> Vec<String> {

--- a/crates/trusty-agents/src/attachments/model_input.rs
+++ b/crates/trusty-agents/src/attachments/model_input.rs
@@ -1,0 +1,170 @@
+//! What an attached turn says to the model, and how a reload reads it back (#7370).
+//!
+//! Why: the prompt assembly path builds a plain `.content(String)` for the user
+//! turn (`ctrl::pm_task::dispatch::persona_prompt`), and this slice deliberately
+//! does not change that — no provider vision payloads, no multipart content
+//! arrays. So an attachment reaches the model the only way a string can carry
+//! it: text and CSV as their own contents under a fenced block, everything else
+//! as a one-line reference naming what was attached. A binary file described
+//! rather than inlined is honest; base64 in the prompt would be neither
+//! readable by the model nor affordable.
+//!
+//! One string serves both consumers. The turn that is persisted is the turn the
+//! model saw — the same bytes, not a summary of them — because the prior
+//! attempt on this issue was blocked precisely for letting the persisted
+//! history and the delivered turn diverge. Rehydration then needs no second
+//! source of truth: [`parse_markers`] reads the ids back out of the stored
+//! content and the cards are rebuilt from the manifest.
+//!
+//! What: [`marker_for`] / [`parse_markers`] own the `[[attachment:<id>]]`
+//! marker; [`render`] turns one row plus its bytes into the block that follows
+//! its marker; [`augment_user_turn`] joins the user's own text to those blocks.
+//!
+//! Test: `super::tests::model_input_tests`.
+
+use super::manifest::Attachment;
+use super::store::is_attachment_id;
+
+/// Opening delimiter of the in-content attachment marker.
+pub const MARKER_OPEN: &str = "[[attachment:";
+/// Closing delimiter of the in-content attachment marker.
+pub const MARKER_CLOSE: &str = "]]";
+
+/// Most bytes of a text or CSV attachment inlined into one turn (32 KiB).
+///
+/// Why: the turn is persisted and replayed as conversation history on EVERY
+/// later turn in the session, so an inlined file is paid for repeatedly, not
+/// once. 32 KiB is roughly 8k tokens — enough for a spreadsheet export or a log
+/// excerpt to be answered about, small enough that a session carrying several
+/// does not crowd out the conversation itself.
+/// Test: `super::tests::model_input_tests::text_is_capped_with_a_truncation_note`.
+pub const MAX_INLINE_TEXT_BYTES: usize = 32 * 1024;
+
+/// The marker that refers to `id` from inside a turn's content.
+///
+/// Test: `super::tests::model_input_tests::markers_round_trip`.
+pub fn marker_for(id: &str) -> String {
+    format!("{MARKER_OPEN}{id}{MARKER_CLOSE}")
+}
+
+/// Every attachment id referenced by `content`, in order, without repeats.
+///
+/// Why: rehydration reads the persisted turn and has to know which cards to
+/// rebuild. Ids are SHAPE-checked here rather than trusted, so ordinary prose
+/// that happens to contain the delimiters cannot make a reload go looking for
+/// an attachment that was never stored.
+/// What: scans for `[[attachment:` … `]]` pairs and keeps the payloads that
+/// pass [`is_attachment_id`], preserving first-seen order.
+/// Test: `super::tests::model_input_tests::markers_round_trip`,
+/// `super::tests::model_input_tests::parse_ignores_malformed_markers`.
+pub fn parse_markers(content: &str) -> Vec<String> {
+    let mut found: Vec<String> = Vec::new();
+    let mut rest = content;
+    while let Some(open) = rest.find(MARKER_OPEN) {
+        let after = &rest[open + MARKER_OPEN.len()..];
+        let Some(close) = after.find(MARKER_CLOSE) else {
+            break;
+        };
+        let candidate = &after[..close];
+        if is_attachment_id(candidate) && !found.iter().any(|seen| seen == candidate) {
+            found.push(candidate.to_string());
+        }
+        rest = &after[close + MARKER_CLOSE.len()..];
+    }
+    found
+}
+
+/// The block one attachment contributes to the user turn.
+///
+/// Why: the marker has to be present whatever the media type, because it is
+/// what a reload resolves the card from. Only the BODY differs — inlined
+/// contents for text, a description for everything else.
+/// What: for a text media type, the marker line, a header naming the file, and
+/// a fenced block holding up to [`MAX_INLINE_TEXT_BYTES`] of the decoded
+/// contents with an explicit truncation note when it did not all fit. For any
+/// other media type, the marker line and a single reference line — name, media
+/// type, size — and nothing else.
+/// Test: `super::tests::model_input_tests::text_is_inlined_under_a_fence`,
+/// `super::tests::model_input_tests::binary_is_one_reference_line`,
+/// `super::tests::model_input_tests::text_is_capped_with_a_truncation_note`.
+pub fn render(attachment: &Attachment, bytes: &[u8]) -> String {
+    let marker = marker_for(&attachment.id);
+    let header = format!(
+        "{marker} {} ({}, {} bytes)",
+        attachment.file_name, attachment.media_type, attachment.size
+    );
+    if !is_inlinable_text(&attachment.media_type) {
+        return format!("{header} — binary attachment; its contents are not included.");
+    }
+    let (text, truncated) = decode_capped(bytes, MAX_INLINE_TEXT_BYTES);
+    let fence = if attachment.media_type == "text/csv" {
+        "csv"
+    } else {
+        "text"
+    };
+    let note = if truncated {
+        format!(
+            "\n[truncated: the first {} of {} bytes are shown]",
+            text.len(),
+            bytes.len()
+        )
+    } else {
+        String::new()
+    };
+    format!("{header}\n```{fence}\n{text}{note}\n```")
+}
+
+/// Join the user's own text to the rendered attachment blocks.
+///
+/// Why: the user's words come FIRST so the instruction is not buried under a
+/// spreadsheet, and the blocks are blank-line separated so a model reading the
+/// turn sees them as distinct attachments rather than one run-on document.
+/// What: `user_text` verbatim when `blocks` is empty — a turn with no
+/// attachments is byte-identical to what it was before this feature existed.
+/// Test: `super::tests::model_input_tests::no_attachments_leaves_the_turn_untouched`,
+/// `super::tests::model_input_tests::blocks_follow_the_users_text`.
+pub fn augment_user_turn(user_text: &str, blocks: &[String]) -> String {
+    if blocks.is_empty() {
+        return user_text.to_string();
+    }
+    let joined = blocks.join("\n\n");
+    if user_text.trim().is_empty() {
+        return joined;
+    }
+    format!("{}\n\n{joined}", user_text.trim_end())
+}
+
+/// Whether a media type's bytes are worth inlining as text.
+///
+/// Why: `text/*` covers plain text, CSV, Markdown and HTML. The three
+/// structured formats below are textual in practice and are what an assistant
+/// is most often handed next to a CSV, so they are named rather than left to
+/// the binary path. Public because the caller assembling a turn asks this
+/// BEFORE reading a file — a 10 MiB binary that will be rendered as one
+/// reference line must not be loaded into memory to produce it.
+/// Test: `super::tests::model_input_tests::binary_is_one_reference_line`.
+pub fn is_inlinable_text(media_type: &str) -> bool {
+    media_type.starts_with("text/")
+        || matches!(
+            media_type,
+            "application/json" | "application/xml" | "application/x-ndjson"
+        )
+}
+
+/// Decode `bytes` as UTF-8, truncated to at most `cap` bytes.
+///
+/// Why: the cap is in BYTES (it is a prompt-size budget) but the result must be
+/// valid UTF-8, so the cut is walked back to a character boundary rather than
+/// taken blind. `from_utf8_lossy` handles a file that was never UTF-8 at all.
+/// What: `(text, truncated)`.
+fn decode_capped(bytes: &[u8], cap: usize) -> (String, bool) {
+    if bytes.len() <= cap {
+        return (String::from_utf8_lossy(bytes).into_owned(), false);
+    }
+    let text = String::from_utf8_lossy(bytes).into_owned();
+    let mut end = cap.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (text[..end].to_string(), true)
+}

--- a/crates/trusty-agents/src/attachments/store.rs
+++ b/crates/trusty-agents/src/attachments/store.rs
@@ -138,16 +138,26 @@ impl AttachmentStore {
             path: session_dir.clone(),
             source,
         })?;
+
+        // #7370: ONE critical section covers choosing the name, writing the
+        // bytes and recording the row. Choosing the name outside it let two
+        // concurrent uploads of the same name both pick the unsuffixed one;
+        // the second then skipped its write on `!target.exists()` and recorded
+        // a row whose digest and size described bytes that were never on disk.
+        let manifest = Manifest::at(&session_dir, session_id);
+        let mut guard = manifest.lock()?;
         let stored_name = self.reserve_name(&session_dir, &name, &id, bytes, &digest)?;
         let target = session_dir.join(&stored_name);
-        if !target.exists() {
+        let wrote = !target.exists();
+        if wrote {
             std::fs::write(&target, bytes).map_err(|source| AttachmentError::Io {
                 path: target.clone(),
                 source,
             })?;
         }
 
-        Manifest::at(&session_dir, session_id).append(
+        match manifest.append_with(
+            &mut guard,
             &id,
             &name,
             &media_type,
@@ -155,7 +165,23 @@ impl AttachmentStore {
             &digest,
             &stored_name,
             &chrono::Utc::now().to_rfc3339(),
-        )
+        ) {
+            Ok(row) => Ok(row),
+            Err(e) => {
+                // #7370: a file no row refers to is unreachable and invisible —
+                // it would sit in the user's home forever. Removed only when
+                // THIS call created it, so a retry that reused an existing
+                // identical file cannot delete what another row still names.
+                if wrote && let Err(removal) = std::fs::remove_file(&target) {
+                    tracing::warn!(
+                        path = %target.display(),
+                        error = %removal,
+                        "attachments: could not remove the orphaned file left by a failed manifest write"
+                    );
+                }
+                Err(e)
+            }
+        }
     }
 
     /// Every attachment recorded for a session, oldest first.
@@ -190,8 +216,16 @@ impl AttachmentStore {
         id: &str,
     ) -> Result<(Attachment, Vec<u8>), AttachmentError> {
         let row = self.get(session_id, id)?;
-        let bytes = match std::fs::read(&row.stored_path) {
-            Ok(bytes) => bytes,
+        let session_dir = self.session_dir(session_id)?;
+        // #7370: the second half of the confinement, and it runs BEFORE a byte
+        // is read. `Manifest::hydrate` already refuses a stored name that is
+        // not one ordinary segment; this catches what a name check cannot — a
+        // SYMLINK sitting inside the session directory under an innocent name.
+        // Both sides are canonicalized, because the session directory itself
+        // routinely contains symlinks (`/var` on macOS) and comparing a
+        // resolved path against an unresolved base would refuse every read.
+        let real = match row.stored_path.canonicalize() {
+            Ok(real) => real,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 return Err(AttachmentError::MissingFile {
                     id: row.id,
@@ -205,6 +239,23 @@ impl AttachmentStore {
                 });
             }
         };
+        let base = session_dir
+            .canonicalize()
+            .map_err(|source| AttachmentError::Io {
+                path: session_dir.clone(),
+                source,
+            })?;
+        if !real.starts_with(&base) {
+            return Err(AttachmentError::TamperedManifest {
+                path: row.stored_path,
+                id: row.id,
+                reason: "it resolves outside the session directory".to_string(),
+            });
+        }
+        let bytes = std::fs::read(&real).map_err(|source| AttachmentError::Io {
+            path: real.clone(),
+            source,
+        })?;
         Ok((row, bytes))
     }
 
@@ -280,7 +331,7 @@ pub fn is_attachment_id(id: &str) -> bool {
 /// Test: `super::tests::store_tests::traversal_file_name_writes_nothing`,
 /// `super::tests::store_tests::session_traversal_is_refused`,
 /// `super::tests::store_tests::absolute_file_name_is_refused`.
-fn single_segment(raw: &str) -> Result<String, String> {
+pub(super) fn single_segment(raw: &str) -> Result<String, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err("it is empty".to_string());

--- a/crates/trusty-agents/src/attachments/store.rs
+++ b/crates/trusty-agents/src/attachments/store.rs
@@ -44,6 +44,33 @@ pub const MAX_ATTACHMENT_BYTES: u64 = 10 * 1024 * 1024;
 /// The media type used when nothing better can be determined.
 pub const FALLBACK_MEDIA_TYPE: &str = "application/octet-stream";
 
+/// Most attachments one turn may carry, and so most files one upload accepts.
+///
+/// Why: each attachment is rendered into the turn and then replayed as
+/// conversation history on every later turn in the session, so the cost is paid
+/// repeatedly. The upload route and `api::server::handlers::submit_task` read
+/// the SAME constant, because a request that may stage more files than a turn
+/// may reference would accept work that can never be used.
+/// Test: `super::tests::store_tests::store_all_refuses_more_than_the_cap`,
+/// `crate::api::server::tests::attachments::send_refuses_too_many_attachments`.
+pub const MAX_ATTACHMENTS_PER_TURN: usize = 8;
+
+/// One file as it arrived, before any guard has looked at it.
+///
+/// Why: [`AttachmentStore::store_all`] has to see every file in a request
+/// BEFORE it writes any of them, so a batch cannot half-apply on a name or a
+/// size the caller could have fixed. Carrying them as values is what makes that
+/// two-pass shape possible.
+#[derive(Debug, Clone)]
+pub struct UploadedFile {
+    /// The name the upload declared. Not yet checked.
+    pub file_name: String,
+    /// The part's declared content type, if it carried one.
+    pub media_type: Option<String>,
+    /// The file's bytes.
+    pub bytes: Vec<u8>,
+}
+
 /// One assistant's attachments tree.
 pub struct AttachmentStore {
     root: PathBuf,
@@ -100,7 +127,7 @@ impl AttachmentStore {
     /// requirement 2 of #7370 ("no partial file left").
     /// What: validates the session id and the file name, enforces
     /// [`MAX_ATTACHMENT_BYTES`], resolves the media type (see
-    /// [`resolve_media_type`]), writes the bytes, and records the row. A file
+    /// `resolve_media_type`), writes the bytes, and records the row. A file
     /// of that name already holding IDENTICAL bytes is reused rather than
     /// rewritten; one holding different bytes is left alone and the new file
     /// lands at `<stem>.<id prefix><ext>` — never clobbered, never silently
@@ -182,6 +209,66 @@ impl AttachmentStore {
                 Err(e)
             }
         }
+    }
+
+    /// Store every file in one request, or none of them.
+    ///
+    /// Why (#7370): a multi-file upload used to keep only the first file and
+    /// discard the rest silently — the user saw one card where they dropped
+    /// three, and nothing said why. Accepting all of them raises a second
+    /// question this answers too: a batch must not HALF apply. Every name and
+    /// size is checked before a single byte is written, so the two refusals a
+    /// caller can act on — a bad name, an oversize file — leave the tree
+    /// exactly as it was.
+    /// What: `Err` on the first guard failure with nothing written; otherwise
+    /// one row per file, in request order. The honest limit: a filesystem
+    /// failure PART WAY through the writing pass leaves the files already
+    /// written in place. They are recorded rows, not orphans — reachable,
+    /// listable and deletable — so this is a partial success, never silent
+    /// corruption.
+    /// Test: `super::tests::store_tests::store_all_writes_every_file`,
+    /// `super::tests::store_tests::store_all_writes_nothing_when_one_name_is_bad`,
+    /// `super::tests::store_tests::store_all_refuses_more_than_the_cap`.
+    pub fn store_all(
+        &self,
+        session_id: &str,
+        files: &[UploadedFile],
+    ) -> Result<Vec<Attachment>, AttachmentError> {
+        self.session_dir(session_id)?;
+        if files.len() > MAX_ATTACHMENTS_PER_TURN {
+            return Err(AttachmentError::TooManyFiles {
+                count: files.len(),
+                cap: MAX_ATTACHMENTS_PER_TURN,
+            });
+        }
+        // Pass one: every guard that can refuse on the caller's own input, with
+        // nothing created yet.
+        for file in files {
+            single_segment(&file.file_name).map_err(|reason| AttachmentError::UnsafeFileName {
+                name: file.file_name.clone(),
+                reason,
+            })?;
+            let size = file.bytes.len() as u64;
+            if size > self.max_bytes {
+                return Err(AttachmentError::TooLarge {
+                    name: file.file_name.clone(),
+                    size,
+                    cap: self.max_bytes,
+                });
+            }
+        }
+        // Pass two: the writes, each through the single write path.
+        files
+            .iter()
+            .map(|file| {
+                self.store(
+                    session_id,
+                    &file.file_name,
+                    file.media_type.as_deref(),
+                    &file.bytes,
+                )
+            })
+            .collect()
     }
 
     /// Every attachment recorded for a session, oldest first.

--- a/crates/trusty-agents/src/attachments/store.rs
+++ b/crates/trusty-agents/src/attachments/store.rs
@@ -1,0 +1,339 @@
+//! The attachments directory, and every guard that stands in front of it (#7370).
+//!
+//! Why: an upload names its own file, and a chat client names its own session.
+//! Both strings are attacker-reachable, and both are used to BUILD A PATH. The
+//! contract here is the one
+//! [`crate::assistants::AssistantHome::store_root`] already holds for store
+//! roots: a name that is not a single ordinary path segment is REFUSED, never
+//! repaired. Substituting a safe name would write the user's file somewhere
+//! they will never look for it while reporting success — worse than the
+//! refusal, because nothing surfaces.
+//!
+//! What: [`AttachmentStore`] resolves `<root>/<session>/<file>`, writes the
+//! bytes, digests them, and records the row through
+//! [`super::manifest::Manifest`]. Reads go back through the manifest, never
+//! through a path the caller supplied — an id is looked up, and the path comes
+//! from the row. That is what keeps the download route from being a static
+//! file mount with a traversal hole in it.
+//!
+//! Size: [`MAX_ATTACHMENT_BYTES`] is checked BEFORE anything is created, so a
+//! rejected upload leaves no partial file behind. The HTTP layer additionally
+//! bounds the request body, so an oversize payload is refused twice — once by
+//! the transport and once here, where the constant lives.
+//!
+//! Test: `super::tests::store_tests`.
+
+use std::path::{Component, Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use super::error::AttachmentError;
+use super::manifest::{Attachment, Manifest};
+use crate::assistants::AssistantHome;
+
+/// Largest attachment this store accepts, in bytes (10 MiB).
+///
+/// Why: an assistant home is the user's own directory, and a chat thread is
+/// not a file server — the cap is sized for the documents, spreadsheets, logs
+/// and screenshots a conversation actually carries, not for archives. It is
+/// named here so the HTTP body limit can be derived from it rather than
+/// drifting from it.
+/// Test: `super::tests::store_tests::store_rejects_an_oversize_payload`.
+pub const MAX_ATTACHMENT_BYTES: u64 = 10 * 1024 * 1024;
+
+/// The media type used when nothing better can be determined.
+pub const FALLBACK_MEDIA_TYPE: &str = "application/octet-stream";
+
+/// One assistant's attachments tree.
+pub struct AttachmentStore {
+    root: PathBuf,
+    max_bytes: u64,
+}
+
+impl AttachmentStore {
+    /// A store rooted at an attachments directory.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: root.into(),
+            max_bytes: MAX_ATTACHMENT_BYTES,
+        }
+    }
+
+    /// The store for an assistant's home — `<home>/attachments`.
+    ///
+    /// Why: the path is [`AssistantHome::attachments_dir`]'s to own, so this
+    /// never rebuilds it from the constant.
+    pub fn for_home(home: &AssistantHome) -> Self {
+        Self::new(home.attachments_dir())
+    }
+
+    /// Override the size cap. Tests only — production uses
+    /// [`MAX_ATTACHMENT_BYTES`].
+    #[cfg(test)]
+    pub fn with_max_bytes(mut self, max_bytes: u64) -> Self {
+        self.max_bytes = max_bytes;
+        self
+    }
+
+    /// The attachments root this store writes under.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// `<root>/<session>`, refusing anything that is not one path segment.
+    ///
+    /// Why: see the module doc — refuse, never repair.
+    /// Test: `super::tests::store_tests::session_traversal_is_refused`.
+    pub fn session_dir(&self, session_id: &str) -> Result<PathBuf, AttachmentError> {
+        let segment =
+            single_segment(session_id).map_err(|reason| AttachmentError::UnsafeSessionId {
+                session: session_id.to_string(),
+                reason,
+            })?;
+        Ok(self.root.join(segment))
+    }
+
+    /// Store `bytes` for `session_id` under `file_name`.
+    ///
+    /// Why: this is the one write path. Every guard runs before a directory or
+    /// a file is created, so a refusal leaves the tree exactly as it was —
+    /// requirement 2 of #7370 ("no partial file left").
+    /// What: validates the session id and the file name, enforces
+    /// [`MAX_ATTACHMENT_BYTES`], resolves the media type (see
+    /// [`resolve_media_type`]), writes the bytes, and records the row. A file
+    /// of that name already holding IDENTICAL bytes is reused rather than
+    /// rewritten; one holding different bytes is left alone and the new file
+    /// lands at `<stem>.<id prefix><ext>` — never clobbered, never silently
+    /// merged.
+    /// Test: `super::tests::store_tests::store_writes_the_file_at_the_exact_path`,
+    /// `super::tests::store_tests::traversal_file_name_writes_nothing`,
+    /// `super::tests::store_tests::store_rejects_an_oversize_payload`,
+    /// `super::tests::store_tests::same_name_different_bytes_does_not_clobber`.
+    pub fn store(
+        &self,
+        session_id: &str,
+        file_name: &str,
+        declared_media_type: Option<&str>,
+        bytes: &[u8],
+    ) -> Result<Attachment, AttachmentError> {
+        let session_dir = self.session_dir(session_id)?;
+        let name = single_segment(file_name).map_err(|reason| AttachmentError::UnsafeFileName {
+            name: file_name.to_string(),
+            reason,
+        })?;
+        let size = bytes.len() as u64;
+        if size > self.max_bytes {
+            return Err(AttachmentError::TooLarge {
+                name: name.clone(),
+                size,
+                cap: self.max_bytes,
+            });
+        }
+
+        let id = uuid::Uuid::new_v4().simple().to_string();
+        let digest = hex_digest(bytes);
+        let media_type = resolve_media_type(&name, declared_media_type);
+
+        std::fs::create_dir_all(&session_dir).map_err(|source| AttachmentError::Io {
+            path: session_dir.clone(),
+            source,
+        })?;
+        let stored_name = self.reserve_name(&session_dir, &name, &id, bytes, &digest)?;
+        let target = session_dir.join(&stored_name);
+        if !target.exists() {
+            std::fs::write(&target, bytes).map_err(|source| AttachmentError::Io {
+                path: target.clone(),
+                source,
+            })?;
+        }
+
+        Manifest::at(&session_dir, session_id).append(
+            &id,
+            &name,
+            &media_type,
+            size,
+            &digest,
+            &stored_name,
+            &chrono::Utc::now().to_rfc3339(),
+        )
+    }
+
+    /// Every attachment recorded for a session, oldest first.
+    ///
+    /// Test: `super::tests::store_tests::list_returns_what_was_stored`.
+    pub fn list(&self, session_id: &str) -> Result<Vec<Attachment>, AttachmentError> {
+        let session_dir = self.session_dir(session_id)?;
+        Manifest::at(&session_dir, session_id).rows()
+    }
+
+    /// One attachment's row, by id.
+    ///
+    /// Why: the id is validated for SHAPE before it is compared, so a
+    /// path-shaped id is refused as an id rather than searched for.
+    /// Test: `super::tests::store_tests::get_rejects_an_unknown_id`.
+    pub fn get(&self, session_id: &str, id: &str) -> Result<Attachment, AttachmentError> {
+        if !is_attachment_id(id) {
+            return Err(AttachmentError::InvalidId(id.to_string()));
+        }
+        let session_dir = self.session_dir(session_id)?;
+        Manifest::at(&session_dir, session_id).get(id)
+    }
+
+    /// One attachment's row AND its bytes.
+    ///
+    /// Why: the path opened is the manifest's, never the caller's — the
+    /// property that keeps the download route from being a file mount.
+    /// Test: `super::tests::store_tests::read_returns_the_stored_bytes`.
+    pub fn read(
+        &self,
+        session_id: &str,
+        id: &str,
+    ) -> Result<(Attachment, Vec<u8>), AttachmentError> {
+        let row = self.get(session_id, id)?;
+        let bytes = match std::fs::read(&row.stored_path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(AttachmentError::MissingFile {
+                    id: row.id,
+                    path: row.stored_path,
+                });
+            }
+            Err(source) => {
+                return Err(AttachmentError::Io {
+                    path: row.stored_path,
+                    source,
+                });
+            }
+        };
+        Ok((row, bytes))
+    }
+
+    /// Pick the name the bytes will live under.
+    ///
+    /// Why: two uploads can name the same file. Overwriting the first would
+    /// silently change what an earlier turn's marker resolves to, which is the
+    /// same class of defect as a renamed target: a reference that now points at
+    /// content nobody agreed to. Identical bytes are the one safe case — the
+    /// file already IS the upload — so they are reused.
+    /// What: `name` when free or already byte-identical; otherwise
+    /// `<stem>.<first 8 of id><ext>`.
+    fn reserve_name(
+        &self,
+        session_dir: &Path,
+        name: &str,
+        id: &str,
+        bytes: &[u8],
+        digest: &str,
+    ) -> Result<String, AttachmentError> {
+        let target = session_dir.join(name);
+        match std::fs::read(&target) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(name.to_string()),
+            Err(source) => {
+                return Err(AttachmentError::Io {
+                    path: target,
+                    source,
+                });
+            }
+            Ok(existing) => {
+                if existing.len() == bytes.len() && hex_digest(&existing) == digest {
+                    return Ok(name.to_string());
+                }
+            }
+        }
+        let short = &id[..8];
+        let path = Path::new(name);
+        Ok(match (path.file_stem(), path.extension()) {
+            (Some(stem), Some(ext)) => format!(
+                "{}.{short}.{}",
+                stem.to_string_lossy(),
+                ext.to_string_lossy()
+            ),
+            _ => format!("{name}.{short}"),
+        })
+    }
+}
+
+/// Lowercase hex SHA-256 of `bytes`.
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Whether `id` has the shape this module mints — 32 lowercase hex characters.
+///
+/// Test: `super::tests::store_tests::get_rejects_an_unknown_id`.
+pub fn is_attachment_id(id: &str) -> bool {
+    id.len() == 32 && id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// Accept `raw` only if it is exactly one ordinary path segment.
+///
+/// Why: this is the whole traversal guard. It rejects rather than sanitizes —
+/// see the module doc — and it rejects on the RAW string as well as on the
+/// parsed components, because a name can be a single component on one platform
+/// and a separator on another (`a\b` is one segment on unix, two on Windows).
+/// What: `Err(reason)` for an empty name, one containing a `/`, `\`, NUL or any
+/// other control character, for `.` and `..`, and for anything whose
+/// [`Path::components`] is not exactly one [`Component::Normal`] equal to the
+/// input. `Ok(name)` otherwise.
+/// Test: `super::tests::store_tests::traversal_file_name_writes_nothing`,
+/// `super::tests::store_tests::session_traversal_is_refused`,
+/// `super::tests::store_tests::absolute_file_name_is_refused`.
+fn single_segment(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("it is empty".to_string());
+    }
+    if trimmed.len() > 255 {
+        return Err("it is longer than 255 bytes".to_string());
+    }
+    if trimmed.contains(['/', '\\']) {
+        return Err("it contains a path separator; a name must be one path segment".to_string());
+    }
+    if trimmed.chars().any(char::is_control) {
+        return Err("it contains a control character".to_string());
+    }
+    let mut components = Path::new(trimmed).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(only)), None) if only == std::ffi::OsStr::new(trimmed) => {
+            Ok(trimmed.to_string())
+        }
+        (Some(Component::ParentDir), _) => {
+            Err("it climbs out of the attachments directory with `..`".to_string())
+        }
+        (Some(Component::RootDir | Component::Prefix(_)), _) => {
+            Err("it is an absolute path; a name is relative to its session".to_string())
+        }
+        _ => Err("it is not a single ordinary path segment".to_string()),
+    }
+}
+
+/// The media type to record for `file_name`.
+///
+/// Why: #7370 requires an unknown type to be stored as
+/// [`FALLBACK_MEDIA_TYPE`], never guessed at from the client's word alone. The
+/// extension is the more trustworthy of the two signals — a browser sends
+/// whatever the OS told it, and a scripted upload sends whatever it likes — so
+/// the guess wins, and the declared value is consulted only when there is no
+/// guess to be had.
+/// What: `mime_guess` from the extension; otherwise a well-formed declared
+/// `type/subtype`; otherwise [`FALLBACK_MEDIA_TYPE`].
+/// Test: `super::tests::store_tests::media_type_prefers_the_extension`,
+/// `super::tests::store_tests::unknown_media_type_becomes_octet_stream`.
+fn resolve_media_type(file_name: &str, declared: Option<&str>) -> String {
+    if let Some(guess) = mime_guess::from_path(file_name).first() {
+        return guess.essence_str().to_string();
+    }
+    let declared = declared.map(str::trim).unwrap_or_default();
+    let essence = declared.split(';').next().unwrap_or_default().trim();
+    let well_formed = essence.split('/').count() == 2
+        && essence
+            .split('/')
+            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_graphic()))
+        && !essence.contains(['\\', '"']);
+    if well_formed && essence != FALLBACK_MEDIA_TYPE {
+        return essence.to_ascii_lowercase();
+    }
+    FALLBACK_MEDIA_TYPE.to_string()
+}

--- a/crates/trusty-agents/src/attachments/tests/isolation_tests.rs
+++ b/crates/trusty-agents/src/attachments/tests/isolation_tests.rs
@@ -1,0 +1,96 @@
+//! The attachments tree is never an index root (#7370, requirement 5).
+//!
+//! Why: `<home>/attachments` holds whatever a user dropped into a chat — a
+//! contract, a payroll export, a screenshot of a password manager. The OKG
+//! tree at `<home>/okg` is indexed and semantically searchable. If the two ever
+//! converged, every attachment would silently become retrievable knowledge, and
+//! no error would say so. These tests pin the separation from both ends: the
+//! knowledge module's default root, and the absence of any call path that hands
+//! `attachments_dir()` to an indexer.
+
+use crate::assistants::{AssistantHome, AssistantInstanceId};
+use crate::knowledge::KnowledgeStore;
+use chrono::{TimeZone, Utc};
+
+/// The knowledge store's protected root is `okg`, and `attachments` is its
+/// SIBLING — neither contains the other, so an index walk rooted at one can
+/// never reach the other.
+///
+/// Pins `knowledge/mod.rs`'s `root: self.home.okg_dir()`.
+#[test]
+fn the_protected_index_root_is_okg_not_attachments() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = AssistantHome::under(
+        temp.path().canonicalize().unwrap(),
+        AssistantInstanceId::new("test-assistant").unwrap(),
+    );
+    let attachments = home.attachments_dir();
+    let okg = home.okg_dir();
+    let store = KnowledgeStore::new(AssistantHome::under(
+        temp.path().canonicalize().unwrap(),
+        AssistantInstanceId::new("test-assistant").unwrap(),
+    ));
+
+    let state = store
+        .initialize(Utc.with_ymd_and_hms(2026, 9, 11, 12, 0, 0).unwrap(), None)
+        .unwrap();
+
+    assert_eq!(state.store.root, okg);
+    assert_ne!(state.store.root, attachments);
+    assert!(!attachments.starts_with(&okg));
+    assert!(!okg.starts_with(&attachments));
+}
+
+/// No source line in this crate hands `attachments_dir()` to an indexer.
+///
+/// Why: the structural test above pins today's default. This one pins that a
+/// LATER change cannot quietly route the attachments tree into `create_index`,
+/// `reindex`, or a `ProtectedStore` root — the three ways a directory becomes
+/// indexed here. A source scan is the only check that covers call paths that do
+/// not exist yet.
+/// What: reads every `.rs` file under `src/`, and fails on any line mentioning
+/// `attachments_dir` alongside an indexing term. Skips silently when `src/` is
+/// absent (a packaged crate), which is the only case where there is nothing to
+/// scan.
+#[test]
+fn no_call_path_indexes_the_attachments_tree() {
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    if !src.is_dir() {
+        return;
+    }
+    const INDEXING_TERMS: [&str; 4] = ["create_index", "reindex", "ProtectedStore", "index_root"];
+    let mut offenders: Vec<String> = Vec::new();
+    for entry in walkdir::WalkDir::new(&src)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        // This file names both on purpose; scanning it would fail itself.
+        if path.ends_with("isolation_tests.rs") {
+            continue;
+        }
+        let Ok(body) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        for (number, line) in body.lines().enumerate() {
+            if line.contains("attachments_dir")
+                && INDEXING_TERMS.iter().any(|term| line.contains(term))
+            {
+                offenders.push(format!(
+                    "{}:{}: {}",
+                    path.display(),
+                    number + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "the attachments tree must never be handed to an indexer:\n{}",
+        offenders.join("\n")
+    );
+}

--- a/crates/trusty-agents/src/attachments/tests/manifest_tests.rs
+++ b/crates/trusty-agents/src/attachments/tests/manifest_tests.rs
@@ -70,3 +70,116 @@ fn a_second_store_sees_the_first_ones_rows() {
     let reopened = super::super::AttachmentStore::new(store.root());
     assert_eq!(reopened.get(SESSION, &row.id).unwrap(), row);
 }
+
+/// Write a manifest by hand, as anything with write access to the home could.
+///
+/// The home is deliberately human-browsable, so this file is editable by the
+/// user and by anything running as them — its contents are not this crate's
+/// word for where a file lives.
+fn tampered_manifest(session_dir: &std::path::Path, id: &str, stored_name: &str) {
+    std::fs::create_dir_all(session_dir).unwrap();
+    let document = serde_json::json!({
+        "version": 1,
+        "session_id": SESSION,
+        "attachments": [{
+            "id": id,
+            "file_name": "innocent.txt",
+            "media_type": "text/plain",
+            "size": 6,
+            "sha256": "deadbeef",
+            "stored_name": stored_name,
+            "created_at": "2026-09-11T00:00:00Z",
+        }],
+    });
+    std::fs::write(
+        session_dir.join(MANIFEST_FILE),
+        serde_json::to_string(&document).unwrap(),
+    )
+    .unwrap();
+}
+
+/// `Path::join` REPLACES the base when handed an absolute component, so an
+/// unchecked `stored_name` of `/etc/passwd` resolves to `/etc/passwd`.
+#[test]
+fn an_absolute_stored_name_is_refused() {
+    let (_temp, store) = super::fixture();
+    let id = "c".repeat(32);
+    let session_dir = store.session_dir(SESSION).unwrap();
+    tampered_manifest(&session_dir, &id, "/etc/hosts");
+
+    for err in [
+        store.get(SESSION, &id).unwrap_err(),
+        store.read(SESSION, &id).unwrap_err(),
+        store.list(SESSION).unwrap_err(),
+    ] {
+        assert!(
+            matches!(err, AttachmentError::TamperedManifest { .. }),
+            "an absolute stored name was accepted: {err:?}"
+        );
+        // Stored state, not a bad request — so it never renders as a 4xx and
+        // (see `api::server::attachments::refuse`) never returns its path.
+        assert!(!err.is_client_error());
+    }
+}
+
+/// The same guard, for a name that climbs out with `..` — and the file it
+/// would have reached is real, so a passing read would be visible as content.
+#[test]
+fn a_traversal_stored_name_is_refused() {
+    let (_temp, store) = super::fixture();
+    let id = "d".repeat(32);
+    let session_dir = store.session_dir(SESSION).unwrap();
+    let outside = store.root().join("outside.txt");
+    std::fs::create_dir_all(store.root()).unwrap();
+    std::fs::write(&outside, b"SECRET").unwrap();
+    tampered_manifest(&session_dir, &id, "../outside.txt");
+
+    let err = store.read(SESSION, &id).unwrap_err();
+    assert!(
+        matches!(err, AttachmentError::TamperedManifest { .. }),
+        "{err:?}"
+    );
+    // Nothing outside the session directory was opened: the refusal happens in
+    // `hydrate`, before a path is built, let alone read.
+    assert!(!err.to_string().contains("SECRET"));
+    assert!(matches!(
+        store.get(SESSION, &id).unwrap_err(),
+        AttachmentError::TamperedManifest { .. }
+    ));
+}
+
+/// The half a NAME check cannot catch: an ordinary single-segment stored name
+/// that is a symlink out of the session directory. `read` re-checks the
+/// canonical result against the canonical session directory.
+#[cfg(unix)]
+#[test]
+fn a_symlink_out_of_the_session_is_refused() {
+    let (_temp, store) = super::fixture();
+    let id = "e".repeat(32);
+    let session_dir = store.session_dir(SESSION).unwrap();
+    let outside = store.root().join("outside.txt");
+    std::fs::create_dir_all(store.root()).unwrap();
+    std::fs::write(&outside, b"SECRET").unwrap();
+    tampered_manifest(&session_dir, &id, "innocent.txt");
+    std::os::unix::fs::symlink(&outside, session_dir.join("innocent.txt")).unwrap();
+
+    // The row hydrates — the name IS one segment — so only the canonical check
+    // stands between the request and the file the symlink points at.
+    assert!(store.get(SESSION, &id).is_ok());
+    let err = store.read(SESSION, &id).unwrap_err();
+    assert!(
+        matches!(err, AttachmentError::TamperedManifest { .. }),
+        "a symlink out of the session was followed: {err:?}"
+    );
+}
+
+/// The confinement holds for an ordinary row: the canonical stored path is
+/// under the canonical session directory.
+#[test]
+fn a_stored_path_stays_under_its_session_directory() {
+    let (_temp, store) = super::fixture();
+    let row = store.store(SESSION, "a.txt", None, b"a").unwrap();
+    let base = store.session_dir(SESSION).unwrap().canonicalize().unwrap();
+    assert!(row.stored_path.canonicalize().unwrap().starts_with(&base));
+    assert!(store.read(SESSION, &row.id).is_ok());
+}

--- a/crates/trusty-agents/src/attachments/tests/manifest_tests.rs
+++ b/crates/trusty-agents/src/attachments/tests/manifest_tests.rs
@@ -1,0 +1,72 @@
+//! Sidecar-manifest coverage (#7370).
+
+use super::super::AttachmentError;
+use super::super::manifest::{MANIFEST_FILE, Manifest};
+use super::fixture;
+
+const SESSION: &str = "persona-izzie";
+
+#[test]
+fn missing_manifest_reads_empty() {
+    let temp = tempfile::tempdir().unwrap();
+    assert!(
+        Manifest::at(temp.path(), SESSION)
+            .rows()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn corrupt_manifest_is_an_error() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join(MANIFEST_FILE), "{ not json").unwrap();
+    let err = Manifest::at(temp.path(), SESSION).rows().unwrap_err();
+    assert!(
+        matches!(err, AttachmentError::Manifest { .. }),
+        "a corrupt manifest must not read as an empty session: {err:?}"
+    );
+}
+
+#[test]
+fn append_then_rows_round_trips() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = Manifest::at(temp.path(), SESSION);
+    let id = "a".repeat(32);
+    let row = manifest
+        .append(&id, "a.txt", "text/plain", 3, "digest", "a.txt", "now")
+        .unwrap();
+
+    assert_eq!(row.stored_path, temp.path().join("a.txt"));
+    assert_eq!(manifest.rows().unwrap(), vec![row.clone()]);
+    assert_eq!(manifest.get(&id).unwrap(), row);
+    // The manifest is human-readable JSON, per the module doc.
+    let raw = std::fs::read_to_string(temp.path().join(MANIFEST_FILE)).unwrap();
+    assert!(raw.contains("\"stored_name\": \"a.txt\""), "{raw}");
+    assert!(
+        !raw.contains(temp.path().to_str().unwrap()),
+        "absolute path leaked into the manifest: {raw}"
+    );
+}
+
+#[test]
+fn append_is_idempotent_on_one_id() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = Manifest::at(temp.path(), SESSION);
+    let id = "b".repeat(32);
+    manifest
+        .append(&id, "a.txt", "text/plain", 3, "d", "a.txt", "now")
+        .unwrap();
+    manifest
+        .append(&id, "a.txt", "text/plain", 3, "d", "a.txt", "later")
+        .unwrap();
+    assert_eq!(manifest.rows().unwrap().len(), 1);
+}
+
+#[test]
+fn a_second_store_sees_the_first_ones_rows() {
+    let (_temp, store) = fixture();
+    let row = store.store(SESSION, "a.txt", None, b"a").unwrap();
+    let reopened = super::super::AttachmentStore::new(store.root());
+    assert_eq!(reopened.get(SESSION, &row.id).unwrap(), row);
+}

--- a/crates/trusty-agents/src/attachments/tests/mod.rs
+++ b/crates/trusty-agents/src/attachments/tests/mod.rs
@@ -1,0 +1,15 @@
+//! Tests for the chat-attachment store (#7370).
+
+mod isolation_tests;
+mod manifest_tests;
+mod model_input_tests;
+mod store_tests;
+
+use super::AttachmentStore;
+
+/// A store over a fresh temp directory, standing in for `<home>/attachments`.
+fn fixture() -> (tempfile::TempDir, AttachmentStore) {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap().join("attachments");
+    (temp, AttachmentStore::new(root))
+}

--- a/crates/trusty-agents/src/attachments/tests/model_input_tests.rs
+++ b/crates/trusty-agents/src/attachments/tests/model_input_tests.rs
@@ -1,0 +1,94 @@
+//! What an attached turn hands the model, and reading its markers back (#7370).
+
+use super::super::model_input::{
+    MAX_INLINE_TEXT_BYTES, augment_user_turn, marker_for, parse_markers, render,
+};
+use super::fixture;
+
+const SESSION: &str = "persona-izzie";
+
+#[test]
+fn markers_round_trip() {
+    let id = "c".repeat(32);
+    let other = "d".repeat(32);
+    let content = format!(
+        "look at these\n\n{} then {}\nand {} again",
+        marker_for(&id),
+        marker_for(&other),
+        marker_for(&id)
+    );
+    assert_eq!(parse_markers(&content), vec![id, other]);
+}
+
+#[test]
+fn parse_ignores_malformed_markers() {
+    assert!(parse_markers("plain prose, no markers").is_empty());
+    assert!(parse_markers("[[attachment:not-an-id]]").is_empty());
+    assert!(parse_markers("[[attachment:unclosed").is_empty());
+    assert!(parse_markers(&format!("[[attachment:{}]]", "Z".repeat(32))).is_empty());
+}
+
+#[test]
+fn text_is_inlined_under_a_fence() {
+    let (_temp, store) = fixture();
+    let row = store
+        .store(SESSION, "data.csv", None, b"a,b\n1,2\n")
+        .unwrap();
+    let block = render(&row, b"a,b\n1,2\n");
+
+    assert!(block.starts_with(&marker_for(&row.id)), "{block}");
+    assert!(block.contains("data.csv (text/csv, 8 bytes)"), "{block}");
+    assert!(block.contains("```csv\na,b\n1,2\n\n```"), "{block}");
+    assert_eq!(parse_markers(&block), vec![row.id]);
+}
+
+#[test]
+fn binary_is_one_reference_line() {
+    let (_temp, store) = fixture();
+    let row = store
+        .store(SESSION, "shot.png", None, b"\x89PNG\r\n\x1a\n")
+        .unwrap();
+    let block = render(&row, b"\x89PNG\r\n\x1a\n");
+
+    assert_eq!(block.lines().count(), 1, "{block}");
+    assert!(block.contains("shot.png (image/png, 8 bytes)"), "{block}");
+    assert!(block.contains("binary attachment"), "{block}");
+    assert!(!block.contains("```"), "{block}");
+    assert_eq!(parse_markers(&block), vec![row.id]);
+}
+
+#[test]
+fn text_is_capped_with_a_truncation_note() {
+    let (_temp, store) = fixture();
+    let big = "x".repeat(MAX_INLINE_TEXT_BYTES + 500);
+    let row = store
+        .store(SESSION, "big.txt", None, big.as_bytes())
+        .unwrap();
+    let block = render(&row, big.as_bytes());
+
+    assert!(block.contains("[truncated: the first"), "note missing");
+    assert!(
+        block.len() < big.len(),
+        "the cap did not shorten the rendered block"
+    );
+    assert!(
+        block.contains(&"x".repeat(MAX_INLINE_TEXT_BYTES)),
+        "the cap cut too much"
+    );
+    assert!(
+        !block.contains(&"x".repeat(MAX_INLINE_TEXT_BYTES + 1)),
+        "the cap let more than {MAX_INLINE_TEXT_BYTES} bytes through"
+    );
+}
+
+#[test]
+fn no_attachments_leaves_the_turn_untouched() {
+    assert_eq!(augment_user_turn("what is this?", &[]), "what is this?");
+}
+
+#[test]
+fn blocks_follow_the_users_text() {
+    let joined = augment_user_turn("summarise", &["ONE".to_string(), "TWO".to_string()]);
+    assert_eq!(joined, "summarise\n\nONE\n\nTWO");
+    assert_eq!(augment_user_turn("  ", &["ONE".to_string()]), "ONE");
+}

--- a/crates/trusty-agents/src/attachments/tests/model_input_tests.rs
+++ b/crates/trusty-agents/src/attachments/tests/model_input_tests.rs
@@ -92,3 +92,40 @@ fn blocks_follow_the_users_text() {
     assert_eq!(joined, "summarise\n\nONE\n\nTWO");
     assert_eq!(augment_user_turn("  ", &["ONE".to_string()]), "ONE");
 }
+
+/// Content holding its own fence must not close the block it is inside.
+///
+/// Why this is a regression: the fence was a fixed three backticks, so a
+/// Markdown file or a code listing ended the block at its own first fence. The
+/// model then read the rest of the attachment as prose addressed to it —
+/// truncated content plus text that was never meant as instruction.
+#[test]
+fn a_fence_inside_the_content_cannot_break_out() {
+    let (_temp, store) = fixture();
+
+    let three = "before\n```\ninner\n```\nafter";
+    let row = store
+        .store(SESSION, "notes.md", None, three.as_bytes())
+        .unwrap();
+    let block = render(&row, three.as_bytes());
+    assert!(block.contains("\n````text\n"), "{block}");
+    assert!(block.ends_with("\n````"), "{block}");
+    assert!(block.contains(three), "the content was altered: {block}");
+
+    let four = "a\n````\nb\n````";
+    let row = store
+        .store(SESSION, "deeper.md", None, four.as_bytes())
+        .unwrap();
+    let block = render(&row, four.as_bytes());
+    assert!(block.contains("\n`````text\n"), "{block}");
+    assert!(block.ends_with("\n`````"), "{block}");
+
+    // Ordinary content still gets the ordinary three-backtick fence.
+    let plain = "a,b\n1,2\n";
+    let row = store
+        .store(SESSION, "plain.csv", None, plain.as_bytes())
+        .unwrap();
+    let block = render(&row, plain.as_bytes());
+    assert!(block.contains("\n```csv\n"), "{block}");
+    assert!(block.ends_with("\n```"), "{block}");
+}

--- a/crates/trusty-agents/src/attachments/tests/store_tests.rs
+++ b/crates/trusty-agents/src/attachments/tests/store_tests.rs
@@ -240,3 +240,67 @@ fn client_errors_are_classified() {
         .is_client_error()
     );
 }
+
+/// Two uploads of the same name, racing, must each keep their own bytes.
+///
+/// Why this is a regression: choosing the file name and writing the bytes used
+/// to happen OUTSIDE the manifest lock. Both threads then saw no `data.csv`,
+/// both chose the unsuffixed name, one overwrote the other, and the loser's
+/// row recorded a digest and size for bytes that were no longer on disk — a
+/// manifest that confidently describes a file it does not match. The barrier
+/// and the repeats are what make the interleaving reliable rather than lucky.
+#[test]
+fn concurrent_same_name_uploads_keep_their_bytes() {
+    use sha2::Digest;
+
+    for round in 0..20 {
+        let (_temp, store) = fixture();
+        let session = format!("persona-round-{round}");
+        let barrier = std::sync::Barrier::new(2);
+        let (first, second) = std::thread::scope(|scope| {
+            let one = scope.spawn(|| {
+                barrier.wait();
+                store.store(&session, "data.csv", None, b"a,b\n1,1\n")
+            });
+            let two = scope.spawn(|| {
+                barrier.wait();
+                store.store(&session, "data.csv", None, b"a,b\n2,2\n")
+            });
+            (one.join().unwrap().unwrap(), two.join().unwrap().unwrap())
+        });
+
+        assert_ne!(
+            first.stored_path, second.stored_path,
+            "round {round}: both uploads claimed the same file"
+        );
+        assert_eq!(store.list(&session).unwrap().len(), 2, "round {round}");
+        for row in [&first, &second] {
+            let on_disk = std::fs::read(&row.stored_path).unwrap();
+            assert_eq!(row.size as usize, on_disk.len(), "round {round}");
+            assert_eq!(
+                row.sha256,
+                format!("{:x}", sha2::Sha256::digest(&on_disk)),
+                "round {round}: the row describes bytes that are not on disk"
+            );
+        }
+    }
+}
+
+/// A manifest write that fails after the bytes are written must not leave the
+/// file behind: no row refers to it, so nothing can ever reach or remove it.
+#[test]
+fn a_failed_manifest_write_leaves_no_orphan() {
+    let (_temp, store) = fixture();
+    let session_dir = store.session_dir(SESSION).unwrap();
+    std::fs::create_dir_all(&session_dir).unwrap();
+    // A manifest that opens and locks but does not decode: the failure lands
+    // in `append`, after `store` has already written the bytes.
+    std::fs::write(session_dir.join("manifest.json"), "{ not json").unwrap();
+
+    let err = store.store(SESSION, "a.txt", None, b"payload").unwrap_err();
+    assert!(matches!(err, AttachmentError::Manifest { .. }), "{err:?}");
+    assert!(
+        !session_dir.join("a.txt").exists(),
+        "a failed manifest write left an orphaned file"
+    );
+}

--- a/crates/trusty-agents/src/attachments/tests/store_tests.rs
+++ b/crates/trusty-agents/src/attachments/tests/store_tests.rs
@@ -1,0 +1,242 @@
+//! Guard and round-trip coverage for [`super::super::AttachmentStore`] (#7370).
+//!
+//! Every guard is asserted on BOTH halves: the call refuses, AND the tree is
+//! unchanged. A guard that refuses but leaves a partial file behind is the
+//! failure this module exists to prevent, and only the second assertion catches
+//! it.
+
+use super::super::store::FALLBACK_MEDIA_TYPE;
+use super::super::{AttachmentError, AttachmentStore};
+use super::fixture;
+
+const SESSION: &str = "persona-izzie";
+
+/// Every entry under the store root, sorted, as `session/name` strings.
+fn tree(store: &AttachmentStore) -> Vec<String> {
+    let root = store.root();
+    if !root.is_dir() {
+        return Vec::new();
+    }
+    let mut found = Vec::new();
+    for session in std::fs::read_dir(root).unwrap() {
+        let session = session.unwrap().path();
+        let label = session.file_name().unwrap().to_string_lossy().to_string();
+        for entry in std::fs::read_dir(&session).unwrap() {
+            let name = entry.unwrap().file_name().to_string_lossy().to_string();
+            found.push(format!("{label}/{name}"));
+        }
+    }
+    found.sort();
+    found
+}
+
+#[test]
+fn store_writes_the_file_at_the_exact_path() {
+    let (_temp, store) = fixture();
+    let row = store
+        .store(SESSION, "notes.txt", Some("text/plain"), b"hello")
+        .unwrap();
+
+    assert_eq!(
+        row.stored_path,
+        store.root().join(SESSION).join("notes.txt")
+    );
+    assert_eq!(std::fs::read(&row.stored_path).unwrap(), b"hello");
+    assert_eq!(row.size, 5);
+    assert_eq!(row.session_id, SESSION);
+    assert_eq!(row.file_name, "notes.txt");
+    // sha256("hello")
+    assert_eq!(
+        row.sha256,
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+    assert_eq!(row.id.len(), 32);
+}
+
+#[test]
+fn traversal_file_name_writes_nothing() {
+    let (_temp, store) = fixture();
+    for name in ["../escape.txt", "a/b.txt", "..", "."] {
+        let err = store.store(SESSION, name, None, b"x").unwrap_err();
+        assert!(
+            matches!(err, AttachmentError::UnsafeFileName { .. }),
+            "{name} produced {err:?}"
+        );
+    }
+    assert!(tree(&store).is_empty(), "a refused name left files behind");
+}
+
+#[test]
+fn absolute_file_name_is_refused() {
+    let (_temp, store) = fixture();
+    let err = store.store(SESSION, "/etc/passwd", None, b"x").unwrap_err();
+    assert!(matches!(err, AttachmentError::UnsafeFileName { .. }));
+    assert!(tree(&store).is_empty());
+}
+
+#[test]
+fn session_traversal_is_refused() {
+    let (_temp, store) = fixture();
+    for session in ["../other", "a/b", "", "  "] {
+        let err = store.store(session, "notes.txt", None, b"x").unwrap_err();
+        assert!(
+            matches!(err, AttachmentError::UnsafeSessionId { .. }),
+            "{session} produced {err:?}"
+        );
+    }
+    assert!(tree(&store).is_empty());
+}
+
+#[test]
+fn store_rejects_an_oversize_payload() {
+    let (temp, _discard) = fixture();
+    let store = AttachmentStore::new(temp.path().join("attachments")).with_max_bytes(8);
+    let err = store
+        .store(SESSION, "big.txt", None, b"123456789")
+        .unwrap_err();
+    match err {
+        AttachmentError::TooLarge { size, cap, .. } => {
+            assert_eq!((size, cap), (9, 8));
+        }
+        other => panic!("expected TooLarge, got {other:?}"),
+    }
+    assert!(
+        tree(&store).is_empty(),
+        "an oversize upload left a partial file"
+    );
+    // The boundary itself is accepted.
+    assert!(store.store(SESSION, "ok.txt", None, b"12345678").is_ok());
+}
+
+#[test]
+fn same_name_different_bytes_does_not_clobber() {
+    let (_temp, store) = fixture();
+    let first = store
+        .store(SESSION, "data.csv", None, b"a,b\n1,2\n")
+        .unwrap();
+    let second = store
+        .store(SESSION, "data.csv", None, b"a,b\n9,9\n")
+        .unwrap();
+
+    assert_ne!(first.stored_path, second.stored_path);
+    assert_eq!(std::fs::read(&first.stored_path).unwrap(), b"a,b\n1,2\n");
+    assert_eq!(std::fs::read(&second.stored_path).unwrap(), b"a,b\n9,9\n");
+    assert_eq!(second.file_name, "data.csv");
+}
+
+#[test]
+fn same_name_identical_bytes_reuses_the_file() {
+    let (_temp, store) = fixture();
+    let first = store
+        .store(SESSION, "data.csv", None, b"a,b\n1,2\n")
+        .unwrap();
+    let second = store
+        .store(SESSION, "data.csv", None, b"a,b\n1,2\n")
+        .unwrap();
+
+    assert_eq!(first.stored_path, second.stored_path);
+    assert_ne!(first.id, second.id);
+    assert_eq!(store.list(SESSION).unwrap().len(), 2);
+}
+
+#[test]
+fn media_type_prefers_the_extension() {
+    let (_temp, store) = fixture();
+    let row = store
+        .store(
+            SESSION,
+            "data.csv",
+            Some("application/octet-stream"),
+            b"a,b",
+        )
+        .unwrap();
+    assert_eq!(row.media_type, "text/csv");
+}
+
+#[test]
+fn unknown_media_type_becomes_octet_stream() {
+    let (_temp, store) = fixture();
+    let unknown = store.store(SESSION, "blob.zzz", None, b"\x00\x01").unwrap();
+    assert_eq!(unknown.media_type, FALLBACK_MEDIA_TYPE);
+
+    let garbage = store
+        .store(SESSION, "blob2.zzz", Some("not a media type"), b"\x00")
+        .unwrap();
+    assert_eq!(garbage.media_type, FALLBACK_MEDIA_TYPE);
+
+    let declared = store
+        .store(SESSION, "blob3.zzz", Some("application/x-thing"), b"\x00")
+        .unwrap();
+    assert_eq!(declared.media_type, "application/x-thing");
+}
+
+#[test]
+fn list_returns_what_was_stored() {
+    let (_temp, store) = fixture();
+    assert!(store.list(SESSION).unwrap().is_empty());
+    let a = store.store(SESSION, "a.txt", None, b"a").unwrap();
+    let b = store.store(SESSION, "b.txt", None, b"b").unwrap();
+    let ids: Vec<String> = store
+        .list(SESSION)
+        .unwrap()
+        .into_iter()
+        .map(|row| row.id)
+        .collect();
+    assert_eq!(ids, vec![a.id, b.id]);
+    assert!(store.list("persona-other").unwrap().is_empty());
+}
+
+#[test]
+fn get_rejects_an_unknown_id() {
+    let (_temp, store) = fixture();
+    let row = store.store(SESSION, "a.txt", None, b"a").unwrap();
+
+    assert!(matches!(
+        store.get(SESSION, "../../etc/passwd").unwrap_err(),
+        AttachmentError::InvalidId(_)
+    ));
+    assert!(matches!(
+        store.get(SESSION, &"0".repeat(32)).unwrap_err(),
+        AttachmentError::NotFound { .. }
+    ));
+    // A row stored in one session is not reachable from another.
+    assert!(matches!(
+        store.get("persona-other", &row.id).unwrap_err(),
+        AttachmentError::NotFound { .. }
+    ));
+    assert_eq!(store.get(SESSION, &row.id).unwrap(), row);
+}
+
+#[test]
+fn read_returns_the_stored_bytes() {
+    let (_temp, store) = fixture();
+    let row = store.store(SESSION, "a.txt", None, b"payload").unwrap();
+    let (echoed, bytes) = store.read(SESSION, &row.id).unwrap();
+    assert_eq!(echoed, row);
+    assert_eq!(bytes, b"payload");
+
+    std::fs::remove_file(&row.stored_path).unwrap();
+    assert!(matches!(
+        store.read(SESSION, &row.id).unwrap_err(),
+        AttachmentError::MissingFile { .. }
+    ));
+}
+
+#[test]
+fn client_errors_are_classified() {
+    let (_temp, store) = fixture();
+    assert!(
+        store
+            .store(SESSION, "../x", None, b"x")
+            .unwrap_err()
+            .is_client_error()
+    );
+    assert!(store.get(SESSION, "nope").unwrap_err().is_client_error());
+    assert!(
+        !AttachmentError::Io {
+            path: std::path::PathBuf::from("/x"),
+            source: std::io::Error::other("boom"),
+        }
+        .is_client_error()
+    );
+}

--- a/crates/trusty-agents/src/attachments/tests/store_tests.rs
+++ b/crates/trusty-agents/src/attachments/tests/store_tests.rs
@@ -304,3 +304,83 @@ fn a_failed_manifest_write_leaves_no_orphan() {
         "a failed manifest write left an orphaned file"
     );
 }
+
+fn uploaded(file_name: &str, bytes: &[u8]) -> super::super::UploadedFile {
+    super::super::UploadedFile {
+        file_name: file_name.to_string(),
+        media_type: None,
+        bytes: bytes.to_vec(),
+    }
+}
+
+#[test]
+fn store_all_writes_every_file() {
+    let (_temp, store) = fixture();
+    let rows = store
+        .store_all(
+            SESSION,
+            &[uploaded("a.txt", b"aaa"), uploaded("b.csv", b"x,y\n")],
+        )
+        .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].file_name, "a.txt");
+    assert_eq!(rows[1].media_type, "text/csv");
+    assert_eq!(std::fs::read(&rows[0].stored_path).unwrap(), b"aaa");
+    assert_eq!(store.list(SESSION).unwrap().len(), 2);
+}
+
+/// Every name and size is checked before a byte is written, so one bad entry
+/// leaves the tree exactly as it was — never half a batch.
+#[test]
+fn store_all_writes_nothing_when_one_name_is_bad() {
+    let (_temp, store) = fixture();
+    let err = store
+        .store_all(
+            SESSION,
+            &[
+                uploaded("good.txt", b"ok"),
+                uploaded("../escape.txt", b"bad"),
+            ],
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, AttachmentError::UnsafeFileName { .. }),
+        "{err:?}"
+    );
+    assert!(
+        tree(&store).is_empty(),
+        "a refused batch wrote its earlier files"
+    );
+
+    let (_temp, store) = fixture();
+    let store = AttachmentStore::new(store.root()).with_max_bytes(4);
+    let err = store
+        .store_all(
+            SESSION,
+            &[uploaded("ok.txt", b"1234"), uploaded("big.txt", b"12345")],
+        )
+        .unwrap_err();
+    assert!(matches!(err, AttachmentError::TooLarge { .. }), "{err:?}");
+    assert!(tree(&store).is_empty());
+}
+
+#[test]
+fn store_all_refuses_more_than_the_cap() {
+    let (_temp, store) = fixture();
+    let files: Vec<_> = (0..super::super::MAX_ATTACHMENTS_PER_TURN + 1)
+        .map(|i| uploaded(&format!("f{i}.txt"), b"x"))
+        .collect();
+    let err = store.store_all(SESSION, &files).unwrap_err();
+    match err {
+        AttachmentError::TooManyFiles { count, cap } => {
+            assert_eq!(
+                (count, cap),
+                (files.len(), super::super::MAX_ATTACHMENTS_PER_TURN)
+            );
+        }
+        other => panic!("expected TooManyFiles, got {other:?}"),
+    }
+    assert!(tree(&store).is_empty());
+    assert!(store.store_all(SESSION, &files[..8]).is_ok());
+}

--- a/crates/trusty-agents/src/lib.rs
+++ b/crates/trusty-agents/src/lib.rs
@@ -78,6 +78,9 @@ pub mod api;
 // TYPE, `izzie`/`cto-assistant` are INSTANCES of it, each with its own home.
 pub mod assistants;
 pub mod ast;
+// #7370: chat-thread attachments stored under `<assistant home>/attachments`,
+// a sibling of `okg` — files a turn references, never indexed knowledge.
+pub mod attachments;
 pub mod knowledge;
 // #4652: last-human-turn timeout — the only signal that can tell a human
 // attending an instance from the assistant's own activity (owner decision D3).

--- a/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
@@ -158,6 +158,10 @@ pub async fn send_message(
     agent: Option<String>,
     model_id: Option<String>,
     provider_id: Option<String>,
+    // #7370: ids of attachments staged on this turn, already uploaded through
+    // the session's attachment route. Omitted from the body when empty so an
+    // ordinary turn's payload is byte-identical to what it was.
+    attachments: Option<Vec<String>>,
 ) -> Result<String, String> {
     let port = state.port.lock().await.unwrap_or(8765);
     let client = reqwest::Client::new();
@@ -179,6 +183,12 @@ pub async fn send_message(
     }
     if let Some(p) = provider_id.as_ref().filter(|s| !s.is_empty()) {
         body.insert("provider_id".into(), Value::String(p.clone()));
+    }
+    if let Some(ids) = attachments.as_ref().filter(|ids| !ids.is_empty()) {
+        body.insert(
+            "attachments".into(),
+            Value::Array(ids.iter().cloned().map(Value::String).collect()),
+        );
     }
 
     let submit_url = format!("{}/api/task", api_base(port));

--- a/crates/trusty-agents/ui/src/components/AttachmentCard.svelte
+++ b/crates/trusty-agents/ui/src/components/AttachmentCard.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  /**
+   * Why (#7370): an attachment on a chat turn is an OBJECT, not a filename in
+   * the text — the epic's wording is "shown as objects (thumbnail,
+   * click-expandable)". A card carries the thumbnail or icon, the name and the
+   * size, and expands to a full view on click, so a user can confirm what they
+   * attached without leaving the conversation.
+   * What: one card per `AttachmentRef`. Images render from the session's
+   * authenticated byte route; text and CSV fetch their own bytes lazily — only
+   * when the card is first expanded, so a thread full of files costs one
+   * request per file the reader actually opens, not one per bubble painted.
+   * Everything else is an icon, a name and a size, which is exactly what the
+   * model was told about it too.
+   * Test: `attachments.test.ts` covers the pure helpers this renders
+   * (`csvPreview`, `formatSize`, `visibleText`); the component itself is
+   * exercised by the chat view's own tests.
+   */
+  import { FileText, File as FileIcon, Table2 } from 'lucide-svelte';
+  import {
+    attachmentUrl,
+    csvPreview,
+    formatSize,
+    isImage,
+    isPreviewableText,
+    type AttachmentRef,
+  } from '../lib/attachments';
+
+  export let attachment: AttachmentRef;
+
+  let expanded = false;
+  let text: string | null = null;
+  let loadError: string | null = null;
+  let loading = false;
+
+  $: isCsv = attachment.media_type === 'text/csv';
+  $: preview = isCsv && text ? csvPreview(text) : null;
+
+  /**
+   * Why: fetching every text attachment's bytes when the thread paints would
+   * cost one request per file whether or not anyone looks. Deferring to the
+   * first expand makes the cost follow the reader's attention.
+   */
+  async function loadText(): Promise<void> {
+    if (text !== null || loading || !isPreviewableText(attachment)) return;
+    loading = true;
+    try {
+      const r = await fetch(attachmentUrl(attachment));
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      text = await r.text();
+      loadError = null;
+    } catch (e) {
+      loadError = `Could not load ${attachment.file_name}: ${e}`;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function toggle(): void {
+    expanded = !expanded;
+    if (expanded) void loadText();
+  }
+</script>
+
+<div
+  class="my-2 w-full max-w-md overflow-hidden rounded-lg border border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface"
+  data-attachment-card
+  data-attachment-id={attachment.id}
+>
+  <button
+    type="button"
+    class="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-foundry-light-bg dark:hover:bg-foundry-bg"
+    on:click={toggle}
+    aria-expanded={expanded}
+    title={expanded ? 'Collapse attachment' : 'Expand attachment'}
+  >
+    {#if isImage(attachment)}
+      <img
+        src={attachmentUrl(attachment)}
+        alt={attachment.file_name}
+        class="h-10 w-10 shrink-0 rounded object-cover"
+      />
+    {:else if isCsv}
+      <Table2 class="h-5 w-5 shrink-0 text-foundry-teal" aria-hidden="true" />
+    {:else if isPreviewableText(attachment)}
+      <FileText class="h-5 w-5 shrink-0 text-foundry-teal" aria-hidden="true" />
+    {:else}
+      <FileIcon class="h-5 w-5 shrink-0 text-foundry-light-muted dark:text-foundry-text/60" aria-hidden="true" />
+    {/if}
+    <span class="min-w-0 flex-1">
+      <span class="block truncate text-sm text-foundry-light-text dark:text-foundry-text">{attachment.file_name}</span>
+      <span class="block text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+        {attachment.media_type} · {formatSize(attachment.size)}
+      </span>
+    </span>
+  </button>
+
+  {#if expanded}
+    <div class="border-t border-foundry-light-border dark:border-foundry-border px-3 py-2">
+      {#if loading}
+        <p class="text-xs text-foundry-light-muted dark:text-foundry-text/50">Loading…</p>
+      {:else if loadError}
+        <p role="alert" class="text-xs text-red-600 dark:text-red-400">{loadError}</p>
+      {:else if isImage(attachment)}
+        <img src={attachmentUrl(attachment)} alt={attachment.file_name} class="max-h-96 w-auto rounded" />
+      {:else if preview}
+        <div class="overflow-x-auto">
+          <table class="w-full border-collapse text-xs">
+            <thead>
+              <tr>
+                {#each preview.header as cell, i (i)}
+                  <th class="border border-foundry-light-border dark:border-foundry-border px-2 py-1 text-left font-medium">{cell}</th>
+                {/each}
+              </tr>
+            </thead>
+            <tbody>
+              {#each preview.rows as cells, r (r)}
+                <tr>
+                  {#each cells as cell, c (c)}
+                    <td class="border border-foundry-light-border dark:border-foundry-border px-2 py-1">{cell}</td>
+                  {/each}
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+        {#if preview.omitted > 0}
+          <p class="mt-1 text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+            {preview.omitted} more row{preview.omitted === 1 ? '' : 's'} not shown
+          </p>
+        {/if}
+      {:else if text !== null}
+        <pre class="max-h-64 overflow-auto whitespace-pre-wrap break-words text-xs">{text.slice(0, 4000)}</pre>
+      {:else}
+        <p class="text-xs text-foundry-light-muted dark:text-foundry-text/50">
+          Binary attachment — <a class="underline" href={attachmentUrl(attachment)} download={attachment.file_name}>download</a> to open it.
+        </p>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  [data-attachment-card] :global(svg) { flex: none; }
+</style>

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -24,6 +24,11 @@
   import ActionIcon from '../lib/icons/ActionIcon.svelte';
   import ToolActivity from './ToolActivity.svelte';
   import { renderChatMarkdown, assistantEmptyNotice } from '../lib/chatRendering';
+  // #7370: a turn's attachments render as cards, and the rendered attachment
+  // blocks the model saw are hidden from the bubble — the cards ARE the
+  // presentation of that content.
+  import AttachmentCard from './AttachmentCard.svelte';
+  import { visibleText } from '../lib/attachments';
   import WorkflowPhaseCard from './WorkflowPhaseCard.svelte';
   import { workflowState } from '../stores/workflow';
 
@@ -238,7 +243,16 @@
       {#if msg.role === 'user' || msg.role === 'event'}
         <div class="flex w-full justify-end" data-incoming-message>
           <div class="incoming-bubble min-w-0 px-4 py-3 text-foundry-light-text dark:text-foundry-text">
-            <p class="whitespace-pre-wrap break-words text-left text-sm leading-7">{msg.content}</p>
+            {#if visibleText(msg.content)}
+              <p class="whitespace-pre-wrap break-words text-left text-sm leading-7">{visibleText(msg.content)}</p>
+            {/if}
+            {#if msg.attachments?.length}
+              <div class="flex flex-col" data-attachment-list>
+                {#each msg.attachments as attachment (attachment.id)}
+                  <AttachmentCard {attachment} />
+                {/each}
+              </div>
+            {/if}
             <p class="mt-1 text-right text-[10px] text-foundry-light-muted dark:text-foundry-text/50">{fmtTime(msg.timestamp)}</p>
           </div>
         </div>

--- a/crates/trusty-agents/ui/src/components/InputArea.svelte
+++ b/crates/trusty-agents/ui/src/components/InputArea.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ArrowUp, Square } from 'lucide-svelte';
+  import { ArrowUp, Paperclip, Square, X } from 'lucide-svelte';
   import {
     activeAgentId,
     conversationKey,
@@ -23,16 +23,86 @@
   import { agentRoster } from '../stores/app';
   import { rosterDisplayName } from '../lib/roster';
 
+  // #7370: files attached to this turn. They are uploaded BEFORE the send, so
+  // the turn carries ids the server has already validated rather than bytes it
+  // has to accept mid-dispatch.
+  import { formatSize, uploadAttachment, type AttachmentRef } from '../lib/attachments';
+
   import ModelSwitcher from './ModelSwitcher.svelte';
   import { chatProjectPath, chatFolderError, detachUnavailableChatFolders } from '../stores/workspace';
 
-  type SubmissionContext = { projectPath: string | null; agent: string | null; model: PickerEntry | null; speaker: string };
+  type SubmissionContext = { projectPath: string | null; agent: string | null; model: PickerEntry | null; speaker: string; attachments: AttachmentRef[] };
 
   let input = '';
   let textareaEl: HTMLTextAreaElement;
   let cancelling = false;
 
-  $: disabled = !input.trim() || !!$chatFolderError;
+  /**
+   * Why (#7370): an attachment is uploaded the moment it is picked, not at
+   * send time — so the server's guards (traversal, size cap, media type) answer
+   * while the user is still composing and can do something about it, rather
+   * than failing a turn they have already committed to.
+   * What: the rows the server returned for files staged on this draft. Cleared
+   * when the turn is sent, so the next turn starts empty.
+   */
+  let pendingAttachments: AttachmentRef[] = [];
+  let attachmentError: string | null = null;
+  let uploading = false;
+  let fileInput: HTMLInputElement;
+  let dragging = false;
+
+  $: disabled = (!input.trim() && pendingAttachments.length === 0) || !!$chatFolderError || uploading;
+
+  /**
+   * Why: the upload is what turns a local `File` into something a turn can
+   * reference. Errors are shown next to the composer rather than thrown,
+   * because the user is mid-draft and the draft must survive.
+   * What: uploads each file to the ACTIVE assistant's chat session and stages
+   * the returned row. The first failure stops the batch and is reported with
+   * the server's own message.
+   * Test: `lib/attachments.test.ts` covers `uploadAttachment`'s two arms.
+   */
+  async function stageFiles(files: File[]): Promise<void> {
+    if (files.length === 0) return;
+    uploading = true;
+    attachmentError = null;
+    try {
+      for (const file of files) {
+        pendingAttachments = [...pendingAttachments, await uploadAttachment(get(activeAgentId), file)];
+      }
+    } catch (e) {
+      attachmentError = `${e instanceof Error ? e.message : e}`;
+    } finally {
+      uploading = false;
+    }
+  }
+
+  function onPick(event: Event): void {
+    const picked = (event.target as HTMLInputElement).files;
+    void stageFiles(picked ? Array.from(picked) : []);
+    // Reset so picking the same file twice in a row still fires `change`.
+    if (fileInput) fileInput.value = '';
+  }
+
+  /**
+   * Why: dropping a FILE onto the composer stages an attachment. This is a
+   * different gesture from the project-folder drop that sets `chatProjectPath`
+   * (`stores/workspace`), which arrives as a Tauri native drop event carrying
+   * paths, not as a DOM `DataTransfer` carrying `File` objects — so the two
+   * cannot be confused. A drop with no `File` in it is ignored here and left
+   * to whatever else is listening.
+   */
+  function onDrop(event: DragEvent): void {
+    dragging = false;
+    const dropped = Array.from(event.dataTransfer?.files ?? []);
+    if (dropped.length === 0) return;
+    event.preventDefault();
+    void stageFiles(dropped);
+  }
+
+  function removeAttachment(id: string): void {
+    pendingAttachments = pendingAttachments.filter((a) => a.id !== id);
+  }
 
   // Why (#3063): a retask can start before the previous submission's
   // `send_message` invoke/poll-loop has resolved (it only notices the abort
@@ -117,6 +187,10 @@
       role: 'user',
       content: displayContent,
       timestamp: now,
+      // #7370: the bubble shows the cards immediately. The server appends the
+      // rendered attachment blocks to the PERSISTED turn, so a later reload
+      // rebuilds these same cards from the markers in that content.
+      ...(context.attachments.length ? { attachments: context.attachments } : {}),
     });
 
     // Assistant placeholder. `taskId` is set to a temp id and patched once
@@ -211,6 +285,11 @@
       if (selectedAgent) {
         invokeArgs.agent = selectedAgent;
       }
+      // #7370: ids only. The bytes are already on the server, validated; the
+      // turn is refused outright if any id is not in the session's manifest.
+      if (context.attachments.length) {
+        invokeArgs.attachments = context.attachments.map((a) => a.id);
+      }
       // #3245: forward the model/provider picker's selection, when any.
       // `resolveOverride` returns `{ modelId: null, providerId: null }` for
       // both the "Default" row and a `null` store (nothing selected yet),
@@ -273,7 +352,8 @@
    */
   async function handleSubmit() {
     const content = input.trim();
-    if (!content || get(chatFolderError)) return;
+    // #7370: an attachment alone is a valid turn — "here, look at this".
+    if ((!content && pendingAttachments.length === 0) || get(chatFolderError)) return;
 
     const project = $activeProject;
     // Freeze all dispatch choices before listener setup or cancellation can yield.
@@ -281,6 +361,7 @@
       projectPath: get(chatProjectPath) ?? project.path ?? null,
       agent: get(activeAgentId), model: get(activeModelEntry),
       speaker: rosterDisplayName(get(agentRoster), get(activeAgentId)),
+      attachments: pendingAttachments,
     };
     const historyForRetask: HistoryTurn[] = $activeMessages
       .filter((m): m is Message & { role: HistoryTurn['role'] } => m.role !== 'topic-boundary')
@@ -319,11 +400,16 @@
       // is a real `HistoryTurn[]`, not a `Message[]` the type checker still
       // sees as possibly carrying `'topic-boundary'`.
       const payload = buildRetaskPayload(historyForRetask, content);
+      pendingAttachments = [];
       await submitTask(project, content, payload, context);
       return;
     }
 
     input = '';
+    // Cleared before the await so a second Enter cannot send the same files
+    // twice; `context` already holds them.
+    pendingAttachments = [];
+    attachmentError = null;
     await submitTask(project, content, content, context);
   }
 
@@ -385,7 +471,13 @@
   }
 </script>
 
-<footer class="shrink-0 min-w-0 border-t border-foundry-light-border dark:border-foundry-border bg-foundry-light-bg dark:bg-foundry-bg p-3">
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<footer
+  class="shrink-0 min-w-0 border-t border-foundry-light-border dark:border-foundry-border bg-foundry-light-bg dark:bg-foundry-bg p-3 {dragging ? 'ring-2 ring-inset ring-foundry-light-primary dark:ring-foundry-primary' : ''}"
+  on:dragover|preventDefault={() => (dragging = true)}
+  on:dragleave={() => (dragging = false)}
+  on:drop={onDrop}
+>
   {#if $chatFolderError}<p role="alert" class="mb-2 text-xs text-foundry-light-muted dark:text-foundry-text/70">{$chatFolderError} <button type="button" class="underline" on:click={detachUnavailableChatFolders}>Remove attachment</button></p>{/if}
   <div class="flex w-full min-w-0 flex-col rounded-xl border border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface shadow-sm focus-within:border-foundry-light-primary dark:focus-within:border-foundry-primary">
     <textarea
@@ -397,8 +489,50 @@
       class="w-full resize-none rounded-t-xl bg-transparent px-3 pt-3 pb-2 text-sm text-foundry-light-text dark:text-foundry-text focus:outline-none placeholder:text-foundry-light-muted dark:placeholder:text-foundry-text/40"
       on:keydown={handleKeydown}
     ></textarea>
+    {#if attachmentError}
+      <p role="alert" class="px-3 pb-1 text-xs text-red-600 dark:text-red-400">{attachmentError}</p>
+    {/if}
+    {#if pendingAttachments.length > 0}
+      <ul class="flex flex-wrap gap-2 px-3 pb-2" data-pending-attachments>
+        {#each pendingAttachments as attachment (attachment.id)}
+          <li class="flex items-center gap-1 rounded-full border border-foundry-light-border dark:border-foundry-border px-2 py-0.5 text-xs text-foundry-light-text dark:text-foundry-text">
+            <span class="max-w-[12rem] truncate">{attachment.file_name}</span>
+            <span class="text-foundry-light-muted dark:text-foundry-text/50">{formatSize(attachment.size)}</span>
+            <button
+              type="button"
+              aria-label={`Remove ${attachment.file_name}`}
+              class="ml-0.5 rounded-full p-0.5 hover:bg-foundry-light-bg dark:hover:bg-foundry-bg"
+              on:click={() => removeAttachment(attachment.id)}
+            >
+              <X class="h-3 w-3" />
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
     <div class="flex min-w-0 items-center justify-between gap-2 px-2 pb-2">
-      <ModelSwitcher />
+      <div class="flex min-w-0 items-center gap-2">
+        <input
+          bind:this={fileInput}
+          type="file"
+          multiple
+          class="hidden"
+          aria-hidden="true"
+          tabindex="-1"
+          on:change={onPick}
+        />
+        <button
+          type="button"
+          aria-label="Attach a file"
+          title={uploading ? 'Uploading…' : 'Attach a file'}
+          class="inline-flex h-8 w-8 items-center justify-center rounded-full text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-bg dark:hover:bg-foundry-bg disabled:opacity-40"
+          on:click={() => fileInput?.click()}
+          disabled={uploading}
+        >
+          <Paperclip class="h-4 w-4" />
+        </button>
+        <ModelSwitcher />
+      </div>
       <div class="flex shrink-0 items-center gap-2">
         {#if $isRunning}
           <button

--- a/crates/trusty-agents/ui/src/components/InputArea.svelte
+++ b/crates/trusty-agents/ui/src/components/InputArea.svelte
@@ -26,7 +26,7 @@
   // #7370: files attached to this turn. They are uploaded BEFORE the send, so
   // the turn carries ids the server has already validated rather than bytes it
   // has to accept mid-dispatch.
-  import { formatSize, uploadAttachment, type AttachmentRef } from '../lib/attachments';
+  import { formatSize, uploadAttachments, type AttachmentRef } from '../lib/attachments';
 
   import ModelSwitcher from './ModelSwitcher.svelte';
   import { chatProjectPath, chatFolderError, detachUnavailableChatFolders } from '../stores/workspace';
@@ -57,19 +57,19 @@
    * Why: the upload is what turns a local `File` into something a turn can
    * reference. Errors are shown next to the composer rather than thrown,
    * because the user is mid-draft and the draft must survive.
-   * What: uploads each file to the ACTIVE assistant's chat session and stages
-   * the returned row. The first failure stops the batch and is reported with
-   * the server's own message.
-   * Test: `lib/attachments.test.ts` covers `uploadAttachment`'s two arms.
+   * What: one request for the whole selection, because dropping three files is
+   * one gesture. The server refuses the batch whole on a bad name or an
+   * oversize file, so a refusal stages nothing and the message it gives is the
+   * one shown.
+   * Test: `lib/attachments.test.ts` covers `uploadAttachments`' two arms.
    */
   async function stageFiles(files: File[]): Promise<void> {
     if (files.length === 0) return;
     uploading = true;
     attachmentError = null;
     try {
-      for (const file of files) {
-        pendingAttachments = [...pendingAttachments, await uploadAttachment(get(activeAgentId), file)];
-      }
+      const staged = await uploadAttachments(get(activeAgentId), files);
+      pendingAttachments = [...pendingAttachments, ...staged];
     } catch (e) {
       attachmentError = `${e instanceof Error ? e.message : e}`;
     } finally {

--- a/crates/trusty-agents/ui/src/lib/attachments.test.ts
+++ b/crates/trusty-agents/ui/src/lib/attachments.test.ts
@@ -6,7 +6,7 @@ import {
   formatSize,
   parseAttachmentIds,
   personaSessionId,
-  uploadAttachment,
+  uploadAttachments,
   visibleText,
   type AttachmentRef,
 } from './attachments';
@@ -97,25 +97,35 @@ describe('formatSize', () => {
   });
 });
 
-describe('uploadAttachment', () => {
-  it('uploadAttachment_posts_multipart_and_returns_the_row', async () => {
-    const seen: { url?: string; init?: RequestInit } = {};
+describe('uploadAttachments', () => {
+  it('uploadAttachments_posts_every_file_in_one_request', async () => {
+    const seen: { url?: string; init?: RequestInit; calls: number } = { calls: 0 };
     vi.stubGlobal('fetch', (url: string, init: RequestInit) => {
       seen.url = url;
       seen.init = init;
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(row()) });
+      seen.calls += 1;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ attachments: [row(), row({ id: OTHER })] }),
+      });
     });
 
-    const file = new File(['a,b\n1,2\n'], 'data.csv', { type: 'text/csv' });
-    const uploaded = await uploadAttachment('izzie', file);
+    const uploaded = await uploadAttachments('izzie', [
+      new File(['a,b\n1,2\n'], 'data.csv', { type: 'text/csv' }),
+      new File(['x'], 'shot.png', { type: 'image/png' }),
+    ]);
 
-    expect(uploaded.id).toBe(ID);
+    // One request, not one per file — dropping two files is one gesture.
+    expect(seen.calls).toBe(1);
+    expect(uploaded.map((a) => a.id)).toEqual([ID, OTHER]);
     expect(seen.url).toContain('/api/agents/izzie/sessions/persona-izzie/attachments');
     expect(seen.init?.method).toBe('POST');
-    expect(seen.init?.body).toBeInstanceOf(FormData);
+    const body = seen.init?.body as FormData;
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.getAll('file')).toHaveLength(2);
   });
 
-  it('uploadAttachment_throws_the_servers_message', async () => {
+  it('uploadAttachments_throws_the_servers_message', async () => {
     vi.stubGlobal('fetch', () =>
       Promise.resolve({
         ok: false,
@@ -124,8 +134,13 @@ describe('uploadAttachment', () => {
       }),
     );
     await expect(
-      uploadAttachment('izzie', new File(['x'], 'big.bin')),
+      uploadAttachments('izzie', [new File(['x'], 'big.bin')]),
     ).rejects.toThrow('attachment `big.bin` is too large');
+  });
+
+  it('uploadAttachments_returns_empty_when_the_body_has_no_rows', async () => {
+    vi.stubGlobal('fetch', () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    expect(await uploadAttachments('izzie', [new File(['x'], 'a.txt')])).toEqual([]);
   });
 });
 

--- a/crates/trusty-agents/ui/src/lib/attachments.test.ts
+++ b/crates/trusty-agents/ui/src/lib/attachments.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  CSV_PREVIEW_ROWS,
+  csvPreview,
+  fetchSessionAttachments,
+  formatSize,
+  parseAttachmentIds,
+  personaSessionId,
+  uploadAttachment,
+  visibleText,
+  type AttachmentRef,
+} from './attachments';
+
+const ID = 'a'.repeat(32);
+const OTHER = 'b'.repeat(32);
+
+function row(overrides: Partial<AttachmentRef> = {}): AttachmentRef {
+  return {
+    id: ID,
+    session_id: 'persona-izzie',
+    file_name: 'data.csv',
+    media_type: 'text/csv',
+    size: 12,
+    sha256: 'deadbeef',
+    url: `/api/agents/izzie/sessions/persona-izzie/attachments/${ID}`,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('personaSessionId', () => {
+  it('personaSessionId_mirrors_the_server_format', () => {
+    expect(personaSessionId('izzie')).toBe('persona-izzie');
+    // `activeAgentId` is null for the base ctrl session (stores/app.ts).
+    expect(personaSessionId(null)).toBe('persona-ctrl');
+  });
+});
+
+describe('markers', () => {
+  it('parseAttachmentIds_reads_markers_in_order', () => {
+    const content = `look\n\n[[attachment:${ID}]] a.csv\n[[attachment:${OTHER}]] b.png\n[[attachment:${ID}]]`;
+    expect(parseAttachmentIds(content)).toEqual([ID, OTHER]);
+  });
+
+  it('parseAttachmentIds_ignores_malformed_markers', () => {
+    expect(parseAttachmentIds('no markers here')).toEqual([]);
+    expect(parseAttachmentIds('[[attachment:nope]]')).toEqual([]);
+    expect(parseAttachmentIds(`[[attachment:${ID.toUpperCase()}]]`)).toEqual([]);
+  });
+
+  it('visibleText_strips_the_attachment_blocks', () => {
+    const content = `what is in this?\n\n[[attachment:${ID}]] data.csv (text/csv, 8 bytes)\n\`\`\`csv\na,b\n1,2\n\`\`\``;
+    expect(visibleText(content)).toBe('what is in this?');
+  });
+
+  it('visibleText_leaves_an_ordinary_turn_alone', () => {
+    expect(visibleText('just a message')).toBe('just a message');
+  });
+});
+
+describe('csvPreview', () => {
+  const header = 'a,b';
+  const body = (n: number) =>
+    Array.from({ length: n }, (_, i) => `${i},${i}`).join('\n');
+
+  it('csvPreview_shows_every_row_at_the_boundary', () => {
+    const preview = csvPreview(`${header}\n${body(CSV_PREVIEW_ROWS)}`);
+    expect(preview.header).toEqual(['a', 'b']);
+    expect(preview.rows).toHaveLength(CSV_PREVIEW_ROWS);
+    expect(preview.omitted).toBe(0);
+  });
+
+  it('csvPreview_reports_omitted_rows_past_the_boundary', () => {
+    const preview = csvPreview(`${header}\n${body(CSV_PREVIEW_ROWS + 1)}`);
+    expect(preview.rows).toHaveLength(CSV_PREVIEW_ROWS);
+    expect(preview.omitted).toBe(1);
+  });
+
+  it('csvPreview_keeps_quoted_commas_together', () => {
+    const preview = csvPreview('name,note\n"Doe, Jane","said ""hi"""');
+    expect(preview.rows[0]).toEqual(['Doe, Jane', 'said "hi"']);
+  });
+
+  it('csvPreview_handles_an_empty_file', () => {
+    expect(csvPreview('')).toEqual({ header: [], rows: [], omitted: 0 });
+  });
+});
+
+describe('formatSize', () => {
+  it('formatSize_scales_to_the_unit', () => {
+    expect(formatSize(512)).toBe('512 B');
+    expect(formatSize(2048)).toBe('2.0 KB');
+    expect(formatSize(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+});
+
+describe('uploadAttachment', () => {
+  it('uploadAttachment_posts_multipart_and_returns_the_row', async () => {
+    const seen: { url?: string; init?: RequestInit } = {};
+    vi.stubGlobal('fetch', (url: string, init: RequestInit) => {
+      seen.url = url;
+      seen.init = init;
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(row()) });
+    });
+
+    const file = new File(['a,b\n1,2\n'], 'data.csv', { type: 'text/csv' });
+    const uploaded = await uploadAttachment('izzie', file);
+
+    expect(uploaded.id).toBe(ID);
+    expect(seen.url).toContain('/api/agents/izzie/sessions/persona-izzie/attachments');
+    expect(seen.init?.method).toBe('POST');
+    expect(seen.init?.body).toBeInstanceOf(FormData);
+  });
+
+  it('uploadAttachment_throws_the_servers_message', async () => {
+    vi.stubGlobal('fetch', () =>
+      Promise.resolve({
+        ok: false,
+        status: 413,
+        json: () => Promise.resolve({ error: 'attachment `big.bin` is too large' }),
+      }),
+    );
+    await expect(
+      uploadAttachment('izzie', new File(['x'], 'big.bin')),
+    ).rejects.toThrow('attachment `big.bin` is too large');
+  });
+});
+
+describe('fetchSessionAttachments', () => {
+  it('fetchSessionAttachments_indexes_rows_by_id', async () => {
+    vi.stubGlobal('fetch', () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ attachments: [row(), row({ id: OTHER })] }),
+      }),
+    );
+    const index = await fetchSessionAttachments('izzie');
+    expect([...index.keys()]).toEqual([ID, OTHER]);
+    expect(index.get(ID)?.file_name).toBe('data.csv');
+  });
+
+  it('fetchSessionAttachments_is_empty_when_unavailable', async () => {
+    vi.stubGlobal('fetch', () => Promise.reject(new Error('down')));
+    expect((await fetchSessionAttachments('izzie')).size).toBe(0);
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/attachments.ts
+++ b/crates/trusty-agents/ui/src/lib/attachments.ts
@@ -64,23 +64,26 @@ export function attachmentUrl(ref: AttachmentRef): string {
 }
 
 /**
- * Upload one file to the active assistant's chat session.
+ * Upload files to the active assistant's chat session, in ONE request.
  *
- * Why: the server owns validation — traversal, the size cap, the media type.
- * Pre-empting any of it here would put a second, drifting copy of those rules
- * in the browser; the client's job is to report what the server said.
- * What: `multipart/form-data` with one `file` part. Throws with the server's
- * own message on any non-2xx, because an upload that silently no-ops leaves a
- * user staring at a chat that never got their file.
- * Test: `uploadAttachment_posts_multipart_and_returns_the_row`,
- * `uploadAttachment_throws_the_servers_message`.
+ * Why: dropping three files is one gesture and should be one round trip. The
+ * server accepts every file part and answers one row per file, having checked
+ * every name and size before writing any of them — so a batch either lands
+ * whole or not at all, and the client never has to reconcile a half-applied
+ * upload of its own making.
+ * What: `multipart/form-data` with one `file` part per file. Throws with the
+ * server's own message on any non-2xx, because an upload that silently no-ops
+ * leaves a user staring at a chat that never got their file. Validation is the
+ * server's: a second copy of those rules here would drift from it.
+ * Test: `uploadAttachments_posts_every_file_in_one_request`,
+ * `uploadAttachments_throws_the_servers_message`.
  */
-export async function uploadAttachment(
+export async function uploadAttachments(
   agentId: string | null,
-  file: File,
-): Promise<AttachmentRef> {
+  files: File[],
+): Promise<AttachmentRef[]> {
   const body = new FormData();
-  body.append('file', file, file.name);
+  for (const file of files) body.append('file', file, file.name);
   const r = await fetch(sessionRoute(agentId), {
     method: 'POST',
     headers: authHeaders(),
@@ -96,7 +99,8 @@ export async function uploadAttachment(
     }
     throw new Error(detail);
   }
-  return (await r.json()) as AttachmentRef;
+  const payload = (await r.json()) as { attachments?: AttachmentRef[] };
+  return Array.isArray(payload.attachments) ? payload.attachments : [];
 }
 
 /**

--- a/crates/trusty-agents/ui/src/lib/attachments.ts
+++ b/crates/trusty-agents/ui/src/lib/attachments.ts
@@ -1,0 +1,246 @@
+// Chat-thread attachments in the browser (#7370).
+//
+// Why: a turn can now carry files, stored server-side under
+// `<assistant home>/attachments/<session>/`. The browser never sees that path —
+// it uploads to the session route, gets an id back, and refers to the file by
+// that id from then on. Everything the chat view needs to DRAW a file (name,
+// media type, size, the URL that fetches the bytes) comes from the server's own
+// row, so nothing here re-derives a path or guesses a type.
+//
+// What: the wire types, the three REST calls, and the pure helpers the chat
+// view uses — reading `[[attachment:<id>]]` markers back out of a persisted
+// turn, hiding the rendered attachment blocks from the visible bubble, and
+// slicing a CSV into a preview table.
+//
+// Test: `attachments.test.ts`.
+
+import { apiBase } from './api-config';
+import { getCurrentApiToken } from '../stores/app';
+
+/** One stored attachment, exactly as the server's wire body describes it. */
+export interface AttachmentRef {
+  id: string;
+  session_id: string;
+  file_name: string;
+  media_type: string;
+  size: number;
+  sha256: string;
+  /** Path (not absolute URL) that serves the bytes. */
+  url: string;
+}
+
+/**
+ * The chat session id for an assistant.
+ *
+ * Why: it mirrors the server's `session_id_for` (`persona-{agent}`), which is
+ * also what `GET /api/agents/:name/chat-history` reports as `session_id`. The
+ * upload has to name a session BEFORE any history has been fetched, so the
+ * format is reproduced here rather than waited for. A drift between the two
+ * cannot corrupt anything: the send-side check resolves ids against the
+ * session the SERVER derives, so a mismatched upload simply fails to resolve.
+ * What: `persona-{agentId}`, with `ctrl` standing in for no roster selection —
+ * the same default `stores/app.ts` documents for `activeAgentId`.
+ * Test: `personaSessionId_mirrors_the_server_format`.
+ */
+export function personaSessionId(agentId: string | null | undefined): string {
+  return `persona-${agentId ?? 'ctrl'}`;
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getCurrentApiToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function sessionRoute(agentId: string | null): string {
+  const agent = agentId ?? 'ctrl';
+  return `${apiBase()}/api/agents/${encodeURIComponent(agent)}/sessions/${encodeURIComponent(
+    personaSessionId(agentId),
+  )}/attachments`;
+}
+
+/** The absolute URL that serves one attachment's bytes. */
+export function attachmentUrl(ref: AttachmentRef): string {
+  return `${apiBase()}${ref.url}`;
+}
+
+/**
+ * Upload one file to the active assistant's chat session.
+ *
+ * Why: the server owns validation — traversal, the size cap, the media type.
+ * Pre-empting any of it here would put a second, drifting copy of those rules
+ * in the browser; the client's job is to report what the server said.
+ * What: `multipart/form-data` with one `file` part. Throws with the server's
+ * own message on any non-2xx, because an upload that silently no-ops leaves a
+ * user staring at a chat that never got their file.
+ * Test: `uploadAttachment_posts_multipart_and_returns_the_row`,
+ * `uploadAttachment_throws_the_servers_message`.
+ */
+export async function uploadAttachment(
+  agentId: string | null,
+  file: File,
+): Promise<AttachmentRef> {
+  const body = new FormData();
+  body.append('file', file, file.name);
+  const r = await fetch(sessionRoute(agentId), {
+    method: 'POST',
+    headers: authHeaders(),
+    body,
+  });
+  if (!r.ok) {
+    let detail = `HTTP ${r.status}`;
+    try {
+      const failure = (await r.json()) as { error?: string };
+      if (failure?.error) detail = failure.error;
+    } catch {
+      /* A non-JSON failure body leaves the status as the only detail. */
+    }
+    throw new Error(detail);
+  }
+  return (await r.json()) as AttachmentRef;
+}
+
+/**
+ * Every attachment stored in an assistant's chat session, by id.
+ *
+ * Why: rehydration reads markers out of persisted turns and needs the row
+ * behind each one. One manifest read answers the whole thread.
+ * What: an empty Map on any failure — a chat must render without its cards
+ * rather than not render at all.
+ * Test: `fetchSessionAttachments_indexes_rows_by_id`,
+ * `fetchSessionAttachments_is_empty_when_unavailable`.
+ */
+export async function fetchSessionAttachments(
+  agentId: string | null,
+): Promise<Map<string, AttachmentRef>> {
+  try {
+    const r = await fetch(sessionRoute(agentId), { headers: authHeaders() });
+    if (!r.ok) return new Map();
+    const body = (await r.json()) as { attachments?: AttachmentRef[] };
+    const rows = Array.isArray(body.attachments) ? body.attachments : [];
+    return new Map(rows.map((row) => [row.id, row]));
+  } catch {
+    return new Map();
+  }
+}
+
+/** Matches the server's `[[attachment:<id>]]` marker — 32 lowercase hex. */
+const MARKER = /\[\[attachment:([0-9a-f]{32})\]\]/g;
+
+/**
+ * Attachment ids referenced by a turn's content, in order, without repeats.
+ *
+ * Why: the marker is what survives a reload — chat messages stay
+ * `{role, content}` and the reference travels inside the content string.
+ * Test: `parseAttachmentIds_reads_markers_in_order`.
+ */
+export function parseAttachmentIds(content: string): string[] {
+  const seen: string[] = [];
+  for (const match of content.matchAll(MARKER)) {
+    if (!seen.includes(match[1])) seen.push(match[1]);
+  }
+  return seen;
+}
+
+/**
+ * The part of a turn a human wrote, with the rendered attachment blocks removed.
+ *
+ * Why: the turn the model saw contains each attachment's contents inlined under
+ * a fence, because the persisted turn and the delivered turn must not diverge.
+ * The BUBBLE should not show that — the cards do. So the display strips from
+ * the first marker onward, which is exactly where the server appended.
+ * What: everything before the first marker, trimmed. A turn with no marker is
+ * returned unchanged.
+ * Test: `visibleText_strips_the_attachment_blocks`,
+ * `visibleText_leaves_an_ordinary_turn_alone`.
+ */
+export function visibleText(content: string): string {
+  const first = content.search(/\[\[attachment:[0-9a-f]{32}\]\]/);
+  return first < 0 ? content : content.slice(0, first).trimEnd();
+}
+
+/** One parsed CSV preview: a header row plus up to `rows` body rows. */
+export interface CsvPreview {
+  header: string[];
+  rows: string[][];
+  /** Body rows that exist beyond the ones returned. */
+  omitted: number;
+}
+
+/** Body rows a CSV card shows before it says how many more there are. */
+export const CSV_PREVIEW_ROWS = 5;
+
+/**
+ * Slice a CSV into a small preview table.
+ *
+ * Why: a card shows the shape of a spreadsheet, not the spreadsheet. The
+ * boundary matters — a file with exactly [`CSV_PREVIEW_ROWS`] body rows must
+ * show all of them and report nothing omitted, while one more row must report
+ * exactly one omitted.
+ * What: a deliberately small splitter — it handles quoted fields containing
+ * commas and doubled quotes, which is what a spreadsheet export actually
+ * produces, and nothing else. A preview is not a parser; the model gets the
+ * raw bytes.
+ * Test: `csvPreview_shows_every_row_at_the_boundary`,
+ * `csvPreview_reports_omitted_rows_past_the_boundary`,
+ * `csvPreview_keeps_quoted_commas_together`.
+ */
+export function csvPreview(text: string, limit = CSV_PREVIEW_ROWS): CsvPreview {
+  const lines = text.split(/\r?\n/).filter((line) => line.length > 0);
+  if (lines.length === 0) return { header: [], rows: [], omitted: 0 };
+  const header = splitCsvLine(lines[0]);
+  const body = lines.slice(1);
+  return {
+    header,
+    rows: body.slice(0, limit).map(splitCsvLine),
+    omitted: Math.max(0, body.length - limit),
+  };
+}
+
+function splitCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let cell = '';
+  let quoted = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const c = line[i];
+    if (quoted) {
+      if (c === '"' && line[i + 1] === '"') {
+        cell += '"';
+        i += 1;
+      } else if (c === '"') {
+        quoted = false;
+      } else {
+        cell += c;
+      }
+    } else if (c === '"') {
+      quoted = true;
+    } else if (c === ',') {
+      cells.push(cell);
+      cell = '';
+    } else {
+      cell += c;
+    }
+  }
+  cells.push(cell);
+  return cells;
+}
+
+/** Human-readable byte size for a card's caption. */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Whether a card should render an image thumbnail rather than an icon. */
+export function isImage(ref: AttachmentRef): boolean {
+  return ref.media_type.startsWith('image/');
+}
+
+/** Whether a card can show a text or CSV excerpt. */
+export function isPreviewableText(ref: AttachmentRef): boolean {
+  return (
+    ref.media_type.startsWith('text/') ||
+    ref.media_type === 'application/json' ||
+    ref.media_type === 'application/x-ndjson'
+  );
+}

--- a/crates/trusty-agents/ui/src/lib/chatHistory.test.ts
+++ b/crates/trusty-agents/ui/src/lib/chatHistory.test.ts
@@ -393,6 +393,41 @@ describe('fetchChatHistory', () => {
 // ---------------------------------------------------------------------------
 
 describe('historyToMessages', () => {
+  // #7370: the regression for "a reload still shows what was attached". The
+  // persisted turn carries only a `[[attachment:<id>]]` marker inside its
+  // content — chat messages stay `{role, content}` — so if the marker were not
+  // resolved back to a row here, a reloaded thread would show the turn with no
+  // card and no way to get one.
+  test('historyToMessages_resolves_attachment_markers_to_rows', () => {
+    const id = 'a'.repeat(32);
+    const ref = {
+      id,
+      session_id: 'persona-izzie',
+      file_name: 'data.csv',
+      media_type: 'text/csv',
+      size: 8,
+      sha256: 'deadbeef',
+      url: `/api/agents/izzie/sessions/persona-izzie/attachments/${id}`,
+    };
+    const withMarker: ChatHistoryPage = {
+      ...page(),
+      messages: [
+        { role: 'user', content: `look at this\n\n[[attachment:${id}]] data.csv` },
+      ],
+    };
+
+    const out = historyToMessages(withMarker, 'Izzie', 999, new Map([[id, ref]]));
+    expect(out[0].attachments).toEqual([ref]);
+
+    // No index, or an id the manifest no longer holds: no card, never a broken
+    // one, and the turn still renders.
+    expect(historyToMessages(withMarker, 'Izzie', 999)[0].attachments).toBeUndefined();
+    expect(
+      historyToMessages(withMarker, 'Izzie', 999, new Map([['b'.repeat(32), ref]]))[0]
+        .attachments,
+    ).toBeUndefined();
+  });
+
   test('historyToMessages_maps_roles_and_preserves_order', () => {
     const out = historyToMessages(page(), 'Izzie', 999);
     expect(out.map((m) => m.role)).toEqual(['user', 'assistant']);

--- a/crates/trusty-agents/ui/src/lib/chatHistory.ts
+++ b/crates/trusty-agents/ui/src/lib/chatHistory.ts
@@ -29,6 +29,11 @@ import { get } from 'svelte/store';
 
 import { apiBase } from './api-config';
 import {
+  fetchSessionAttachments,
+  parseAttachmentIds,
+  type AttachmentRef,
+} from './attachments';
+import {
   canLoadOlderChat,
   conversationKey,
   activeConversationKey,
@@ -173,6 +178,7 @@ export function historyToMessages(
   page: ChatHistoryPage,
   speaker: string,
   now: number,
+  attachments?: Map<string, AttachmentRef>,
 ): Message[] {
   const ts = page.updated_at ? Date.parse(page.updated_at) : NaN;
   const timestamp = Number.isNaN(ts) ? now : ts;
@@ -192,6 +198,16 @@ export function historyToMessages(
         }
       } catch { /* Ordinary system content stays an ordinary banner. */ }
     }
+    // #7370: a persisted turn carries its attachments as `[[attachment:<id>]]`
+    // markers inside `content` — the only place they can live while chat
+    // messages stay `{role, content}`. Resolving them here is what makes a
+    // reload show the same cards the live turn showed; an id whose row is
+    // gone simply yields no card, never a broken one.
+    const refs = attachments?.size
+      ? parseAttachmentIds(content)
+          .map((id) => attachments.get(id))
+          .filter((ref): ref is AttachmentRef => !!ref)
+      : [];
     return {
       // Stable and collision-free against live ids, which are uuid/task-based.
       id: `history-${page.start + i}`,
@@ -199,6 +215,7 @@ export function historyToMessages(
       content,
       timestamp,
       ...activity,
+      ...(refs.length ? { attachments: refs } : {}),
       ...(role === 'assistant' ? { speaker } : {}),
     };
   });
@@ -290,7 +307,14 @@ export async function rehydrateChat(
     if (selected()) chatHistoryCursor.set(null);
     return { seeded: 0, hasMore: false, reason: page.reason };
   }
-  const restored = historyToMessages(page, speaker, Date.now());
+  // #7370: one manifest read answers every marker in the thread; a metadata
+  // request per marker would not. A thread whose turns carry NO marker skips
+  // the read entirely, so rehydrating an ordinary conversation costs exactly
+  // the requests it always did.
+  const refs = page.messages.some((m) => parseAttachmentIds(m.content ?? '').length > 0)
+    ? await fetchSessionAttachments(agentId)
+    : undefined;
+  const restored = historyToMessages(page, speaker, Date.now(), refs);
   const seeded = hydrateMessages(key, restored);
   if (seeded) rememberCursor(key, { agentId, speaker, projectId, start: page.start, hasMore: page.has_more });
   const cursor = cachedCursor(key);

--- a/crates/trusty-agents/ui/src/lib/transport.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.ts
@@ -143,6 +143,13 @@ async function fetchFallback(command: string, args?: Record<string, unknown>): P
       if (typeof providerId === 'string' && providerId.trim()) {
         body.provider_id = providerId;
       }
+      // #7370: attachment ids for this turn, mirroring the Tauri
+      // `send_message` command's own forwarding. Omitted entirely when the
+      // composer staged none, so an ordinary turn's payload is unchanged.
+      const attachments = args?.attachments;
+      if (Array.isArray(attachments) && attachments.length > 0) {
+        body.attachments = attachments;
+      }
       const submit = await fetch(`${base}/api/task`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -47,6 +47,8 @@ export interface Project {
   sessions?: SessionSummary[];
 }
 
+import type { AttachmentRef } from '../lib/attachments';
+
 export interface Message {
   id: string;
   // #3819: 'topic-boundary' is a non-destructive divider row inserted by
@@ -82,6 +84,16 @@ export interface Message {
    * is `[step_label, result_text]`, mirroring the SSE event shape.
    */
   recapRows?: [string, string][];
+  /**
+   * Why (#7370): a turn can carry files. Chat messages stay `{role, content}`
+   * on the wire, so the reference travels as a `[[attachment:<id>]]` marker
+   * INSIDE `content`; this field is the resolved row behind each marker, so
+   * `ChatView` can draw a card without re-fetching per bubble. Populated by
+   * `InputArea` at send time and by `chatHistory` on rehydration.
+   * What: absent for every turn that carries no attachment, which is what
+   * keeps an ordinary message identical to what it was before this existed.
+   */
+  attachments?: AttachmentRef[];
 }
 
 export interface TaskHistoryEntry {


### PR DESCRIPTION
## Outcome

Item (e) of epic #7425. Text, binary and CSV attachments on a chat thread:
uploaded via multipart to `<assistant home>/attachments/<session>/<file>` with
a per-session `manifest.json`, referenced from the turn as
`[[attachment:<id>]]` (shared chat-message types unchanged), rendered as cards
(image thumbnail, CSV table, text excerpt, binary icon; click-expand),
rehydrated on reload; text/CSV content reaches the model as a size-capped
fenced block, binary as a one-line reference. Validate-then-persist: a send
naming an unknown attachment is refused before any history write (the defect
that blocked #7396).

## Changes

New `crates/trusty-agents/src/attachments/{store,manifest,model_input,error}.rs`,
`api/server/attachments.rs` (POST, GET list, GET by id), `handlers.rs`
`resolve_attachments`, `state.rs`, `Cargo.toml` axum `multipart`; UI
`attachments.ts`, `AttachmentCard.svelte`, `InputArea.svelte`, `ChatView.svelte`,
`chatHistory.ts`, `transport.ts`, `stores/app.ts`, `src-tauri/task_commands.rs`.

Second commit: manifest rows re-confined on read (refuse absolute/`..`/symlink-out),
same-name uploads serialized under the manifest lock, 5xx bodies carry no path,
fence widened past the longest backtick run in the content, orphaned file
removed on a failed manifest write.

Out of scope: clipboard paste (#7370 acceptance item, next slice), XLSX,
provider vision content arrays.

## Risk

High (persisted files, upload path, UI/API surface; rung 6).

## Tests

`cargo test -p trusty-agents --no-fail-fast` — 13 targets, lib 3785 passed /
0 failed / 13 ignored; proven failing pre-change: `send_with_an_unknown_attachment_is_refused`
(202 → 404), then with the fixes reverted `an_absolute_stored_name_is_refused`
(printed `stored_path: "/etc/hosts"`), `a_traversal_stored_name_is_refused`,
`a_symlink_out_of_the_session_is_refused`, `download_refuses_a_tampered_stored_name`,
`concurrent_same_name_uploads_keep_their_bytes`, `a_failed_manifest_write_leaves_no_orphan`,
`a_server_error_body_carries_no_path`, `a_fence_inside_the_content_cannot_break_out`.
fmt/clippy `-D warnings`/`check_line_cap`/`check_changelog_fragment`/`check_test_pointers`/`check_doc_paths`
exit 0; UI `pnpm test:unit` 60 files / 610 tests, `pnpm check` 0 errors,
`pnpm build` ok.

Live QA (rung 6) on a worktree build, port 47371, throwaway home: 7/7 PASS —
tampered manifest (`/etc/hosts`) → 500 generic body, no content; symlink-out →
500; fence widening verified in the persisted turn (five-backtick fence);
concurrent same-name uploads → two rows, two files, digests match; garbage
manifest → 500 generic; browser pass via Playwright script (pick PNG+CSV,
chips add/remove/re-add, send, cards render, expand, reload rehydrates) with 9
screenshots; API checks from round 1 (traversal 400, 11 MiB 413, unknown id
404 with history unchanged, HTML served as `attachment`).

## Baseline

Playwright `config-takeover.spec.ts` ×5 and `smoke.spec.ts` "ready within 8s"
fail identically on `origin/main` 7a390a893 (same names, same modes) —
pre-existing; hand to ticketing for a canonical issue. Environmental flakes
#7442 not seen.

## Changelog

`crates/trusty-agents/changelog.d/7370-chat-attachments.md` (Added).

## Review

Security BLOCK (manifest re-confinement) + 3 WARN all fixed in commit 2 and
re-verified live; code-critic APPROVE (MEDIUM orphan fixed); trusty-review
below.

Refs #7370
Refs #7425

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_014co1TJqBd2EMvjb6gkbfyP
