### PR TITLE
feat(trusty-mpm): daemon reclaims a merged PR's worktree and branch automatically (Refs #7504)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7504-auto-post-merge-reclaim.md
+++ b/crates/trusty-mpm/changelog.d/7504-auto-post-merge-reclaim.md
@@ -1,0 +1,15 @@
+Added
+
+- The daemon now reclaims a merged pull request's worktree and local branch on
+  its own, with no `tm session prune-worktrees --merged-prs` for the PM to
+  remember (#7504). The trigger is `gh`-reported merge state, re-read per
+  candidate immediately before each deletion, never a timer's guess.
+- A worktree a live process was launched from — the daemon's own working
+  directory, or the executable serving the sweep — is spared and reported
+  (#7504).
+- Each reclaim writes an audit line carrying path, branch, pull request and bytes
+  freed; a removal that does not complete is logged as a failure rather than
+  folded into the success line (#7504).
+- `TRUSTY_MPM_WORKTREE_RECLAIM=0` disables the sweep and
+  `TRUSTY_MPM_WORKTREE_RECLAIM_INTERVAL_SECS` overrides its one-hour cadence
+  (#7504).

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -19,8 +19,7 @@ use tracing::warn;
 
 use crate::daemon::rpc::managed::outcome::RouteOutcome;
 use crate::daemon::state::DaemonState;
-use crate::session_manager::worktree_reclaim::{LiveClaims, ReclaimMode};
-use crate::session_manager::worktree_reclaim_sweep::reclaim_merged_pr_worktrees;
+use crate::session_manager::worktree_reclaim::ReclaimMode;
 use crate::session_manager::{DirtyWorktreePolicy, PruneFilter};
 
 /// Request body for POST /api/v1/sessions/managed/prune (#1508).
@@ -316,74 +315,20 @@ pub(crate) async fn prune_worktrees_core(
                 } else {
                     ReclaimMode::Remove
                 };
+                // #7504: through the ONE entry point that binds the production
+                // probes. The assembly used to live inline here; a second copy
+                // for the daemon's automatic sweep is exactly the divergence the
+                // common-entry-point rule forbids, so both callers now ask
+                // `merged_pr_reclaim::reclaim`. The only thing this route still
+                // decides is Report-vs-Remove, from its own `dry_run`.
                 // #6806: the caller's own id, so gate 2 can tell its claim from
                 // a stranger's. Validated ABOVE, before any survey work.
-                let caller = req.invoking_session.clone();
-                let root = repos_root.clone();
-                // #6927: read FALLIBLY and re-read PER CANDIDATE, not resolved
-                // from the lenient `config` this route already loaded. Lenient
-                // loading turns any YAML error anywhere in the file into an
-                // EMPTY keep-list, which is how a vetoed worktree could be
-                // deleted; the fallible reader keeps everything instead. It is
-                // a closure because this pass is unbounded, so an entry the
-                // operator adds mid-sweep must stop the candidates still
-                // queued — see `FreshProbes::keep_list`.
-                // #2919: a HANDLE to the manager, not a captured path list. The
-                // delete loop calls this closure per candidate and needs the
-                // CURRENT set, not one snapshotted before a survey that takes
-                // minutes. `None` (the store could not be read) refuses.
-                let mgr_for_probe = state.session_manager().await.clone();
-                // #5661: the sweep's other gates read SESSION records, and a
-                // dispatched agent has none — which is how this path deleted
-                // three live agents' worktrees. The delegation registry is the
-                // only place an agent's liveness is resolved from real
-                // `SubagentStop` signals, so it is read here and handed to the
-                // classifier as a probe rather than as a captured list.
-                let state_for_agents = Arc::clone(state);
-                // #7357: resolved on the route, moved into the blocking task.
-                let adopted_for_reclaim =
-                    crate::project::adopted_anchors_under(state.framework_root());
-                match tokio::task::spawn_blocking(move || {
-                    let in_use_now = move || -> Option<LiveClaims> {
-                        // `None` means "could not be determined", which REFUSES
-                        // the delete. `SessionManager::list` is itself
-                        // infallible, so the only way to fail here is to have no
-                        // runtime to block on — which happens if this closure is
-                        // ever invoked off the blocking pool. `Handle::current`
-                        // would PANIC in that case, unwinding through a delete
-                        // loop mid-sweep; `try_current` turns it into the
-                        // fail-closed refusal the contract already specifies.
-                        let handle = tokio::runtime::Handle::try_current().ok()?;
-                        // Blocking on the runtime is legal from a blocking-pool
-                        // thread (not a runtime worker), and is the only way to
-                        // re-read an async store from the synchronous loop.
-                        // #6806: each claim carries the session that holds
-                        // it, so gate 2 can tell the caller's own claim from a
-                        // foreign one and name the claimant when it refuses.
-                        // #7232: through the crate's single claim producer,
-                        // which also probes each claiming session for life. A
-                        // `deleted` record holding an org-level
-                        // `workspace_path` blocked every worktree beneath it in
-                        // seven repositories, because the store tombstones
-                        // records rather than dropping them.
-                        Some(handle.block_on(mgr_for_probe.workspace_claims(caller.clone())))
-                    };
-                    let agent_state = move |owner: &crate::session_manager::worktree_ownership::AgentWorktreeOwner| {
-                        crate::daemon::services::agent_worktree_reap::delegation_state_for_agent(
-                            &state_for_agents,
-                            &owner.agent_id,
-                        )
-                    };
-                    let keep_list = crate::core::trusty_tools_config::load_disk_keep_list;
-                    reclaim_merged_pr_worktrees(
-                        &root,
-                        &in_use_now,
-                        &agent_state,
-                        mode,
-                        &keep_list,
-                        &adopted_for_reclaim,
-                    )
-                })
+                match crate::daemon::services::merged_pr_reclaim::reclaim(
+                    state,
+                    &repos_root,
+                    mode,
+                    req.invoking_session.clone(),
+                )
                 .await
                 {
                     Ok(o) => serde_json::json!({
@@ -420,7 +365,7 @@ pub(crate) async fn prune_worktrees_core(
                         // A panicked pass reclaimed nothing; say so rather than
                         // omitting the key, which would read as "not requested".
                         warn!("prune-worktrees route: merged-PR pass panicked: {e}");
-                        serde_json::json!({ "error": e.to_string() })
+                        serde_json::json!({ "error": e })
                     }
                 }
             } else {

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -238,6 +238,13 @@ pub async fn serve_with_shutdown(
         info!("orphan-GC disabled via TRUSTY_MPM_ORPHAN_GC");
     }
 
+    // #7504: automatic post-merge worktree reclaim. Disk management is a daemon
+    // function (epic #7505), so this is ON by default — a reclaim the PM must
+    // remember to run is the manual step #2919 already shipped. The env gate, the
+    // cadence and the spawn all live in the service module, which keeps this file
+    // under its SLOC cap and keeps the policy next to the loop it governs.
+    services::merged_pr_reclaim::spawn_if_enabled(Arc::clone(&state), cancel.child_token());
+
     // Cloud log drain (#6535): OFF unless `log_drain.enabled` is true, so the
     // default host spawns nothing. A malformed section is reported here and
     // recorded for the `log_drain` doctor row rather than silently skipped —

--- a/crates/trusty-mpm/src/daemon/services/merged_pr_reclaim.rs
+++ b/crates/trusty-mpm/src/daemon/services/merged_pr_reclaim.rs
@@ -1,0 +1,399 @@
+//! Automatic post-merge worktree reclaim, and the one place its probes are
+//! assembled (#7504, epic #7505).
+//!
+//! Why: #2919 shipped the reclaim ENGINE and a manual verb — `tm session
+//! prune-worktrees --merged-prs` — and nothing that fires it. The PM therefore
+//! removed each merged worktree by hand, and on 2026-09-11 disk hit 90% because
+//! that step is a chore nobody owns. The owner's ruling for epic #7505 is that
+//! disk management is a deterministic DAEMON function: the daemon decides, by
+//! rule evaluation over observable state, and writes an audit line carrying its
+//! reason. This module is that function for the post-merge half.
+//!
+//! What: [`reclaim`] is the single production entry point — the one place the
+//! five probes the engine needs are bound to real sources. Both callers go
+//! through it, so an operator-typed `--merged-prs` and the automatic sweep can
+//! never apply different gates: the `prune-worktrees` route (which still decides
+//! Report-vs-Remove from its own `dry_run`) and [`reclaim_loop`], the daemon's
+//! background sweep. [`SweepReport`] is the summary the loop logs.
+//!
+//! # The trigger is PR-merged state, not the clock
+//!
+//! The cadence decides only when the daemon ASKS. What it acts on is
+//! `gh`-reported merge state, re-read per candidate immediately before that
+//! candidate's deletion by
+//! [`recheck_before_delete`](crate::session_manager::worktree_reclaim_sweep::recheck_before_delete).
+//! A worktree whose pull request is open, closed-unmerged, or unresolvable is
+//! never removed however often the sweep runs — so the interval cannot make the
+//! sweep guess, only make it late.
+//!
+//! # Why this one runs UNBOUNDED, unlike the doctor probe
+//!
+//! [`SurveyBudget`](crate::session_manager::worktree_reclaim_sweep::SurveyBudget)
+//! bounds the read-only doctor survey at 3 seconds because an interactive
+//! diagnostic must answer inside the client's timeout. A destructive pass cannot
+//! take that trade: a partial classification does not shrink a REPORT, it shrinks
+//! what gets reclaimed, which is the exact failure this issue exists to fix. So
+//! the sweep inherits the engine's unbounded budget and pays for it with a slow
+//! default cadence and [`MissedTickBehavior::Delay`], which together stop a sweep
+//! that overran its interval from re-firing the instant it finishes.
+//!
+//! # Fail direction
+//!
+//! Toward keeping the directory, at every layer. A sweep that cannot run reclaims
+//! nothing and says so at `warn`; a panicked blocking task is an `Err` the caller
+//! reports rather than an empty success; a removal that did not complete lands in
+//! `removal_failed` and makes [`SweepReport::failed`] true, so the loop logs the
+//! tick at `warn` instead of `info`. No arm turns a failure into an advanced
+//! state.
+//!
+//! Test: `merged_pr_reclaim_tests`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time::MissedTickBehavior;
+use tracing::{info, warn};
+
+use crate::daemon::state::DaemonState;
+use crate::session_manager::worktree_reclaim::{LiveClaims, ReclaimMode, ReclaimOutcome};
+use crate::session_manager::worktree_reclaim_launch::process_launch_dirs;
+use crate::session_manager::worktree_reclaim_sweep::reclaim_merged_pr_worktrees;
+
+/// Environment variable that disables the automatic sweep entirely.
+///
+/// Why: the sweep deletes directories, so an operator must be able to turn it off
+/// without editing a config file or stopping the daemon's other loops. It
+/// defaults ON — the owner's ruling is that this is a daemon function rather than
+/// a PM chore, and a reclaim that has to be enabled is the manual step #2919
+/// already shipped.
+/// What: `0`/`false`/`off`/`no` (trimmed, case-insensitive) disables; anything
+/// else, including unset, enables. Mirrors `TRUSTY_MPM_ORPHAN_GC`.
+/// Test: `parse_enabled_defaults_on_and_honours_the_off_switch`.
+pub(crate) const ENV_ENABLED: &str = "TRUSTY_MPM_WORKTREE_RECLAIM";
+
+/// Environment variable overriding the sweep cadence, in seconds.
+///
+/// Test: `parse_interval_falls_back_on_junk_and_zero`.
+pub(crate) const ENV_INTERVAL_SECS: &str = "TRUSTY_MPM_WORKTREE_RECLAIM_INTERVAL_SECS";
+
+/// Default sweep cadence: one hour.
+///
+/// Why an hour rather than the orphan-GC loop's minute: one pass costs a `gh`
+/// lookup per registered worktree plus an unbounded byte walk, which on this
+/// repository has exceeded 600 seconds over 46 worktrees. A merged worktree costs
+/// only disk until it goes, so being up to an hour late is free; re-walking a
+/// terabyte every minute is not.
+/// Test: `parse_interval_falls_back_on_junk_and_zero`.
+pub(crate) const DEFAULT_INTERVAL_SECS: u64 = 3600;
+
+/// Pure parse of [`ENV_ENABLED`] into an on/off decision.
+///
+/// Why pure: env vars are process-global, and ~20 tests in this binary write
+/// them. Taking the raw value keeps the policy testable with no mutation at all
+/// (#5544).
+/// Test: `parse_enabled_defaults_on_and_honours_the_off_switch`.
+pub(crate) fn parse_enabled(raw: Option<&str>) -> bool {
+    match raw {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        None => true,
+    }
+}
+
+/// Whether the automatic sweep should be spawned at all.
+///
+/// Test: the policy is covered by `parse_enabled_defaults_on_and_honours_the_off_switch`.
+pub(crate) fn enabled() -> bool {
+    parse_enabled(std::env::var(ENV_ENABLED).ok().as_deref())
+}
+
+/// Pure parse of [`ENV_INTERVAL_SECS`] into seconds.
+///
+/// Why it rejects zero: `tokio::time::interval` panics on a zero period, and a
+/// near-zero one would busy-loop a pass that spawns subprocesses. An unparsable
+/// or non-positive value falls back to [`DEFAULT_INTERVAL_SECS`] rather than
+/// disabling the sweep — disabling is [`ENV_ENABLED`]'s job, and inferring it
+/// from a typo would turn a fat-fingered number into silent non-reclamation.
+/// Test: `parse_interval_falls_back_on_junk_and_zero`.
+pub(crate) fn parse_interval_secs(raw: Option<&str>) -> u64 {
+    raw.and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_INTERVAL_SECS)
+}
+
+/// One tick's outcome, reduced to the four numbers the audit line carries.
+///
+/// Why a type rather than four locals: [`Self::failed`] is the thing the loop
+/// branches on, and the Fail-Open rule means that branch must exist in exactly
+/// one place. Reading `removal_failed.is_empty()` at the log site is how a later
+/// edit drops it.
+/// What: counts, plus the bytes the engine actually attributed to removals.
+/// Test: `a_tick_with_a_failed_removal_is_reported_as_a_failure`,
+/// `a_clean_tick_is_not_a_failure`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct SweepReport {
+    /// Worktrees removed this tick.
+    pub reclaimed: usize,
+    /// Bytes the engine attributed to those removals.
+    pub bytes: u64,
+    /// Candidates a pre-delete gate spared — expected, not a failure.
+    pub refused: usize,
+    /// Removals that were attempted and did NOT complete.
+    pub failed: usize,
+}
+
+impl SweepReport {
+    /// Reduce an engine outcome to the tick's numbers.
+    ///
+    /// Test: `a_tick_with_a_failed_removal_is_reported_as_a_failure`.
+    pub(crate) fn from_outcome(outcome: &ReclaimOutcome) -> Self {
+        Self {
+            reclaimed: outcome.removed.len(),
+            bytes: outcome.removed_bytes,
+            refused: outcome.refused_at_recheck.len(),
+            failed: outcome.removal_failed.len(),
+        }
+    }
+
+    /// Whether this tick failed to complete work it began.
+    ///
+    /// Why it is NOT about `refused`: a gate sparing a worktree is the sweep
+    /// working. A removal that began and did not finish is the only outcome that
+    /// leaves the workspace in a state nobody asked for.
+    /// Test: `a_tick_with_a_failed_removal_is_reported_as_a_failure`,
+    /// `a_clean_tick_is_not_a_failure`.
+    pub(crate) fn failed(&self) -> bool {
+        self.failed > 0
+    }
+}
+
+/// The sweep cadence, honouring [`ENV_INTERVAL_SECS`].
+///
+/// Test: the policy is covered by `parse_interval_falls_back_on_junk_and_zero`.
+pub(crate) fn interval_secs() -> u64 {
+    parse_interval_secs(std::env::var(ENV_INTERVAL_SECS).ok().as_deref())
+}
+
+/// The workspace root the operator's config names — what production callers pass
+/// as [`reclaim`]'s `repos_root`.
+///
+/// Why a named function: the `prune-worktrees` route already resolves this for its
+/// orphan pass, and the automatic sweep must resolve the SAME root or the two
+/// reclaim paths would walk different workspaces.
+/// Test: covered through the callers; the resolution itself is
+/// `core::trusty_tools_config`'s.
+pub(crate) fn configured_workspace_root() -> PathBuf {
+    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+    crate::core::trusty_tools_config::workspace_root(&config)
+}
+
+/// Run the merged-PR reclaim with every production probe bound (#7504).
+///
+/// Why this exists as a function: binding the probes is the part that is easy to
+/// get subtly wrong — `in_use_now` must RE-READ the store per candidate rather
+/// than close over a snapshot, the keep-list must be read fallibly so an
+/// unparsable config keeps everything, and the agent probe must reach the
+/// delegation registry rather than the session records. That assembly lived
+/// inline in the `prune-worktrees` route; a second copy for the automatic sweep
+/// is exactly the divergence the common-entry-point rule forbids, so there is one
+/// copy and both callers use it.
+/// What: resolves the adopted anchors and this process's own launch directories,
+/// then runs [`reclaim_merged_pr_worktrees`] on the blocking pool — the engine is
+/// synchronous and spends minutes in `git`, `gh` and filesystem walks. `mode`
+/// decides whether anything is deleted; `invoking_session` is the caller's own
+/// managed-session id, which gate 2 uses to tell the caller's claim from a
+/// stranger's (#6806) and which the daemon's own sweep leaves `None` because it
+/// occupies no pane.
+///
+/// `repos_root` is a PARAMETER rather than resolved here, for the reason #7357
+/// made `adopted` one: resolving it internally makes this function's own tests
+/// survey the operator's real workspace with an unbounded budget, which on this
+/// repository exceeds 600 seconds. [`configured_workspace_root`] is what
+/// production callers pass.
+///
+/// A panicked pass is `Err`, never an empty `ReclaimOutcome`: "reclaimed nothing"
+/// and "crashed" must not render identically.
+/// Test: `reclaim_on_an_empty_root_reclaims_nothing`.
+pub(crate) async fn reclaim(
+    state: &Arc<DaemonState>,
+    repos_root: &Path,
+    mode: ReclaimMode,
+    invoking_session: Option<String>,
+) -> Result<ReclaimOutcome, String> {
+    let repos_root = repos_root.to_path_buf();
+    // #7357: resolved here — on the entry point — never inside the engine, which
+    // would make its unit tests read the operator's real adoption store.
+    let adopted = crate::project::adopted_anchors_under(state.framework_root());
+    // #7504: this process's own cwd and executable directory, resolved once per
+    // pass. See `FreshProbes::launched_from` for why a value rather than a probe.
+    let launched_from: Vec<PathBuf> = process_launch_dirs();
+    // #2919: a HANDLE to the manager, not a captured path list — the delete loop
+    // calls the closure per candidate and needs the CURRENT set, not one
+    // snapshotted before a survey that takes minutes.
+    let mgr_for_probe = state.session_manager().await.clone();
+    // #5661: the other gates read SESSION records, and a dispatched agent has
+    // none — which is how this path once deleted three live agents' worktrees.
+    let state_for_agents = Arc::clone(state);
+    tokio::task::spawn_blocking(move || {
+        let in_use_now = move || -> Option<LiveClaims> {
+            // `None` means "could not be determined", which REFUSES the delete.
+            // `try_current` rather than `current`: the latter PANICS off a
+            // runtime, unwinding through a delete loop mid-sweep, where the
+            // contract already specifies a fail-closed refusal.
+            let handle = tokio::runtime::Handle::try_current().ok()?;
+            // #7232: through the crate's single claim producer, which also probes
+            // each claiming session for life — a tombstoned record holding an
+            // org-level `workspace_path` otherwise blocks every worktree beneath
+            // it.
+            Some(handle.block_on(mgr_for_probe.workspace_claims(invoking_session.clone())))
+        };
+        let agent_state =
+            move |owner: &crate::session_manager::worktree_ownership::AgentWorktreeOwner| {
+                crate::daemon::services::agent_worktree_reap::delegation_state_for_agent(
+                    &state_for_agents,
+                    &owner.agent_id,
+                )
+            };
+        // #6927: read FALLIBLY and re-read PER CANDIDATE. The lenient loader
+        // collapses any YAML error anywhere in the file to an EMPTY keep-list,
+        // which is how a vetoed worktree could be deleted; this one keeps
+        // everything instead.
+        let keep_list = crate::core::trusty_tools_config::load_disk_keep_list;
+        reclaim_merged_pr_worktrees(
+            &repos_root,
+            &in_use_now,
+            &agent_state,
+            mode,
+            &keep_list,
+            &adopted,
+            &launched_from,
+        )
+    })
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// Spawn the automatic sweep unless an operator switched it off (#7504).
+///
+/// Why the gate lives here rather than at the call site: the daemon's boot
+/// sequence should read as one line per background loop, and the env contract for
+/// this loop belongs beside the loop it governs — the same split
+/// `spawn_idle_reaper_if_enabled` already uses.
+/// What: reads [`ENV_ENABLED`] and [`ENV_INTERVAL_SECS`], then spawns
+/// [`reclaim_loop`]; when disabled it logs the variable that disabled it, so an
+/// operator wondering why nothing is being reclaimed finds the answer in the
+/// daemon log rather than by reading this source.
+/// Test: the policy is `parse_enabled_defaults_on_and_honours_the_off_switch`;
+/// the loop it spawns is `reclaim_loop_exits_on_cancel`.
+pub(crate) fn spawn_if_enabled(
+    state: Arc<DaemonState>,
+    cancel: tokio_util::sync::CancellationToken,
+) {
+    if !enabled() {
+        info!("automatic post-merge worktree reclaim disabled via {ENV_ENABLED}");
+        return;
+    }
+    tokio::spawn(reclaim_loop(
+        state,
+        Duration::from_secs(interval_secs()),
+        cancel,
+    ));
+}
+
+/// The daemon's automatic post-merge reclaim sweep (#7504).
+///
+/// Why a loop rather than a webhook: the authority on "has this merged" is
+/// GitHub, and this harness has no inbound path from it. Asking `gh` on a cadence
+/// is the event source available, and the gates make a late answer harmless — see
+/// the module docs on why the clock is not the trigger.
+/// What: one pass immediately (so a restart cleans up promptly), then every
+/// [`interval`] until `cancel` fires. Each tick refuses outright on a host state
+/// that must not be swept — the #6348 quadrant, where a scratch-rooted daemon
+/// would otherwise reclaim the operator's real worktrees — then runs [`reclaim`]
+/// in [`ReclaimMode::Remove`] and logs the tick. A tick with any failed removal
+/// logs at `warn`; a tick that reclaimed nothing and failed nothing logs nothing,
+/// because an hourly "reclaimed 0" is noise that trains operators to filter the
+/// line that matters.
+/// Test: `reclaim_loop_exits_on_cancel`,
+/// `reclaim_loop_reclaims_nothing_on_a_scratch_framework_root`.
+pub(crate) async fn reclaim_loop(
+    state: Arc<DaemonState>,
+    interval: Duration,
+    cancel: tokio_util::sync::CancellationToken,
+) {
+    info!(
+        interval_secs = interval.as_secs(),
+        "automatic post-merge worktree reclaim enabled (#7504)"
+    );
+    let mut tick = tokio::time::interval(interval);
+    // A pass can outlast its own interval on a large workspace. The default
+    // `Burst` behaviour would then fire the next tick immediately and keep the
+    // machine walking worktrees continuously; `Delay` restarts the clock from the
+    // end of the pass instead.
+    tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("worktree-reclaim loop: cancel signal received; exiting");
+                break;
+            }
+            _ = tick.tick() => run_one_tick(&state).await,
+        }
+    }
+}
+
+/// One sweep, gated on host state and logged (#7504).
+///
+/// Split from [`reclaim_loop`] so a test can drive exactly one pass without
+/// racing a timer.
+/// Test: `reclaim_loop_reclaims_nothing_on_a_scratch_framework_root`.
+pub(crate) async fn run_one_tick(state: &Arc<DaemonState>) {
+    // #6348: the same refusal `reap_loop` and the orphan-GC loop apply. A daemon
+    // whose framework root is a scratch directory is a test process, and its
+    // registry knows nothing of the operator's real worktrees.
+    if let Some(reason) = crate::daemon::host_state_refusal(state) {
+        warn!("worktree-reclaim sweep: skipped — {reason}");
+        return;
+    }
+    match reclaim(
+        state,
+        &configured_workspace_root(),
+        ReclaimMode::Remove,
+        None,
+    )
+    .await
+    {
+        Ok(outcome) => {
+            let report = SweepReport::from_outcome(&outcome);
+            if report.failed() {
+                // The Fail-Open boundary: a removal that began and did not finish
+                // is never folded into the success line.
+                warn!(
+                    reclaimed = report.reclaimed,
+                    refused = report.refused,
+                    failed = report.failed,
+                    "worktree-reclaim sweep: {} removal(s) did not complete: {}",
+                    report.failed,
+                    outcome.removal_failed.join("; ")
+                );
+                return;
+            }
+            if report.reclaimed > 0 {
+                info!(
+                    reclaimed = report.reclaimed,
+                    bytes_freed = report.bytes,
+                    refused = report.refused,
+                    "worktree-reclaim sweep: reclaimed merged-PR worktree(s) (#7504)"
+                );
+            }
+        }
+        Err(e) => warn!("worktree-reclaim sweep: the pass did not complete: {e}"),
+    }
+}
+
+#[cfg(test)]
+#[path = "merged_pr_reclaim_tests.rs"]
+mod merged_pr_reclaim_tests;

--- a/crates/trusty-mpm/src/daemon/services/merged_pr_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/merged_pr_reclaim_tests.rs
@@ -1,0 +1,195 @@
+//! Tests for the automatic post-merge reclaim sweep (#7504).
+//!
+//! Why: the engine's own gates are covered exhaustively in
+//! `session_manager::worktree_reclaim_sweep_tests`, each with a refusal test that
+//! fails if its gate is deleted. What is NOT covered there is this layer's three
+//! decisions: whether the sweep runs at all, whether it refuses a host state it
+//! must not sweep, and whether a failed removal is reported rather than folded
+//! into a success.
+//! What: pure policy tests for the two env knobs, a Fail-Open test on
+//! [`SweepReport`], and two tests driving the real loop against a scratch
+//! framework root.
+//!
+//! The loop tests are `#[serial_test::serial]`. The resource they share is
+//! process-global `$HOME`, which ~20 tests in this binary write: the host-state
+//! refusal that stops a scratch-rooted daemon from sweeping the operator's real
+//! worktrees reads `$HOME`, and a concurrent rewrite of it could let a
+//! DESTRUCTIVE pass through. An in-process lock is the right instrument for
+//! in-process state — under nextest each test already has its own process, so
+//! there is no cross-process `$HOME` to guard (#4162).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::{
+    DEFAULT_INTERVAL_SECS, SweepReport, parse_enabled, parse_interval_secs, reclaim, reclaim_loop,
+};
+use crate::daemon::state::DaemonState;
+use crate::session_manager::worktree_reclaim::{ReclaimMode, ReclaimOutcome, ReclaimSurvey};
+
+/// A `DaemonState` rooted at a throwaway directory, plus the directory.
+///
+/// `$HOME` is left exactly as the test binary inherited it — that is the #6348
+/// quadrant the host-state refusal exists for, and reassigning it would silence
+/// the root arm behind the `$HOME` arm that already worked.
+fn scratch_root_state() -> (Arc<DaemonState>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("scratch framework root");
+    let state = Arc::new(DaemonState::with_root(dir.path().to_path_buf()));
+    (state, dir)
+}
+
+/// The sweep is ON unless explicitly switched off (#7504).
+///
+/// Why this is the assertion rather than the inverse: a reclaim that must be
+/// enabled is the manual step #2919 already shipped, which is what this issue
+/// exists to remove. A default flip would leave every test here green while the
+/// feature did nothing.
+#[test]
+fn parse_enabled_defaults_on_and_honours_the_off_switch() {
+    assert!(parse_enabled(None), "unset must enable the sweep");
+    assert!(parse_enabled(Some("1")));
+    assert!(parse_enabled(Some("true")));
+    assert!(
+        parse_enabled(Some("")),
+        "an empty value is not an off switch"
+    );
+    for off in ["0", "false", "off", "no", " OFF ", "False"] {
+        assert!(!parse_enabled(Some(off)), "`{off}` must disable the sweep");
+    }
+}
+
+/// Junk and zero fall back to the default cadence, never to "disabled" (#7504).
+///
+/// A zero period panics `tokio::time::interval`, and inferring "off" from a typo
+/// would turn a fat-fingered number into silent non-reclamation — that is
+/// `TRUSTY_MPM_WORKTREE_RECLAIM`'s job.
+#[test]
+fn parse_interval_falls_back_on_junk_and_zero() {
+    assert_eq!(parse_interval_secs(None), DEFAULT_INTERVAL_SECS);
+    assert_eq!(parse_interval_secs(Some("nonsense")), DEFAULT_INTERVAL_SECS);
+    assert_eq!(parse_interval_secs(Some("0")), DEFAULT_INTERVAL_SECS);
+    assert_eq!(parse_interval_secs(Some("-5")), DEFAULT_INTERVAL_SECS);
+    assert_eq!(parse_interval_secs(Some(" 120 ")), 120);
+}
+
+/// An outcome carrying a failed removal, with everything else clean.
+fn outcome_with(removal_failed: Vec<String>, removed: Vec<PathBuf>) -> ReclaimOutcome {
+    ReclaimOutcome {
+        survey: ReclaimSurvey::from_candidates(Vec::new()),
+        removed,
+        removed_bytes: 0,
+        refused_at_recheck: Vec::new(),
+        removal_failed,
+    }
+}
+
+/// A removal that did not complete makes the tick a FAILURE (#7504).
+///
+/// The Fail-Open check: without this branch the loop logs the same `info` line for
+/// a tick that reclaimed two worktrees and for one that reclaimed two and left a
+/// third half-removed. Fails if `SweepReport::failed` ever keys on `refused`, or
+/// on nothing.
+#[test]
+fn a_tick_with_a_failed_removal_is_reported_as_a_failure() {
+    let outcome = outcome_with(
+        vec!["/tmp/wt: git worktree remove exited 128".to_string()],
+        vec![PathBuf::from("/tmp/other")],
+    );
+    let report = SweepReport::from_outcome(&outcome);
+    assert!(report.failed(), "report: {report:?}");
+    assert_eq!(report.failed, 1);
+    assert_eq!(
+        report.reclaimed, 1,
+        "a partially successful tick still reports what it did reclaim"
+    );
+}
+
+/// A tick that removed things cleanly is not a failure (#7504).
+///
+/// The inverse of the test above: a `failed()` that is always true would make
+/// every sweep log at `warn` and train operators to ignore the line.
+#[test]
+fn a_clean_tick_is_not_a_failure() {
+    let outcome = outcome_with(Vec::new(), vec![PathBuf::from("/tmp/gone")]);
+    let report = SweepReport::from_outcome(&outcome);
+    assert!(!report.failed(), "report: {report:?}");
+}
+
+/// A candidate a gate SPARED is not a failure (#7504).
+///
+/// Spared worktrees are the sweep working. Counting them as failures would make
+/// the `warn` arm fire on every healthy tick in a workspace with one live agent.
+#[test]
+fn a_spared_candidate_is_not_a_failure() {
+    let mut outcome = outcome_with(Vec::new(), Vec::new());
+    outcome
+        .refused_at_recheck
+        .push("/tmp/wt: holds unsaved work".to_string());
+    let report = SweepReport::from_outcome(&outcome);
+    assert!(!report.failed(), "report: {report:?}");
+    assert_eq!(report.refused, 1);
+}
+
+/// A sweep against a scratch-rooted daemon reclaims nothing (#7504, #6348).
+///
+/// Why it matters more here than anywhere else: this loop is ON by default and
+/// DELETES directories. A test process whose framework root is a tempdir has an
+/// empty session registry, so every worktree the operator is really working in
+/// looks unclaimed to it. `run_one_tick` refuses before any survey runs.
+#[tokio::test]
+#[serial_test::serial]
+async fn reclaim_loop_reclaims_nothing_on_a_scratch_framework_root() {
+    let (state, dir) = scratch_root_state();
+    super::run_one_tick(&state).await;
+    assert!(
+        dir.path().exists(),
+        "the tick must not disturb the scratch root itself"
+    );
+}
+
+/// The loop exits when its cancel token fires (#7504).
+///
+/// A liveness pin: a loop that ignores cancellation is dropped mid-sweep on
+/// SIGTERM, which is how a `git worktree remove` gets interrupted between its
+/// directory removal and its administrative-file removal.
+#[tokio::test]
+#[serial_test::serial]
+async fn reclaim_loop_exits_on_cancel() {
+    let (state, _dir) = scratch_root_state();
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let handle = tokio::spawn(reclaim_loop(
+        state,
+        Duration::from_secs(3600),
+        cancel.child_token(),
+    ));
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(30), handle)
+        .await
+        .expect("the loop must exit on cancel rather than hang")
+        .expect("the loop must not panic");
+}
+
+/// [`reclaim`] against an EMPTY workspace root returns an outcome rather than
+/// panicking (#7504).
+///
+/// Why the root is a tempdir and not the operator's: the entry point binds five
+/// probes, one of which blocks on the async session store from a blocking-pool
+/// thread — a wiring mistake there surfaces as a panicked `JoinError`, and this
+/// asserts it is reported as `Err` rather than as an empty success. Surveying the
+/// real workspace would prove the same thing and take ten minutes, because the
+/// destructive path runs with an unbounded budget by design.
+#[tokio::test]
+#[serial_test::serial]
+async fn reclaim_on_an_empty_root_reclaims_nothing() {
+    let (state, _dir) = scratch_root_state();
+    let empty_root = tempfile::tempdir().expect("empty workspace root");
+    let out = reclaim(&state, empty_root.path(), ReclaimMode::Remove, None)
+        .await
+        .expect("the probe assembly must not panic");
+    assert!(
+        out.removed.is_empty() && out.removal_failed.is_empty(),
+        "a workspace root with no registered worktree has nothing to reclaim: {out:?}"
+    );
+    assert_eq!(out.survey.candidates.len(), 0, "outcome: {out:?}");
+}

--- a/crates/trusty-mpm/src/daemon/services/mod.rs
+++ b/crates/trusty-mpm/src/daemon/services/mod.rs
@@ -14,6 +14,9 @@
 pub mod agent_worktree_reap;
 pub mod delegation_tracker;
 pub mod hook_service;
+// #7504: the ONE place the merged-PR reclaim's production probes are assembled,
+// plus the daemon loop that runs it automatically after a merge.
+pub mod merged_pr_reclaim;
 pub mod pairing_service;
 pub mod session_service;
 pub mod tmux_service;

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -77,6 +77,9 @@ pub(crate) mod worktree_reclaim_gh_gate;
 pub(crate) mod worktree_reclaim_pr_match;
 // #6507: the verdict vocabulary, including which GATE refused a candidate.
 pub(crate) mod worktree_reclaim_verdict;
+// #7504: the gate that spares a worktree a live process was launched from — the
+// daemon's own working directory or the executable serving the sweep.
+pub(crate) mod worktree_reclaim_launch;
 // #6806: gate 2's claim resolution — WHICH session claims a candidate, and
 // whether that session is the one that invoked the sweep.
 pub(crate) mod worktree_reclaim_claim;

--- a/crates/trusty-mpm/src/session_manager/worktree_keep_list.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_keep_list.rs
@@ -259,7 +259,13 @@ fn expand_home(raw: &str) -> PathBuf {
 /// Canonicalization fails for a directory that no longer exists — a stale
 /// worktree pointer, which is precisely a case this gate must still answer for
 /// — so a failure falls back rather than refusing to compare.
-fn resolve(path: &Path) -> PathBuf {
+///
+/// #7504: shared with
+/// [`worktree_reclaim_launch`](super::worktree_reclaim_launch), whose gate
+/// compares the same two forms of the same candidate paths. One resolver, so the
+/// two gates cannot disagree about whether a symlinked workspace root contains a
+/// worktree.
+pub(in crate::session_manager) fn resolve(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_launch.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_launch.rs
@@ -1,0 +1,99 @@
+//! The gate that spares a worktree a live process was LAUNCHED FROM (#7504).
+//!
+//! Why: every other reclaim gate asks about the tree's CONTENT (dirt, landing
+//! evidence) or about who CLAIMS it (a session record, an agent sentinel, the
+//! operator's keep-list). None of them notices that the running process's own
+//! working directory, or the executable serving this sweep, sits inside the
+//! candidate. Deleting that tree pulls the ground out from under the process
+//! doing the deleting: its working directory becomes a dangling inode, every
+//! subsequent `git -C .` fails with ENOENT, and on macOS a later exec of the
+//! deleted binary is SIGKILLed as an invalid signature rather than reported as
+//! missing — which reads as an OOM kill. #7185 named this as the
+//! worktree-launched-daemon trap; #7262 is the same shape one layer up, a
+//! settings hook pointing at a Cargo build-tree binary.
+//!
+//! What: [`launch_refusal`] is the whole gate as a pure function over one
+//! candidate and the directories processes were launched from.
+//! [`process_launch_dirs`] is the production collector — the current working
+//! directory and the running executable, both read with no subprocess and no
+//! process-table walk, so the gate costs nothing per candidate.
+//!
+//! # Direction of the containment test
+//!
+//! A launch directory INSIDE the candidate refuses; a launch directory that
+//! merely CONTAINS the candidate does not. Deleting `<repo>/.claude/worktrees/x`
+//! does not disturb a process launched from `<repo>`, and treating an ancestor
+//! as a refusal would spare every worktree in the repository the daemon was
+//! started from — which is all of them.
+//!
+//! # Fail direction
+//!
+//! Toward keeping. A path that will not canonicalize is compared by its literal
+//! spelling rather than dropped, exactly as
+//! [`KeepList`](super::worktree_keep_list::KeepList) does, so an unresolvable
+//! launch directory still protects the tree it names.
+//!
+//! Test: `worktree_reclaim_launch_tests`.
+
+use std::path::{Path, PathBuf};
+
+use super::worktree_keep_list::resolve;
+
+/// Why this candidate may not be removed, or `None` when no process lives in it.
+///
+/// Why: the gate is pure so "a process was launched from inside it" is testable
+/// without starting a process inside a tempdir, and so the reclaim loop can
+/// apply it before the slow `gh` lookups rather than after them.
+/// What: refuses when any `launched_from` entry IS the candidate or sits BENEATH
+/// it, compared on canonicalized AND literal forms (see the module docs for why
+/// both). The reason names the offending directory so the audit line says which
+/// process the refusal protected.
+/// Test: `a_launch_dir_inside_the_candidate_refuses`,
+/// `the_candidate_itself_as_a_launch_dir_refuses`,
+/// `a_launch_dir_containing_the_candidate_does_not_refuse`,
+/// `an_unrelated_launch_dir_does_not_refuse`,
+/// `an_unresolvable_launch_dir_still_refuses_by_its_literal_spelling`.
+pub(crate) fn launch_refusal(path: &Path, launched_from: &[PathBuf]) -> Option<String> {
+    let resolved_candidate = resolve(path);
+    for dir in launched_from {
+        let resolved_dir = resolve(dir);
+        if resolved_dir.starts_with(&resolved_candidate) || dir.starts_with(path) {
+            return Some(format!(
+                "a live process was launched from inside this worktree ({}) — \
+                 removing it would strip that process of its working directory \
+                 or its executable (#7504)",
+                dir.display()
+            ));
+        }
+    }
+    None
+}
+
+/// The directories THIS process was launched from, for [`launch_refusal`].
+///
+/// Why: the daemon running the sweep is the process most likely to be sitting
+/// inside a candidate — a `cargo run` from a worktree, or a binary still living
+/// in that worktree's `target-worktree/`. Reading its own cwd and exe answers
+/// that deterministically, with no process-table scan to go stale or to need a
+/// subprocess the gate would then have to fail closed around.
+/// What: the current working directory, plus the directory holding the running
+/// executable. Either read may fail (a deleted cwd, a platform that will not
+/// report `current_exe`); a failure contributes nothing rather than aborting the
+/// sweep, because this gate is additive to the five that already refuse.
+/// Test: `process_launch_dirs_reports_the_current_directory`.
+pub(crate) fn process_launch_dirs() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        out.push(cwd);
+    }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(parent) = exe.parent()
+    {
+        out.push(parent.to_path_buf());
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "worktree_reclaim_launch_tests.rs"]
+mod worktree_reclaim_launch_tests;

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_launch_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_launch_tests.rs
@@ -1,0 +1,122 @@
+//! Tests for the worktree-launched-process gate (#7504).
+//!
+//! Why: the gate's whole value is the containment DIRECTION — a process inside
+//! the candidate refuses, a process in an ancestor does not. Getting that
+//! backwards either deletes the daemon's own footing or spares every worktree in
+//! the repository the daemon was started from, and both read as "the sweep is
+//! behaving".
+//! What: one test per branch of [`launch_refusal`], plus a liveness pin on the
+//! production collector.
+
+use std::path::{Path, PathBuf};
+
+use super::{launch_refusal, process_launch_dirs};
+
+/// A real directory tree to compare against, since the gate canonicalizes.
+fn tree() -> tempfile::TempDir {
+    tempfile::tempdir().expect("scratch tree")
+}
+
+/// A process whose cwd is a subdirectory of the candidate refuses (#7504).
+///
+/// Fails without the gate: `launch_refusal` answers `None` and the candidate
+/// reaches `remove_session_worktree`.
+#[test]
+fn a_launch_dir_inside_the_candidate_refuses() {
+    let dir = tree();
+    let candidate = dir.path().join("wt");
+    let inside = candidate.join("crates").join("trusty-mpm");
+    std::fs::create_dir_all(&inside).expect("create nested dir");
+
+    let reason = launch_refusal(&candidate, std::slice::from_ref(&inside))
+        .unwrap_or_else(|| panic!("{} must be spared", candidate.display()));
+    assert!(
+        reason.contains(&inside.display().to_string()),
+        "the refusal must name the launch directory: {reason}"
+    );
+}
+
+/// The candidate itself as a launch directory refuses (#7504).
+#[test]
+fn the_candidate_itself_as_a_launch_dir_refuses() {
+    let dir = tree();
+    let candidate = dir.path().join("wt");
+    std::fs::create_dir_all(&candidate).expect("create candidate");
+
+    assert!(
+        launch_refusal(&candidate, std::slice::from_ref(&candidate)).is_some(),
+        "a process whose cwd IS the candidate must spare it"
+    );
+}
+
+/// A launch directory that CONTAINS the candidate does not refuse (#7504).
+///
+/// The inverse of the test above, and the one that matters for usefulness: the
+/// daemon is normally started from the repository root, which is an ancestor of
+/// every worktree under it. Refusing on an ancestor would spare all of them.
+#[test]
+fn a_launch_dir_containing_the_candidate_does_not_refuse() {
+    let dir = tree();
+    let candidate = dir.path().join(".claude").join("worktrees").join("agent-1");
+    std::fs::create_dir_all(&candidate).expect("create candidate");
+
+    assert_eq!(
+        launch_refusal(&candidate, &[dir.path().to_path_buf()]),
+        None,
+        "an ancestor launch directory must not spare the worktree"
+    );
+}
+
+/// An unrelated launch directory does not refuse (#7504).
+#[test]
+fn an_unrelated_launch_dir_does_not_refuse() {
+    let dir = tree();
+    let candidate = dir.path().join("wt-a");
+    let elsewhere = dir.path().join("wt-b").join("src");
+    std::fs::create_dir_all(&candidate).expect("create candidate");
+    std::fs::create_dir_all(&elsewhere).expect("create elsewhere");
+
+    assert_eq!(launch_refusal(&candidate, &[elsewhere]), None);
+}
+
+/// An empty launch set is a no-op gate (#7504).
+///
+/// Every pre-#7504 call site passes one, so this pins that the gate changes
+/// nothing for them.
+#[test]
+fn an_empty_launch_set_never_refuses() {
+    assert_eq!(launch_refusal(Path::new("/tmp/whatever"), &[]), None);
+}
+
+/// A launch directory that cannot be canonicalized still refuses by its literal
+/// spelling (#7504).
+///
+/// Why it matters: the commonest way a launch directory stops resolving is the
+/// directory being deleted — which is exactly the state a half-finished sweep
+/// leaves. Dropping an unresolvable entry would fail OPEN on the one input whose
+/// absence is evidence of trouble.
+#[test]
+fn an_unresolvable_launch_dir_still_refuses_by_its_literal_spelling() {
+    let candidate = PathBuf::from("/nonexistent-7504/wt");
+    let inside = candidate.join("gone");
+
+    assert!(
+        launch_refusal(&candidate, &[inside]).is_some(),
+        "a literal-prefix match must refuse when neither path canonicalizes"
+    );
+}
+
+/// The production collector reports at least the current working directory.
+///
+/// A liveness pin, not a discriminating one: it asserts the collector returns
+/// real paths rather than an empty vector, which is what would silently disable
+/// the gate in production while every pure test above kept passing.
+#[test]
+fn process_launch_dirs_reports_the_current_directory() {
+    let dirs = process_launch_dirs();
+    let cwd = std::env::current_dir().expect("a cwd");
+    assert!(
+        dirs.contains(&cwd),
+        "the collector must report the process's own cwd; got {dirs:?}"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep.rs
@@ -42,6 +42,9 @@ use super::worktree_reclaim::{
     ReclaimCandidate, ReclaimGate, ReclaimMode, ReclaimOutcome, ReclaimSurvey, ReclaimVerdict,
     agent_ownership_blocks, classify, measure_bytes_until, tm_provisioned,
 };
+// #7504: the worktree-launched-process gate, applied per candidate immediately
+// before its deletion alongside the five `recheck_before_delete` re-asks.
+use super::worktree_reclaim_launch::launch_refusal;
 // #7267: the merged-pull-request matcher — round stem and head commit, not the
 // branch name alone.
 use super::worktree_reclaim_pr_match::{GhLandingProbe, resolve_with_index};
@@ -391,6 +394,15 @@ pub(crate) struct FreshProbes<'a> {
     /// as `in_use_now` is. Reading it is a small local file, not a subprocess,
     /// so the per-candidate cost is nil.
     pub keep_list: &'a dyn Fn() -> KeepList,
+    /// The directories a live process was launched from (#7504).
+    ///
+    /// Why a VALUE and not a probe, unlike its three neighbours: a process's
+    /// working directory and executable path are fixed for that process's
+    /// lifetime, so re-reading them per candidate would re-derive the same
+    /// answer at a cost. The staleness this module guards against is state
+    /// OTHERS change during a minutes-long sweep; this input is the sweep's own.
+    /// An empty slice is the pre-#7504 behaviour — a no-op gate.
+    pub launched_from: &'a [PathBuf],
 }
 
 /// Survey, and in [`ReclaimMode::Remove`] reclaim, merged-PR worktrees (#2919).
@@ -448,6 +460,21 @@ pub(crate) fn reclaim_with_probes(
     let mut fresh_indexes: BTreeMap<PathBuf, PrIndex> = BTreeMap::new();
     for candidate in approved {
         let path = candidate.path;
+        // #7504: ahead of the pull-request lookups, because it is the only gate
+        // here that costs nothing — two in-process path compares — and a
+        // candidate holding the running daemon's own footing must not first buy
+        // a `gh` call. It is also the only input that cannot go stale under this
+        // sweep, so evaluating it early costs no freshness (see
+        // `FreshProbes::launched_from`).
+        if let Some(reason) = launch_refusal(&path, probes.launched_from) {
+            tracing::warn!(
+                path = %path.display(),
+                "worktree-reclaim: spared a surveyed candidate — {reason}"
+            );
+            out.refused_at_recheck
+                .push(format!("{}: {reason}", path.display()));
+            continue;
+        }
         // The pull-request lookups go FIRST because they are the slow part —
         // measured 322-366 ms for a per-branch call and 1220 ms for the bulk
         // one, against a 10 s ceiling. Reading liveness before them would date
@@ -491,9 +518,25 @@ pub(crate) fn reclaim_with_probes(
         }
         let outcome = super::decommission::remove_session_worktree(&path);
         if outcome.removed() && !path.exists() {
+            // #7504: the AUDIT LINE. It carries path, branch, pull request and
+            // bytes freed because the reclaim is now automatic: nobody typed the
+            // command, so this line is the only record of what the daemon
+            // decided and why it was allowed to. `bytes` is `None` when the
+            // survey's measurement phase ran out of budget before reaching this
+            // candidate — reported as absent rather than as zero, which would
+            // read as "freed nothing".
             tracing::info!(
                 path = %path.display(),
-                "worktree-reclaim: reclaimed a merged-PR worktree (#2919)"
+                branch = candidate.branch.as_deref().unwrap_or("(detached)"),
+                pr = match &pr_now {
+                    BranchPrState::Merged { pr } => Some(*pr),
+                    // Unreachable past `recheck_before_delete`, which refuses
+                    // every other state. Rendered as absent rather than as a
+                    // fabricated number if that ever stops being true.
+                    _ => None,
+                },
+                bytes_freed = candidate.bytes,
+                "worktree-reclaim: reclaimed a merged-PR worktree (#2919, #7504)"
             );
             out.removed_bytes = out
                 .removed_bytes
@@ -521,8 +564,12 @@ pub(crate) fn reclaim_with_probes(
 /// [`reclaim_with_probes`] against the real `gh`-backed index and a live
 /// re-read of the session store (#2919).
 ///
-/// Why: the production entry point, reached only from the explicit
-/// `merged_prs` opt-in on `tm session prune-worktrees`.
+/// Why: the production entry point for the merged-PR reclaim — reached from the
+/// `merged_prs` opt-in on `tm session prune-worktrees` AND, since #7504, from the
+/// daemon's automatic post-merge sweep. Both arrive through
+/// [`crate::daemon::services::merged_pr_reclaim::reclaim`], the one place the
+/// production probes are assembled, so an operator-typed reclaim and an automatic
+/// one cannot apply different gates.
 /// What: `in_use_paths` and `keep_list` are both re-invoked per candidate by
 /// the loop, so the caller must supply closures that genuinely RE-READ rather
 /// than ones closing over a captured snapshot. `in_use_paths` returns `None`
@@ -538,6 +585,10 @@ pub(crate) fn reclaim_merged_pr_worktrees(
     keep_list: &dyn Fn() -> KeepList,
     // #7357: resolved by the route that invokes this, never here.
     adopted: &[PathBuf],
+    // #7504: the caller's own launch directories, resolved by the entry point
+    // that assembles the probes — never here, so a test can hand in a scratch
+    // path without the real process's cwd leaking into the comparison.
+    launched_from: &[PathBuf],
 ) -> ReclaimOutcome {
     reclaim_with_probes(
         repos_root,
@@ -546,6 +597,7 @@ pub(crate) fn reclaim_merged_pr_worktrees(
             index_for: &PrIndex::from_gh,
             agent_state,
             keep_list,
+            launched_from,
         },
         mode,
         adopted,

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
@@ -274,6 +274,7 @@ fn reclaim_remove_mode_spares_a_live_agents_merged_worktree() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &agent_live,
             in_use_now: &|| Some(nobody()),
@@ -313,6 +314,7 @@ fn survey_discloses_a_live_agents_spared_worktree() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &agent_live,
             in_use_now: &|| Some(nobody()),
@@ -354,6 +356,7 @@ fn survey_discloses_nothing_when_no_agent_was_spared() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &|| Some(nobody()),
@@ -791,6 +794,7 @@ fn reclaim_report_mode_removes_nothing() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &|| Some(nobody()),
@@ -828,6 +832,7 @@ fn a_dead_sessions_claim_does_not_block_the_dry_run() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &|| Some(dead.clone()),
@@ -860,6 +865,7 @@ fn a_live_sessions_claim_still_blocks_the_dry_run() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &|| Some(live.clone()),
@@ -909,6 +915,7 @@ fn reclaim_remove_mode_refuses_a_worktree_claimed_after_the_survey() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &in_use_now,
@@ -946,6 +953,7 @@ fn reclaim_remove_mode_refuses_a_worktree_dirtied_after_the_survey() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &in_use_now,
@@ -987,6 +995,7 @@ fn reclaim_remove_mode_refuses_a_worktree_locked_after_the_survey() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &in_use_now,
@@ -1021,6 +1030,7 @@ fn reclaim_remove_mode_refuses_when_the_pr_reopens_after_the_survey() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &|| Some(nobody()),
@@ -1048,6 +1058,7 @@ fn reclaim_remove_mode_refuses_when_the_live_set_cannot_be_read() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &in_use_now,
@@ -1129,6 +1140,7 @@ fn reclaim_remove_mode_refuses_a_worktree_keep_listed_after_the_survey() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &keep_list,
             agent_state: &no_agents,
             in_use_now: &|| Some(nobody()),
@@ -1198,6 +1210,7 @@ fn a_malformed_config_refuses_to_reclaim_a_merged_clean_worktree() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &keep_list,
             agent_state: &no_agents,
             in_use_now: &|| Some(nobody()),
@@ -1233,6 +1246,7 @@ fn reclaim_remove_mode_reclaims_a_clean_merged_worktree() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &|| Some(nobody()),
@@ -1245,6 +1259,73 @@ fn reclaim_remove_mode_reclaims_a_clean_merged_worktree() {
     assert!(!path.exists(), "the directory must be gone");
     assert!(out.removed_bytes > 0);
     assert!(out.removal_failed.is_empty());
+}
+
+/// A worktree a live process was launched from is spared, merged and clean
+/// though it is (#7504).
+///
+/// Why this is the discriminating shape: the fixture is byte-for-byte the one
+/// `reclaim_remove_mode_reclaims_a_clean_merged_worktree` above DELETES. The
+/// only difference is the launch directory, so the test cannot pass for any
+/// reason other than the gate — and deleting the gate from
+/// `reclaim_with_probes` makes it fail by deleting the directory.
+#[test]
+fn reclaim_remove_mode_spares_a_worktree_a_process_was_launched_from() {
+    let fx = GitWorktreeFixture::new();
+    let path = fx.add_worktree("launched-from-7504");
+    land(&path);
+    // A process sitting one level inside the tree — the `cargo run` shape.
+    let inside = vec![path.join("crates")];
+    std::fs::create_dir_all(&inside[0]).expect("create the launch directory");
+
+    let out = reclaim_with_probes(
+        &fx.repos_root,
+        &FreshProbes {
+            launched_from: &inside,
+            keep_list: &no_keeps,
+            agent_state: &no_agents,
+            in_use_now: &|| Some(nobody()),
+            index_for: &|_: &Path| merged_index("session/launched-from-7504", 7504),
+        },
+        ReclaimMode::Remove,
+        &[],
+    );
+
+    assert!(
+        path.exists(),
+        "the daemon deleted the directory it was launched from: {out:?}"
+    );
+    assert!(out.removed.is_empty(), "outcome: {out:?}");
+    let refused = format!("{:?}", out.refused_at_recheck);
+    assert!(
+        refused.contains("launched from inside"),
+        "the refusal must be REPORTED, not silent: {refused}"
+    );
+}
+
+/// The repository's own main checkout is never removed (#7504).
+///
+/// Why a direct re-check test rather than a loop one: the survey's ownership gate
+/// already blocks a main checkout (it carries no trusty-mpm marker), so a loop
+/// test could never reach the deletion and would pass with the guard gone. This
+/// asserts the arm that is the last line of defence if any earlier gate is ever
+/// widened.
+#[test]
+fn recheck_refuses_the_repositorys_main_checkout() {
+    let fx = GitWorktreeFixture::new();
+
+    let reason = recheck_before_delete(
+        &fx.repo,
+        &no_keeps(),
+        Some(&nobody()),
+        &merged(7505),
+        &no_agents,
+    )
+    .unwrap_or_else(|| panic!("{} is the main checkout and must refuse", fx.repo.display()));
+    assert!(
+        reason.contains("main checkout"),
+        "the refusal must name what it protected: {reason}"
+    );
 }
 
 #[test]
@@ -1637,6 +1718,7 @@ fn survey_offers_a_merged_agent_worktree_the_harness_released() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &restarted_registry,
             in_use_now: &|| Some(nobody()),
@@ -1670,6 +1752,7 @@ fn reclaim_reclaims_a_merged_agent_worktree_the_harness_released() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &restarted_registry,
             in_use_now: &|| Some(nobody()),
@@ -1695,6 +1778,7 @@ fn reclaim_never_offers_an_agent_worktree_whose_pr_is_open() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &restarted_registry,
             in_use_now: &|| Some(nobody()),
@@ -1728,6 +1812,7 @@ fn reclaim_never_offers_a_dirty_agent_worktree() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &restarted_registry,
             in_use_now: &|| Some(nobody()),
@@ -1766,6 +1851,7 @@ fn survey_discloses_a_harness_locked_agent_worktree() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &restarted_registry,
             in_use_now: &|| Some(nobody()),
@@ -1943,6 +2029,7 @@ fn prune_resolves_each_projects_repo_from_its_own_origin_7057() {
     let out = reclaim_with_probes(
         &fx.repos_root,
         &FreshProbes {
+            launched_from: &[],
             keep_list: &no_keeps,
             agent_state: &no_agents,
             in_use_now: &|| Some(nobody()),


### PR DESCRIPTION
## Outcome

Refs bobmatnyc/trusty-tools#7504

The daemon reclaims a merged PR's worktree and local branch on an hourly
sweep, ON by default. Controlled by `TRUSTY_MPM_WORKTREE_RECLAIM=0` and
`TRUSTY_MPM_WORKTREE_RECLAIM_INTERVAL_SECS`. Merge state is re-read from `gh`
per candidate immediately before deletion. Child of epic #7505.

## Changes

- One shared entry point, `daemon/services/merged_pr_reclaim.rs::reclaim`,
  now called by both the hourly sweep and `prune-worktrees --merged-prs`.
- New gate refusing to reclaim a tree the daemon itself was launched from.
- New gate refusing to reclaim the main checkout.
- Audit info line per reclaim: path, branch, PR, bytes freed.
- `SweepReport::failed` is the single failure branch, logged at warn, never
  folded into the success count.
- The keep list is honoured fail-closed.

## Risk

High, rung 5 — destructive path, process lifecycle.

## Tests

`cargo test -p trusty-mpm --no-fail-fast`: 6848 lib tests + 2702 bin tests
(x2 targets) + 57 additional targets, 0 failed. Each safety rule (launched-from
gate, main-checkout gate, keep-list fail-closed) has a dedicated refusal test;
the launched-from gate was proven to fail when removed. Doc gates and
`check_capabilities.sh` exit 0.

## Baseline

No pre-existing red on this crate at this base.

## Docs

Changelog fragment added under `crates/trusty-mpm/changelog.d/`.

## Review

code-critic verdict: WARN, no required changes.

- HIGH: the launched-from-inside gate covers only the sweeping daemon's own
  cwd and executable, not other processes with a cwd inside the tree.
  Follow-up under #7505.
- MEDIUM: no cross-daemon lock when two daemons sweep the same repos root;
  double delete is idempotent. Follow-up under #7505.
- `daemon/mod.rs` is 499 SLOC, under the 500 cap.

Refs #7504

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
