### PR TITLE
chore(trusty-mpm): bump to 1.5.32 for owner-authorized reinstall (Refs #7490)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.31"
+version = "1.5.32"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -53,7 +53,10 @@ name = "trusty-mpm"
 # 1.5.31 (owner-authorized reinstall, refs #7488): patch, version-only —
 # 1.5.30 is already published and this bump exists solely so `tm --version`
 # identifies the reinstalled build.
-version = "1.5.31"
+# 1.5.32 (owner-authorized reinstall, refs #7490): patch, version-only —
+# 1.5.31 is already published and this bump exists solely so `tm --version`
+# identifies the reinstalled build.
+version = "1.5.32"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome
Version-only bump 1.5.31 -> 1.5.32 for the owner-authorized reinstall carrying
the #7496 fix.

## Changes
- `Cargo.lock`
- `crates/trusty-mpm/Cargo.toml`

## Risk
Low, version-only.

## Tests
Rung 1.
- `cargo check -p trusty-mpm`: OK
- `scripts/check-pr-version-bump.sh`: OK

## Baseline
None owed.

## Docs
None owed.

## Review
None owed.

Refs #7490

Shape of PR #7494.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0138Hn9mp8iFDWH8PLqcXVwY
