### PR TITLE
chore(trusty-mpm): bump to 1.5.31 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.30"
+version = "1.5.31"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -50,7 +50,10 @@ name = "trusty-mpm"
 # 1.5.30 (owner-authorized reinstall, refs #7422 #7471 #7399 #7424): patch,
 # version-only — 1.5.29 is already published and this bump exists solely so
 # `tm --version` identifies the reinstalled build.
-version = "1.5.30"
+# 1.5.31 (owner-authorized reinstall, refs #7488): patch, version-only —
+# 1.5.30 is already published and this bump exists solely so `tm --version`
+# identifies the reinstalled build.
+version = "1.5.31"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome
Reinstall version bump so `tm --version` identifies the build. Carries #7488
(PR #7492, 08bfe4e2b) on top of 1.5.30.

## Changes
- `Cargo.lock`
- `crates/trusty-mpm/Cargo.toml`

## Risk
Low, version-only.

## Tests
Rung 1.
- `cargo check -p trusty-mpm`: OK
- `scripts/check-pr-version-bump.sh`: OK
- `scripts/check_changelog_fragment.sh`: OK (no crate source changed)

## Baseline
None owed.

## Docs
None owed.

## Review
None owed.

Refs #7488

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0138Hn9mp8iFDWH8PLqcXVwY
