### PR TITLE
chore(trusty-mpm): bump to 1.5.33 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.32"
+version = "1.5.33"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -56,7 +56,11 @@ name = "trusty-mpm"
 # 1.5.32 (owner-authorized reinstall, refs #7490): patch, version-only —
 # 1.5.31 is already published and this bump exists solely so `tm --version`
 # identifies the reinstalled build.
-version = "1.5.32"
+# 1.5.33 (owner-authorized reinstall, refs #7461 #7464 #7491 #7497 #7498
+# #7479 #7499 #7185 #7487 #7518 #7504): patch, version-only — 1.5.32 is
+# already published and this bump exists solely so `tm --version` identifies
+# the reinstalled build.
+version = "1.5.33"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome

`trusty-mpm` bumped 1.5.32 → 1.5.33, version-only, so `tm --version` identifies
the owner-authorized reinstall build. Makes eleven previously-merged issues
verifiable against a live install: #7461 #7464 #7491 #7497 #7498 #7479 #7499
#7185 #7487 #7518 #7504.

## Changes

- `crates/trusty-mpm/Cargo.toml`: version 1.5.32 → 1.5.33.
- `Cargo.lock`: refreshed for the bump.

## Risk

Low — version-only change, no source edits.

## Tests

Rung 1 (docs/version-only). `cargo check -p trusty-mpm`: exit 0.
`./scripts/check_workspace_dep_versions.sh`: all 12 rows OK (PATCH bump needs
no widening). `./scripts/check-pr-version-bump.sh`: OK. `./scripts/check_changelog_fragment.sh`: OK (version-only, no crate source changed, no fragment owed).

## Baseline

No pre-existing red gates encountered.

## Docs

None needed — version-only bump.

## Review

Version-only reinstall bump; no functional review surface.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
