### PR TITLE
chore(sessions): pause snapshot for session tm-agents 2026-09-11 (Refs #7425)

### DIFF
--- a/.trusty-mpm/sessions/b175bb88-af7f-5ba5-b75d-85795d60b234/session-20260911-143428.md
+++ b/.trusty-mpm/sessions/b175bb88-af7f-5ba5-b75d-85795d60b234/session-20260911-143428.md
@@ -1,0 +1,36 @@
+# Session Pause - 2026-09-11T14:34:28.849969+00:00
+
+## Summary
+trusty-agents 1.0 milestone (#83, epic #7425) — owner-set scope items a–g, agents crates only (plus item g reaching trusty-mcp). Six PRs merged today: #7433 (a, crate fold), #7438 (changelog script fix), #7432 (spec alignment), #7441 (f, OKG-only exposed graph), #7446 (b PR1 channel adapter model), #7449 (c1 palace per assistant), #7458 (g spec + ADR-0060). Open PRs: #7455 (e attachments; auto-merge DISARMED pending a third commit fixing the rustdoc link in attachments/manifest.rs:19 and multi-file upload), #7459 (b PR2 Telegram inbound; auto-merge armed). Branches awaiting PR: feat/7452-trusty-mcp-config-authority (g1, head c92b5f304, third hardening commit in flight: 0600 file mode + Debug redaction; code-critic round in flight), feat/7427-gworkspace-binding (b PR3 engineer in flight), feat/7454-agents-mcp-shared-config (g4 engineer in flight, stacked on g1). Blocked: #7429 (c2) by trusty-search #7434; #4358 (d) by #7429; Notion by trusty-channels #7437; #7453/#5428 handed to session tm-dogfood by pointer (acknowledged). Palace checkpoints in trusty-tools/checkpoint room carry the full state and lessons.
+
+## Completed
+- Gap analyses: docs/research/trusty-agents-1.0-gap-analysis-2026-09-11.md and trusty-agents-mcp-connectors-gap-analysis-2026-09-11.md
+- Milestone #83 + epic #7425 with children #7359 #7426 #7427 #7428 #7429 #4358 #7370 #7430 #7451(#7452 #7453 #5428 #7454)
+- Merged: #7433 #7438 #7432 #7441 #7446 #7449 #7458
+- Issues at status:merged: #7359 #7426 #7428 #7430; #7370 status:coded; #7427 #7452 #7454 status:in-progress
+- Backlog filed: #7434 #7435 #7436 #7437 #7439 #7440 #7442 #7443 #7444 #7447 #7448 #7450 #7456 #7457 #7461
+- Four merged worktrees and three throwaway QA worktrees removed; stray smoke index assistant-okg-0333fa3aeff40f24d8fbc2b4 deleted from the shared trusty-search daemon
+
+## In Progress
+- #7455 attachments: engineer a458eba9f542ff9f4 adding third commit (rustdoc link manifest.rs:19, accept every multipart file field); auto-merge disarmed — re-arm via version-control after the commit lands and Rustdoc intra-doc links passes
+- #7459 Telegram inbound: auto-merge armed; after merge advance nothing (PR 2 of 3) — comment on #7427
+- g1 #7452: engineer ad5a7837ffafd5b7a third commit (save 0600, Debug redaction); code-critic a048fe7456b54898d verdict pending; then version-control opens PR (rung 4, semver compared=1, version bump 0.1.4→0.1.5 already in branch)
+- b PR3 gworkspace binding: engineer a760542677eb9aba1 on feat/7427-gworkspace-binding; then security + critic + PR
+- g4 #7454: engineer a6d431721eb56812a on feat/7454-agents-mcp-shared-config stacked on g1 head c92b5f304 (must rebase onto g1 latest or main before push); then security + critic + api-qa smoke + PR
+
+## Next Steps
+- Re-arm #7455 once the third commit is green (version-control), then advance #7370 status:merged after merge
+- After #7459 merges: comment on #7427; after PR3 merges: #7427 status:coded then merged
+- Open g1 PR after critic + hardening commit; then g4 PR; advance #7452/#7454
+- Live verification pass for status:merged issues (#7359 #7426 #7428 #7430) — install trusty-agents from main, verify, then tm issue transition N status:tested / closed with evidence
+- Check tm-dogfood progress on #7453 and #5428 (pointer sent and acknowledged)
+- Remaining #7370 acceptance item: clipboard paste (next slice); remaining QA worktree agent-a6a1519b74695a4a1 (locked by a live agent) to remove once released
+- Blocked items need the other session: #7434 (trusty-search multi-root) unblocks #7429 then #4358; #7437 (Notion connector)
+
+## Git Context
+Branch: main
+Last commit: c7e38dbfa chore(trusty-mpm): bump to 1.5.21 for owner-authorized reinstall (#7292)
+Uncommitted changes: 144 file(s) changed
+
+## Tmux Window
+tm-agents:0:@10753

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -113,3 +113,4 @@
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260910-153636.md","timestamp":"2026-09-10T15:36:36.117706+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-020211.md","timestamp":"2026-09-11T02:02:11.865112+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-113536.md","timestamp":"2026-09-11T11:35:36.224371+00:00"}
+{"session_id":"b175bb88-af7f-5ba5-b75d-85795d60b234","event":"pause","snapshot":"b175bb88-af7f-5ba5-b75d-85795d60b234/session-20260911-143428.md","timestamp":"2026-09-11T14:34:28.849969+00:00"}


### PR DESCRIPTION
## Outcome
Session pause snapshot for session `tm-agents`, taken 2026-09-11. Docs-only, per #7282.

## Changes
- `.trusty-mpm/sessions/b175bb88-af7f-5ba5-b75d-85795d60b234/session-20260911-143428.md` — new session snapshot
- `.trusty-mpm/sessions/sessions-log.jsonl` — appended pause-log entry

## Risk
Low — tracked session-state files only, no source changes.

## Tests
None owed — docs-only change.

## Baseline
None applicable.

## Changelog
None — session snapshot files are exempt from the changelog-fragment gate.

## Review
None requested.

Refs #7425

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
