### PR TITLE
fix(trusty-mpm): pm_guard routes shell writes (redirects, git --output) through the ADR-0044 main-checkout boundary; one heredoc-aware redirect scanner (Refs #7399)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7399-git-diff-output-boundary.md
+++ b/crates/trusty-mpm/changelog.d/7399-git-diff-output-boundary.md
@@ -1,0 +1,19 @@
+Fixed
+
+- `tm hook --pm-guard` now puts a Bash file write through the ADR-0044 /
+  ADR-0048 main-checkout write boundary, the rule that until now only an
+  `Edit`/`Write` call took. A shell write reached only `SHELL_EDIT_REASON`,
+  which asks WHO is writing: it allows the first writes of a turn and both
+  subagent markers skip it, so `git diff --output=<file>` and
+  `echo … > <file>` each landed a source file in a shared main checkout with
+  nothing refused (#7399).
+- The boundary reads its target from the one detector `pm_guard_bash` already
+  keeps — a redirect target, or the file a git write option names — so
+  `git diff --output=`, `git log --output=` and a `>` redirect all reach one
+  deny with one message. Denied when the file is source and lands in a main
+  checkout; allowed inside a worktree, for a document or configuration file,
+  and anywhere outside a checkout (#7399).
+- Reads are untouched: `git diff --no-index a b`, a plain `git diff`,
+  `git format-patch --stdout`, and a `sed -n` whose trailing token names a file
+  it only reads are all still allowed — the boundary acts only on a write it
+  can positively identify (#7399).

--- a/crates/trusty-mpm/changelog.d/7399-git-diff-output-boundary.md
+++ b/crates/trusty-mpm/changelog.d/7399-git-diff-output-boundary.md
@@ -13,6 +13,11 @@ Fixed
   deny with one message. Denied when the file is source and lands in a main
   checkout; allowed inside a worktree, for a document or configuration file,
   and anywhere outside a checkout (#7399).
+- The redirect scan the boundary reads is the heredoc-aware one, so a `>` in
+  here-document PROSE — `cat <<'EOF'` … `see: git diff > src/lib.rs` … `EOF`,
+  or a `len(k) > 3` comparison in a `python3 <<'PY'` script — names no write.
+  That scan existed in two copies and only one had learned #5356's heredoc
+  skip; they are now one function with two callers (#7399).
 - Reads are untouched: `git diff --no-index a b`, a plain `git diff`,
   `git format-patch --stdout`, and a `sed -n` whose trailing token names a file
   it only reads are all still allowed — the boundary acts only on a write it

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -583,9 +583,10 @@ fn classify_command_substitutions(segment: &str, depth: usize) -> Option<&'stati
 /// non-flag token ([`trailing_file_token`]) — the conventional position of the
 /// target file for those verbs. Returns the first match found; `None` when no
 /// segment yields a plausible target (the caller then falls back to the
-/// generic delegation hint). This is a best-effort HINT only — it never
-/// affects the allow/deny decision, only which agent name a denial message
-/// suggests.
+/// generic delegation hint). The sed/awk-family half is a best-effort HINT
+/// only — its trailing token may name a file the command READS. The positively
+/// identified half is [`shell_write_target`], which the write boundary decides
+/// on.
 /// Test: `extract_shell_edit_target_*`.
 pub(crate) fn extract_shell_edit_target(command: &str) -> Option<String> {
     for segment in split_shell_segments(command) {
@@ -593,20 +594,11 @@ pub(crate) fn extract_shell_edit_target(command: &str) -> Option<String> {
         if trimmed.is_empty() {
             continue;
         }
-        if let Some(target) = redirection_target(trimmed) {
+        if let Some(target) = segment_write_target(trimmed) {
             return Some(target);
         }
         if let Some(program) = first_command_token(trimmed) {
             let program = program.as_str();
-            // #7399: the file a git write option names is the target, and it
-            // sits in the option rather than the trailing position the verbs
-            // below use.
-            if program == "git"
-                && let Some(target) = shell_lex::git_file_write_target(trimmed)
-                && !target.is_empty()
-            {
-                return Some(target);
-            }
             let is_sed_awk_family =
                 matches!(program, "patch" | "sed" | "awk" | "gawk" | "nawk" | "mawk");
             let is_git_apply =
@@ -617,6 +609,61 @@ pub(crate) fn extract_shell_edit_target(command: &str) -> Option<String> {
                 return Some(target);
             }
         }
+    }
+    None
+}
+
+/// The file a Bash command would WRITE, when one is positively identified.
+///
+/// Why (#7399): the main-checkout write boundary (ADR-0044, enforced by
+/// ADR-0048) asks WHERE a write lands, and until now it could only ask that of
+/// the Edit/Write tools — a Bash write reached `SHELL_EDIT_REASON`, which asks
+/// WHO is writing and is budget-tiered, so `git diff --output=<file>` and
+/// `echo … > <file>` both landed a source file in a shared main checkout
+/// within budget. This is the half of [`extract_shell_edit_target`] the
+/// boundary can decide on: a redirect and a git write option each NAME the file
+/// git or the shell will create, with no reading arm. The sed/awk trailing
+/// token is deliberately excluded — `sed -n '1,5p' <file>` puts a file it only
+/// READS in that same position, so deciding a deny on it would refuse reads.
+/// What: the first [`segment_write_target`] across the command's composition
+/// segments ([`split_shell_segments`]). `None` when no segment names a write —
+/// which includes every command the guard cannot lex, so this can never turn an
+/// existing allow into a deny on a parse failure.
+/// Test: `shell_write_target_reads_redirects_and_git_output`,
+/// `shell_write_target_ignores_reads`, and end to end in
+/// `pm_guard_denies_a_git_output_write_in_a_main_checkout`.
+pub(crate) fn shell_write_target(command: &str) -> Option<String> {
+    split_shell_segments(command)
+        .into_iter()
+        .find_map(|segment| segment_write_target(segment.trim()))
+}
+
+/// The file ONE command segment would write, if its text names one.
+///
+/// Why: [`extract_shell_edit_target`] and [`shell_write_target`] ask the same
+/// question of a segment and must never drift apart — one rule about what a
+/// segment writes, read by the routing hint and by the write boundary alike.
+/// What: the redirect target ([`redirection_target`]) or, on a `git` segment,
+/// the file a git write option names ([`shell_lex::git_file_write_target`]).
+/// A git write that names no readable path (a valueless `--output`, a bare
+/// `format-patch`) yields an empty string from that function and is skipped
+/// here: the write is real and `classify_bash_segment` still denies it, but
+/// there is no path for the boundary to place.
+/// Test: `shell_write_target_reads_redirects_and_git_output`.
+fn segment_write_target(segment: &str) -> Option<String> {
+    if segment.is_empty() {
+        return None;
+    }
+    if let Some(target) = redirection_target(segment) {
+        return Some(target);
+    }
+    // #7399: a git write option names its file in the option, not in the
+    // trailing position the sed/awk verbs use.
+    if first_command_token(segment).as_deref() == Some("git")
+        && let Some(target) = shell_lex::git_file_write_target(segment)
+        && !target.is_empty()
+    {
+        return Some(target);
     }
     None
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -668,17 +668,28 @@ fn segment_write_target(segment: &str) -> Option<String> {
     None
 }
 
-/// The real file-write redirect target in `command`, if any (owned-string
-/// sibling of [`has_file_write_redirection`], for routing-hint extraction
-/// rather than a pure yes/no classification).
+/// The file a real write redirect in `command` names, if any.
 ///
-/// What: same scan rules as [`has_file_write_redirection`] — skips fd-dups
-/// (`>&`, `2>&1`) and `/dev/null` discards — but returns the target token
-/// itself the first time a real file-write redirect is found, instead of a
-/// bool.
-/// Test: `extract_shell_edit_target_from_redirection`.
-fn redirection_target(command: &str) -> Option<String> {
+/// Why (#7399 review, HIGH): this scan used to exist twice — once returning a
+/// bool for [`has_file_write_redirection`] and once returning the token for
+/// [`redirection_target`] — and only the bool copy learned #5356's heredoc
+/// skip. Once the write boundary began deciding a hard, budget-exempt deny on
+/// the token copy, that drift meant a `>` in here-document PROSE denied a
+/// command that writes nothing. One scanner, two thin callers, so the two
+/// cannot re-diverge.
+/// What: scans for `>` outside quotes ([`QuoteScan`]) and outside
+/// here-document bodies ([`heredoc::HeredocBodies`]); skips a second `>`
+/// (append) and any spaces, treats a following `&` as an fd-duplication
+/// (`2>&1`, `>&2`) and `/dev/null` as an output discard, and returns the
+/// target token of the first real file-write redirect. `Some("")` when the
+/// redirect is real but names no token (`cmd >|`, a trailing `>`): still a
+/// write for the bool caller, no path for the boundary.
+/// Test: `has_file_write_redirection_*`,
+/// `extract_shell_edit_target_from_redirection`,
+/// `shell_write_target_ignores_a_heredoc_body_redirect`.
+fn scan_file_write_redirect(command: &str) -> Option<String> {
     let scan = QuoteScan::new(command);
+    let bodies = heredoc::HeredocBodies::scan(command);
     let bytes = command.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
@@ -686,24 +697,43 @@ fn redirection_target(command: &str) -> Option<String> {
             i += 1;
             continue;
         }
+        // #5356: a here-document body is data, not shell syntax.
+        if bodies.contains(i) {
+            i += 1;
+            continue;
+        }
         if bytes[i] == b'>' {
             let mut j = i + 1;
+            // `>>` append is still a file write; skip the second `>`.
             if j < bytes.len() && bytes[j] == b'>' {
                 j += 1;
             }
-            while j < bytes.len() && bytes[j] == b' ' {
+            while j < bytes.len() && matches!(bytes[j], b' ' | b'\t') {
                 j += 1;
             }
+            // `>&fd` / `2>&1` duplicate a descriptor — not a file write.
             if j < bytes.len() && bytes[j] == b'&' {
                 i = j + 1;
                 continue;
             }
+            // `/dev/null` is an output-discard sink, not a file write
+            // (`which cargo 2>/dev/null`) — allow it and keep scanning.
+            // #7399 review: a newline and a tab end a shell word exactly as a
+            // space does. Without them `python3 <<'PY' > out.rs\nprint(1)\nPY`
+            // read its target as `out.rs\nprint(1)\nPY`, and `cmd >/dev/null`
+            // followed by a newline read as `/dev/null\n…`, missing the
+            // discard and denying a benign command.
             let start = j;
-            while j < bytes.len() && !matches!(bytes[j], b' ' | b'>' | b'<' | b'|' | b';' | b'&') {
+            while j < bytes.len()
+                && !matches!(
+                    bytes[j],
+                    b' ' | b'\t' | b'\n' | b'\r' | b'>' | b'<' | b'|' | b';' | b'&'
+                )
+            {
                 j += 1;
             }
             let target = &command[start..j];
-            if target == "/dev/null" || target.is_empty() {
+            if target == "/dev/null" {
                 i = j;
                 continue;
             }
@@ -712,6 +742,17 @@ fn redirection_target(command: &str) -> Option<String> {
         i += 1;
     }
     None
+}
+
+/// The real file-write redirect target in `command`, if any (owned-string
+/// sibling of [`has_file_write_redirection`], for routing-hint extraction and
+/// for the write boundary rather than a pure yes/no classification).
+///
+/// What: [`scan_file_write_redirect`], with the no-token case dropped — a
+/// redirect that names nothing gives a caller asking "which file" no answer.
+/// Test: `extract_shell_edit_target_from_redirection`.
+fn redirection_target(command: &str) -> Option<String> {
+    scan_file_write_redirect(command).filter(|target| !target.is_empty())
 }
 
 /// The trailing non-flag whitespace-separated token of `command`.
@@ -738,12 +779,13 @@ fn trailing_file_token(command: &str) -> Option<String> {
 /// redirection. But blanket-denying every `>` would false-positive on the very
 /// common `… 2>&1` / `>&2` fd redirects, which are not file writes, so those
 /// must be distinguished.
-/// What: scans for `>`; for each, skips a second `>` (append) and any spaces,
-/// then treats it as an fd-duplication (allow, keep scanning) only when the
-/// next non-space byte is `&`. It then reads the redirect *target* token and
-/// treats `/dev/null` as benign (output discard, e.g. `2>/dev/null` /
-/// `>/dev/null` / `&>/dev/null`) — allow, keep scanning. Any other `>` is a
-/// file-write redirect → `true`.
+/// What: `true` when [`scan_file_write_redirect`] — the one scanner this and
+/// [`redirection_target`] share since #7399 — finds a redirect. It skips a
+/// second `>` (append) and any spaces, treats it as an fd-duplication (allow,
+/// keep scanning) only when the next non-space byte is `&`, then reads the
+/// redirect *target* token and treats `/dev/null` as benign (output discard,
+/// e.g. `2>/dev/null` / `>/dev/null` / `&>/dev/null`) — allow, keep scanning.
+/// Any other `>` is a file-write redirect → `true`.
 /// Quote-aware (#2734): a `>` inside a quoted string is literal argument content
 /// (`git commit -m 'spec -> code'` — Bob's live false positive), not a
 /// redirection, and is skipped — UNLESS the command's quotes are unbalanced, in
@@ -767,50 +809,7 @@ fn trailing_file_token(command: &str) -> Option<String> {
 /// `has_file_write_redirection_detects_redirect_on_a_heredoc_operator_line`,
 /// `has_file_write_redirection_false_for_plain_command`.
 pub(crate) fn has_file_write_redirection(command: &str) -> bool {
-    let scan = QuoteScan::new(command);
-    let bodies = heredoc::HeredocBodies::scan(command);
-    let bytes = command.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if scan.balanced && !scan.is_unquoted(i) {
-            i += 1;
-            continue;
-        }
-        // #5356: a here-document body is data, not shell syntax.
-        if bodies.contains(i) {
-            i += 1;
-            continue;
-        }
-        if bytes[i] == b'>' {
-            let mut j = i + 1;
-            // `>>` append is still a file write; skip the second `>`.
-            if j < bytes.len() && bytes[j] == b'>' {
-                j += 1;
-            }
-            while j < bytes.len() && bytes[j] == b' ' {
-                j += 1;
-            }
-            // `>&fd` / `2>&1` duplicate a descriptor — not a file write.
-            if j < bytes.len() && bytes[j] == b'&' {
-                i = j + 1;
-                continue;
-            }
-            // Read the redirect target token. `/dev/null` is an output-discard
-            // sink, not a file write (`which cargo 2>/dev/null`,
-            // `command -v foo >/dev/null`) — allow it and keep scanning.
-            let start = j;
-            while j < bytes.len() && !matches!(bytes[j], b' ' | b'>' | b'<' | b'|' | b';' | b'&') {
-                j += 1;
-            }
-            if &command[start..j] == "/dev/null" {
-                i = j;
-                continue;
-            }
-            return true;
-        }
-        i += 1;
-    }
-    false
+    scan_file_write_redirect(command).is_some()
 }
 
 /// Deny reason for `git worktree add` targeting a denylisted temp root.

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -2377,3 +2377,32 @@ fn shell_write_target_ignores_reads() {
         Some(SHELL_EDIT_REASON)
     );
 }
+
+// #7399 review, HIGH: `redirection_target` was the one copy of the redirect
+// scan that never learned #5356's heredoc skip, and `split_shell_segments_raw`
+// keeps the operator line, the body and the terminator as ONE segment (#6946).
+// A `>` in here-document PROSE would therefore have named a write target and
+// driven a hard ADR-0044 deny on a command that writes nothing.
+#[test]
+fn shell_write_target_ignores_a_heredoc_body_redirect() {
+    for command in [
+        "cat <<'EOF'\nsee: git diff > crates/x/src/lib.rs\nEOF",
+        "python3 <<'PY'\nprint([k for k in d if len(k) > 3])\nPY",
+        "cat <<EOF\nthe pipeline is read -> parse -> write\nEOF",
+    ] {
+        assert_eq!(shell_write_target(command), None, "{command}");
+        assert_eq!(extract_shell_edit_target(command), None, "{command}");
+        assert_eq!(evaluate_bash_command(command), None, "{command}");
+    }
+    // The skip must not fail open: only the BODY is data. A redirect on the
+    // operator line, or after the terminator, still names its file — the
+    // mirror of `has_file_write_redirection_detects_redirect_on_a_heredoc_operator_line`.
+    assert_eq!(
+        shell_write_target("python3 <<'PY' > out.rs\nprint(1)\nPY").as_deref(),
+        Some("out.rs")
+    );
+    assert_eq!(
+        shell_write_target("python3 <<'PY'\nprint(1)\nPY\necho done > f.rs").as_deref(),
+        Some("f.rs")
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -2319,3 +2319,61 @@ fn an_unlexable_git_segment_keeps_every_deny_it_already_had() {
         "the round-2 spellings inherit the same withhold-only failure"
     );
 }
+
+// #7399: the write boundary decides on `shell_write_target`, so a redirect and
+// a git write option must both resolve to the file they name.
+#[test]
+fn shell_write_target_reads_redirects_and_git_output() {
+    for (command, target) in [
+        ("echo hi > /tmp/o.diff", "/tmp/o.diff"),
+        ("cat a >> /tmp/o.diff", "/tmp/o.diff"),
+        ("git diff --output=/tmp/o.diff HEAD~1 HEAD", "/tmp/o.diff"),
+        ("git diff --output /tmp/o.diff HEAD", "/tmp/o.diff"),
+        ("git -C /repo log -1 --output=/tmp/l.txt", "/tmp/l.txt"),
+        ("git show HEAD --output=/tmp/s.txt", "/tmp/s.txt"),
+        ("git format-patch -o /tmp/d -1 HEAD", "/tmp/d"),
+        ("git archive -o /tmp/a.tar HEAD", "/tmp/a.tar"),
+        ("git bundle create /tmp/x.bundle HEAD", "/tmp/x.bundle"),
+        (
+            "cargo check -p trusty-mpm && git diff --output=/tmp/o.diff",
+            "/tmp/o.diff",
+        ),
+    ] {
+        assert_eq!(
+            shell_write_target(command).as_deref(),
+            Some(target),
+            "{command}"
+        );
+    }
+}
+
+// #7399: the boundary must not deny a read. Everything here either writes
+// nothing or names its file in a position that can also be a read.
+#[test]
+fn shell_write_target_ignores_reads() {
+    for command in [
+        "git diff HEAD~1 HEAD",
+        "git diff --no-index /tmp/a.txt /tmp/b.txt",
+        "git diff --stat -- docs/",
+        "git diff --output-indicator-new=+",
+        "git format-patch --stdout -1 HEAD",
+        "git bundle create - HEAD",
+        "cargo test -p trusty-mpm 2>&1",
+        "echo hi > /dev/null",
+        // The sed/awk trailing token is a routing HINT, never a write the
+        // boundary may act on: `sed -n` only reads this file.
+        "sed -n '1,5p' /tmp/f.rs",
+        "git apply /tmp/f.patch",
+        // Unlexable: withholds, never invents, a target.
+        "git diff --output='/tmp/o.diff",
+    ] {
+        assert_eq!(shell_write_target(command), None, "{command}");
+    }
+    // A write that names no readable path still denies through
+    // `classify_bash_segment`; it just gives the boundary nothing to place.
+    assert_eq!(shell_write_target("git diff --output"), None);
+    assert_eq!(
+        evaluate_bash_command("git diff --output"),
+        Some(SHELL_EDIT_REASON)
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_write_boundary.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_write_boundary.rs
@@ -39,13 +39,25 @@
 //! non-source extension is not this rule's business. The guard denies only on
 //! positive evidence of both halves.
 //!
+//! **A `Bash` write lands here too (#7399).** A shell write used to reach only
+//! `pm_guard_bash`'s `SHELL_EDIT_REASON`, which asks WHO is writing: it is
+//! budget-tiered and both subagent exemptions skip it, so `git diff
+//! --output=<file>` and `echo … > <file>` each landed a source file in a shared
+//! main checkout within budget. `Bash` now takes the same two halves as an edit
+//! tool, reading its target from
+//! [`pm_guard_bash::shell_write_target`](super::pm_guard_bash::shell_write_target)
+//! — the redirect-or-git-write-option half of the one detector `pm_guard_bash`
+//! already keeps, never a second parser. `SHELL_EDIT_REASON` is unchanged and
+//! still fires for the PM on every shell write; this rule adds the WHERE
+//! dimension ADR-0048's Consequences recorded as open.
+//!
 //! Residual bypasses, stated rather than hidden: the path is resolved
 //! lexically, so a symlink into a checkout is not followed — the same limit
-//! [`is_main_checkout`] carries and documents. A write performed through `Bash`
-//! rather than an edit tool is classified by `pm_guard_bash` instead, which
-//! reaches the same deny through `SHELL_EDIT_REASON` for the PM but does not
-//! yet carry the main-checkout dimension for dispatched agents; that is stated
-//! in ADR-0048's Consequences rather than closed here.
+//! [`is_main_checkout`] carries and documents. The `Bash` half sees only a
+//! write it can positively identify, so a write performed by an interpreter
+//! (`python -c`), by a verb whose target sits in a trailing position
+//! (`sed -i`), or through a variable the guard does not expand is not resolved
+//! into a path and keeps only the `SHELL_EDIT_REASON` treatment.
 //!
 //! Test: `denies_*`, `allows_*` below; `pm_guard_denies_a_source_write_in_a_main_checkout`
 //! and siblings in `tests/tm_hook_pm_guard.rs` run the real binary, including
@@ -56,31 +68,56 @@ use std::path::{Path, PathBuf};
 use trusty_mpm::core::project_aliases::is_main_checkout;
 
 use super::pm_guard::{EDIT_TOOLS, edit_tool_target_path, is_source_code_path};
+use super::pm_guard_bash::shell_write_target;
 
 /// Deny a source-file write whose target lives in a project's main checkout.
 ///
 /// Why: the one entry point `pm_guard` calls, ordered cheapest test first so
-/// the overwhelming majority of tool calls — everything that is not an edit —
-/// costs one slice comparison and nothing else.
-/// What: `Some(reason)` when `tool_name` is an [`EDIT_TOOLS`] member, its
-/// target path [`is_source_code_path`], and the directory that path resolves
-/// into [`is_main_checkout`]. `None` (ALLOW) in every other case.
+/// the overwhelming majority of tool calls — everything that is neither an edit
+/// nor a `Bash` call — costs one slice comparison and nothing else.
+/// What: `Some(reason)` when the call names a write target, that target
+/// [`is_source_code_path`], and the directory it resolves into
+/// [`is_main_checkout`]. The target comes from [`edit_tool_target_path`] for an
+/// [`EDIT_TOOLS`] member and from [`shell_write_target`] for `Bash` (#7399).
+/// `None` (ALLOW) in every other case.
 /// Test: `denies_a_source_write_in_a_main_checkout`,
-/// `allows_documents_and_configuration`, `allows_a_write_inside_a_worktree`.
+/// `allows_documents_and_configuration`, `allows_a_write_inside_a_worktree`,
+/// `denies_a_git_output_write_in_a_main_checkout`,
+/// `allows_a_git_read_in_a_main_checkout`.
 pub(crate) fn evaluate_main_checkout_write(
     tool_name: &str,
     tool_input: Option<&serde_json::Value>,
     cwd: &Path,
 ) -> Option<String> {
-    if !EDIT_TOOLS.contains(&tool_name) {
+    let target = write_target(tool_name, tool_input)?;
+    if !is_source_code_path(&target) {
         return None;
     }
-    let target = edit_tool_target_path(tool_input)?;
-    if !is_source_code_path(target) {
+    let resolved = resolve_write_target(&target, cwd);
+    is_main_checkout(&resolved).then(|| deny_reason(&target))
+}
+
+/// The file this tool call would write, whichever tool named it.
+///
+/// Why (#7399): the boundary's question is WHERE a write lands, and the answer
+/// is the same question for an edit tool and for a shell write — only the place
+/// the path is written down differs. Resolving both here keeps one deny, one
+/// message and one pair of halves rather than a second rule for `Bash`.
+/// What: `tool_input.file_path` for an [`EDIT_TOOLS`] member, and for `Bash`
+/// the positively identified write target of its command
+/// ([`shell_write_target`]). `None` for every other tool, and for a command
+/// that names no write.
+/// Test: `denies_a_git_output_write_in_a_main_checkout`,
+/// `denies_a_shell_redirect_into_a_main_checkout`.
+fn write_target(tool_name: &str, tool_input: Option<&serde_json::Value>) -> Option<String> {
+    if EDIT_TOOLS.contains(&tool_name) {
+        return edit_tool_target_path(tool_input).map(str::to_owned);
+    }
+    if tool_name != "Bash" {
         return None;
     }
-    let resolved = resolve_write_target(target, cwd);
-    is_main_checkout(&resolved).then(|| deny_reason(target))
+    let command = tool_input?.get("command")?.as_str()?;
+    shell_write_target(command)
 }
 
 /// The directory a write to `target` would land in.
@@ -218,7 +255,10 @@ mod tests {
     }
 
     #[test]
-    fn allows_every_non_edit_tool() {
+    fn allows_every_tool_that_names_no_write() {
+        // `Bash` is in the list since #7399, and stays here: this payload
+        // carries a `file_path` and no `command`, so the shell half finds
+        // nothing to resolve.
         let dir = main_checkout();
         for tool in ["Read", "Bash", "Grep", "Agent", "SendMessage"] {
             assert_eq!(
@@ -228,9 +268,102 @@ mod tests {
                     dir.path()
                 ),
                 None,
-                "{tool} is not an edit tool"
+                "{tool} names no write here"
             );
         }
+    }
+
+    /// A `Bash` payload running `command`.
+    fn bash_input(command: &str) -> serde_json::Value {
+        serde_json::json!({"command": command})
+    }
+
+    // #7399: `git diff --output=<file>` writes exactly as `> <file>` does, so
+    // the boundary must answer the same way for both.
+    #[test]
+    fn denies_a_git_output_write_in_a_main_checkout() {
+        let dir = main_checkout();
+        let target = dir.path().join("crates/x/src/lib.rs");
+        let target = target.display().to_string();
+        for command in [
+            format!("git diff --output={target} HEAD~1 HEAD"),
+            format!("git diff --output {target} HEAD"),
+            format!("git log -1 --output={target}"),
+            format!("git show HEAD --output={target}"),
+            // `format-patch -o` and `archive -o` reach the same detector; they
+            // name a directory and an archive, which `is_source_code_path`
+            // does not classify as source, so the boundary leaves them to the
+            // `SHELL_EDIT_REASON` deny #7405 already gives them.
+            format!("git -C {} diff --output={target}", dir.path().display()),
+        ] {
+            let reason =
+                evaluate_main_checkout_write("Bash", Some(&bash_input(&command)), dir.path())
+                    .unwrap_or_else(|| {
+                        panic!("`{command}` writes into a main checkout and must deny")
+                    });
+            assert!(reason.contains("ADR-0044"), "{reason}");
+        }
+    }
+
+    // #7399: the redirect the boundary is made to match, proving both spellings
+    // reach one deny with one message.
+    #[test]
+    fn denies_a_shell_redirect_into_a_main_checkout() {
+        let dir = main_checkout();
+        let target = dir.path().join("crates/x/src/lib.rs");
+        let command = format!("echo 'fn main() {{}}' > {}", target.display());
+        let reason = evaluate_main_checkout_write("Bash", Some(&bash_input(&command)), dir.path())
+            .expect("a redirect into a main checkout's source must deny");
+        assert!(reason.contains("ADR-0044"), "{reason}");
+    }
+
+    // #7399: the worktree is where the write is SUPPOSED to land.
+    #[test]
+    fn allows_a_git_output_write_inside_a_worktree() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(".git"), "gitdir: /elsewhere").expect("write .git");
+        let target = dir.path().join("crates/x/src/lib.rs");
+        let command = format!("git diff --output={} HEAD", target.display());
+        assert_eq!(
+            evaluate_main_checkout_write("Bash", Some(&bash_input(&command)), dir.path()),
+            None
+        );
+    }
+
+    // #7399 must not cost a single read. `--no-index` compares two files and
+    // writes none; the plain forms write nothing either.
+    #[test]
+    fn allows_a_git_read_in_a_main_checkout() {
+        let dir = main_checkout();
+        let a = dir.path().join("crates/x/src/lib.rs");
+        let a = a.display().to_string();
+        for command in [
+            format!("git diff --no-index {a} {a}"),
+            "git diff HEAD~1 HEAD".to_string(),
+            "git diff --stat".to_string(),
+            format!("git diff --output-indicator-new=+ -- {a}"),
+            format!("git format-patch --stdout -1 HEAD -- {a}"),
+            // The sed/awk trailing token names a file `sed -n` only READS, so
+            // the boundary deliberately does not resolve it.
+            format!("sed -n '1,5p' {a}"),
+        ] {
+            assert_eq!(
+                evaluate_main_checkout_write("Bash", Some(&bash_input(&command)), dir.path()),
+                None,
+                "`{command}` writes nothing"
+            );
+        }
+    }
+
+    // #7399: documents keep the ADR-0049 carve-out through the shell too.
+    #[test]
+    fn allows_a_git_output_write_of_a_document() {
+        let dir = main_checkout();
+        let command = format!("git diff --output={}/notes.md HEAD", dir.path().display());
+        assert_eq!(
+            evaluate_main_checkout_write("Bash", Some(&bash_input(&command)), dir.path()),
+            None
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_write_boundary.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_write_boundary.rs
@@ -53,11 +53,24 @@
 //!
 //! Residual bypasses, stated rather than hidden: the path is resolved
 //! lexically, so a symlink into a checkout is not followed — the same limit
-//! [`is_main_checkout`] carries and documents. The `Bash` half sees only a
-//! write it can positively identify, so a write performed by an interpreter
-//! (`python -c`), by a verb whose target sits in a trailing position
-//! (`sed -i`), or through a variable the guard does not expand is not resolved
-//! into a path and keeps only the `SHELL_EDIT_REASON` treatment.
+//! [`is_main_checkout`] carries and documents. The `Bash` half sees only the
+//! two shapes that NAME their target unambiguously — a redirect, and a git
+//! write option — so everything else keeps only the `SHELL_EDIT_REASON`
+//! treatment and gets no WHERE dimension:
+//!
+//! * `git apply` and `git am` write the files a patch names, and the patch
+//!   names them, not the argv.
+//! * `tee`, `cp`, `mv`, `install` and `dd` write a target that is an ordinary
+//!   argument, indistinguishable here from the source they read.
+//! * `sed -i` and the awk family put their target in the trailing position,
+//!   which a read (`sed -n '1,5p' <file>`) occupies identically.
+//! * An interpreter (`python -c`, `node -e`) carries its write inside a
+//!   program string this guard does not parse.
+//! * A target built from a shell variable or a command substitution is not
+//!   expanded.
+//!
+//! Each is a candidate for the same detector rather than a second rule; none
+//! is closed here.
 //!
 //! Test: `denies_*`, `allows_*` below; `pm_guard_denies_a_source_write_in_a_main_checkout`
 //! and siblings in `tests/tm_hook_pm_guard.rs` run the real binary, including
@@ -353,6 +366,28 @@ mod tests {
                 "`{command}` writes nothing"
             );
         }
+    }
+
+    // #7399 review, HIGH: a `>` inside a here-document BODY is prose, and the
+    // whole heredoc reaches the guard as one segment (#6946). Denying on it
+    // would refuse a command that writes nothing, through a deny no budget and
+    // no subagent marker can soften.
+    #[test]
+    fn allows_a_heredoc_body_redirect_in_a_main_checkout() {
+        let dir = main_checkout();
+        let target = dir.path().join("crates/x/src/lib.rs");
+        let command = format!("cat <<'EOF'\nsee: git diff > {}\nEOF", target.display());
+        assert_eq!(
+            evaluate_main_checkout_write("Bash", Some(&bash_input(&command)), dir.path()),
+            None,
+            "a here-document body is data, not a write"
+        );
+        // The operator line is still live.
+        let live = format!("python3 <<'PY' > {}\nprint(1)\nPY", target.display());
+        assert!(
+            evaluate_main_checkout_write("Bash", Some(&bash_input(&live)), dir.path()).is_some(),
+            "a redirect on the operator line is still a write"
+        );
     }
 
     // #7399: documents keep the ADR-0049 carve-out through the shell too.

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -3209,6 +3209,109 @@ fn pm_guard_allows_documents_and_configuration_in_a_main_checkout() {
 }
 
 #[test]
+fn pm_guard_denies_a_git_output_write_in_a_main_checkout() {
+    // #7399 finding (a), live-verified: `git diff --output=<file>` writes a
+    // file with no `>`, and until now the only rule that saw it was the
+    // budget-tiered `SHELL_EDIT_REASON` — which allows the first writes of a
+    // turn and which both subagent markers skip. So the write landed in a
+    // shared main checkout. It now takes the same ADR-0044 boundary an `Edit`
+    // takes, and so does the `>` redirect it is a spelling of.
+    let (_dir, repo) = main_checkout_fixture();
+    let target = repo.join("crates/trusty-mpm/src/lib.rs");
+    let target = target.display().to_string();
+
+    for command in [
+        format!("git diff --output={target} HEAD~1 HEAD"),
+        format!("git diff --output {target} HEAD"),
+        format!("git log -1 --output={target}"),
+        format!("echo 'fn main() {{}}' > {target}"),
+    ] {
+        let stdout = run_pm_guard(&bash_payload_at(&command, &repo, ""), &[]);
+        assert_denied(&stdout);
+        assert!(
+            stdout.contains("ADR-0044"),
+            "`{command}` must deny through the write boundary, not the budget: {stdout}"
+        );
+    }
+
+    // ADR-0044 binds every dispatched agent too, so the deny must pierce both
+    // subagent markers exactly as the `Edit` half does.
+    let command = format!("git diff --output={target} HEAD");
+    let dispatched = run_pm_guard(
+        &bash_payload_at(&command, &repo, r#""agent_id":"agt_1","#),
+        &[],
+    );
+    assert_denied(&dispatched);
+    assert!(dispatched.contains("ADR-0044"), "{dispatched}");
+    let nested = run_pm_guard(
+        &bash_payload_at(&command, &repo, ""),
+        &[("CLAUDE_MPM_SUB_AGENT", "1")],
+    );
+    assert_denied(&nested);
+    assert!(nested.contains("ADR-0044"), "{nested}");
+}
+
+#[test]
+fn pm_guard_allows_a_git_output_write_inside_a_worktree() {
+    // The worktree is where delegated work is SUPPOSED to write, and a rule
+    // that denied there would leave nowhere to write at all. A linked worktree
+    // carries a `.git` FILE rather than a directory.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let worktree = dir.path().join("wt");
+    std::fs::create_dir_all(worktree.join("crates/trusty-mpm/src")).expect("mkdir");
+    std::fs::write(worktree.join(".git"), "gitdir: /elsewhere").expect("write .git");
+    let target = worktree.join("crates/trusty-mpm/src/lib.rs");
+
+    let command = format!("git diff --output={} HEAD", target.display());
+    let stdout = run_pm_guard(
+        &bash_payload_at(&command, &worktree, r#""agent_id":"agt_1","#),
+        &[],
+    );
+    assert_eq!(
+        stdout.trim(),
+        "",
+        "a worktree write is the outcome the rule steers toward: {stdout}"
+    );
+}
+
+#[test]
+fn pm_guard_keeps_the_reads_and_the_quoted_verb_decision_unchanged() {
+    // #7399 findings (b) and (c), pinned end to end so the boundary cannot
+    // regress them: `--no-index` compares two files and writes none, a plain
+    // diff writes nothing, and a forbidden verb reached through a quoted path
+    // stays refused (#7374 / #7402).
+    let (_dir, repo) = main_checkout_fixture();
+    let a = repo.join("crates/trusty-mpm/src/lib.rs");
+    let a = a.display().to_string();
+
+    for command in [
+        format!("git diff --no-index {a} {a}"),
+        "git diff HEAD~1 HEAD".to_string(),
+        "git diff --stat".to_string(),
+        "git format-patch --stdout -1 HEAD".to_string(),
+    ] {
+        let stdout = run_pm_guard(&bash_payload_at(&command, &repo, ""), &[]);
+        assert_eq!(
+            stdout.trim(),
+            "",
+            "`{command}` writes nothing and must allow"
+        );
+    }
+
+    let quoted = run_pm_guard(
+        &serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "cwd": repo.display().to_string(),
+            "tool_name": "Bash",
+            "tool_input": {"command": r#""/opt/My Tools/npm" test"#},
+        })
+        .to_string(),
+        &[],
+    );
+    assert_denied(&quoted);
+}
+
+#[test]
 fn pm_guard_denies_a_commit_in_a_main_checkout() {
     // The commit is where a write becomes permanent on a branch another
     // session is standing on — the step that produced `f1da7bce` landing on a


### PR DESCRIPTION
## Outcome

Refs [#7399](https://github.com/bobmatnyc/trusty-tools/issues/7399). Live check on 1.5.29 showed `git diff --output=<file>` allowed: the #7405 detector worked but `SHELL_EDIT_REASON` is budget-tiered, and no Bash write ever reached the ADR-0044/0048 write boundary (it bound Edit/Write only), so a redirect into a main checkout's source passed the same way.

## Changes

`pm_guard_bash::shell_write_target` (redirects and git `--output=`/`--output <f>` on diff/log/show, `format-patch -o`) feeds `evaluate_main_checkout_write` for Bash; one `segment_write_target` helper serves both the routing hint and the boundary; one heredoc-aware `scan_file_write_redirect` replaces the duplicated bool/token scanners (the token copy had missed #5356's heredoc skip and terminated on space but not newline, a pre-existing false deny on `>/dev/null\n…`). `/tmp` and out-of-checkout writes stay budget-tiered (parity with redirects; scratchpad workflow). Residual-bypass paragraph now names `git apply`/`am`, `tee`/`cp`/`mv`/`install`/`dd`, sed/awk trailing position, interpreter strings, unexpanded variables.

## Risk

Guard/security-boundary change (rung 5). Blast radius: `pm_guard_bash` write-target detection used by every Bash dispatch through the ADR-0044/0048 boundary. Live matrix on a branch build: DENY `git diff --output=<main>/crates/…/lib.rs`, `git log --output=<main>/…`, `echo hi > <main>/…/lib.rs`; ALLOW `--output=/tmp/o.diff`, `--no-index`, plain `git diff`, `sed -n '1,5p' f`, `--output=<worktree>/…`, heredoc body containing `>`.

## Tests

Test rung: 5 (guard). Gates: `cargo fmt --check`; `cargo check -p trusty-mpm --all-targets`; `cargo clippy -p trusty-mpm --all-targets -- -D warnings`; `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` (57 targets ok; lib 6685, bin 2671, `tm_hook_pm_guard` 159 passed). Regression tests shown failing without the fix (deny test: empty stdout = the reported allow; heredoc test: token ran past the newline).

## Baseline

No pre-existing red encountered on this branch; all gates above are branch-clean.

## Docs

check_line_cap, check_changelog_fragment, check_test_pointers all OK. Fragment: `crates/trusty-mpm/changelog.d/7399-git-diff-output-boundary.md`.

## Review

code-critic WARN → HIGH (heredoc) fixed, MEDIUM doc fixed; LOW (quoted-space redirect target truncation) deferred, noted on the issue. Security scan PASS.

Refs #7399

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
