### PR TITLE
fix(trusty-mpm): tm pr merge cleanup clears the harness marker before git worktree remove; dispatch claims released on deny and TaskStop (Refs #7185 #7487)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7185-7487-worktree-claim-lifecycle.md
+++ b/crates/trusty-mpm/changelog.d/7185-7487-worktree-claim-lifecycle.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `tm pr merge`'s post-merge cleanup now clears the harness's own
+  `.trusty-mpm-worktree` ownership marker before `git worktree remove`, so git's
+  clean check agrees with the clean-tree decision tm already made instead of
+  refusing every merged worktree in a project that does not gitignore the
+  marker. The removal is still never forced. (Refs #7185)
+- A shared-tree dispatch claim is released when the agent is cancelled with
+  `TaskStop`, and a dispatch the guard denies no longer records one, so a
+  stopped agent plus one refusal can no longer exhaust a working directory for
+  the rest of a session. (Refs #7487)

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs
@@ -82,7 +82,8 @@ fn compact_tool_response(response: &Value) -> Option<Value> {
 /// that joins `tool_use_id` to `SubagentStop`, and `TaskStop`, whose response
 /// is the only signal that a cancellation actually took.
 /// What: [`is_subagent_dispatch_tool`](trusty_mpm::core::agent::is_subagent_dispatch_tool)
-/// or an exact [`TASK_STOP_TOOL`] match.
+/// or an exact [`TASK_STOP_TOOL`](trusty_mpm::core::agent::TASK_STOP_TOOL)
+/// match.
 /// Test: `compacts_tool_response_to_correlation_keys`,
 /// `forwards_the_task_stop_tool_response`,
 /// `forwards_no_tool_response_for_an_ordinary_tool`.

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs
@@ -74,6 +74,23 @@ fn compact_tool_response(response: &Value) -> Option<Value> {
     (!out.is_empty()).then_some(Value::Object(out))
 }
 
+/// Which tools' `tool_response` the daemon is given (#2864, #7487).
+///
+/// Why: the projection is an ALLOWLIST, not a filter — a `tool_response` is
+/// unbounded output and every tool not named here forwards none of it. Two
+/// tools earn it: a subagent dispatch, whose response carries the `agentId`
+/// that joins `tool_use_id` to `SubagentStop`, and `TaskStop`, whose response
+/// is the only signal that a cancellation actually took.
+/// What: [`is_subagent_dispatch_tool`](trusty_mpm::core::agent::is_subagent_dispatch_tool)
+/// or an exact [`TASK_STOP_TOOL`] match.
+/// Test: `compacts_tool_response_to_correlation_keys`,
+/// `forwards_the_task_stop_tool_response`,
+/// `forwards_no_tool_response_for_an_ordinary_tool`.
+fn carries_tool_response(tool_name: &str) -> bool {
+    trusty_mpm::core::agent::is_subagent_dispatch_tool(tool_name)
+        || tool_name == trusty_mpm::core::agent::TASK_STOP_TOOL
+}
+
 /// Build the `payload` object for one `POST /hooks` relay.
 ///
 /// Why: one place that decides what the daemon is told about a hook event, so
@@ -128,9 +145,11 @@ pub(crate) fn build_hook_payload(
         }
     }
 
-    // #2864: the dispatch response, compacted, and only for a subagent-dispatch
-    // tool — this is where `agentId` comes from.
-    if tool_name.is_some_and(trusty_mpm::core::agent::is_subagent_dispatch_tool)
+    // #2864: the dispatch response, compacted — this is where `agentId` comes
+    // from. #7487 adds `TaskStop`, whose response is the only thing that says
+    // whether the stop actually took; without it the daemon would release a
+    // shared-tree claim on a stop that failed and the agent is still writing.
+    if tool_name.is_some_and(carries_tool_response)
         && let Some(response) = stdin.get("tool_response")
         && let Some(compact) = compact_tool_response(response)
     {
@@ -286,5 +305,40 @@ mod tests {
         assert!(p.get("agent_id").is_none());
         assert!(p.get("tool_use_id").is_none());
         assert!(p.get("transcript_path").is_none());
+    }
+
+    /// 🔴 #7487: `TaskStop`'s response is the only thing on the wire that says
+    /// whether a cancellation took, and the daemon releases a shared-tree claim
+    /// on it. Without this forward the daemon cannot tell a stop that failed
+    /// from one that succeeded. Fails on c7eb75d5b, which forwarded a
+    /// `tool_response` for dispatch tools alone.
+    #[test]
+    fn forwards_the_task_stop_tool_response() {
+        let stdin = serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "TaskStop",
+            "tool_use_id": "toolu_stop",
+            "tool_input": { "task_id": "a403cdbc078b5c474" },
+            "tool_response": { "is_error": true, "stderr": "no such task" }
+        });
+        let p = build_hook_payload("/w", Some(&stdin), None);
+        assert_eq!(p["input"]["task_id"], "a403cdbc078b5c474");
+        assert_eq!(p["tool_response"]["is_error"], true);
+        // Still an allowlist: the bulk field never travels.
+        assert!(p["tool_response"].get("stderr").is_none());
+    }
+
+    /// The forward stays an ALLOWLIST — an ordinary tool's response is dropped
+    /// whole, however small it looks.
+    #[test]
+    fn forwards_no_tool_response_for_an_ordinary_tool() {
+        let stdin = serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": "ls" },
+            "tool_response": { "is_error": false }
+        });
+        let p = build_hook_payload("/w", Some(&stdin), None);
+        assert!(p.get("tool_response").is_none());
     }
 }

--- a/crates/trusty-mpm/src/core/agent.rs
+++ b/crates/trusty-mpm/src/core/agent.rs
@@ -81,6 +81,17 @@ pub fn is_subagent_dispatch_tool(tool_name: &str) -> bool {
     SUBAGENT_DISPATCH_TOOLS.contains(&tool_name)
 }
 
+/// The tool a PM calls to cancel a running subagent (#7487).
+///
+/// Why: a cancelled subagent emits no `SubagentStop`, so this tool's own
+/// `PostToolUse` is the only evidence that its claim on a shared working tree
+/// has ended. Named here beside [`SUBAGENT_DISPATCH_TOOLS`] because the same
+/// two halves must agree on it: `tm hook` decides whether to forward the
+/// `tool_response` and the daemon's tracker decides what to do with it.
+/// Test: `forwards_the_task_stop_tool_response`,
+/// `a_failed_task_stop_releases_nothing`.
+pub const TASK_STOP_TOOL: &str = "TaskStop";
+
 /// Keys retained from (and recognised in) a subagent-dispatch `tool_response`.
 ///
 /// Why: this list is the contract between the two halves of #2864, and both

--- a/crates/trusty-mpm/src/core/pr_cleanup/mod.rs
+++ b/crates/trusty-mpm/src/core/pr_cleanup/mod.rs
@@ -102,6 +102,7 @@ pub use registry::{CleanupRegistry, OpenedPr};
 pub use sweep::{SweepDecision, sweep_decision};
 
 use crate::session_manager::DirtyWorktree;
+use crate::session_manager::worktree_ownership::clear_worktree_sentinel;
 
 /// The `--json` field set step 1 reads.
 const VIEW_FIELDS: &str = "state,headRefName,headRefOid,mergeCommit,baseRefName";
@@ -543,6 +544,16 @@ async fn remove_one<T: Git, C: ClaimEnder>(
                 format!("{shown} could not be re-read before removal: {why} (#7275)"),
             );
         }
+    }
+    // #7185: git's own clean check has no exemption for the harness marker tm's
+    // dirty gate just excused, so a tree whose only untracked entry is that
+    // marker is authorised here and refused by git below. Clear it, and report
+    // a marker that cannot be cleared rather than running into that refusal.
+    if let Err(e) = clear_worktree_sentinel(path) {
+        return StepLine::failed(
+            STEP,
+            format!("{shown}: the harness ownership marker could not be cleared: {e} (#7185)"),
+        );
     }
     // Never `--force`: the dirty gate above is the only thing standing between
     // this call and an operator's unsaved work.

--- a/crates/trusty-mpm/src/core/pr_cleanup/mod.rs
+++ b/crates/trusty-mpm/src/core/pr_cleanup/mod.rs
@@ -102,7 +102,9 @@ pub use registry::{CleanupRegistry, OpenedPr};
 pub use sweep::{SweepDecision, sweep_decision};
 
 use crate::session_manager::DirtyWorktree;
-use crate::session_manager::worktree_ownership::clear_worktree_sentinel;
+use crate::session_manager::worktree_ownership::{
+    restore_worktree_sentinel, take_worktree_sentinel,
+};
 
 /// The `--json` field set step 1 reads.
 const VIEW_FIELDS: &str = "state,headRefName,headRefOid,mergeCommit,baseRefName";
@@ -547,14 +549,17 @@ async fn remove_one<T: Git, C: ClaimEnder>(
     }
     // #7185: git's own clean check has no exemption for the harness marker tm's
     // dirty gate just excused, so a tree whose only untracked entry is that
-    // marker is authorised here and refused by git below. Clear it, and report
-    // a marker that cannot be cleared rather than running into that refusal.
-    if let Err(e) = clear_worktree_sentinel(path) {
-        return StepLine::failed(
-            STEP,
-            format!("{shown}: the harness ownership marker could not be cleared: {e} (#7185)"),
-        );
-    }
+    // marker is authorised here and refused by git below. Take it, and report a
+    // marker that cannot be taken rather than running into that refusal.
+    let marker = match take_worktree_sentinel(path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return StepLine::failed(
+                STEP,
+                format!("{shown}: the harness ownership marker could not be cleared: {e} (#7185)"),
+            );
+        }
+    };
     // Never `--force`: the dirty gate above is the only thing standing between
     // this call and an operator's unsaved work.
     match run_git(git, req, &["worktree", "remove", &shown]) {
@@ -565,7 +570,34 @@ async fn remove_one<T: Git, C: ClaimEnder>(
                 claim_note(&holders, "ended ")
             ),
         ),
-        Err(e) => StepLine::failed(STEP, format!("{e:#}")),
+        // The removal the clear above prepared did not happen, so the tree is
+        // still here and must not be left unattributed (#7511 review).
+        Err(e) => StepLine::failed(STEP, format!("{e:#}{}", restore_marker(path, &marker))),
+    }
+}
+
+/// Put the harness marker back after a removal that did not happen (#7185).
+///
+/// Why: taking the marker is only safe because the removal that follows deletes
+/// the whole directory. When that removal fails, the tree survives with no
+/// ownership record — `agent_ownership_blocks` then refuses it and
+/// `prune_orphaned_worktrees` reports it `owner_unknown`, so nothing destroys
+/// it, but nothing reclaims it either and `disk_survey` charges it to no
+/// session. The cost is a stranded tree, and the restore removes it.
+/// What: `None` (no marker was taken) contributes nothing. A restore that
+/// itself fails is reported in the step line beside git's own error, because
+/// the operator is the only one who can then re-attribute the tree.
+/// Test: `cleanup_restores_the_harness_marker_when_the_removal_fails`.
+fn restore_marker(path: &Path, marker: &Option<Vec<u8>>) -> String {
+    let Some(bytes) = marker.as_deref() else {
+        return String::new();
+    };
+    match restore_worktree_sentinel(path, bytes) {
+        Ok(()) => String::new(),
+        Err(e) => format!(
+            " — and its harness ownership marker could not be restored ({e}), so the tree is \
+             now unattributed and no sweep will reclaim it (#7185)"
+        ),
     }
 }
 

--- a/crates/trusty-mpm/src/core/pr_cleanup/tests.rs
+++ b/crates/trusty-mpm/src/core/pr_cleanup/tests.rs
@@ -1533,3 +1533,125 @@ fn registry_unreadable_file_reads_as_empty() {
         "a corrupt registry makes the sweep idle, never guess"
     );
 }
+
+// ── #7185: the harness marker git counts and this engine's gate does not ─────
+
+/// 🔴 REGRESSION (#7185, recurrence 2026-09-11): the worktree step clears the
+/// harness ownership marker before it removes the tree.
+///
+/// Why: `count_dirty_files` excuses `.trusty-mpm-worktree` (it is the harness's
+/// marker, not the agent's work), so the dirt gate above authorises the
+/// removal — but `git worktree remove` runs git's OWN clean check, which counts
+/// every untracked entry. Verified against git 2.54.0: a worktree whose only
+/// untracked file is that marker is refused with `contains modified or
+/// untracked files, use --force to delete it`. The two answers agree only where
+/// the project gitignores the marker (this repo does; the project that hit the
+/// recurrence does not), so `tm pr merge`'s cleanup left EVERY merged worktree
+/// on disk there. Fails on 4cc327dbc, where nothing clears the marker.
+/// What this does NOT assert: `--force`. Forcing would override the dirt gate
+/// itself, which is the one thing standing between this step and unsaved work.
+#[tokio::test]
+async fn cleanup_clears_the_harness_marker_before_removing_the_tree() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tree = tmp.path().join("agent-aa11");
+    std::fs::create_dir_all(&tree).expect("tree");
+    let marker = tree.join(crate::session_manager::decommission::WORKTREE_SENTINEL_FILE);
+    std::fs::write(&marker, b"{}").expect("marker");
+    let kept = tree.join("notes.md");
+    std::fs::write(&kept, "left alone\n").expect("sibling");
+    let shown = tree.display().to_string();
+
+    let listing = format!(
+        "worktree /repo\nHEAD 1111111111111111111111111111111111111111\n\
+         branch refs/heads/main\n\n\
+         worktree {shown}\nHEAD {HEAD_OID}\nbranch refs/heads/{BRANCH}\n\n"
+    );
+    let git = Scripted::new()
+        .on(ORIGIN_QUERY, ORIGIN_URL)
+        .on(
+            "git ls-remote",
+            &format!("{HEAD_OID}\trefs/heads/{BRANCH}\n"),
+        )
+        .on("git push origin --delete", "")
+        .on("git worktree list", &listing)
+        .on("git worktree remove", "")
+        .on("git branch --format", &branch_listing())
+        .on("git branch -D", "")
+        .on("git worktree prune", "")
+        .on("git fetch --prune", "");
+
+    let report = run(
+        &gh_merged(),
+        &git,
+        &FakeClaims::none(),
+        &FakeLanding::nothing_merged(),
+        &clean,
+        &req(false),
+    )
+    .await;
+
+    assert!(!report.failed(), "{}", report.render());
+    assert!(
+        !marker.exists(),
+        "the harness marker must be cleared before the removal, or git refuses it"
+    );
+    assert!(
+        kept.exists(),
+        "clearing the marker must touch nothing else in the tree"
+    );
+    let joined = git.calls().join("\n");
+    assert!(
+        joined.contains(&format!("git worktree remove {shown}")),
+        "the tree must still be removed: {joined}"
+    );
+    assert!(
+        !joined.contains("--force"),
+        "clearing the marker is not licence to force: {joined}"
+    );
+}
+
+/// 🔴 A dry run inspects and reports; it must not touch the tree.
+///
+/// Why: `--dry-run` exists so an operator can see what cleanup would do. A
+/// marker deleted by a preview is a write the preview promised not to make, and
+/// the tree stays registered afterwards — so the next real run would find it
+/// unmarked and owner-unknown.
+#[tokio::test]
+async fn a_dry_run_leaves_the_harness_marker_in_place() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tree = tmp.path().join("agent-aa11");
+    std::fs::create_dir_all(&tree).expect("tree");
+    let marker = tree.join(crate::session_manager::decommission::WORKTREE_SENTINEL_FILE);
+    std::fs::write(&marker, b"{}").expect("marker");
+    let shown = tree.display().to_string();
+
+    let listing = format!(
+        "worktree /repo\nHEAD 1111111111111111111111111111111111111111\n\
+         branch refs/heads/main\n\n\
+         worktree {shown}\nHEAD {HEAD_OID}\nbranch refs/heads/{BRANCH}\n\n"
+    );
+    let git = Scripted::new()
+        .on(ORIGIN_QUERY, ORIGIN_URL)
+        .on(
+            "git ls-remote",
+            &format!("{HEAD_OID}\trefs/heads/{BRANCH}\n"),
+        )
+        .on("git worktree list", &listing)
+        .on("git branch --format", &branch_listing());
+
+    let report = run(
+        &gh_merged(),
+        &git,
+        &FakeClaims::none(),
+        &FakeLanding::nothing_merged(),
+        &clean,
+        &req(true),
+    )
+    .await;
+
+    assert!(!report.failed(), "{}", report.render());
+    assert!(
+        marker.exists(),
+        "a dry run must leave the tree exactly as it found it"
+    );
+}

--- a/crates/trusty-mpm/src/core/pr_cleanup/tests.rs
+++ b/crates/trusty-mpm/src/core/pr_cleanup/tests.rs
@@ -1610,6 +1610,78 @@ async fn cleanup_clears_the_harness_marker_before_removing_the_tree() {
     );
 }
 
+/// 🔴 REGRESSION (#7511 review, MEDIUM 1): a removal that fails AFTER the clear
+/// puts the marker back.
+///
+/// Why: taking the marker is safe only because the removal that follows deletes
+/// the directory. When the removal fails the tree survives, and without the
+/// marker it is unattributed — `agent_ownership_blocks` refuses it and
+/// `prune_orphaned_worktrees` reports it `owner_unknown`, so it is stranded
+/// rather than lost, which is the #7185 symptom in a rarer branch. The failure
+/// is forced by leaving `git worktree remove` unrouted on the fake, which is
+/// what `Scripted` turns into an `Err` — the same arm a locked worktree or a
+/// permission error reaches in production.
+#[tokio::test]
+async fn cleanup_restores_the_harness_marker_when_the_removal_fails() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let tree = tmp.path().join("agent-aa11");
+    std::fs::create_dir_all(&tree).expect("tree");
+    let marker = tree.join(crate::session_manager::decommission::WORKTREE_SENTINEL_FILE);
+    // Real sentinel bytes, so the restore is proved faithful and not merely present.
+    let original = br#"{"owner_session_id":"s-1","created_at":"2026-09-11T00:00:00Z"}"#;
+    std::fs::write(&marker, original).expect("marker");
+    let shown = tree.display().to_string();
+
+    let listing = format!(
+        "worktree /repo\nHEAD 1111111111111111111111111111111111111111\n\
+         branch refs/heads/main\n\n\
+         worktree {shown}\nHEAD {HEAD_OID}\nbranch refs/heads/{BRANCH}\n\n"
+    );
+    // Every route the run needs EXCEPT `worktree remove`, which therefore errors.
+    let git = Scripted::new()
+        .on(ORIGIN_QUERY, ORIGIN_URL)
+        .on(
+            "git ls-remote",
+            &format!("{HEAD_OID}\trefs/heads/{BRANCH}\n"),
+        )
+        .on("git push origin --delete", "")
+        .on("git worktree list", &listing)
+        .on("git branch --format", &branch_listing())
+        .on("git branch -D", "")
+        .on("git worktree prune", "")
+        .on("git fetch --prune", "");
+
+    let report = run(
+        &gh_merged(),
+        &git,
+        &FakeClaims::none(),
+        &FakeLanding::nothing_merged(),
+        &clean,
+        &req(false),
+    )
+    .await;
+
+    assert!(
+        report.failed(),
+        "an unroutable removal must fail the step: {}",
+        report.render()
+    );
+    assert!(
+        marker.exists(),
+        "a removal that did not happen must leave the tree attributed"
+    );
+    assert_eq!(
+        std::fs::read(&marker).expect("read restored marker"),
+        original,
+        "the restore must write back the ORIGINAL bytes, not a re-serialised payload"
+    );
+    assert!(
+        !report.render().contains("could not be restored"),
+        "a successful restore must add no note: {}",
+        report.render()
+    );
+}
+
 /// 🔴 A dry run inspects and reports; it must not touch the tree.
 ///
 /// Why: `--dry-run` exists so an operator can see what cleanup would do. A

--- a/crates/trusty-mpm/src/daemon/delegation_routes.rs
+++ b/crates/trusty-mpm/src/daemon/delegation_routes.rs
@@ -327,6 +327,17 @@ pub fn shared_tree_dispatch_op(
             );
         });
 
+    // #7487: `eligible && !claimed` IS the guard's deny — `claimed` is
+    // `eligible && occupants.is_empty()`, and `evaluate_shared_tree_dispatch`
+    // denies on exactly that non-empty answer. The dispatch will not run, so the
+    // record the tracker's own `matcher: "*"` hook writes for it (before or
+    // after this call) must not go on occupying the tree.
+    if eligible && !claimed {
+        crate::daemon::services::delegation_tracker::release_denied_dispatch(
+            state, session, payload,
+        );
+    }
+
     Ok(writers_response(&names, claimed))
 }
 

--- a/crates/trusty-mpm/src/daemon/delegation_routes_tests.rs
+++ b/crates/trusty-mpm/src/daemon/delegation_routes_tests.rs
@@ -702,8 +702,15 @@ async fn shared_tree_dispatch_route_does_not_reserve_when_it_denies() {
         vec!["rust-engineer".to_string()],
         "the denied dispatch must not occupy the directory"
     );
-    let denied = state
-        .delegations_for(session)
+    // The record pin the occupancy assertion cannot make: exactly ONE tombstone
+    // is added, so a deny can never multiply records for one `tool_use_id`.
+    let records = state.delegations_for(session);
+    assert_eq!(
+        records.len(),
+        2,
+        "the live writer plus exactly one tombstone: {records:?}"
+    );
+    let denied = records
         .into_iter()
         .find(|d| d.tool_use_id.as_deref() == Some("toolu_B"))
         .expect("the deny records a tombstone so a late observation cannot revive it");
@@ -1074,23 +1081,38 @@ fn launch(state: &Arc<DaemonState>, session: SessionId, tool_use_id: &str, agent
 }
 
 /// The `PostToolUse` a `TaskStop` emits, as `tm hook` forwards it (#7487).
-fn task_stop(state: &Arc<DaemonState>, session: SessionId, task_id: &str, ok: bool) {
-    let event = if ok {
-        crate::core::hook::HookEvent::PostToolUse
-    } else {
-        crate::core::hook::HookEvent::PostToolUseFailure
-    };
+///
+/// `outcome` is the `tool_response` the hook projection carries — the REAL wire
+/// discrimination between a stop that took and one that did not (#7511 review).
+/// `HookEvent::PostToolUseFailure` is deliberately not used: no hook block `tm`
+/// writes registers that name, so a test driving it would prove the branch and
+/// not the production path.
+fn task_stop(state: &Arc<DaemonState>, session: SessionId, task_id: &str, outcome: Option<Value>) {
+    let mut payload = serde_json::json!({
+        "cwd": "/repo",
+        "tool": "TaskStop",
+        "tool_use_id": "toolu_stop",
+        "input": {"task_id": task_id},
+    });
+    if let Some(response) = outcome {
+        payload["tool_response"] = response;
+    }
     crate::daemon::services::delegation_tracker::observe(
         state,
         session,
-        event,
-        &serde_json::json!({
-            "cwd": "/repo",
-            "tool": "TaskStop",
-            "tool_use_id": "toolu_stop",
-            "input": {"task_id": task_id},
-        }),
+        crate::core::hook::HookEvent::PostToolUse,
+        &payload,
     );
+}
+
+/// What `tm hook` forwards for a stop that took: `is_error` present and false.
+fn stop_succeeded() -> Option<Value> {
+    Some(serde_json::json!({"is_error": false}))
+}
+
+/// What `tm hook` forwards for a stop that did NOT take.
+fn stop_failed() -> Option<Value> {
+    Some(serde_json::json!({"is_error": true}))
 }
 
 /// 🔴 REGRESSION (#7487a): a `TaskStop`-cancelled agent releases the tree.
@@ -1122,7 +1144,7 @@ async fn a_task_stop_releases_the_stopped_agents_claim() {
     assert_eq!(while_running.total, 1, "a live claim must still refuse");
     assert!(!while_running.claimed);
 
-    task_stop(&state, session, "agent-qa-1", true);
+    task_stop(&state, session, "agent-qa-1", stop_succeeded());
 
     let after_stop = call(
         &state,
@@ -1139,6 +1161,10 @@ async fn a_task_stop_releases_the_stopped_agents_claim() {
 }
 
 /// 🔴 A stop that did NOT take leaves the agent running, so it releases nothing.
+///
+/// The discrimination is the forwarded `tool_response`, which is the only thing
+/// on the wire that says whether the stop succeeded (#7511 review, MEDIUM 2+3).
+/// Fails on c7eb75d5b, which released on the `PostToolUse` event alone.
 #[tokio::test]
 async fn a_failed_task_stop_releases_nothing() {
     let (state, _dir, session) = hermetic();
@@ -1150,7 +1176,7 @@ async fn a_failed_task_stop_releases_nothing() {
     .await;
     launch(&state, session, "toolu_qa", "agent-qa-1");
 
-    task_stop(&state, session, "agent-qa-1", false);
+    task_stop(&state, session, "agent-qa-1", stop_failed());
 
     let after = call(
         &state,
@@ -1160,6 +1186,41 @@ async fn a_failed_task_stop_releases_nothing() {
     .await;
     assert_eq!(after.total, 1, "a failed stop must not release the tree");
     assert!(!after.claimed);
+}
+
+/// 🔴 The documented fail-OPEN branch: a stop whose response says nothing still
+/// releases.
+///
+/// Why: `TaskStop`'s response shape is pinned by no contract this repo owns, and
+/// `tm hook` forwards only `TOOL_RESPONSE_KEYS` — so a plain-string or
+/// `is_error`-less answer arrives as no response at all. Requiring positive
+/// proof of success would release nothing, ever, reinstating #7487 silently.
+/// This pins the choice so a later tightening has to argue with it rather than
+/// make it by accident.
+#[tokio::test]
+async fn a_task_stop_with_no_response_still_releases() {
+    let (state, _dir, session) = hermetic();
+    call(
+        &state,
+        session,
+        dispatch("/repo", "qa", None, Some("toolu_qa")),
+    )
+    .await;
+    launch(&state, session, "toolu_qa", "agent-qa-1");
+
+    task_stop(&state, session, "agent-qa-1", None);
+
+    let after = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_a")),
+    )
+    .await;
+    assert_eq!(
+        after.total, 0,
+        "a response that cannot say either way must not re-lock the tree"
+    );
+    assert!(after.claimed);
 }
 
 /// 🔴 A `task_id` no delegation carries terminalizes nothing.
@@ -1174,7 +1235,7 @@ async fn a_task_stop_naming_an_unknown_id_terminalizes_nothing() {
     .await;
     launch(&state, session, "toolu_qa", "agent-qa-1");
 
-    task_stop(&state, session, "some-background-shell", true);
+    task_stop(&state, session, "some-background-shell", stop_succeeded());
 
     let after = call(
         &state,

--- a/crates/trusty-mpm/src/daemon/delegation_routes_tests.rs
+++ b/crates/trusty-mpm/src/daemon/delegation_routes_tests.rs
@@ -690,10 +690,27 @@ async fn shared_tree_dispatch_route_does_not_reserve_when_it_denies() {
     .await;
 
     assert!(!body.claimed);
+    // #7487: the guarantee is unchanged — a denied dispatch must never OCCUPY
+    // the directory — but its shape is. The deny now leaves a TERMINAL tombstone
+    // on `toolu_B` instead of nothing at all, because the tracker's
+    // `matcher: "*"` hook POSTs the same dispatch independently and can land
+    // AFTER this call; an absent record is exactly what let that late
+    // observation write a live claim for an agent that never ran. A terminal
+    // record occupies nothing and makes `on_dispatch` a no-op on that id.
     assert_eq!(
-        state.delegations_for(session).len(),
-        1,
-        "the denied dispatch must leave no record of its own"
+        state.shared_tree_occupants(std::path::Path::new("/repo"), None),
+        vec!["rust-engineer".to_string()],
+        "the denied dispatch must not occupy the directory"
+    );
+    let denied = state
+        .delegations_for(session)
+        .into_iter()
+        .find(|d| d.tool_use_id.as_deref() == Some("toolu_B"))
+        .expect("the deny records a tombstone so a late observation cannot revive it");
+    assert_eq!(
+        denied.status,
+        DelegationStatus::Cancelled,
+        "and that tombstone must be terminal"
     );
 }
 
@@ -1037,4 +1054,230 @@ async fn the_two_questions_disagree_about_the_callers_own_record() {
     .await;
     assert_eq!(commit.total, 0, "the commit hears nothing of its own agent");
     assert_eq!(disp.total, 1, "the dispatch still hears the occupant");
+}
+
+// ── #7487: a claim outlives neither a TaskStop nor its own denial ────────────
+
+/// Teach the tracker the `agentId` a dispatch's `PostToolUse` carries (#7487).
+fn launch(state: &Arc<DaemonState>, session: SessionId, tool_use_id: &str, agent_id: &str) {
+    crate::daemon::services::delegation_tracker::observe(
+        state,
+        session,
+        crate::core::hook::HookEvent::PostToolUse,
+        &serde_json::json!({
+            "cwd": "/repo",
+            "tool": "Agent",
+            "tool_use_id": tool_use_id,
+            "tool_response": {"isAsync": true, "agentId": agent_id},
+        }),
+    );
+}
+
+/// The `PostToolUse` a `TaskStop` emits, as `tm hook` forwards it (#7487).
+fn task_stop(state: &Arc<DaemonState>, session: SessionId, task_id: &str, ok: bool) {
+    let event = if ok {
+        crate::core::hook::HookEvent::PostToolUse
+    } else {
+        crate::core::hook::HookEvent::PostToolUseFailure
+    };
+    crate::daemon::services::delegation_tracker::observe(
+        state,
+        session,
+        event,
+        &serde_json::json!({
+            "cwd": "/repo",
+            "tool": "TaskStop",
+            "tool_use_id": "toolu_stop",
+            "input": {"task_id": task_id},
+        }),
+    );
+}
+
+/// 🔴 REGRESSION (#7487a): a `TaskStop`-cancelled agent releases the tree.
+///
+/// Why: a stopped subagent emits no `SubagentStop`, so nothing terminalized its
+/// record and `shared_tree_occupants` kept naming it for the six hours of
+/// `RUNNING_STALE_AFTER_SECS`. Fails on 4cc327dbc, where the third dispatch is
+/// still refused by an agent that was stopped two minutes earlier.
+#[tokio::test]
+async fn a_task_stop_releases_the_stopped_agents_claim() {
+    let (state, _dir, session) = hermetic();
+
+    let first = call(
+        &state,
+        session,
+        dispatch("/repo", "qa", None, Some("toolu_qa")),
+    )
+    .await;
+    assert!(first.claimed, "the first dispatch takes the tree");
+    launch(&state, session, "toolu_qa", "agent-qa-1");
+
+    // Control: while `qa` is running, a second unisolated writer is refused.
+    let while_running = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_a")),
+    )
+    .await;
+    assert_eq!(while_running.total, 1, "a live claim must still refuse");
+    assert!(!while_running.claimed);
+
+    task_stop(&state, session, "agent-qa-1", true);
+
+    let after_stop = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_b")),
+    )
+    .await;
+    assert_eq!(
+        after_stop.total, 0,
+        "a stopped agent holds nothing; occupants were {:?}",
+        after_stop.agents
+    );
+    assert!(after_stop.claimed, "the tree must be claimable again");
+}
+
+/// 🔴 A stop that did NOT take leaves the agent running, so it releases nothing.
+#[tokio::test]
+async fn a_failed_task_stop_releases_nothing() {
+    let (state, _dir, session) = hermetic();
+    call(
+        &state,
+        session,
+        dispatch("/repo", "qa", None, Some("toolu_qa")),
+    )
+    .await;
+    launch(&state, session, "toolu_qa", "agent-qa-1");
+
+    task_stop(&state, session, "agent-qa-1", false);
+
+    let after = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_a")),
+    )
+    .await;
+    assert_eq!(after.total, 1, "a failed stop must not release the tree");
+    assert!(!after.claimed);
+}
+
+/// 🔴 A `task_id` no delegation carries terminalizes nothing.
+#[tokio::test]
+async fn a_task_stop_naming_an_unknown_id_terminalizes_nothing() {
+    let (state, _dir, session) = hermetic();
+    call(
+        &state,
+        session,
+        dispatch("/repo", "qa", None, Some("toolu_qa")),
+    )
+    .await;
+    launch(&state, session, "toolu_qa", "agent-qa-1");
+
+    task_stop(&state, session, "some-background-shell", true);
+
+    let after = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_a")),
+    )
+    .await;
+    assert_eq!(
+        after.total, 1,
+        "a stop naming something else must close nothing — a 'most recent live \
+         record' guess is what the tracker forbids"
+    );
+}
+
+/// 🔴 REGRESSION (#7487b): a dispatch the guard denies records no claim, when
+/// the tracker's own hook lands AFTER the deny.
+///
+/// Why: two `PreToolUse` hooks see one dispatch — `tm hook --pm-guard` decides
+/// and the `matcher: "*"` tracker records, independently and in either order —
+/// so a denied dispatch left a live record carrying its `cwd` and became the
+/// next dispatch's collision. The reported incident's second refusal read
+/// "qa, rust-engineer", naming the very dispatch the guard had just refused.
+/// Fails on 4cc327dbc, where the third call hears two occupants.
+#[tokio::test]
+async fn a_late_observation_of_a_denied_dispatch_records_nothing() {
+    let (state, _dir, session) = hermetic();
+    call(
+        &state,
+        session,
+        dispatch("/repo", "qa", None, Some("toolu_qa")),
+    )
+    .await;
+    launch(&state, session, "toolu_qa", "agent-qa-1");
+    call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_denied")),
+    )
+    .await;
+
+    // The `matcher: "*"` hook's POST, arriving after the guard already denied.
+    crate::daemon::services::delegation_tracker::observe(
+        &state,
+        session,
+        crate::core::hook::HookEvent::PreToolUse,
+        &unisolated_hook_payload("toolu_denied"),
+    );
+
+    let next = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_next")),
+    )
+    .await;
+    assert_eq!(
+        next.total, 1,
+        "a late observation must not resurrect a refused dispatch's claim. Got {:?}",
+        next.agents
+    );
+    let names: Vec<&str> = next.agents.iter().map(|a| a.agent.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["qa"],
+        "a denial must not manufacture an occupant"
+    );
+}
+
+/// 🔴 The mirror order: the tracker's hook lands FIRST, and the deny must
+/// cancel the record it already wrote. Fails on 4cc327dbc for the same reason.
+#[tokio::test]
+async fn a_denied_dispatch_cancels_a_record_the_tracker_already_wrote() {
+    let (state, _dir, session) = hermetic();
+    call(
+        &state,
+        session,
+        dispatch("/repo", "qa", None, Some("toolu_qa")),
+    )
+    .await;
+    launch(&state, session, "toolu_qa", "agent-qa-1");
+
+    // The `matcher: "*"` hook wins the race and records the dispatch first.
+    crate::daemon::services::delegation_tracker::observe(
+        &state,
+        session,
+        crate::core::hook::HookEvent::PreToolUse,
+        &unisolated_hook_payload("toolu_denied"),
+    );
+    call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_denied")),
+    )
+    .await;
+
+    let next = call(
+        &state,
+        session,
+        dispatch("/repo", "rust-engineer", None, Some("toolu_next")),
+    )
+    .await;
+    assert_eq!(
+        next.total, 1,
+        "the deny must cancel the record the tracker had already written. Got {:?}",
+        next.agents
+    );
 }

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
@@ -115,8 +115,8 @@ use chrono::Utc;
 use serde_json::Value;
 
 use crate::core::agent::{
-    Delegation, DelegationId, DelegationSource, DelegationStatus, ModelTier, TOOL_RESPONSE_KEYS,
-    is_subagent_dispatch_tool,
+    Delegation, DelegationId, DelegationSource, DelegationStatus, ModelTier, TASK_STOP_TOOL,
+    TOOL_RESPONSE_KEYS, is_subagent_dispatch_tool,
 };
 use crate::core::dispatch_isolation::{dispatch_isolation, isolation_separates_working_tree};
 use crate::core::hook::HookEvent;
@@ -149,8 +149,9 @@ const DEDUP_WINDOW_SECS: i64 = 120;
 /// calls, so the hook pipeline gains delegation tracking by way of one line and
 /// all the correlation rules stay here.
 /// What: routes a subagent-dispatch `PreToolUse` to [`on_dispatch`], its
-/// `PostToolUse`/`PostToolUseFailure` to [`on_launched`], and
-/// `SubagentStop`/`SubagentStopFailure` to [`on_subagent_stop`]. Every other
+/// `PostToolUse`/`PostToolUseFailure` to [`on_launched`], a `PostToolUse` on
+/// any OTHER tool to [`on_task_stop`] (which acts only on `TaskStop`, #7487),
+/// and `SubagentStop`/`SubagentStopFailure` to [`on_subagent_stop`]. Every other
 /// event returns immediately. Never panics and never blocks; a payload missing
 /// the fields it needs is skipped silently (fail-open — tracking is
 /// observational and must never affect the hook verdict).
@@ -186,8 +187,26 @@ pub fn observe(state: &DaemonState, session: SessionId, event: HookEvent, payloa
     }
 }
 
-/// The tool a PM calls to cancel a running subagent (#7487).
-const TASK_STOP_TOOL: &str = "TaskStop";
+/// Does this `tool_response` say the call it answers FAILED (#7487)?
+///
+/// Why: `TaskStop` "returns a success or failure status", and a stop that did
+/// not take leaves the agent running in the tree. The wire shape is
+/// `is_error` — the one [`TOOL_RESPONSE_KEYS`] member whose meaning is the same
+/// for every tool, and the same key [`on_launched`] already trusts for exactly
+/// this question. `HookEvent::PostToolUseFailure` is NOT the production signal:
+/// no hook block `tm` writes registers that name, so it can never arrive.
+/// What: `true` only for an explicit `is_error: true`. An absent, non-object or
+/// `is_error`-less response is "cannot tell", which does not refuse — see
+/// [`on_task_stop`]'s own note on why that is the right direction here.
+/// Test: `a_failed_task_stop_releases_nothing`,
+/// `a_task_stop_with_no_response_still_releases`.
+fn stop_reported_failure(payload: &Value) -> bool {
+    payload
+        .get("tool_response")
+        .and_then(|r| r.get("is_error"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
 
 /// `TaskStop` returned: the agent it names is gone, so release its claim.
 ///
@@ -204,9 +223,9 @@ const TASK_STOP_TOOL: &str = "TaskStop";
 /// this fact, and is terminal, so nothing counts the record as a writer again.
 /// Returns whether it wrote.
 ///
-/// Three refusals, each fail-CLOSED in the module's own direction:
-/// * `PostToolUseFailure` never reaches here — a stop that did not take leaves
-///   the agent running, and releasing its tree would admit a second writer.
+/// Three refusals:
+/// * [`stop_reported_failure`] — the stop did not take, so the agent is still
+///   in the tree and releasing it would admit a second writer.
 /// * No `task_id` (nor its deprecated `shell_id` alias) matches nothing.
 /// * A `task_id` naming a background shell, a teammate, or an agent this
 ///   session never dispatched matches no record and writes nothing. The match
@@ -216,11 +235,29 @@ const TASK_STOP_TOOL: &str = "TaskStop";
 ///   `agent_id` was never taught is unreachable here for the same reason it is
 ///   unreachable by a stop; the staleness sweep remains its only route out.
 ///
+/// # A response that says nothing releases, and that is deliberate
+///
+/// This is the module's ONE fail-open branch, chosen against its own default
+/// because the alternative is worse HERE. `TaskStop`'s response shape is not
+/// pinned by any contract this repo owns, and `tm hook`'s projection keeps only
+/// [`TOOL_RESPONSE_KEYS`] — so a plain-string or `is_error`-less answer yields
+/// no forwarded response at all. Requiring positive proof of success would then
+/// release nothing, ever, which is #7487 itself reinstated silently and
+/// invisibly to every test. Refusing on the one shape that positively says
+/// "failed" closes the hazard the response can actually express; the residual
+/// is a stop that failed and said so in a spelling this cannot read, whose cost
+/// is the pre-#7487 six-hour lock arriving by a different route.
+///
 /// Test: `a_task_stop_releases_the_stopped_agents_claim`,
 /// `a_failed_task_stop_releases_nothing`,
+/// `a_task_stop_with_no_response_still_releases`,
 /// `a_task_stop_naming_an_unknown_id_terminalizes_nothing`.
 fn on_task_stop(state: &DaemonState, session: SessionId, payload: &Value) -> bool {
     if payload.get("tool").and_then(Value::as_str) != Some(TASK_STOP_TOOL) {
+        return false;
+    }
+    if stop_reported_failure(payload) {
+        tracing::debug!("delegation: a TaskStop reported failure — the agent stays live (#7487)");
         return false;
     }
     let Some(task_id) = payload

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
@@ -173,6 +173,10 @@ pub fn observe(state: &DaemonState, session: SessionId, event: HookEvent, payloa
         HookEvent::PostToolUse | HookEvent::PostToolUseFailure => {
             if dispatch_tool(payload).is_some() {
                 on_launched(state, session, payload, event);
+            } else if event == HookEvent::PostToolUse {
+                // #7487: a stopped agent emits no `SubagentStop`, so this is the
+                // only signal that its claim on a shared tree is over.
+                on_task_stop(state, session, payload);
             }
         }
         HookEvent::SubagentStop | HookEvent::SubagentStopFailure => {
@@ -180,6 +184,121 @@ pub fn observe(state: &DaemonState, session: SessionId, event: HookEvent, payloa
         }
         _ => {}
     }
+}
+
+/// The tool a PM calls to cancel a running subagent (#7487).
+const TASK_STOP_TOOL: &str = "TaskStop";
+
+/// `TaskStop` returned: the agent it names is gone, so release its claim.
+///
+/// Why: the tracker terminalizes on `SubagentStop`, and a subagent cancelled
+/// with `TaskStop` emits none — it is killed, it does not finish. Its record
+/// therefore stayed live for the six hours of `RUNNING_STALE_AFTER_SECS`, and
+/// [`crate::daemon::state::DaemonState::shared_tree_occupants`] kept naming it,
+/// so every later unisolated file-mutating dispatch into that directory was
+/// denied for a collision that had already ended. Observed 2026-09-11: one
+/// stopped `qa` agent blocked the cwd for the rest of the session (#7487).
+/// What: on the `PostToolUse` for a successful `TaskStop`, terminalizes the
+/// delegation whose `agent_id` equals the stopped `task_id` with
+/// [`DelegationStatus::Cancelled`] — the status that already exists for exactly
+/// this fact, and is terminal, so nothing counts the record as a writer again.
+/// Returns whether it wrote.
+///
+/// Three refusals, each fail-CLOSED in the module's own direction:
+/// * `PostToolUseFailure` never reaches here — a stop that did not take leaves
+///   the agent running, and releasing its tree would admit a second writer.
+/// * No `task_id` (nor its deprecated `shell_id` alias) matches nothing.
+/// * A `task_id` naming a background shell, a teammate, or an agent this
+///   session never dispatched matches no record and writes nothing. The match
+///   is on `agent_id` alone — the exact key `SubagentStop` uses — because a
+///   "most recent live record" guess would close the wrong one under
+///   concurrency, which is what the module note forbids. A dispatch whose
+///   `agent_id` was never taught is unreachable here for the same reason it is
+///   unreachable by a stop; the staleness sweep remains its only route out.
+///
+/// Test: `a_task_stop_releases_the_stopped_agents_claim`,
+/// `a_failed_task_stop_releases_nothing`,
+/// `a_task_stop_naming_an_unknown_id_terminalizes_nothing`.
+fn on_task_stop(state: &DaemonState, session: SessionId, payload: &Value) -> bool {
+    if payload.get("tool").and_then(Value::as_str) != Some(TASK_STOP_TOOL) {
+        return false;
+    }
+    let Some(task_id) = payload
+        .get("input")
+        .and_then(|i| i.get("task_id").or_else(|| i.get("shell_id")))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+    else {
+        return false;
+    };
+    let Some(id) = state.find_delegation(session, |d| {
+        d.agent_id.as_deref() == Some(task_id) && !d.status.is_terminal()
+    }) else {
+        return false;
+    };
+    tracing::info!(
+        task_id,
+        "delegation: a TaskStop cancelled this agent — releasing the tree it claimed (#7487)"
+    );
+    state.terminate_delegation(id, DelegationStatus::Cancelled)
+}
+
+/// The guard denied this dispatch: it never ran, so it holds nothing (#7487).
+///
+/// Why: two `PreToolUse` hooks see one dispatch. `tm hook --pm-guard` decides,
+/// and the `matcher: "*"` tracker hook records — independently, and whatever
+/// the guard decided. A denied dispatch therefore left a live record carrying
+/// its `cwd`, which [`crate::daemon::state::DaemonState::shared_tree_occupants`]
+/// then counted as a writer, so the deny for one collision manufactured the
+/// next one. Observed 2026-09-11: the second refusal named "qa, rust-engineer",
+/// the `rust-engineer` being the dispatch the guard had just refused (#7487).
+/// What: with the dispatch-record lock held, terminalizes the record carrying
+/// this `tool_use_id` as [`DelegationStatus::Cancelled`], or writes one in that
+/// status when none exists yet. Returns whether it wrote.
+///
+/// The write-when-absent arm is not bookkeeping for its own sake: the two hooks
+/// race, so the tracker's POST can land AFTER this one. A terminal record on the
+/// `tool_use_id` is what [`on_dispatch_locked`]'s existing idempotence check
+/// then finds, so the late observation records nothing rather than resurrecting
+/// the claim this call just released. The lock is what makes those two orders
+/// converge instead of one of them deciding.
+///
+/// Scope: the shared-tree dispatch route only. The grant route's own denial is a
+/// different shape — the guard rewrites the payload there — and is not addressed
+/// here.
+/// Test: `a_late_observation_of_a_denied_dispatch_records_nothing`,
+/// `a_denied_dispatch_cancels_a_record_the_tracker_already_wrote`.
+pub fn release_denied_dispatch(state: &DaemonState, session: SessionId, payload: &Value) -> bool {
+    let Some(tool_use_id) = field(payload, "tool_use_id") else {
+        return false;
+    };
+    let _guard = state.dispatch_record_guard();
+    if let Some(id) =
+        state.find_delegation(session, |d| d.tool_use_id.as_deref() == Some(tool_use_id))
+    {
+        return state.mutate_delegation(id, |d| {
+            if !d.status.is_terminal() {
+                d.status = DelegationStatus::Cancelled;
+                d.ended_at = Some(Utc::now());
+            }
+        });
+    }
+    let input = payload.get("input");
+    let agent = input
+        .and_then(|i| i.get("subagent_type"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let task = input
+        .and_then(|i| i.get("description"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let mut delegation = Delegation::observed(session, agent, task, Some(tool_use_id.to_string()));
+    delegation.cwd = field(payload, "cwd").map(std::path::PathBuf::from);
+    delegation.isolation = dispatch_isolation(input).map(str::to_string);
+    delegation.status = DelegationStatus::Cancelled;
+    delegation.ended_at = Some(Utc::now());
+    state.upsert_delegation(delegation);
+    true
 }
 
 /// The tool name, when this payload names a subagent-dispatch tool.

--- a/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
@@ -333,7 +333,7 @@ pub(crate) fn write_agent_sentinel(
     std::fs::write(worktree_path.join(WORKTREE_SENTINEL_FILE), bytes)
 }
 
-/// Delete the harness's own ownership sentinel from `worktree_path` (#7185).
+/// Take the harness's own ownership sentinel out of `worktree_path` (#7185).
 ///
 /// Why: tm's clean-tree decision
 /// ([`super::worktree_safety::count_dirty_files`]) excuses this file — it is
@@ -345,17 +345,36 @@ pub(crate) fn write_agent_sentinel(
 /// disk. Clearing the marker is what makes git's answer match the decision tm
 /// already made; adding `--force` would instead override the one gate standing
 /// between the removal and an operator's unsaved work.
-/// What: removes `<worktree_path>/.trusty-mpm-worktree`. An absent file is
-/// success — this runs immediately before a removal, and "the marker is not
-/// there" is the state it exists to reach. Any other error is propagated so the
-/// caller reports a removal it could not prepare rather than one that will fail.
+/// What: reads `<worktree_path>/.trusty-mpm-worktree`, removes it, and hands
+/// the bytes back so a caller whose removal then fails can put them back with
+/// [`restore_worktree_sentinel`] — the removal is what makes the deletion safe,
+/// so a removal that does not happen must not leave the tree unattributed
+/// (#7511 review). `Ok(None)` means there was no marker, which is the state
+/// this exists to reach and so is success. Any other error is propagated, so
+/// the caller reports a removal it could not prepare rather than one that will
+/// fail.
 /// Test: `a_worktree_holding_only_the_harness_marker_is_removable_by_plain_git`,
-/// `clearing_the_marker_leaves_every_other_file_alone`.
-pub(crate) fn clear_worktree_sentinel(worktree_path: &Path) -> std::io::Result<()> {
-    match std::fs::remove_file(worktree_path.join(WORKTREE_SENTINEL_FILE)) {
-        Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e),
-        _ => Ok(()),
-    }
+/// `clearing_the_marker_leaves_every_other_file_alone`,
+/// `cleanup_restores_the_harness_marker_when_the_removal_fails`.
+pub(crate) fn take_worktree_sentinel(worktree_path: &Path) -> std::io::Result<Option<Vec<u8>>> {
+    let path = worktree_path.join(WORKTREE_SENTINEL_FILE);
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    std::fs::remove_file(&path)?;
+    Ok(Some(bytes))
+}
+
+/// Put back the exact bytes [`take_worktree_sentinel`] removed (#7185).
+///
+/// Why: the only caller is the error arm of a removal that did not happen.
+/// Writing the ORIGINAL bytes rather than a freshly serialised payload is what
+/// keeps the restore faithful — this code does not know whose sentinel it is.
+/// Test: `cleanup_restores_the_harness_marker_when_the_removal_fails`.
+pub(crate) fn restore_worktree_sentinel(worktree_path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(worktree_path.join(WORKTREE_SENTINEL_FILE), bytes)
 }
 
 /// Rebuild one agent worktree's ownership from disk alone (#4311).

--- a/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
@@ -333,6 +333,31 @@ pub(crate) fn write_agent_sentinel(
     std::fs::write(worktree_path.join(WORKTREE_SENTINEL_FILE), bytes)
 }
 
+/// Delete the harness's own ownership sentinel from `worktree_path` (#7185).
+///
+/// Why: tm's clean-tree decision
+/// ([`super::worktree_safety::count_dirty_files`]) excuses this file — it is
+/// the harness's marker, not the agent's work — but `git worktree remove`
+/// applies git's OWN clean check, which counts any untracked entry and has no
+/// such exemption. The two agree only in a project whose `.gitignore` lists the
+/// marker. Everywhere else tm authorises a removal git then refuses with
+/// `contains modified or untracked files`, so every merged worktree is left on
+/// disk. Clearing the marker is what makes git's answer match the decision tm
+/// already made; adding `--force` would instead override the one gate standing
+/// between the removal and an operator's unsaved work.
+/// What: removes `<worktree_path>/.trusty-mpm-worktree`. An absent file is
+/// success — this runs immediately before a removal, and "the marker is not
+/// there" is the state it exists to reach. Any other error is propagated so the
+/// caller reports a removal it could not prepare rather than one that will fail.
+/// Test: `a_worktree_holding_only_the_harness_marker_is_removable_by_plain_git`,
+/// `clearing_the_marker_leaves_every_other_file_alone`.
+pub(crate) fn clear_worktree_sentinel(worktree_path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(worktree_path.join(WORKTREE_SENTINEL_FILE)) {
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e),
+        _ => Ok(()),
+    }
+}
+
 /// Rebuild one agent worktree's ownership from disk alone (#4311).
 ///
 /// Why: ADR-0023 point 4 — the ownership record must be reconstructable from

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -1098,3 +1098,104 @@ fn inspect_dirt_discounts_nothing_without_a_remote_landing_branch() {
     let dirt = inspect_dirt(&repo).expect("a commit on no remote is unsaved work");
     assert_eq!(dirt.unpushed_commits, 1, "reason was: {}", dirt.reason);
 }
+
+// ── #7185: every reclaim path agrees about the harness marker, git included ──
+
+/// Run `git -C <dir> <args>` and return whether it succeeded, plus its stderr.
+fn git_try(dir: &Path, args: &[&str]) -> (bool, String) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("`git {}` could not be run: {e}", args.join(" ")));
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// 🔴 REGRESSION (#7185): a tree carrying ONLY the harness ownership marker
+/// reads clean on BOTH reclaim decisions, and plain `git worktree remove` can
+/// only agree once the marker is cleared.
+///
+/// Why: #7212 made [`count_dirty_files`] and the ADR-0057 removal guard's
+/// `dirty_entries` one answer, and that answer excuses the marker. It does not
+/// bind git. `git worktree remove` applies its own clean check, which counts
+/// every untracked entry — so the `tm pr merge` cleanup path, which deliberately
+/// never forces, was authorised by tm and refused by git on every worktree in a
+/// project that does not gitignore the marker. This pins all three answers in
+/// one place so they cannot drift apart again.
+#[test]
+fn a_worktree_holding_only_the_harness_marker_is_removable_by_plain_git() {
+    use crate::core::worktree_removal_facts::{GitAndGhProbe, WorktreeRemovalProbe};
+    use crate::session_manager::worktree_ownership::clear_worktree_sentinel;
+
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("marker-only");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+
+    // Decision 1 — the reclaim sweep and `tm pr merge`'s cleanup probe.
+    assert!(
+        inspect_dirt(&wt).is_none(),
+        "the harness marker is not unsaved work; got {:?}",
+        inspect_dirt(&wt)
+    );
+    // Decision 2 — the ADR-0057 `git worktree remove` guard.
+    assert_eq!(
+        GitAndGhProbe
+            .dirty_entries(&wt)
+            .expect("status must be readable"),
+        0,
+        "both reclaim paths must read the marker-only tree as clean"
+    );
+
+    // Git's own answer, which neither decision above can change.
+    let (removed, stderr) = git_try(&fx.repo, &["worktree", "remove", wt.to_str().unwrap()]);
+    assert!(
+        !removed && stderr.contains("untracked files"),
+        "git itself counts the untracked marker — if this ever stops being true \
+         the clearing step below is no longer needed; stderr: {stderr}"
+    );
+
+    clear_worktree_sentinel(&wt).expect("the harness marker must be clearable");
+    let (removed, stderr) = git_try(&fx.repo, &["worktree", "remove", wt.to_str().unwrap()]);
+    assert!(
+        removed,
+        "clearing the marker must let a NON-forced removal succeed; stderr: {stderr}"
+    );
+}
+
+/// 🔴 The excusal covers that one name and nothing else: real work beside the
+/// marker still refuses, and clearing the marker never touches it.
+#[test]
+fn clearing_the_marker_leaves_every_other_file_alone() {
+    use crate::core::worktree_removal_facts::{GitAndGhProbe, WorktreeRemovalProbe};
+    use crate::session_manager::worktree_ownership::clear_worktree_sentinel;
+
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("marker-plus-work");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+    // One modified tracked file and one untracked source file, beside the marker.
+    std::fs::write(wt.join("README.md"), "edited\n").expect("modify tracked file");
+    let untracked = wt.join("scratch.rs");
+    std::fs::write(&untracked, "fn main() {}\n").expect("write untracked source");
+
+    let dirt = inspect_dirt(&wt).expect("real work beside the marker is still unsaved work");
+    assert_eq!(dirt.dirty_files, 2, "reason was: {}", dirt.reason);
+    assert_eq!(
+        GitAndGhProbe
+            .dirty_entries(&wt)
+            .expect("status must be readable"),
+        2,
+        "the removal guard must count the same two files"
+    );
+
+    clear_worktree_sentinel(&wt).expect("clearing must succeed");
+    assert!(
+        untracked.exists() && wt.join("README.md").exists(),
+        "clearing the marker must remove the marker and nothing else"
+    );
+    // Clearing is idempotent: an absent marker is the state it exists to reach.
+    clear_worktree_sentinel(&wt).expect("a second clear must be a no-op");
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -1129,7 +1129,7 @@ fn git_try(dir: &Path, args: &[&str]) -> (bool, String) {
 #[test]
 fn a_worktree_holding_only_the_harness_marker_is_removable_by_plain_git() {
     use crate::core::worktree_removal_facts::{GitAndGhProbe, WorktreeRemovalProbe};
-    use crate::session_manager::worktree_ownership::clear_worktree_sentinel;
+    use crate::session_manager::worktree_ownership::take_worktree_sentinel;
 
     let fx = GitWorktreeFixture::new();
     let wt = fx.add_worktree("marker-only");
@@ -1158,7 +1158,11 @@ fn a_worktree_holding_only_the_harness_marker_is_removable_by_plain_git() {
          the clearing step below is no longer needed; stderr: {stderr}"
     );
 
-    clear_worktree_sentinel(&wt).expect("the harness marker must be clearable");
+    let taken = take_worktree_sentinel(&wt).expect("the harness marker must be clearable");
+    assert!(
+        taken.is_some_and(|b| !b.is_empty()),
+        "taking the marker must hand back the bytes a failed removal would restore"
+    );
     let (removed, stderr) = git_try(&fx.repo, &["worktree", "remove", wt.to_str().unwrap()]);
     assert!(
         removed,
@@ -1171,7 +1175,9 @@ fn a_worktree_holding_only_the_harness_marker_is_removable_by_plain_git() {
 #[test]
 fn clearing_the_marker_leaves_every_other_file_alone() {
     use crate::core::worktree_removal_facts::{GitAndGhProbe, WorktreeRemovalProbe};
-    use crate::session_manager::worktree_ownership::clear_worktree_sentinel;
+    use crate::session_manager::worktree_ownership::{
+        restore_worktree_sentinel, take_worktree_sentinel,
+    };
 
     let fx = GitWorktreeFixture::new();
     let wt = fx.add_worktree("marker-plus-work");
@@ -1191,11 +1197,35 @@ fn clearing_the_marker_leaves_every_other_file_alone() {
         "the removal guard must count the same two files"
     );
 
-    clear_worktree_sentinel(&wt).expect("clearing must succeed");
+    let taken = take_worktree_sentinel(&wt)
+        .expect("clearing must succeed")
+        .expect("the marker was there, so its bytes come back");
     assert!(
         untracked.exists() && wt.join("README.md").exists(),
         "clearing the marker must remove the marker and nothing else"
     );
-    // Clearing is idempotent: an absent marker is the state it exists to reach.
-    clear_worktree_sentinel(&wt).expect("a second clear must be a no-op");
+    // An absent marker is the state this exists to reach, so a second take is a
+    // no-op that reports nothing to restore.
+    assert!(
+        take_worktree_sentinel(&wt)
+            .expect("a second take must be a no-op")
+            .is_none()
+    );
+
+    // The round trip a failed removal relies on: the bytes go back verbatim.
+    restore_worktree_sentinel(&wt, &taken).expect("restore must succeed");
+    assert_eq!(
+        std::fs::read(wt.join(super::super::decommission::WORKTREE_SENTINEL_FILE))
+            .expect("read restored marker"),
+        taken,
+        "the restore must be byte-faithful"
+    );
+    // And the restored marker is still excused by both decisions.
+    assert_eq!(
+        GitAndGhProbe
+            .dirty_entries(&wt)
+            .expect("status must be readable"),
+        2,
+        "a restored marker must not become work"
+    );
 }


### PR DESCRIPTION
#7185 (reopened recurrence): tm's clean-tree decision already excused the `.trusty-mpm-worktree` marker (#7212), but plain `git worktree remove` refuses an UNTRACKED marker in a project that does not gitignore it (git 2.54: exit 128 untracked, exit 0 ignored), and `pr_cleanup::remove_one` never passes `--force`. The cleanup now clears the harness-owned marker immediately before removal; `--force` is still never used. #7487: a denied dispatch now leaves a terminal Cancelled tombstone on its tool_use_id so a late tracker POST records nothing live, and TaskStop releases the stopped agent's claim. One existing test strengthened (`shared_tree_dispatch_route_does_not_reserve_when_it_denies` asserts occupants and the tombstone instead of a count). Failing-before evidence in the commit.

Refs #7185, Refs #7487

Test ladder: rung 5 (destructive reclaim path) — `cargo fmt --check`; `cargo check -p trusty-mpm --all-targets`; `cargo clippy -p trusty-mpm --all-targets -- -D warnings`; `cargo test -p trusty-mpm --no-fail-fast` (57 targets, passed=12635 failed=0; lib 6814 passed); `check_line_cap.sh` 0 violations; `check_test_pointers.sh` 0 dangling; `check_sld.sh` 0; `check_changelog_fragment.sh` OK; `check-pr-version-bump.sh` OK. code-critic round pending before auto-merge.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0138Hn9mp8iFDWH8PLqcXVwY
