### PR TITLE
chore(trusty-mpm): bump to 1.5.29 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11910,7 +11910,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.28"
+version = "1.5.29"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -44,7 +44,10 @@ name = "trusty-mpm"
 # 1.5.28 (owner-authorized reinstall, refs #7418): patch, version-only —
 # 1.5.27 is already published and this bump exists solely so `tm --version`
 # identifies the reinstalled build.
-version = "1.5.28"
+# 1.5.29 (owner-authorized reinstall, 2026-09-11): patch, version-only —
+# 1.5.28 is already published and this bump exists solely so `tm --version`
+# identifies the reinstalled build.
+version = "1.5.29"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
- Version-only bump, trusty-mpm 1.5.28 → 1.5.29, for the owner-authorized reinstall carrying the #7421 picker-ordering fix (PR #7431) and the #7423 context-trim change (PR #7460).
- `Cargo.toml` and `Cargo.lock` only.

Refs #7421 #7423

## Test plan
- Rung 1 (Low, version metadata only).
- `scripts/check_workspace_dep_versions.sh` — 12 rows accept (patch bump, no widening required).
- `scripts/check-pr-version-bump.sh` — OK.
- Gates run by `local-ops` at publish time; no functional change to verify.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
