### PR TITLE
chore(trusty-mpm): bump to 1.5.30 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.29"
+version = "1.5.30"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -47,7 +47,10 @@ name = "trusty-mpm"
 # 1.5.29 (owner-authorized reinstall, 2026-09-11): patch, version-only —
 # 1.5.28 is already published and this bump exists solely so `tm --version`
 # identifies the reinstalled build.
-version = "1.5.29"
+# 1.5.30 (owner-authorized reinstall, refs #7422 #7471 #7399 #7424): patch,
+# version-only — 1.5.29 is already published and this bump exists solely so
+# `tm --version` identifies the reinstalled build.
+version = "1.5.30"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome
Owner-authorized reinstall bump, 2026-09-11. Every reinstall carries a patch bump so `tm --version` identifies the build.

## Changes
Bump trusty-mpm to 1.5.30. Carries into the installed binary: #7422 default-deny scoping, #7471 doctor deploy-gap, #7399 boundary correction, #7424 startup-context budget gate.

## Risk
Version-only change (Cargo.toml + Cargo.lock); no crate source touched.

## Tests
Rung 1 (version-only, no crate source). `cargo check -p trusty-mpm` OK, `scripts/check-pr-version-bump.sh` OK, `scripts/check_changelog_fragment.sh` OK (no crate source changed).

## Baseline
N/A — version-only change, nothing to compare against a pre-existing red.

## Docs
None required.

## Review
Refs #7424

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0138Hn9mp8iFDWH8PLqcXVwY
