### PR TITLE
fix(trusty-mpm): pm_guard false positives — secret-file glob, .env.example, Go-template braces (Refs #7498 #7479 #7499; #7477 #7436 found upstream)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7498-pm-guard-false-positives.md
+++ b/crates/trusty-mpm/changelog.d/7498-pm-guard-false-positives.md
@@ -1,0 +1,5 @@
+Fixed
+- `pm_guard`'s secret-file class no longer refuses a one-character glob fragment such as `s*`: the word-family shape gate now uses the same glob matcher the deny used, so a candidate reaching only `credentials`/`secrets`/`token` must still be written as a path (Refs #7498).
+- `pm_guard` reads `.env.example`, `.env.sample` and `.env.template` as placeholders rather than secrets, keyed on the final extension so `.env.example.bak` still denies (Refs #7479).
+- `pm_guard` treats a comma-free brace group as literal text the way a shell does, so a Go-template argument such as `docker ps --format '{{.ID}}'` allows while a real brace alternation still resolves or fails closed (Refs #7499).
+- `pm_guard`'s own verdict for the read-only commands reported as nondeterministically refused is pinned as classifiable, allowed and stable across repeated evaluation; the refusal text belongs to the Claude Code harness, not to `tm` (Refs #7477, Refs #7436).

--- a/crates/trusty-mpm/changelog.d/7498-pm-guard-false-positives.md
+++ b/crates/trusty-mpm/changelog.d/7498-pm-guard-false-positives.md
@@ -1,5 +1,5 @@
 Fixed
 - `pm_guard`'s secret-file class no longer refuses a one-character glob fragment such as `s*`: the word-family shape gate now uses the same glob matcher the deny used, so a candidate reaching only `credentials`/`secrets`/`token` must still be written as a path (Refs #7498).
-- `pm_guard` reads `.env.example`, `.env.sample` and `.env.template` as placeholders rather than secrets, keyed on the final extension so `.env.example.bak` still denies (Refs #7479).
-- `pm_guard` treats a comma-free brace group as literal text the way a shell does, so a Go-template argument such as `docker ps --format '{{.ID}}'` allows while a real brace alternation still resolves or fails closed (Refs #7499).
+- `pm_guard` reads `.env.example`, `.env.sample` and `.env.template` as placeholders rather than secrets, scoped to the `.env` family and to the final extension so `id_rsa.sample`, `secrets.example` and `.env.example.bak` all still deny (Refs #7479).
+- `pm_guard` gives a comma-free brace group both the readings a shell gives it, so a Go-template argument such as `docker ps --format '{{.ID}}'` allows while a sequence group that expands onto a secret name — `cat .en{v..v}`, and now `cat .en{u..v}` — still denies (Refs #7499).
 - `pm_guard`'s own verdict for the read-only commands reported as nondeterministically refused is pinned as classifiable, allowed and stable across repeated evaluation; the refusal text belongs to the Claude Code harness, not to `tm` (Refs #7477, Refs #7436).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/false_positive_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/false_positive_tests.rs
@@ -1,0 +1,296 @@
+//! Regression tests for reported pm_guard FALSE POSITIVES (#7498, #7479,
+//! #7499, #7477, #7436).
+//!
+//! Why: the guard is quote-unaware and conservatively over-blocking by design
+//! (see `super`'s module doc), so every false positive it produces is a real
+//! cost paid for a real guarantee, and each one is fixed by narrowing exactly
+//! one reading — never by weakening a deny. These rows are kept apart from
+//! `tests.rs` so the allow case and the deny case that bounds it sit side by
+//! side for each issue.
+//! What: one module per issue, each pairing the issue's verbatim repro command
+//! with the deny case that must survive the fix.
+//! Test: itself.
+//!
+//! This file is classified as a test file (3000-SLOC cap) by its
+//! `_tests.rs` basename.
+
+use super::{evaluate_bash_command, unclassifiable_command};
+use crate::commands::pm_guard_secret_read::evaluate_secret_file_read_command;
+
+/// #7498: a bare `s*` token is a regex fragment, not a glob naming `secrets`.
+mod secret_file_glob_matches_an_unrelated_token {
+    use super::*;
+
+    /// The issue's verbatim repro command must allow.
+    ///
+    /// Why: `s*` carries a `*`, so the candidate took
+    /// `secret_pattern_overlaps`'s GLOB branch and was overlap-tested against
+    /// the literal core `secrets`. `s` + `*` does reach `secrets`, so a
+    /// one-character regex fragment denied a `gh` search and the
+    /// BASE-ENGINEER file-size precheck alike.
+    /// What: asserts the two reported spellings allow.
+    /// Test: itself.
+    #[test]
+    fn a_one_character_glob_fragment_does_not_name_a_secret_family() {
+        for command in [
+            r#"gh issue list --search "\s* guard" --state all"#,
+            r"grep -cvE '^\s*(//|\*|/\*|\*/|$)' crates/trusty-mpm/src/lib.rs",
+            "gh issue list --search 's* guard' --state all",
+        ] {
+            assert_eq!(
+                evaluate_secret_file_read_command(command),
+                None,
+                "a regex fragment must not read as a secret glob: {command}"
+            );
+        }
+    }
+
+    /// The deny this fix must not weaken.
+    ///
+    /// Why: narrowing the glob branch is only correct while a glob that really
+    /// does target a credential family by name still denies.
+    /// What: asserts the natural globs for the file families, a word-family
+    /// glob written as a path, and three literal secret paths, all still deny.
+    ///
+    /// `cat *secrets*` is absent deliberately: a word family written with no
+    /// directory in front of it has been allowed since #7266 round 6, which is
+    /// why `./secrets*` is the row here.
+    /// Test: itself.
+    #[test]
+    fn a_real_secret_glob_and_a_real_secret_path_still_deny() {
+        for command in [
+            "cat *.env",
+            "cat .e*",
+            "cat *.pem",
+            "cat ./secrets*",
+            "cat .env",
+            "cat secrets.pem",
+            "cat id_rsa",
+        ] {
+            assert!(
+                evaluate_secret_file_read_command(command).is_some(),
+                "a real secret target must still deny: {command}"
+            );
+        }
+    }
+}
+
+/// #7479: `.env.example` is a placeholder file, not a secret.
+mod dotenv_placeholder_files {
+    use super::*;
+
+    /// The issue's verbatim repro shapes must allow.
+    ///
+    /// Why: `.env.*` classed every suffix as secret-bearing, so a tracked
+    /// placeholder could not be read by any verb and an operator had to make
+    /// the change by hand.
+    /// What: asserts the three placeholder suffixes allow under a reading verb,
+    /// bare and with a directory in front.
+    /// Test: itself.
+    #[test]
+    fn placeholder_suffixes_are_readable() {
+        for command in [
+            "cat apps/advisor/.env.example",
+            "printf 'KEY=\\n' >> apps/advisor/.env.example",
+            "cat .env.example",
+            "cat .env.sample",
+            "cat .env.template",
+            "cat config/.env.example",
+        ] {
+            assert_eq!(
+                evaluate_secret_file_read_command(command),
+                None,
+                "a placeholder env file must be readable: {command}"
+            );
+        }
+    }
+
+    /// The deny this fix must not weaken.
+    ///
+    /// Why: the exemption is keyed on the SUFFIX, so every other `.env.*`
+    /// spelling — and a real secret file of another family — must still deny.
+    /// What: asserts the secret-bearing `.env` spellings and two other families
+    /// still deny.
+    ///
+    /// `secrets.yaml` is absent deliberately: `yaml` has been a transparent
+    /// source extension since #7266 round 6, so that name allowed before this
+    /// change and still does.
+    /// Test: itself.
+    #[test]
+    fn real_dotenv_files_still_deny() {
+        for command in [
+            "cat .env",
+            "cat .env.local",
+            "cat .env.production",
+            "cat apps/advisor/.env.local",
+            "cat terraform.tfvars",
+            "cat id_rsa",
+        ] {
+            assert!(
+                evaluate_secret_file_read_command(command).is_some(),
+                "a real secret env file must still deny: {command}"
+            );
+        }
+    }
+
+    /// The placeholder suffix counts only as the FINAL extension.
+    ///
+    /// Why: the exemption is a naming convention, and a convention that
+    /// matched anywhere in the name would let `.env.example.bak` — a real
+    /// dump of a real environment — read freely.
+    /// What: asserts a placeholder suffix followed by another extension still
+    /// denies.
+    /// Test: itself.
+    #[test]
+    fn a_placeholder_suffix_is_honoured_only_as_the_final_extension() {
+        for command in ["cat .env.example.bak", "cat .env.sample.local"] {
+            assert!(
+                evaluate_secret_file_read_command(command).is_some(),
+                "a placeholder suffix behind another extension must deny: {command}"
+            );
+        }
+    }
+}
+
+/// #7499: a Go-template `--format` argument is a brace literal, not an
+/// alternation.
+mod go_template_braces {
+    use super::*;
+
+    /// The issue's verbatim repro command must allow.
+    ///
+    /// Why: #7414 repaired the ORPHANED brace a word cut creates, but a
+    /// Go-template argument survives the cut with BOTH braces intact — `{{`
+    /// and `}}` — so it reached the shared expander as a real alternation and
+    /// failed closed on a shape it cannot resolve.
+    /// What: asserts the reported `docker` spellings allow.
+    /// Test: itself.
+    #[test]
+    fn a_go_template_format_argument_is_allowed() {
+        for command in [
+            "docker images --format '{{.Repository}}:{{.Tag}}'",
+            "docker ps --format '{{.ID}}'",
+            "docker inspect --format '{{.Created}}' abc123",
+            "docker ps --format \"{{.Names}}\\t{{.Status}}\"",
+        ] {
+            assert_eq!(
+                evaluate_secret_file_read_command(command),
+                None,
+                "a Go-template format argument must allow: {command}"
+            );
+        }
+    }
+
+    /// The #7414 deny cases must still deny.
+    ///
+    /// Why: a brace pair that survives the cut whole is a real alternation, and
+    /// the whole point of failing closed on an unresolvable one is that a
+    /// secret cannot be hidden inside it.
+    /// What: asserts a real alternation naming a secret still denies, and that
+    /// an unresolvable single-brace alternation still fails closed.
+    /// Test: itself.
+    #[test]
+    fn a_real_brace_alternation_still_denies() {
+        for command in [
+            "cat {.env,.env.prod}",
+            "cp secret.{tfvars,bak} /tmp/",
+            "cat .{e,env}",
+        ] {
+            assert!(
+                evaluate_secret_file_read_command(command).is_some(),
+                "a real brace alternation naming a secret must still deny: {command}"
+            );
+        }
+    }
+}
+
+/// #7477 and #7436: the reported refusals do not come from this guard, and
+/// this guard's own answer for them never varies.
+///
+/// The refusal text both issues quote — "too complex to verify that it stays
+/// inside the worktree", inside "This agent is isolated in the worktree …" —
+/// is emitted by the Claude Code binary, not by any `trusty-*` binary. That was
+/// already established for a different shape family by #6982 (see
+/// `HARNESS_REFUSED_SHAPES` and `harness_refused_shapes_stay_classifiable_here`
+/// in this module's `tests` sibling); these rows extend the same catalogue with
+/// the shapes these two issues report, and add the DETERMINISM claim neither
+/// issue could make about the harness.
+mod harness_refusals_are_not_this_guard {
+    use super::*;
+
+    /// The command shapes #7477 and #7436 report as refused.
+    ///
+    /// Rows 1-4 are #7477's verbatim list. Rows 5-7 are #7436's scratchpad
+    /// read-back, plus two shapes refused live in the session that produced
+    /// this fix — a multi-file `grep` and a `grep` carrying context flags —
+    /// each of which has an allowed twin differing only in a flag.
+    const REPORTED_REFUSALS: &[&str] = &[
+        "ls apps",
+        "ls -la",
+        "grep -rl healthz services",
+        "grep -n healthz docs/specs/domain-service-shell.md",
+        r#"grep -E "^test result" /private/tmp/claude-502/proj/sess/scratchpad/gate-7359-test.txt"#,
+        "grep -n scratchpad crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs \
+         crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs",
+        "grep -n fn -B 4 -A 12 crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs",
+    ];
+
+    /// Every reported shape is classifiable and allowed here.
+    ///
+    /// Why: a `Some` from either band would mean the refusal really did
+    /// originate in this guard and a fix belonged in this repository. `None`
+    /// from both is the finding: the shapes are answerable, so the refusal came
+    /// from the harness and a change here would fix nothing.
+    /// What: asserts both bands answer `None` — [`unclassifiable_command`], the
+    /// ABSOLUTE band a dispatched subagent reaches, and
+    /// [`evaluate_bash_command`], the PM classifier.
+    /// Test: itself.
+    #[test]
+    fn every_reported_shape_is_classifiable_and_allowed_here() {
+        for command in REPORTED_REFUSALS {
+            assert_eq!(
+                unclassifiable_command(command),
+                None,
+                "the harness refused this as unverifiable; this guard must still \
+                 establish what it runs: {command}"
+            );
+            assert_eq!(
+                evaluate_bash_command(command),
+                None,
+                "a read-only command must allow: {command}"
+            );
+        }
+    }
+
+    /// The same command evaluated 50 times yields the same verdict every time.
+    ///
+    /// Why: #7477 reports "no complexity pattern predicts the refusal" and
+    /// #7436's comment reports an identical command flipping PASS to REFUSED
+    /// four calls later. Both readings blame a nondeterministic decision. This
+    /// guard's decision is a pure function of the command string — no clock, no
+    /// filesystem read, no environment read, no map iteration — so it cannot be
+    /// the varying party, and a future report of the same flip should not spend
+    /// a second session re-establishing that.
+    /// What: evaluates each row 50 times and asserts every verdict equals the
+    /// first.
+    /// Test: itself.
+    #[test]
+    fn the_verdict_for_one_command_never_varies() {
+        for command in REPORTED_REFUSALS {
+            let first = (
+                unclassifiable_command(command),
+                evaluate_bash_command(command),
+            );
+            for round in 1..50 {
+                assert_eq!(
+                    (
+                        unclassifiable_command(command),
+                        evaluate_bash_command(command)
+                    ),
+                    first,
+                    "verdict changed on round {round} for: {command}"
+                );
+            }
+        }
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/false_positive_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/false_positive_tests.rs
@@ -133,6 +133,33 @@ mod dotenv_placeholder_files {
         }
     }
 
+    /// The exemption covers the dotenv family and no other.
+    ///
+    /// Why: review round on #7479. The first round keyed only on the final
+    /// extension, so it handed the SSH-key and word families a placeholder
+    /// convention neither the issue nor its reporter asked for — exactly the
+    /// two families where a misnamed file leaks a key rather than a variable
+    /// name.
+    /// What: asserts a `.env` placeholder allows while the same suffix on the
+    /// two PREFIX-typed families — the ones the exemption really did reach —
+    /// still denies.
+    ///
+    /// An EXTENSION-typed family is not testable here and is not a regression:
+    /// `server.pem.example` allowed before this change too, because `*.pem`
+    /// matches only a name ENDING `.pem` and the placeholder suffix displaces
+    /// it. That is the pre-existing `*.<ext>` rule, not the exemption.
+    /// Test: itself.
+    #[test]
+    fn the_placeholder_exemption_covers_only_the_dotenv_family() {
+        assert_eq!(evaluate_secret_file_read_command("cat .env.example"), None);
+        for command in ["cat id_rsa.sample", "cat secrets.example"] {
+            assert!(
+                evaluate_secret_file_read_command(command).is_some(),
+                "only the dotenv family is exempt: {command}"
+            );
+        }
+    }
+
     /// The placeholder suffix counts only as the FINAL extension.
     ///
     /// Why: the exemption is a naming convention, and a convention that
@@ -177,6 +204,58 @@ mod go_template_braces {
                 evaluate_secret_file_read_command(command),
                 None,
                 "a Go-template format argument must allow: {command}"
+            );
+        }
+    }
+
+    /// A Bash SEQUENCE group is expanded, not read as literal text.
+    ///
+    /// Why: review round on #7499. A comma-free body is not always literal —
+    /// `{v..v}` is a degenerate sequence a shell expands to `v`, so
+    /// `cat .en{v..v}` opens `.env`. `origin/main` denied that by ACCIDENT:
+    /// stripping the group produced `.env..v`, which `.env.*` matches. Reading
+    /// the group as literal removed the accident and the coverage with it.
+    /// Rows 2 and 4 are the wider hole the accident never covered — open on
+    /// `origin/main` too — closed here because the fix is in this function.
+    /// What: asserts every sequence spelling that expands onto a secret name
+    /// denies.
+    /// Test: itself.
+    #[test]
+    fn a_sequence_group_that_expands_onto_a_secret_name_denies() {
+        for command in [
+            "cat .en{v..v}",
+            "cat .en{u..v}",
+            "cat id_rs{a..a}",
+            "cat id_rs{a..c}",
+            "cat secret{s..s}.txt",
+            "cp .en{v..v} /tmp/x/",
+        ] {
+            assert!(
+                evaluate_secret_file_read_command(command).is_some(),
+                "a sequence group reaching a secret name must deny: {command}"
+            );
+        }
+    }
+
+    /// An ordinary sequence group naming no secret still allows.
+    ///
+    /// Why: expanding sequences is only affordable while the shapes an agent
+    /// writes all day stay allowed. These are the two common ones.
+    /// What: asserts a numeric and an alphabetic range allow, alongside the
+    /// Go-template rows above.
+    /// Test: itself.
+    #[test]
+    fn an_ordinary_sequence_group_is_allowed() {
+        for command in [
+            "for i in {1..5}; do echo $i; done",
+            "echo {a..e}",
+            "mkdir -p build/{1..3}",
+            "echo {1..5000}",
+        ] {
+            assert_eq!(
+                evaluate_secret_file_read_command(command),
+                None,
+                "an ordinary sequence group must allow: {command}"
             );
         }
     }
@@ -262,20 +341,27 @@ mod harness_refusals_are_not_this_guard {
         }
     }
 
-    /// The same command evaluated 50 times yields the same verdict every time.
+    /// The same command evaluated 50 times IN ONE PROCESS yields the same
+    /// verdict every time.
     ///
     /// Why: #7477 reports "no complexity pattern predicts the refusal" and
     /// #7436's comment reports an identical command flipping PASS to REFUSED
     /// four calls later. Both readings blame a nondeterministic decision. This
     /// guard's decision is a pure function of the command string — no clock, no
     /// filesystem read, no environment read, no map iteration — so it cannot be
-    /// the varying party, and a future report of the same flip should not spend
-    /// a second session re-establishing that.
+    /// the varying party.
+    ///
+    /// Scope, narrowed in review: one process is all this row proves, and the
+    /// reported flips happened BETWEEN `tm hook` invocations — separate
+    /// processes with separate `RandomState` seeds and separate environments.
+    /// `pm_guard_gives_one_command_the_same_verdict_across_separate_processes`
+    /// in `tests/tm_hook_pm_guard_false_positives.rs` is the row that covers
+    /// that; this one covers the pure policy underneath it.
     /// What: evaluates each row 50 times and asserts every verdict equals the
     /// first.
     /// Test: itself.
     #[test]
-    fn the_verdict_for_one_command_never_varies() {
+    fn the_verdict_for_one_command_never_varies_within_one_process() {
         for command in REPORTED_REFUSALS {
             let first = (
                 unclassifiable_command(command),

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -1056,3 +1056,8 @@ fn resolves_under_denylisted_tmp(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests;
+
+// #7498, #7479, #7499: reported false positives get their own test file, so
+// the allow case and the deny case bounding it sit side by side per issue.
+#[cfg(test)]
+mod false_positive_tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/secret_file_copy.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/secret_file_copy.rs
@@ -107,14 +107,26 @@
 //! - A directory copy (`cp -r secrets/ dest/`) is not inspected recursively —
 //!   only the literal source token's basename is checked against the
 //!   denylist.
-//! - [`expand_brace_alternatives`] resolves only a single-level,
-//!   comma-separated alternation (`secret.{tfvars,bak}`); a NESTED group
-//!   (`{a,{b,c}}`) or an unbalanced `{`/`}` is not expanded — it fails closed
-//!   (denied outright by [`is_secret_bearing_source`]) rather than allowing
-//!   an unexamined source through, so this is a residual over-match, not a
-//!   bypass. A Bash sequence expansion (`{1..3}`) is likewise not expanded as
-//!   a sequence, but since its literal text still matches this guard's
-//!   `*.<ext>` suffix patterns unchanged, it costs no coverage either way.
+//! - [`expand_brace_alternatives`] reads a brace group by what is inside it
+//!   (corrected in #7499's review round, which found the previous two
+//!   sentences here false):
+//!   * a COMMA-separated body is a single-level alternation
+//!     (`secret.{tfvars,bak}`) and is expanded. A NESTED group inside a
+//!     comma-carrying body (`{a,{b,c}}`) is not, and neither is an unbalanced
+//!     `{`/`}` — both fail closed (denied outright by
+//!     [`is_secret_bearing_source`]) rather than letting an unexamined source
+//!     through, so that is a residual over-match, not a bypass.
+//!   * a COMMA-FREE body yields TWO readings, because a shell gives it two.
+//!     The literal spelling covers a Go template (`{{.Id}}` names `{{.Id}}`),
+//!     and [`expand_sequence`] covers a range (`.en{v..v}` also names `.env`).
+//!     A nested group is reached here only through the literal reading, so a
+//!     comma-free outer body returns `Some` where the alternation arm returns
+//!     `None`.
+//!   * a sequence this expander declines — a multi-character or mixed
+//!     endpoint, or more than [`SEQUENCE_ELEMENT_CAP`] elements — keeps the
+//!     literal reading alone, which is what a shell does with a group it
+//!     cannot expand either. A long range is always numeric, and a digit
+//!     string spells no family core, so declining it costs no coverage.
 //!
 //! Test: `denies_tfvars_copy_into_a_worktree`, `denies_dotenv_copy_into_a_worktree`,
 //! `denies_pem_copy_into_a_worktree`, `denies_credentials_named_source`,
@@ -240,8 +252,8 @@ const SECRET_BEARING_FILE_PATTERNS: &[&str] = &[
 /// `matches_only_name_substring_family_separates_word_families_from_file_families`.
 const NAME_SUBSTRING_PATTERNS: &[&str] = &["*credentials*", "*secrets*", "token*"];
 
-/// Final extensions that mark a file as a committed PLACEHOLDER rather than a
-/// secret (#7479).
+/// Final extensions that mark a DOTENV file as a committed PLACEHOLDER rather
+/// than a secret (#7479).
 ///
 /// Why: `.env.*` classes every suffix as secret-bearing, so a tracked
 /// `.env.example` — a file that exists to be read, copied and edited — could
@@ -249,29 +261,36 @@ const NAME_SUBSTRING_PATTERNS: &[&str] = &["*credentials*", "*secrets*", "token*
 /// back to the operator. These three extensions are a naming CONVENTION for
 /// "this holds key names and no key values", the same kind of convention
 /// `is_ssh_public_key_name`'s `.pub` already reads.
-/// What: the extension is honoured only as the FINAL one, so
-/// `.env.example.bak` is still a `.env.*` secret.
-/// Deliberate trade: a file that really does hold a credential and is named
-/// `*.example` reads freely. A guard keyed on names cannot tell those apart,
-/// and refusing every placeholder to catch a misnamed secret is the
-/// over-blocking #7266 round 4 already had to reverse.
+/// What: honoured only as the FINAL extension, and only on a `.env`-family
+/// name, so `.env.example.bak`, `id_rsa.sample` and `secrets.example` all stay
+/// secret. Review round on #7479: the exemption was family-wide, which handed
+/// the SSH-key and word families a convention neither issue asked for.
+/// Deliberate trade, now bounded to one family: a file that really does hold
+/// credentials and is named `.env.example` reads freely. A guard keyed on names
+/// cannot tell that from a genuine placeholder, and refusing every placeholder
+/// to catch a misnamed secret is the over-blocking #7266 round 4 reversed.
 /// Test: `placeholder_suffixes_are_readable`, `real_dotenv_files_still_deny`,
-/// `a_placeholder_suffix_is_honoured_only_as_the_final_extension`.
+/// `a_placeholder_suffix_is_honoured_only_as_the_final_extension`,
+/// `the_placeholder_exemption_covers_only_the_dotenv_family`.
 const PLACEHOLDER_SUFFIXES: &[&str] = &["example", "sample", "template"];
 
-/// Whether `name`'s final extension marks it as a placeholder (#7479).
+/// Whether `name` is a `.env`-family placeholder (#7479).
 ///
 /// Why: the one place the placeholder convention is decided, so the read rule
 /// and the `cp`/`mv` rule can never disagree about `.env.example`.
-/// What: `true` when the lowercased final extension is a
-/// [`PLACEHOLDER_SUFFIXES`] entry.
+/// What: `true` when the name begins `.env` AND its lowercased final extension
+/// is a [`PLACEHOLDER_SUFFIXES`] entry. `name` is a basename by the time every
+/// caller here has it.
 /// Test: see [`PLACEHOLDER_SUFFIXES`].
 fn is_placeholder_name(name: &str) -> bool {
-    Path::new(name)
+    let lower = name.to_ascii_lowercase();
+    if !lower.starts_with(".env") {
+        return false;
+    }
+    Path::new(&lower)
         .extension()
         .and_then(|e| e.to_str())
-        .map(|e| e.to_ascii_lowercase())
-        .is_some_and(|e| PLACEHOLDER_SUFFIXES.contains(&e.as_str()))
+        .is_some_and(|e| PLACEHOLDER_SUFFIXES.contains(&e))
 }
 
 /// Whether `name` is matched by the denylist AND only by its word-shaped
@@ -319,6 +338,11 @@ pub(crate) fn matches_only_name_substring_family(name: &str) -> bool {
 /// implement. That is exactly the union the two list-level functions apply.
 /// Test: `a_one_character_glob_fragment_does_not_name_a_secret_family`,
 /// `matches_only_name_substring_family_separates_word_families_from_file_families`.
+// #7479 review round, LOW 1: this is the one matcher over the denylist with no
+// `is_placeholder_name` early return, and it needs none. A placeholder always
+// carries an extension, and the sole caller reaches it only for a name that has
+// neither a leading `.` nor an extension — so the predicate is unreachable here,
+// and adding the call would be dead code rather than a second decision site.
 fn pattern_reaches(pattern: &str, lower_candidate: &str) -> bool {
     let lower_pattern = pattern.to_ascii_lowercase();
     if glob_match(&lower_pattern, lower_candidate) {
@@ -493,13 +517,16 @@ pub(crate) fn strip_process_substitution(token: &str) -> &str {
 /// [`SECRET_BEARING_FILE_PATTERNS`] even though a real shell would copy BOTH
 /// `secret.tfvars` (denylisted) and `secret.bak` (not) — critic finding on
 /// the original #7122 PR.
-/// What: recursively expands every `{comma,separated,alternative}` group in
-/// `token`, left to right, returning every resulting literal string. A token
-/// with no `{` returns `Some(vec![token])` unchanged. `None` — never a
-/// partial answer — when a group is unbalanced (no matching `}`) or nested (a
-/// `{` inside a `{…}` group's alternatives): both are residual shapes the
-/// module doc's bypass list names, and [`is_secret_bearing_source`] treats
-/// `None` as secret-shaped rather than guessing.
+/// What: recursively expands every brace group in `token`, left to right,
+/// returning every resulting string. A token with no `{` returns
+/// `Some(vec![token])` unchanged. A COMMA-separated body expands to its
+/// alternatives; a COMMA-FREE body yields both its literal spelling and, when
+/// [`expand_sequence`] reads it as a range, that range's elements — see the
+/// module doc for why a shell gives it two readings. `None` — never a partial
+/// answer — when a group is unbalanced (no matching `}`), when a `{` is nested
+/// inside a COMMA-carrying body, or when the readings would exceed
+/// [`BRACE_READING_CAP`]; [`is_secret_bearing_source`] treats `None` as
+/// secret-shaped rather than guessing.
 /// Test: `denies_brace_expanded_source_copy_into_a_worktree`,
 /// `allows_brace_expanded_source_with_no_secret_alternative`,
 /// `denies_source_with_an_unresolved_brace_group`.
@@ -513,15 +540,26 @@ pub(crate) fn expand_brace_alternatives(token: &str) -> Option<Vec<String>> {
     let after_open = &token[start + 1..];
     let end_rel = after_open.find('}')?;
     let alternatives = &after_open[..end_rel];
-    // #7499: a group with no `,` is not an alternation, so a shell leaves it
-    // literal — `{{.Id}}` names the file `{{.Id}}`, never `.Id`. Keeping the
-    // braces is therefore the FAITHFUL reading, not a relaxation: the group
-    // reaches no name it did not already reach.
+    // #7499, corrected in review: a comma-free group has TWO readings, and the
+    // guard owes both. A shell leaves `{{.Id}}` literal, but expands the
+    // sequence `{v..v}` to `v`, so `cat .en{v..v}` opens `.env`.
     if !alternatives.contains(',') {
         let after_close = start + 1 + end_rel + 1;
-        let head = &token[..after_close];
+        let literal_head = &token[..after_close];
+        let prefix = &token[..start];
         let tails = expand_brace_alternatives(&token[after_close..])?;
-        return Some(tails.iter().map(|tail| format!("{head}{tail}")).collect());
+        let elements = expand_sequence(alternatives);
+        if tails.len().saturating_mul(elements.len() + 1) > BRACE_READING_CAP {
+            return None;
+        }
+        let mut out = Vec::with_capacity(tails.len() * (elements.len() + 1));
+        for tail in &tails {
+            out.push(format!("{literal_head}{tail}"));
+            for element in &elements {
+                out.push(format!("{prefix}{element}{tail}"));
+            }
+        }
+        return Some(out);
     }
     if alternatives.contains('{') {
         // Nested group — not a shape this expander resolves; caller fails closed.
@@ -537,6 +575,77 @@ pub(crate) fn expand_brace_alternatives(token: &str) -> Option<Vec<String>> {
         }
     }
     Some(out)
+}
+
+/// The most readings one brace group may contribute before the expander gives
+/// up and fails closed.
+///
+/// Why: two readings per comma-free group multiply through a nested suffix, and
+/// a `PreToolUse` hook must not be turned into a fork bomb by an argument. A
+/// command spelling more than this many brace readings is pathological, and
+/// failing closed on it is this module's standing bias.
+/// Test: `an_ordinary_sequence_group_is_allowed`.
+const BRACE_READING_CAP: usize = 4096;
+
+/// The most elements one `{x..y}` sequence may expand to (#7499 review round).
+///
+/// Why: an alphabetic Bash sequence is single-character, so it can never exceed
+/// 26 useful elements; anything longer is a NUMERIC range, whose elements are
+/// digit strings and therefore cannot spell any denylist family's literal core.
+/// Declining to enumerate a long range costs no coverage, and enumerating one
+/// would let `echo {1..100000}` cost real time.
+/// Test: `an_ordinary_sequence_group_is_allowed`.
+const SEQUENCE_ELEMENT_CAP: usize = 128;
+
+/// Expand a Bash sequence body (`v..v`, `a..e`, `1..5`) to its elements.
+///
+/// Why: #7499's first round read every comma-free group as literal text, which
+/// is right for a Go template (`{{.Id}}`) and wrong for a sequence: a shell
+/// expands `{v..v}` to `v`, so `cat .en{v..v}` opens `.env`. `origin/main`
+/// denied that spelling by accident — stripping the braces left `.env..v`,
+/// which `.env.*` matches — and reading the group as literal removed the
+/// accident without replacing it. Expanding the sequence replaces it on
+/// purpose, and also closes `cat .en{u..v}`, which the accident never caught.
+/// What: the elements of an inclusive single-character alphabetic or integer
+/// range, or an EMPTY vector when `body` is not a sequence this expander reads
+/// — no `..`, a multi-character endpoint, a mixed range, or more than
+/// [`SEQUENCE_ELEMENT_CAP`] elements. An empty vector leaves the caller with
+/// the literal reading alone, which is what a shell would do with a group it
+/// cannot expand either.
+/// Test: `a_sequence_group_that_expands_onto_a_secret_name_denies`,
+/// `an_ordinary_sequence_group_is_allowed`.
+fn expand_sequence(body: &str) -> Vec<String> {
+    let mut parts = body.split("..");
+    let (Some(from), Some(to)) = (parts.next(), parts.next()) else {
+        return Vec::new();
+    };
+    // A third `..` field is Bash's STEP; the range is still bounded by its
+    // endpoints, so enumerating every element over-approximates it safely.
+    if parts.next().is_some() && parts.next().is_some() {
+        return Vec::new();
+    }
+    let one_char = |s: &str| {
+        let mut chars = s.chars();
+        match (chars.next(), chars.next()) {
+            (Some(c), None) if c.is_ascii_alphabetic() => Some(c as u8),
+            _ => None,
+        }
+    };
+    if let (Some(lo), Some(hi)) = (one_char(from), one_char(to)) {
+        let (lo, hi) = (lo.min(hi), lo.max(hi));
+        if usize::from(hi - lo) + 1 > SEQUENCE_ELEMENT_CAP {
+            return Vec::new();
+        }
+        return (lo..=hi).map(|b| (b as char).to_string()).collect();
+    }
+    let (Ok(lo), Ok(hi)) = (from.parse::<i64>(), to.parse::<i64>()) else {
+        return Vec::new();
+    };
+    let (lo, hi) = (lo.min(hi), lo.max(hi));
+    if hi.saturating_sub(lo).saturating_add(1) > SEQUENCE_ELEMENT_CAP as i64 {
+        return Vec::new();
+    }
+    (lo..=hi).map(|n| n.to_string()).collect()
 }
 
 /// Whether a `cp`/`mv` source basename is secret-shaped, expanding a brace

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/secret_file_copy.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/secret_file_copy.rs
@@ -240,6 +240,40 @@ const SECRET_BEARING_FILE_PATTERNS: &[&str] = &[
 /// `matches_only_name_substring_family_separates_word_families_from_file_families`.
 const NAME_SUBSTRING_PATTERNS: &[&str] = &["*credentials*", "*secrets*", "token*"];
 
+/// Final extensions that mark a file as a committed PLACEHOLDER rather than a
+/// secret (#7479).
+///
+/// Why: `.env.*` classes every suffix as secret-bearing, so a tracked
+/// `.env.example` — a file that exists to be read, copied and edited — could
+/// not be reached by any verb, and a review-required change to one was handed
+/// back to the operator. These three extensions are a naming CONVENTION for
+/// "this holds key names and no key values", the same kind of convention
+/// `is_ssh_public_key_name`'s `.pub` already reads.
+/// What: the extension is honoured only as the FINAL one, so
+/// `.env.example.bak` is still a `.env.*` secret.
+/// Deliberate trade: a file that really does hold a credential and is named
+/// `*.example` reads freely. A guard keyed on names cannot tell those apart,
+/// and refusing every placeholder to catch a misnamed secret is the
+/// over-blocking #7266 round 4 already had to reverse.
+/// Test: `placeholder_suffixes_are_readable`, `real_dotenv_files_still_deny`,
+/// `a_placeholder_suffix_is_honoured_only_as_the_final_extension`.
+const PLACEHOLDER_SUFFIXES: &[&str] = &["example", "sample", "template"];
+
+/// Whether `name`'s final extension marks it as a placeholder (#7479).
+///
+/// Why: the one place the placeholder convention is decided, so the read rule
+/// and the `cp`/`mv` rule can never disagree about `.env.example`.
+/// What: `true` when the lowercased final extension is a
+/// [`PLACEHOLDER_SUFFIXES`] entry.
+/// Test: see [`PLACEHOLDER_SUFFIXES`].
+fn is_placeholder_name(name: &str) -> bool {
+    Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .is_some_and(|e| PLACEHOLDER_SUFFIXES.contains(&e.as_str()))
+}
+
 /// Whether `name` is matched by the denylist AND only by its word-shaped
 /// families ([`NAME_SUBSTRING_PATTERNS`]).
 ///
@@ -257,7 +291,7 @@ pub(crate) fn matches_only_name_substring_family(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     let mut matched = false;
     for pattern in SECRET_BEARING_FILE_PATTERNS {
-        if glob_match(&pattern.to_ascii_lowercase(), &lower) {
+        if pattern_reaches(pattern, &lower) {
             if !NAME_SUBSTRING_PATTERNS.contains(pattern) {
                 return false;
             }
@@ -267,8 +301,46 @@ pub(crate) fn matches_only_name_substring_family(name: &str) -> bool {
     matched
 }
 
+/// Whether ONE denylist entry reaches `lower_candidate` — the per-entry
+/// question [`secret_pattern_overlaps`] and [`any_pattern_overlaps`] ask of the
+/// whole list (#7498).
+///
+/// Why: [`matches_only_name_substring_family`] decided WHICH family produced a
+/// deny by literal matching, while the deny itself was produced by GLOB
+/// overlap. The two disagreed on every glob: `s*` denied because it overlaps
+/// the word family `*secrets*`'s core, but matched no entry literally, so the
+/// shape gate read it as a file family and skipped the rule that a word family
+/// counts only when written as a path. A one-character regex fragment therefore
+/// refused `gh issue list --search` and the BASE-ENGINEER file-size precheck.
+/// Asking one question of one entry is what keeps the two halves in agreement.
+/// What: a literal [`glob_match`], then — for a candidate carrying a wildcard —
+/// [`globs_overlap`] against the entry's [`pattern_literal_core`], and against
+/// the FULL entry when the candidate carries the `?` [`glob_match`] does not
+/// implement. That is exactly the union the two list-level functions apply.
+/// Test: `a_one_character_glob_fragment_does_not_name_a_secret_family`,
+/// `matches_only_name_substring_family_separates_word_families_from_file_families`.
+fn pattern_reaches(pattern: &str, lower_candidate: &str) -> bool {
+    let lower_pattern = pattern.to_ascii_lowercase();
+    if glob_match(&lower_pattern, lower_candidate) {
+        return true;
+    }
+    if !lower_candidate.bytes().any(|b| b == b'*' || b == b'?') {
+        return false;
+    }
+    let core = pattern_literal_core(&lower_pattern);
+    if !core.is_empty() && globs_overlap(lower_candidate.as_bytes(), core.as_bytes()) {
+        return true;
+    }
+    lower_candidate.contains('?')
+        && globs_overlap(lower_candidate.as_bytes(), lower_pattern.as_bytes())
+}
+
 /// Whether `name` matches one of [`SECRET_BEARING_FILE_PATTERNS`], case-insensitively.
 fn is_secret_bearing_name(name: &str) -> bool {
+    // #7479: a placeholder name is not a secret under any family.
+    if is_placeholder_name(name) {
+        return false;
+    }
     let lower = name.to_ascii_lowercase();
     SECRET_BEARING_FILE_PATTERNS
         .iter()
@@ -314,6 +386,11 @@ fn pattern_literal_core(pattern: &str) -> String {
 /// `overlap_answers_where_literal_matching_did_not`.
 pub(crate) fn secret_pattern_overlaps(candidate: &str) -> bool {
     let lower = candidate.to_ascii_lowercase();
+    // #7479: `*.example`/`*.sample`/`*.template`, literal or glob, is a
+    // placeholder and reaches only placeholder names.
+    if is_placeholder_name(&lower) {
+        return false;
+    }
     if is_secret_bearing_name(&lower) {
         return true;
     }
@@ -379,6 +456,11 @@ fn globs_overlap(a: &[u8], b: &[u8]) -> bool {
 /// `single_character_wildcards_reach_the_full_entries`.
 pub(crate) fn any_pattern_overlaps(candidate: &str) -> bool {
     let lower = candidate.to_ascii_lowercase();
+    // #7479: same placeholder exemption the sibling matchers apply, so the
+    // `?` arm cannot reintroduce the deny the `*` arm just withdrew.
+    if is_placeholder_name(&lower) {
+        return false;
+    }
     SECRET_BEARING_FILE_PATTERNS
         .iter()
         .any(|pattern| globs_overlap(lower.as_bytes(), pattern.to_ascii_lowercase().as_bytes()))
@@ -431,6 +513,16 @@ pub(crate) fn expand_brace_alternatives(token: &str) -> Option<Vec<String>> {
     let after_open = &token[start + 1..];
     let end_rel = after_open.find('}')?;
     let alternatives = &after_open[..end_rel];
+    // #7499: a group with no `,` is not an alternation, so a shell leaves it
+    // literal — `{{.Id}}` names the file `{{.Id}}`, never `.Id`. Keeping the
+    // braces is therefore the FAITHFUL reading, not a relaxation: the group
+    // reaches no name it did not already reach.
+    if !alternatives.contains(',') {
+        let after_close = start + 1 + end_rel + 1;
+        let head = &token[..after_close];
+        let tails = expand_brace_alternatives(&token[after_close..])?;
+        return Some(tails.iter().map(|tail| format!("{head}{tail}")).collect());
+    }
     if alternatives.contains('{') {
         // Nested group — not a shape this expander resolves; caller fails closed.
         return None;

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard_false_positives.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard_false_positives.rs
@@ -1,0 +1,186 @@
+//! End-to-end proof that the reported `pm_guard` FALSE POSITIVES are gone from
+//! the real binary (#7498, #7479, #7499) — and that two more (#7477, #7436)
+//! never reached it (issue #6982's finding, re-confirmed here).
+//!
+//! Why: the unit rows in
+//! `commands::pm_guard_bash::false_positive_tests` prove the policy, but the
+//! thing an agent actually hits is `tm hook --pm-guard` reading a `PreToolUse`
+//! payload on stdin. Every one of these five issues was reported against a
+//! LIVE binary, so the fix is only credible when the same stdin → classify →
+//! stdout path answers ALLOW. This file is separate from the older
+//! `tm_hook_pm_guard.rs` so the false-positive corpus stays one readable
+//! catalogue rather than an append to a 4,000-line neighbour.
+//! What: spawns the built `tm` binary against an unreachable daemon URL, writes
+//! one `PreToolUse` payload, and asserts ALLOW (empty stdout) or DENY (one JSON
+//! line carrying `permissionDecision: "deny"`). Each issue contributes the
+//! reported command verbatim plus the deny that bounds the fix.
+//! Test: `cargo test -p trusty-mpm --test tm_hook_pm_guard_false_positives`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// The daemon URL every spawn here pins: nothing listens on port 1, so the
+/// best-effort audit POST on a deny path fails fast on a refused connection
+/// rather than on a timeout. Same value and same reason as
+/// `tm_hook_pm_guard.rs`; an integration test binary cannot import a sibling
+/// test binary's helpers, so the minimal spawn shape is restated rather than
+/// shared.
+const UNREACHABLE_DAEMON: &str = "http://127.0.0.1:1";
+
+/// Run `tm hook --pm-guard` over one `PreToolUse` payload and return stdout.
+///
+/// Why: the one place this file scrubs the environment. Each of the five
+/// operator escape hatches below would turn every assertion in this file into a
+/// tautology if it leaked in from the runner.
+/// What: spawns the built binary, writes `stdin_json`, and asserts the
+/// fail-open contract (`exit 0`, always) before handing back stdout. `HOME` is
+/// pinned to a caller-supplied temporary directory so the per-turn budget
+/// counter can never touch the developer's real `$HOME`.
+/// Test: every assertion below routes through it.
+fn run_pm_guard(stdin_json: &str, home: &std::path::Path) -> String {
+    let bin = env!("CARGO_BIN_EXE_tm");
+    let mut command = Command::new(bin);
+    command
+        .args(["--url", UNREACHABLE_DAEMON, "hook", "--pm-guard"])
+        .env("HOME", home)
+        .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
+        .env_remove("CLAUDE_MPM_SUB_AGENT")
+        .env_remove("TRUSTY_MPM_PM_UNRESTRICTED")
+        .env_remove("TRUSTY_MPM_PM_DENY_BY_DEFAULT")
+        .env_remove("TM_MANAGED_SESSION_ID")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .expect("failed to spawn `tm hook --pm-guard`");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(stdin_json.as_bytes())
+        .expect("write stdin");
+    let output = child
+        .wait_with_output()
+        .expect("wait for tm hook --pm-guard");
+    assert!(
+        output.status.success(),
+        "tm hook --pm-guard must always exit 0 (fail-open): status={:?} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("stdout is utf8")
+}
+
+/// A `PreToolUse` Bash payload carrying `command`.
+fn bash_payload(command: &str) -> String {
+    let input = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": { "command": command },
+    });
+    input.to_string()
+}
+
+/// Assert the guard ALLOWED `command` — an allow prints nothing at all.
+fn assert_allowed(command: &str) {
+    let home = tempfile::tempdir().expect("tempdir");
+    let stdout = run_pm_guard(&bash_payload(command), home.path());
+    assert_eq!(
+        stdout.trim(),
+        "",
+        "expected ALLOW (empty stdout) for: {command}\ngot: {stdout}"
+    );
+}
+
+/// Assert the guard DENIED `command`, with a non-empty reason.
+fn assert_denied(command: &str) {
+    let home = tempfile::tempdir().expect("tempdir");
+    let stdout = run_pm_guard(&bash_payload(command), home.path());
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "a deny must print exactly one JSON line for {command}, got: {stdout:?}"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(lines[0]).expect("deny stdout must be valid JSON");
+    assert_eq!(parsed["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+    assert_eq!(
+        parsed["hookSpecificOutput"]["permissionDecision"], "deny",
+        "expected a DENY for: {command}\ngot: {stdout}"
+    );
+    assert!(
+        parsed["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .is_some_and(|r| !r.is_empty()),
+        "deny must carry a non-empty reason for: {command}"
+    );
+}
+
+/// #7498: the issue's repro commands allow through the real binary.
+#[test]
+fn pm_guard_allows_a_one_character_glob_fragment_in_a_search_argument() {
+    assert_allowed(r#"gh issue list --search "\s* guard" --state all"#);
+    assert_allowed(r"grep -cvE '^\s*(//|\*|/\*|\*/|$)' crates/trusty-mpm/src/lib.rs");
+    assert_allowed("gh issue list --search 's* guard' --state all");
+}
+
+/// #7479: a placeholder env file is readable and appendable through the real
+/// binary.
+#[test]
+fn pm_guard_allows_reading_and_appending_a_placeholder_env_file() {
+    assert_allowed("cat apps/advisor/.env.example");
+    assert_allowed(r"printf 'KEY=\n' >> apps/advisor/.env.example");
+    assert_allowed("cat .env.sample");
+    assert_allowed("cat .env.template");
+}
+
+/// #7499: a Go-template `--format` argument allows through the real binary.
+#[test]
+fn pm_guard_allows_a_go_template_format_argument() {
+    assert_allowed("docker images --format '{{.Repository}}:{{.Tag}}'");
+    assert_allowed("docker ps --format '{{.ID}}'");
+    assert_allowed("docker inspect --format '{{.Created}}' abc123");
+}
+
+/// #7477 and #7436: the shapes both issues report as refused ALLOW here.
+///
+/// Why: the refusal text those issues quote is emitted by the Claude Code
+/// binary, not by `tm` — the string "too complex to verify that it stays inside
+/// the worktree" is absent from the `tm` binary and present in the harness. A
+/// change to this guard could not have fixed either issue, and this row is what
+/// a future reporter should re-run before routing a third one here (#6982).
+#[test]
+fn pm_guard_allows_every_shape_the_harness_refused_as_unverifiable() {
+    assert_allowed("ls apps");
+    assert_allowed("ls -la");
+    assert_allowed("grep -rl healthz services");
+    assert_allowed("grep -n healthz docs/specs/domain-service-shell.md");
+    assert_allowed(
+        r#"grep -E "^test result" /private/tmp/claude-502/proj/sess/scratchpad/gate-7359.txt"#,
+    );
+}
+
+/// The denies these three fixes must not weaken, through the real binary.
+///
+/// Why: every row above withdraws a refusal, and a withdrawal is only correct
+/// while the target it was protecting still denies. Keeping the pair in ONE
+/// test is what stops a later edit from relaxing the allow side alone.
+#[test]
+fn pm_guard_still_denies_a_real_secret_file_and_a_real_brace_alternation() {
+    // #7479: every `.env` spelling that is not a placeholder.
+    assert_denied("cat .env");
+    assert_denied("cat .env.local");
+    assert_denied("cat .env.production");
+    assert_denied("cat .env.example.bak");
+    // #7498: a glob that really does target a family by name, and a literal.
+    assert_denied("cat *.env");
+    assert_denied("cat ./secrets*");
+    assert_denied("cat id_rsa");
+    assert_denied("cat terraform.tfvars");
+    // #7499: a brace group that is a real alternation still resolves, and a
+    // shape the expander cannot read still fails closed.
+    assert_denied("cat {.env,.env.prod}");
+    assert_denied("cat .{e:x,{y,env}}");
+}

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard_false_positives.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard_false_positives.rs
@@ -162,6 +162,60 @@ fn pm_guard_allows_every_shape_the_harness_refused_as_unverifiable() {
     );
 }
 
+/// #7477 and #7436: one command gets the same verdict across SEPARATE
+/// `tm hook --pm-guard` processes.
+///
+/// Why: both issues report a verdict FLIPPING between tool calls, which are
+/// separate `tm hook` invocations — separate processes, separate `RandomState`
+/// seeds, separate environments. A single-process loop cannot speak to that, so
+/// this row spawns the real binary repeatedly and asserts the answer is stable
+/// across process boundaries. Twelve spawns is the most this can cost without
+/// the row becoming the slowest test in the crate; each takes ~60ms.
+/// What: runs one allowed and one denied command six times each and asserts
+/// every run matches the first.
+#[test]
+fn pm_guard_gives_one_command_the_same_verdict_across_separate_processes() {
+    let home = tempfile::tempdir().expect("tempdir");
+    for command in ["grep -rl healthz services", "cat .env"] {
+        let payload = bash_payload(command);
+        let first = run_pm_guard(&payload, home.path());
+        for round in 1..6 {
+            let again = run_pm_guard(&payload, home.path());
+            assert_eq!(
+                again, first,
+                "verdict changed in process {round} for: {command}"
+            );
+        }
+    }
+}
+
+/// #7479 review round: the placeholder exemption covers the dotenv family only.
+///
+/// Why: the first round exempted `*.example`/`*.sample`/`*.template` on every
+/// family, so `cat id_rsa.sample` and `cat secrets.example` went DENY to ALLOW
+/// — a convention neither #7479 nor its reporter asked for, on the two families
+/// where a misnamed file leaks a key rather than a variable name.
+#[test]
+fn pm_guard_exempts_only_the_dotenv_family_as_a_placeholder() {
+    assert_allowed("cat .env.example");
+    assert_denied("cat id_rsa.sample");
+    assert_denied("cat secrets.example");
+}
+
+/// #7499 review round: a Bash sequence group is expanded, not read as literal.
+///
+/// Why: the first round read every comma-free group as literal text, which
+/// dropped the one coverage `origin/main` had of a degenerate sequence —
+/// `cat .en{v..v}`, which a shell expands to `cat .env`.
+#[test]
+fn pm_guard_denies_a_sequence_group_that_expands_onto_a_secret() {
+    assert_denied("cat .en{v..v}");
+    assert_denied("cat .en{u..v}");
+    assert_denied("cat id_rs{a..c}");
+    assert_allowed("for i in {1..5}; do echo $i; done");
+    assert_allowed("echo {a..e}");
+}
+
 /// The denies these three fixes must not weaken, through the real binary.
 ///
 /// Why: every row above withdraws a refusal, and a withdrawal is only correct


### PR DESCRIPTION
Fixes three pm_guard false positives, one regression test each, failing-before evidence in the commit: #7498 (a glob fragment overlapping only a word family was misread as a file family — `pattern_reaches` now decides consistently), #7479 (`.env.example`/`.sample`/`.template` as the final extension are placeholders), #7499 (a comma-free brace group such as `{{.Id}}` is literal, as bash treats it). #7477 and #7436 investigated: the refusal is emitted by the Claude Code binary, not `tm` (`strings` evidence on the issues); only a determinism test was added; upstream via #6982.

Refs #7498, Refs #7479, Refs #7499, Refs #7477, Refs #7436

Test ladder: rung 3 (localized, trusty-mpm) — `cargo fmt --check`, `cargo check -p trusty-mpm`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `cargo test -p trusty-mpm --no-fail-fast` (58 targets ok, 0 FAILED; lib 6805 passed), `check_line_cap.sh` 0 violations, `check_test_pointers.sh` 0 dangling, `check_changelog_fragment.sh` valid, `check-pr-version-bump.sh` OK. code-critic round pending before auto-merge.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0138Hn9mp8iFDWH8PLqcXVwY
