### PR TITLE
docs(trusty-mpm): resolve the intra-doc links #7506 left broken (Refs #7497)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7497-rustdoc-links.md
+++ b/crates/trusty-mpm/changelog.d/7497-rustdoc-links.md
@@ -1,0 +1,3 @@
+Documentation
+
+- Fixed the four intra-doc links #7506 left broken: `disk_usage_guard`'s module header now carries explicit crate-absolute reference definitions for `DEFAULT_MAX_USAGE_PCT`, `check_measured` and `bash_refusal` — a module whose docs are split between a `pub mod` outer comment and the file's own `//!` header resolves bare links in the parent module's scope — and the `pm_guard_bash::disk_usage` header names `trusty_mpm::core::disk_usage_guard`, since `crate::` inside the `tm` bin is the bin, not the library (#7497).

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/disk_usage.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/disk_usage.rs
@@ -10,7 +10,7 @@
 //! What: [`evaluate_worktree_add_disk_usage`] reuses
 //! [`super::worktree_add_targets`] — the same `cd` / `git -C` / flag-skipping
 //! resolution the temp-root rule uses — and asks
-//! [`crate::core::disk_usage_guard`] whether the mount holding each target is at
+//! [`trusty_mpm::core::disk_usage_guard`] whether the mount holding each target is at
 //! or above the threshold. Only `worktree add` is examined;
 //! `list`/`remove`/`prune` are never gated.
 //!

--- a/crates/trusty-mpm/src/core/disk_usage_guard.rs
+++ b/crates/trusty-mpm/src/core/disk_usage_guard.rs
@@ -31,6 +31,10 @@
 //! Test: `disk_usage_guard_tests.rs`, plus the end-to-end
 //! `tests/worktree_disk_usage_gate.rs` and the `pm_guard_*disk*` cases in
 //! `tests/tm_hook_pm_guard.rs`.
+//!
+//! [`DEFAULT_MAX_USAGE_PCT`]: crate::core::disk_usage_guard::DEFAULT_MAX_USAGE_PCT
+//! [`check_measured`]: crate::core::disk_usage_guard::check_measured
+//! [`bash_refusal`]: crate::core::disk_usage_guard::bash_refusal
 
 use std::path::Path;
 


### PR DESCRIPTION
## Outcome

Refs #7497

PR #7506 left four intra-doc links broken on `main` (`Rustdoc intra-doc
links` red). This PR resolves all four; no new issue needed beyond #7497.

## Changes

- `crates/trusty-mpm/src/core/disk_usage_guard.rs`: three links. Rustdoc
  merged the outer `///` on `pub mod` at `core/mod.rs:92` with the file's own
  `//!` header and resolved bare names in `core` scope. Fixed with
  crate-absolute reference-link definitions, the idiom
  `core/dispatch_isolation.rs:87-94` already uses.
- `crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/disk_usage.rs:13`: one
  link. `crate::` inside the `tm` bin resolves against the bin crate, not
  `trusty-mpm`; changed to `trusty_mpm::`.
- Out of scope: no behavior change, doc comments only.

## Risk

Rung 1 — doc comments only, no source logic touched.

## Tests

- `bash scripts/check_rustdoc_links.sh`: 25 crates examined, 0 broken.
- `cargo fmt --check`: exit 0.
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: exit 0.
- `bash scripts/check_sld.sh`: exit 0.
- `bash scripts/check_line_cap.sh`: exit 0.
- `bash scripts/check_changelog_fragment.sh`: exit 0.

## Baseline

CI on #7506 surfaced three of the four broken links; the fourth appeared only
once the bin crate's doc unit re-ran. No unrelated baseline red.

## Docs

Changelog fragment: `crates/trusty-mpm/changelog.d/7497-rustdoc-links.md`.

## Review

No review findings outstanding.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
