### PR TITLE
chore(sessions): pause snapshot 2026-09-11 20:13 (session trusty-tools-c4)

### DIFF
--- a/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-201301.md
+++ b/.trusty-mpm/sessions/0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-201301.md
@@ -1,0 +1,36 @@
+# Session Pause - 2026-09-11T20:13:01.195612+00:00
+
+## Summary
+Owner-invoked pause 2026-09-11 ~21:4xZ, session trusty-tools-c4 (resumed from its 18:39:52Z pause after /clear). Standing owner authorization: "keep going, merge them when green" (the four bug-wave PRs). FIVE AGENTS IN FLIGHT AT PAUSE — background agents die with the session, so on resume reconcile each with gh/git, never assume it finished: (1) code-critic narrow re-check of PR #7507 round-2 commit 6ee3f5a6c (gates its push); (2) version-control pushing round-2 3b8b9fce1 to PR #7511 and arming on green; (3) rust-engineer fix round for PR #7506 (#7497) in worktree agent-acc385de7ec8e6b13 (regenerate tm-capabilities [required drift check red], device-miss = unmeasurable, replace TRUSTY_TEST_HARNESS seam with explicit test threshold, surface rejected config, E2E measurement seam); (4) research drafting the secrets-integration spec DOC on branch docs/secrets-integration-spec in its own worktree; (5) ticketing filing the secrets epic with children a–i. LANDED THIS LEG: PR #7496 (#7490) 811186c08; PR #7503 (1.5.32 bump) 4cc327dbc; PR #7512 (#7461 #7464 #7491, status:merged) edbb9dd9d. tm 1.5.32 INSTALLED, signed, daemon restarted pid 53788, `tm doctor --fix --yes` restored the SessionStart tm-hook group; #7490 CLOSED. DISK: eight merged worktrees dropped by the PM, data volume 92% → 84% (623 GiB free); bump + install + tm-CLI worktrees removed; 28 worktrees remain registered. FILED: #7497 (gate, coded, PR #7506), #7502 (worktree manager dashboard), #7504 (auto post-merge reclaim, child of #7505), #7505 (epic: deterministic daemon disk management), #7508 #7509 #7510 (engineer recommendations), #7513 (#7464 label seeding), #7514 (13-byte compiled-prompt writer), #7515 (reopen-comment rule), #7516 (console 24h peak memory gauge, queued behind bugs); comments on #7103, #6982 (closed; new refusal shapes). #7477 #7436 returned to open: not tm defects (Claude Code binary emits the refusal). OWNER RULINGS THIS LEG (verbatim, all in the palace): disk management is a deterministic daemon function; drop merged worktrees; clean up worktrees after merges (PM removes each after its PR merges); secrets integration (1P/Keeper/Keychain via tm secrets in trusty-common; per-project store choice + copy between stores; default = machine keychain; `tm secrets exec` for gh without exposing values; secrets-manager agent + tm-secrets skill as FRAMEWORK-bundled features). Installed tm: 1.5.32.
+
+## Completed
+- PR #7496 merged 811186c08; #7490 → merged → tested → CLOSED with live evidence
+- trusty-mpm 1.5.32 bump PR #7503 merged 4cc327dbc; installed via cargo install --locked from detached 4cc327dbc, tctl-signed, daemon restarted (pid 53788); tm doctor --fix --yes restored SessionStart hook group in trusty-tools
+- Disk survey (read-only) + PM removal of eight merged, clean worktrees (~315 GiB); 92% → 84%
+- PR #7512 (tm CLI cluster #7461 #7464 #7491) merged edbb9dd9d; issues at status:merged; worktree removed
+- Filed #7497 #7502 #7504 #7505 #7508 #7509 #7510 #7513 #7514 #7515 #7516; epic #7505 parents #7497/#7504
+- #7477/#7436 investigated: upstream Claude Code behaviour, evidence on the issues and #6982; returned to open
+- Palace: board (fact_key ws:trusty-tools-c4/board), reinstall discharged, merge-on-green, secrets requirement + 4 amendments, PM lesson (cite the pinning test in acceptance criteria)
+
+## In Progress
+- PR #7506 feat/7497-disk-usage-worktree-gate (#7497 status:coded) — critic WARN; fix round in flight in .claude/worktrees/agent-acc385de7ec8e6b13 (second commit expected); after it: security three-dot scan → version-control push → verify HIGHs closed (check_capabilities.sh exit 0) → arm on green
+- PR #7507 fix/7498-pm-guard-false-positives-cluster (#7498 #7479 #7499 coded) — round-2 commit 6ee3f5a6c committed, scan PASS; narrow critic re-check of the sequence-group fix in flight; then push + arm on green
+- PR #7511 fix/7185-7487-worktree-claim-lifecycle (#7185 #7487 still status:in-progress → set coded/merged) — critic APPROVE; round-2 3b8b9fce1 scan PASS; version-control pushing and arming on green
+- Secrets integration: research drafting docs/specs DOC-<n> on branch docs/secrets-integration-spec (own worktree, not pushed); ticketing filing the epic + children (a) spec (b) 1P/Keeper KeyStore backends + ProjectVault (c) session cache single unlock (d) tm secrets CLI incl. copy (e) daemon load-on-start + reference MCP tool (f) trusty-code/agents consumers (g) security round (h) secrets-manager bundled agent (i) tm-secrets bundled skill (+ tm secrets exec)
+- Held for owner: cluster 4 trusty-agents bugs #7448 #7478 (other live session owns the crate); #7456 UI; singletons #7500 #7482 #7480 #7466 #7442 #7435; #4612 relabel question; 321G main-checkout target dirs; 57G stale scratchpad 12eb325b; dirty merged tree agent-ae22d6de65eda2ce2 (16G); 68 wont-do issues
+
+## Next Steps
+- On resume: `gh pr view 7506 7507 7511 --json state,headRefOid,autoMergeRequest`; `git -C <main checkout> worktree list` for the three engineer worktrees; check each engineer worktree's HEAD for the expected second commit; re-dispatch only what did not land
+- For each PR that merges: ticketing coded→merged; PM removes the worktree and deletes the branch (git -C main checkout; never cd into the worktree); after #7506 merges, dispatch #7504 (rung 5, critic) — it collides with #7497 on doctor.rs until then
+- Secrets: once the spec draft commits, version-control opens the docs PR (rung 1); owner reviews open questions (backend first, reference syntax, .env deletion after import, headless/CI); then dispatch mpm-agent-manager (secrets-manager agent) and mpm-skills-manager (tm-secrets skill) citing the spec; implementation children after owner sign-off; standing order bugs-first for capacity
+- Bug wave continuation: remaining open bugs per census — singletons and cluster 4 need owner's word
+- Live verification after next tm reinstall: #7461 #7464 #7491 (merged) and, once merged, #7497 #7498 #7479 #7499 #7185 #7487 → tested → closed
+- Standing rules: disarm auto-merge before any fix round; arm only with no red check on head; engineer briefs never say push; security three-dot scan before every push; worktree removal is PM-executed; acceptance criteria cite the pinning test
+
+## Git Context
+Branch: main
+Last commit: c7e38dbfa chore(trusty-mpm): bump to 1.5.21 for owner-authorized reinstall (#7292)
+Uncommitted changes: 148 file(s) changed
+
+## Tmux Window
+tm-dogfood:0:@1

--- a/.trusty-mpm/sessions/sessions-log.jsonl
+++ b/.trusty-mpm/sessions/sessions-log.jsonl
@@ -116,3 +116,5 @@
 {"session_id":"b175bb88-af7f-5ba5-b75d-85795d60b234","event":"pause","snapshot":"b175bb88-af7f-5ba5-b75d-85795d60b234/session-20260911-143428.md","timestamp":"2026-09-11T14:34:28.849969+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-160552.md","timestamp":"2026-09-11T16:05:52.715232+00:00"}
 {"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-163216.md","timestamp":"2026-09-11T16:32:16.753776+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-183952.md","timestamp":"2026-09-11T18:39:52.667984+00:00"}
+{"session_id":"0b318c84-bae9-4a50-8832-65ed61f8ab22","event":"pause","snapshot":"0b318c84-bae9-4a50-8832-65ed61f8ab22/session-20260911-201301.md","timestamp":"2026-09-11T20:13:01.195612+00:00"}


### PR DESCRIPTION
Docs-only: session pause snapshot and log line, published by hand because the installed tm hit #7464 (label ws/<uuid>). Rung 1.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_0138Hn9mp8iFDWH8PLqcXVwY