### PR TITLE
fix(trusty-mpm): tm pr open keeps #N refs out of headings; pause derives ws/ label from session name; savings ledger declines implausible compiled rows (Refs #7461 #7464 #7491)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7461-7464-7491-tm-cli-cluster.md
+++ b/crates/trusty-mpm/changelog.d/7461-7464-7491-tm-cli-cluster.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `tm pr open` no longer reads a line starting with an issue reference (`#7459 …`) as an ATX heading, so the fields after it are reported correctly; the opener now needs whitespace after the `#` run, as CommonMark requires (Refs #7461).
+- `session_context_pause` derives the snapshot PR's `ws/<session>` label from the session NAME instead of its managed UUID, so `gh pr create` no longer fails with `could not add label: 'ws/<uuid>' not found` and strands the snapshot commit (Refs #7464).
+- The instruction-compression savings row is declined when the compiled prompt is smaller than the smallest instruction section it is assembled from, so a stub, truncated or stale file at the compiled-prompt path can no longer record a near-100% saving and inflate the 💸 percentage (Refs #7491).

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/body.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/body.rs
@@ -160,16 +160,39 @@ fn field_index(f: Field) -> usize {
     FIELDS.iter().position(|c| *c == f).unwrap_or(0) + 1
 }
 
+/// Maximum `#` characters an ATX heading opener may carry.
+///
+/// Why (#7461): CommonMark caps the opening sequence at six; a seventh `#`
+/// makes the line a paragraph. Spelled here so [`heading_text`] states the rule
+/// rather than a literal.
+const MAX_ATX_LEVEL: usize = 6;
+
 /// Normalize a heading line to its comparable text.
 ///
 /// Why: headings arrive as `## 4. Test evidence` / `### RISK / blast radius`,
 /// and the contract is about the words, not the punctuation or the numbering.
-/// What: strips leading `#`, digits, `.`/`)`/`:` and `*`/`_` emphasis, then
-/// lowercases. Returns `None` for a line that is not an ATX heading.
-/// Test: `heading_text_strips_numbering_and_emphasis`.
+/// What: strips the ATX opener, then digits, `.`/`)`/`:` and `*`/`_` emphasis,
+/// then lowercases. Returns `None` for a line that is not an ATX heading.
+///
+/// The opener is the CommonMark one (#7461): one to six `#`, then a space, a
+/// tab, or the end of the line. `#7459 flakes not seen.` is therefore a
+/// paragraph that happens to start with an issue reference, not a heading —
+/// reading it as one ended the previous field's section and reported every
+/// field after it empty.
+/// Test: `heading_text_strips_numbering_and_emphasis`,
+/// `an_issue_ref_at_line_start_is_not_a_heading`.
 fn heading_text(line: &str) -> Option<String> {
-    let rest = line.trim_start().strip_prefix('#')?;
-    let rest = rest.trim_start_matches('#').trim();
+    let opener = line.trim_start();
+    // #7461: `#` is one byte, so the count is also the byte offset of the rest.
+    let level = opener.chars().take_while(|c| *c == '#').count();
+    if level == 0 || level > MAX_ATX_LEVEL {
+        return None;
+    }
+    let rest = &opener[level..];
+    if !rest.is_empty() && !rest.starts_with([' ', '\t']) {
+        return None;
+    }
+    let rest = rest.trim();
     let cleaned: String = rest
         .chars()
         .map(|c| if c == '*' || c == '_' { ' ' } else { c })

--- a/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pr/tests.rs
@@ -250,6 +250,41 @@ fn heading_text_strips_numbering_and_emphasis() {
 }
 
 #[test]
+fn an_issue_ref_at_line_start_is_not_a_heading() {
+    // #7461: `#7459 flakes not seen.` was consumed as an ATX heading, which
+    // ended the section it sat in and claimed no field — so every field after
+    // it reported empty. CommonMark needs whitespace after the `#` run, and a
+    // real `# Heading` (one `#`, then a space) must still claim its field.
+    let body = full_body().replace(
+        "## Risk\n\nsomething real.\n",
+        "# Risk\n\n#7459 flakes not seen.\n#12 and a second ref, also prose.\n",
+    );
+    let report = body::validate(&body);
+    assert!(report.missing.is_empty(), "{report:?}");
+    assert!(report.empty.is_empty(), "{report:?}");
+    assert!(
+        report.supplied.contains(&Field::Risk),
+        "the `# Risk` h1 must still be read as a heading: {report:?}"
+    );
+
+    // The ref lines are prose, so they travel into the body `gh` is handed.
+    let args = open_args("/dev/null");
+    let plan = open::plan(
+        &args,
+        &body,
+        Some("tm-test-01"),
+        ChangelogVerdict::Pass,
+        &ResolvedTicketing::default(),
+    )
+    .expect("a complete body plans");
+    assert!(
+        plan.body.contains("#7459 flakes not seen."),
+        "the issue ref must survive into the PR body: {}",
+        plan.body
+    );
+}
+
+#[test]
 fn body_validate_is_repeatable() {
     let text = full_body();
     assert_eq!(body::validate(&text), body::validate(&text));

--- a/crates/trusty-mpm/src/core/savings_instructions.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions.rs
@@ -63,7 +63,17 @@
 //! `the_row_is_keyed_by_the_claude_session_id`,
 //! `no_claude_id_stages_the_row_instead_of_writing_an_unfoldable_one`,
 //! `a_staged_row_becomes_foldable_at_the_first_hook_invocation`,
-//! `a_prompt_that_folds_nothing_warns_once_and_writes_no_row`.
+//! `a_prompt_that_folds_nothing_warns_once_and_writes_no_row`,
+//! `the_row_reports_the_compiled_prompts_own_size`,
+//! `a_stub_compiled_prompt_writes_no_row`.
+//!
+//! **The implausibly small compiled prompt (#7491).** `compiled < sources` was
+//! the producer's only plausibility test, and a stub, a truncated write, or a
+//! stale file at the compiled-prompt path passes it trivially — the owner's
+//! ledger carried `sources 22559 B - compiled 13 B`, a claimed ~100% reduction
+//! that inflated the `💸` percentage for as long as the append-only ledger kept
+//! it. [`min_plausible_compiled_bytes`] is now the floor, and a file below it
+//! declines the row with a `warn!` naming the path and both byte counts.
 
 use std::path::Path;
 
@@ -128,6 +138,20 @@ fn record_instruction_compression_to(
     };
     let source_bytes = folded_source_bytes(&harness_root);
     let compiled_bytes = prompt.len();
+    // #7491: a compiled prompt this small is not a fold, it is a stub,
+    // a truncated write, or a stale file at the compiled-prompt path.
+    if compiled_bytes < min_plausible_compiled_bytes() {
+        tracing::warn!(
+            compiled_prompt = %dest.display(),
+            compiled_bytes,
+            source_bytes,
+            floor = min_plausible_compiled_bytes(),
+            "the compiled prompt is smaller than the smallest instruction section \
+             it is assembled from, so it cannot be a real compiled prompt; writing \
+             no instruction-compression savings row rather than a near-100% one"
+        );
+        return;
+    }
     // #7245: checked here, where the project root is in hand, so the decline that
     // makes the 💸 segment structurally absent for an override-free project is
     // stated once instead of hidden at `debug!` inside the row builder.
@@ -248,6 +272,28 @@ fn folded_source_bytes(project_dir: &Path) -> usize {
         .map(|applied| applied.body.len())
         .sum();
     bundled + overrides
+}
+
+/// The smallest byte count a real compiled PM prompt can have.
+///
+/// Why (#7491): the ledger recorded `sources 22559 B - compiled 13 B` — a
+/// claimed ~100% reduction — because the producer's only plausibility test was
+/// `compiled < sources`, which a stub, a truncated write, or a stale file at the
+/// compiled-prompt path passes trivially. The ledger is append-only, so one such
+/// row inflates the `💸` percentage for as long as it is folded.
+/// What: the smallest single bundled instruction section. The compiled prompt is
+/// an assembly of those sections (with overrides substituted for some of them),
+/// so anything below one whole section cannot be such an assembly. Derived from
+/// the corpus rather than spelled as a constant, so it re-derives when the
+/// sections change.
+/// Test: `a_stub_compiled_prompt_writes_no_row`,
+/// `the_row_reports_the_compiled_prompts_own_size`.
+pub(crate) fn min_plausible_compiled_bytes() -> usize {
+    crate::core::instruction_pipeline::SECTION_SOURCES
+        .iter()
+        .map(|(_, body)| body.len())
+        .min()
+        .unwrap_or(0)
 }
 
 /// Build the row, or decline to.

--- a/crates/trusty-mpm/src/core/savings_instructions_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions_tests.rs
@@ -17,6 +17,16 @@ fn sonnet_price() -> Option<(String, f64)> {
     Some(("claude-sonnet-4-6".to_string(), 3.0))
 }
 
+/// A compiled prompt that is a genuine fold: far smaller than the source set,
+/// but large enough to be a real assembly of the bundled sections.
+///
+/// Why (#7491): the producer now refuses anything below
+/// [`min_plausible_compiled_bytes`], so a four-byte stand-in no longer stands in
+/// for a compiled prompt. This is the smallest fixture the contract accepts.
+fn plausible_prompt() -> String {
+    "x".repeat(min_plausible_compiled_bytes().max(1))
+}
+
 /// Why (#6958, required acceptance): the common case is a project that
 /// overrides nothing, where the composer ADDS generated context and the
 /// delivered prompt is larger than its sources. Writing a row there would put a
@@ -228,7 +238,7 @@ fn the_row_is_keyed_by_the_claude_session_id() {
     record_instruction_compression_to(
         framework_root.path(),
         &dest,
-        "a compiled prompt far smaller than its sources",
+        &plausible_prompt(),
         Some("claude-abc-123".to_string()),
         sonnet_price,
     );
@@ -263,7 +273,13 @@ fn no_claude_id_stages_the_row_instead_of_writing_an_unfoldable_one() {
     let framework_root = tempfile::tempdir().expect("temp framework root");
     let dest = compiled_prompt_dest(project.path(), "sess-42");
 
-    record_instruction_compression_to(framework_root.path(), &dest, "tiny", None, sonnet_price);
+    record_instruction_compression_to(
+        framework_root.path(),
+        &dest,
+        &plausible_prompt(),
+        None,
+        sonnet_price,
+    );
 
     let ledger = crate::core::savings::savings_log_in(framework_root.path());
     assert!(
@@ -291,7 +307,13 @@ fn a_staged_row_becomes_foldable_at_the_first_hook_invocation() {
     let dest = compiled_prompt_dest(project.path(), "m1");
     let ledger = crate::core::savings::savings_log_in(framework_root.path());
 
-    record_instruction_compression_to(framework_root.path(), &dest, "tiny", None, sonnet_price);
+    record_instruction_compression_to(
+        framework_root.path(),
+        &dest,
+        &plausible_prompt(),
+        None,
+        sonnet_price,
+    );
     assert!(
         crate::core::savings::fold_session(&ledger, "c1").is_zero(),
         "before the hook there is nothing for the statusline to fold"
@@ -360,7 +382,7 @@ fn rederiving_from_the_compiled_prompt_appends_under_the_session_id() {
     let project = tempfile::tempdir().expect("temp project");
     let framework_root = tempfile::tempdir().expect("temp framework root");
     let dest = compiled_prompt_dest(project.path(), "local");
-    std::fs::write(&dest, "tiny").expect("compiled prompt");
+    std::fs::write(&dest, plausible_prompt()).expect("compiled prompt");
     let ledger = crate::core::savings::savings_log_in(framework_root.path());
 
     assert!(
@@ -396,6 +418,88 @@ fn rederiving_a_prompt_that_folds_nothing_appends_nothing() {
         "a prompt that folded nothing must report no row"
     );
     assert!(crate::core::savings::fold_session(&ledger, "c1").is_zero());
+}
+
+/// Why (#7491): the row's `compiled_bytes` must be the size of the compiled
+/// prompt the producer actually measured. The owner's ledger carried
+/// `sources 22559 B - compiled 13 B` — a claimed ~100% reduction — so nothing
+/// pinned that the number describes the file at the compiled-prompt path.
+/// Test: itself.
+#[test]
+fn the_row_reports_the_compiled_prompts_own_size() {
+    let project = tempfile::tempdir().expect("temp project");
+    let framework_root = tempfile::tempdir().expect("temp framework root");
+    let dest = compiled_prompt_dest(project.path(), "local");
+    // A known size, comfortably above the floor and below the source set.
+    let staged_bytes = min_plausible_compiled_bytes() + 137;
+    std::fs::write(&dest, "x".repeat(staged_bytes)).expect("compiled prompt");
+    let on_disk = std::fs::metadata(&dest).expect("compiled prompt").len() as usize;
+    assert_eq!(
+        on_disk, staged_bytes,
+        "the fixture must be the size it claims"
+    );
+    let ledger = crate::core::savings::savings_log_in(framework_root.path());
+
+    assert!(
+        rederive_from_compiled_prompt(framework_root.path(), &dest, "c1"),
+        "a plausible compiled prompt must produce a row"
+    );
+
+    let written = std::fs::read_to_string(&ledger).expect("the ledger must exist");
+    assert!(
+        written.contains(&format!("compiled {on_disk} B")),
+        "the row must report the compiled prompt's own size ({on_disk} B): {written}"
+    );
+    assert!(
+        !written.contains("compiled 13 B"),
+        "the #7491 placeholder measurement must be unreachable: {written}"
+    );
+}
+
+/// Why (#7491): a stub, a truncated write, or a stale file at the
+/// compiled-prompt path is smaller than any real compiled prompt, and the only
+/// plausibility test was `compiled < sources` — which such a file passes
+/// trivially, producing a near-100% saving that inflates the `💸` percentage for
+/// as long as the append-only ledger keeps it. A missing file must likewise
+/// produce nothing.
+/// Test: itself.
+#[test]
+fn a_stub_compiled_prompt_writes_no_row() {
+    let project = tempfile::tempdir().expect("temp project");
+    let framework_root = tempfile::tempdir().expect("temp framework root");
+    let dest = compiled_prompt_dest(project.path(), "local");
+    let ledger = crate::core::savings::savings_log_in(framework_root.path());
+
+    // The exact shape the owner's ledger recorded: 13 bytes against a 22 kB
+    // source set.
+    std::fs::write(&dest, "placeholder\n\n").expect("compiled prompt");
+    assert_eq!(
+        std::fs::metadata(&dest).expect("compiled prompt").len(),
+        13,
+        "the fixture reproduces the reported 13-byte compiled row"
+    );
+    assert!(
+        !rederive_from_compiled_prompt(framework_root.path(), &dest, "c1"),
+        "a stub compiled prompt must report no row"
+    );
+    assert!(
+        !ledger.exists(),
+        "a stub compiled prompt must not reach the ledger: {}",
+        std::fs::read_to_string(&ledger).unwrap_or_default()
+    );
+    assert!(
+        !crate::core::savings_sidecar::pending_row_path_in(framework_root.path(), &dest).exists(),
+        "a stub compiled prompt must not be staged either"
+    );
+
+    // A path with no file at all is the other arm: still no row, no panic.
+    let missing = compiled_prompt_dest(project.path(), "gone");
+    std::fs::remove_file(&missing).ok();
+    assert!(
+        !rederive_from_compiled_prompt(framework_root.path(), &missing, "c2"),
+        "a missing compiled prompt must report no row"
+    );
+    assert!(!ledger.exists(), "a missing file must write nothing");
 }
 
 /// Why (#7209): the producers must read one variable name. A rename on one side

--- a/crates/trusty-mpm/src/core/savings_sidecar_sweep_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar_sweep_tests.rs
@@ -35,13 +35,17 @@ fn a_row(session_id: &str) -> SavingsRow {
 
 /// A project directory holding a compiled prompt at `scope`, written to disk.
 ///
-/// What: returns the compiled prompt's path. The body is deliberately tiny so
-/// the producer's fold measurement comes out positive when a test re-derives.
+/// What: returns the compiled prompt's path. The body is far smaller than the
+/// bundled source set so the producer's fold measurement comes out positive when
+/// a test re-derives, and — since #7491 — at least
+/// [`crate::core::savings_instructions::min_plausible_compiled_bytes`], below
+/// which the producer treats the file as a stub and writes no row at all.
 fn project_with_compiled_prompt(under: &Path, name: &str, scope: &str) -> PathBuf {
     let project = under.join(name);
     let compiled = crate::core::instruction_pipeline::compiled_prompt_path(&project, scope);
     std::fs::create_dir_all(compiled.parent().expect("session dir")).expect("session dir");
-    std::fs::write(&compiled, "tiny").expect("compiled prompt");
+    let body = "x".repeat(crate::core::savings_instructions::min_plausible_compiled_bytes().max(1));
+    std::fs::write(&compiled, &body).expect("compiled prompt");
     compiled
 }
 

--- a/crates/trusty-mpm/src/core/session_pause_pr.rs
+++ b/crates/trusty-mpm/src/core/session_pause_pr.rs
@@ -108,17 +108,24 @@ pub trait PauseVcs {
 /// Why: the snapshot writer already knows the session id, the timestamp, and
 /// exactly which files it touched; re-deriving any of them here would be a
 /// second answer to a question already settled.
-/// What: the checkout, the session id, the pause timestamp, the repo-relative
-/// paths to publish, and the project's configured default branch when one is
-/// declared. The scratch directory is NOT a field: this module makes its own,
-/// so no caller can hand two concurrent pauses the same one (#7282 review).
-/// Test: `publish_commits_only_the_allowlisted_paths`.
+/// What: the checkout, the session id, the session's NAME, the pause timestamp,
+/// the repo-relative paths to publish, and the project's configured default
+/// branch when one is declared. The scratch directory is NOT a field: this
+/// module makes its own, so no caller can hand two concurrent pauses the same
+/// one (#7282 review).
+/// Test: `publish_commits_only_the_allowlisted_paths`,
+/// `the_workstream_label_comes_from_the_session_name`.
 #[derive(Debug)]
 pub struct PublishRequest<'a> {
     /// The git checkout holding `.trusty-mpm/sessions/`.
     pub repo: &'a Path,
     /// The session id the snapshot was filed under.
     pub session_id: &'a str,
+    /// The session's NAME — what the `ws/<session>` label is built from.
+    ///
+    /// #7464: `None` falls back to [`PublishRequest::session_id`], which is a
+    /// UUID for a managed session and names no existing label.
+    pub session_name: Option<&'a str>,
     /// The pause timestamp, used for the branch suffix and the title.
     pub timestamp: DateTime<Utc>,
     /// Repo-relative paths to commit. Every one must start with
@@ -424,8 +431,9 @@ pub fn publish_pause_snapshot<V: PauseVcs>(
                 "--docs-only",
                 "--rung",
                 "1",
+                // #7464: the NAME, never the UUID — `ws/<uuid>` names no label.
                 "--session",
-                req.session_id,
+                workstream_session(req),
             ]),
         )
         .map_err(|e| {
@@ -597,6 +605,26 @@ fn branch_name(session_id: &str, ts: DateTime<Utc>) -> String {
         slug(session_id),
         ts.format("%Y%m%d-%H%M%S")
     )
+}
+
+/// The workstream name `tm pr open --session` is given, and so the `ws/<name>`
+/// label the PR is opened with.
+///
+/// Why (#7464): a managed session's id is a UUID, and the `ws/` label seeded at
+/// launch and by `tm issue seed-labels` carries the session's NAME. Handing the
+/// UUID over made `gh pr create` fail with `could not add label:
+/// 'ws/<uuid>' not found`, stranding the snapshot commit on a local branch with
+/// no PR.
+/// What: the trimmed session name when the caller resolved one; otherwise the
+/// session id — the documented fallback, which is the pre-#7464 behaviour and
+/// is still the best available answer when no record names the session.
+/// Test: `the_workstream_label_comes_from_the_session_name`,
+/// `an_unnamed_session_falls_back_to_the_session_id`.
+fn workstream_session<'a>(req: &'a PublishRequest<'a>) -> &'a str {
+    req.session_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .unwrap_or(req.session_id)
 }
 
 /// The PR and commit-subject line.

--- a/crates/trusty-mpm/src/core/session_pause_pr_tests.rs
+++ b/crates/trusty-mpm/src/core/session_pause_pr_tests.rs
@@ -183,6 +183,8 @@ fn request<'a>(dir: &'a Path, paths: Vec<String>) -> PublishRequest<'a> {
     PublishRequest {
         repo: dir,
         session_id: "trusty-tools-95",
+        // #7464: `None` exercises the documented fallback to the session id.
+        session_name: None,
         timestamp: ts(),
         paths,
         default_branch: None,
@@ -202,6 +204,73 @@ fn snapshot_paths() -> Vec<String> {
         ".trusty-mpm/sessions/abc/session-20260909-183015.md".to_string(),
         ".trusty-mpm/sessions/sessions-log.jsonl".to_string(),
     ]
+}
+
+/// The `--session` value the publish handed `tm pr open`.
+///
+/// Why (#7464): that value is the whole `ws/<session>` label, so a test has to
+/// read it off the recorded argv rather than infer it.
+fn pr_open_session(vcs: &FakeVcs) -> String {
+    let call = vcs
+        .calls()
+        .into_iter()
+        .find(|c| c.program == "tm" && c.args.first().is_some_and(|a| a == "pr"))
+        .expect("the publish must call `tm pr open`");
+    let at = call
+        .args
+        .iter()
+        .position(|a| a == "--session")
+        .expect("`tm pr open` must be given a session");
+    call.args[at + 1].clone()
+}
+
+/// Why (#7464): the publish handed `tm pr open` the managed session's UUID, so
+/// `gh pr create` failed with `could not add label: 'ws/<uuid>' not found` and
+/// the snapshot commit stranded on a local branch with no PR. The label carries
+/// the session NAME — the one session launch and `tm issue seed-labels` create.
+/// Test: itself.
+#[test]
+fn the_workstream_label_comes_from_the_session_name() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let vcs = happy();
+    let uuid = "b175bb88-af7f-5ba5-b75d-85795d60b234";
+    let req = PublishRequest {
+        session_id: uuid,
+        session_name: Some("tm-agents"),
+        ..request(dir.path(), snapshot_paths())
+    };
+
+    publish_pause_snapshot(&vcs, &req)
+        .unwrap()
+        .expect("a changed tree publishes");
+
+    let session = pr_open_session(&vcs);
+    assert_eq!(session, "tm-agents", "the NAME, not the managed id");
+    assert_ne!(session, uuid);
+    let label = crate::core::policy_labels::workstream_label(&session)
+        .expect("a non-blank name derives a label");
+    assert_eq!(label.name, "ws/tm-agents");
+}
+
+/// Why (#7464): a caller that cannot resolve a name — an unmanaged session, or
+/// one already pruned from the store — must still publish. The documented
+/// fallback is the session id itself, which is the pre-#7464 behaviour.
+/// Test: itself.
+#[test]
+fn an_unnamed_session_falls_back_to_the_session_id() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let vcs = happy();
+    let req = PublishRequest {
+        session_name: Some("   "),
+        ..request(dir.path(), snapshot_paths())
+    };
+
+    publish_pause_snapshot(&vcs, &req)
+        .unwrap()
+        .expect("a changed tree publishes");
+
+    // The DOCUMENTED fallback: `PublishRequest::session_id`.
+    assert_eq!(pr_open_session(&vcs), "trusty-tools-95");
 }
 
 /// Why: the defect was a commit on whatever branch the checkout was on. The

--- a/crates/trusty-mpm/src/daemon/mcp_context.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_context.rs
@@ -376,7 +376,11 @@ pub async fn session_context_pause(
     // A failure here is an ERROR, never a warning — the previous behaviour
     // (commit onto whatever branch the checkout was on) failed silently for
     // weeks, and the snapshot file is already on disk either way.
-    let publish = publish_snapshot(&project_path, session_id, &outcome).await;
+    // #7464: the `ws/<session>` label carries the session's NAME, so resolve it
+    // from the managed record before the publish spends it on `gh pr create`.
+    let session_name = managed_session_name(state, session_id).await;
+    let publish =
+        publish_snapshot(&project_path, session_id, session_name.as_deref(), &outcome).await;
 
     let publish_json = match publish {
         Ok(SnapshotPublish::Opened(out)) => json!({
@@ -439,6 +443,7 @@ pub async fn session_context_pause(
 async fn publish_snapshot(
     project_path: &Path,
     session_id: &str,
+    session_name: Option<&str>,
     outcome: &trusty_common::catchup::pause::PauseSnapshotOutcome,
 ) -> Result<SnapshotPublish, String> {
     use crate::core::session_pause_pr as pause_pr;
@@ -457,12 +462,16 @@ async fn publish_snapshot(
 
     let repo = project_path.to_path_buf();
     let session = session_id.to_string();
+    // #7464: carried into the blocking task so the publish can name the `ws/`
+    // label after the session rather than after its UUID.
+    let name = session_name.map(str::to_string);
     let timestamp = outcome.timestamp;
     let default_branch = configured_default_branch(project_path);
     tokio::task::spawn_blocking(move || {
         let req = pause_pr::PublishRequest {
             repo: &repo,
             session_id: &session,
+            session_name: name.as_deref(),
             timestamp,
             paths,
             default_branch: default_branch.as_deref(),
@@ -481,6 +490,29 @@ async fn publish_snapshot(
     })
     .await
     .map_err(|e| format!("snapshot publish task failed: {e}"))?
+}
+
+/// The NAME of the managed session `session_id` identifies, when one is on
+/// record.
+///
+/// Why (#7464): the `ws/<session>` label the snapshot PR is opened with is
+/// derived from the session's name — that is the label session launch and
+/// `tm issue seed-labels` create. The pause tool is handed the session ID, so
+/// without this lookup the publish spent a UUID on a label that has never
+/// existed and `gh pr create` refused the PR.
+/// What: the managed record's tmux session name, or `None` when nothing on
+/// record matches — an unmanaged or already-pruned caller, which the publish
+/// then falls back to the session id for.
+/// Test: `session_pause_pr::the_workstream_label_comes_from_the_session_name`
+/// covers the derivation this feeds; this lookup is a single store read.
+async fn managed_session_name(state: &Arc<DaemonState>, session_id: &str) -> Option<String> {
+    let manager = state.session_manager().await;
+    manager
+        .list()
+        .await
+        .into_iter()
+        .find(|record| record.id.to_string() == session_id)
+        .map(|record| record.tmux_name)
 }
 
 /// What a pause snapshot publish produced.
@@ -545,7 +577,11 @@ mod tests {
             timestamp: chrono::Utc::now(),
         };
 
-        let publish = publish_snapshot(tmp.path(), "s", &outcome).await.unwrap();
+        // #7464: `None` for the session name — this skip is decided before the
+        // `ws/` label matters.
+        let publish = publish_snapshot(tmp.path(), "s", None, &outcome)
+            .await
+            .unwrap();
         let SnapshotPublish::Skipped(reason) = publish else {
             panic!("{publish:?}");
         };


### PR DESCRIPTION
#7461: `heading_text` accepted any line whose first non-space char was `#`, so `#7459 …` ended the current field's section; the opener is now CommonMark's (one to six `#` then whitespace or EOL). #7464: `session_context_pause` passed the managed UUID to `tm pr open --session`, so the `ws/<uuid>` label was never found; the publish now resolves the session NAME from the managed record and falls back to the id when none is on record. The label-SEEDING half of #7464 is a follow-up issue, not in this PR. #7491: the savings producer's only plausibility test was `compiled < sources`; a compiled prompt smaller than the smallest bundled instruction section now declines the row with a warn naming the path and both byte counts. The writer of the 13-byte file is a separate follow-up issue. One regression test per issue, failing-before evidence in the commit; four fixtures resized, no assertion changed.

Refs #7461, Refs #7464, Refs #7491

Test ladder: rung 3 (localized, trusty-mpm) — `cargo fmt --check`, `cargo check -p trusty-mpm`, `cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `cargo test -p trusty-mpm --no-fail-fast` (57 targets, passed=12632 failed=0; lib 6809 passed), `check_line_cap.sh` 0 violations, `check_test_pointers.sh` 0 dangling, `check_sld.sh` 0, `check_changelog_fragment.sh` OK, `check-pr-version-bump.sh` clear.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0138Hn9mp8iFDWH8PLqcXVwY
