### PR TITLE
chore(trusty-agents): bump to 0.39.2 for owner-authorized reinstall (Refs #7454, #7427)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11300,7 +11300,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -8,7 +8,9 @@ name = "trusty-agents"
 # 0.39.1: patch bump for a reinstall carrying #6537/#7158 for live verification
 # (owner ruling 2026-09-08 — every reinstall carries a patch bump so
 # `--version` identifies the build); no public API change.
-version = "0.39.1"
+# 0.39.2: patch bump for an owner-authorized reinstall carrying #7454/#7427
+# for live verification; no public API change.
+version = "0.39.2"
 edition = "2024"
 description = "Trusty Agents: Rust-native agentic harness with multi-model routing, tool execution, and subprocess delegation."
 license.workspace = true


### PR DESCRIPTION
## Summary
- Version-only bump, trusty-agents 0.39.1 → 0.39.2, for the owner-authorized reinstall carrying [#7475](https://github.com/bobmatnyc/trusty-tools/pull/7475) and [#7495](https://github.com/bobmatnyc/trusty-tools/pull/7495), so the reinstalled `tagent --version` identifies the build (owner ruling: every reinstall carries a patch bump).
- `crates/trusty-agents/Cargo.toml` and `Cargo.lock` only.

Refs [#7454](https://github.com/bobmatnyc/trusty-tools/issues/7454), [#7427](https://github.com/bobmatnyc/trusty-tools/issues/7427)

## Test plan
- Rung 1 (Low, version metadata only).
- `scripts/check_workspace_dep_versions.sh` — EXIT 0.
- `scripts/check-pr-version-bump.sh` — EXIT 0.
- No source change, so no changelog fragment owed.
- Gates run by `local-ops` at publish time; no functional change to verify.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
