### PR TITLE
fix(trusty-agents-common): native test compression keeps failure diagnostics and every suite summary (Refs #7544)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7544-test-compression-diagnostics.md
+++ b/crates/trusty-agents-common/changelog.d/7544-test-compression-diagnostics.md
@@ -1,0 +1,14 @@
+Fixed
+
+- `compress::filter_test_runner` keeps a failed test run readable. It was an
+  allowlist — a line survived only by containing `FAILED`/`error`/`warning` or
+  starting `---- ` / `failures:` — so the panic location, the `left:`/`right:`
+  assertion values and every multiline context line were dropped as noise, and
+  only the LAST `test result:` line was kept, which left a failing suite
+  followed by a passing one compressed to output ending `test result: ok`. It
+  is now a blocklist: passing and ignored per-test lines and cargo's indented
+  build-progress verbs are dropped, every other line is kept in its original
+  position, so every suite summary survives in order beside the diagnostics
+  that explain it and an unrecognised harness's output is kept rather than
+  discarded. A green run still compresses to its `running`/`Running` lines and
+  summaries (#7544).

--- a/crates/trusty-agents-common/src/compress/tool_output/mod.rs
+++ b/crates/trusty-agents-common/src/compress/tool_output/mod.rs
@@ -236,47 +236,56 @@ pub fn compress_tool_output(tool_name: &str, output: &str) -> String {
     compressed
 }
 
-/// Strip passing test lines from `cargo test` output.
+/// Drop a test runner's passing-test lines and keep everything else.
 ///
 /// Why: Hundreds of `test foo ... ok` lines drown out the few failures the
-/// model needs to see.
-/// What: Drops lines matching `test <name> ... ok`. Keeps `FAILED`, `error`,
-/// `warning`, and the final `test result:` summary. Returns summary-only
-/// when nothing else remains.
-/// Test: `test_runner_strips_passing_tests`, `test_runner_keeps_summary_line`,
+/// model needs to see. Until #7544 this was an ALLOWLIST — a line survived
+/// only by containing `FAILED`/`error`/`warning` or starting `---- ` /
+/// `failures:` — so the panic location, the `left:`/`right:` assertion values
+/// and every multiline context line were discarded as noise, and only the LAST
+/// `test result:` line was kept. A failing suite followed by a passing one
+/// therefore compressed to output ending `test result: ok`, which reads as a
+/// green run.
+/// What: A blocklist. Every line is emitted in its original position except a
+/// passing or ignored per-test line ([`is_passing_test_line`]) and cargo's
+/// indented build-progress chatter ([`is_cargo_progress_line`]); runs of blank
+/// lines collapse to one and leading/trailing blanks are dropped. Every
+/// `test result:` summary survives in order, next to the diagnostics that
+/// explain it, and a shape this function does not recognise is kept rather
+/// than discarded.
+/// Test: `test_runner_keeps_every_suite_summary_in_order`,
+/// `test_runner_keeps_panic_location_and_assertion_values`,
+/// `test_runner_keeps_the_failing_test_name_list`,
+/// `test_runner_keeps_unrecognised_blocks`,
+/// `test_runner_drops_cargo_progress_lines`,
+/// `test_runner_still_reduces_passing_only_output`,
+/// `test_runner_strips_passing_tests`, `test_runner_keeps_summary_line`,
 /// `test_runner_no_failures_returns_summary_only`.
 pub fn filter_test_runner(output: &str) -> String {
     let mut kept: Vec<&str> = Vec::new();
-    let mut summary: Option<&str> = None;
+    // #7544: a blank line is held back rather than emitted, so a run collapses
+    // to one and a trailing run is dropped without a second pass.
+    let mut pending_blank: Option<&str> = None;
     for line in output.lines() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("test result:") {
-            summary = Some(line);
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            if !kept.is_empty() {
+                pending_blank = Some(line);
+            }
             continue;
         }
-        if is_passing_test_line(trimmed) {
+        // #7544: the only two droppable shapes. Everything else — panics,
+        // assertion values, every `test result:` summary, output from a
+        // harness this has never seen — is kept where it stands.
+        if is_passing_test_line(trimmed) || is_cargo_progress_line(line, trimmed) {
             continue;
         }
-        let lower = trimmed.to_ascii_lowercase();
-        if trimmed.contains("FAILED")
-            || lower.contains("error")
-            || lower.contains("warning")
-            || trimmed.starts_with("---- ")
-            || trimmed.starts_with("failures:")
-        {
-            kept.push(line);
+        if let Some(blank) = pending_blank.take() {
+            kept.push(blank);
         }
+        kept.push(line);
     }
-
-    if kept.is_empty() {
-        return summary.map(|s| s.to_string()).unwrap_or_default();
-    }
-    let mut out = kept.join("\n");
-    if let Some(s) = summary {
-        out.push('\n');
-        out.push_str(s);
-    }
-    out
+    kept.join("\n")
 }
 
 fn is_passing_test_line(s: &str) -> bool {
@@ -285,6 +294,34 @@ fn is_passing_test_line(s: &str) -> bool {
         return false;
     }
     s.ends_with(" ... ok") || s.ends_with(" ... ignored")
+}
+
+/// Whether `raw` is one of cargo's build-progress lines.
+///
+/// Why: #7544 made the filter keep every unrecognised line, so the only lines
+/// it may still drop are ones whose shape is known to carry no test signal.
+/// Cargo's progress chatter is that shape; `Running`, which names the suite
+/// each `test result:` line belongs to, deliberately is not.
+/// What: true when `raw` is indented — cargo right-aligns these verbs into a
+/// 12-column gutter — and `trimmed` starts with one of them. A line at column
+/// 0 is a test's own stdout and is kept whatever it says. `Blocking` is absent
+/// on purpose: a build waiting on a lock is worth seeing.
+/// Test: `test_runner_drops_cargo_progress_lines`,
+/// `test_runner_keeps_column_zero_lines_that_look_like_progress`.
+fn is_cargo_progress_line(raw: &str, trimmed: &str) -> bool {
+    if !raw.starts_with(' ') {
+        return false;
+    }
+    const VERBS: [&str; 7] = [
+        "Compiling ",
+        "Finished ",
+        "Updating ",
+        "Downloading ",
+        "Downloaded ",
+        "Fresh ",
+        "Locking ",
+    ];
+    VERBS.iter().any(|verb| trimmed.starts_with(verb))
 }
 
 /// Collapse runs of context lines in a unified diff.

--- a/crates/trusty-agents-common/src/compress/tool_output/tests.rs
+++ b/crates/trusty-agents-common/src/compress/tool_output/tests.rs
@@ -1035,3 +1035,207 @@ fn dispatch_never_returns_empty_for_non_empty_input() {
         passing_only
     );
 }
+
+// ── Test-runner failure diagnostics and per-suite summaries (#7544) ─────
+
+/// `cargo test` output for a failing suite followed by a passing one.
+///
+/// The shape #7544 reproduced: a panic block carrying a file:line:col
+/// location, an `assertion `left == right`` message with its left/right
+/// values, a multiline `---- <test> stdout ----` section, and TWO
+/// `test result:` summaries — `FAILED` first, `ok` second.
+fn two_suites_failed_then_passing() -> String {
+    String::from(
+        r#"   Compiling trusty-demo v0.1.0 (/w/demo)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.20s
+     Running unittests src/lib.rs (target/debug/deps/demo-1111111111111111)
+
+running 2 tests
+test keeps_working ... ok
+test breaks ... FAILED
+
+failures:
+
+---- breaks stdout ----
+
+thread 'breaks' panicked at crates/trusty-demo/src/lib.rs:42:9:
+assertion `left == right` failed: shunt budget must match the ledger
+  left: 1
+  right: 2
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+failures:
+    breaks
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+
+     Running tests/integration.rs (target/debug/deps/integration-2222222222222222)
+
+running 1 test
+test integration_smoke ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+"#,
+    )
+}
+
+/// Native-fallback output for `cargo test`, with `rtk` ruled out.
+///
+/// `no_rtk` makes the route deterministic instead of depending on whether an
+/// `rtk` binary happens to be installed on the machine running the suite.
+async fn native_cargo_test(output: &str) -> String {
+    let (text, path) =
+        compress_tool_output_async_with_path_using(no_rtk, "cargo test", output).await;
+    assert_eq!(path, CompressionPath::NativeFallback);
+    text
+}
+
+#[tokio::test]
+async fn test_runner_keeps_every_suite_summary_in_order() {
+    // #7544: only the LAST `test result:` line survived, so a passing suite
+    // after a failing one left the output ending `test result: ok` — the
+    // failure was unreadable from the compressed text.
+    let out = native_cargo_test(&two_suites_failed_then_passing()).await;
+    let failed = out
+        .find("test result: FAILED. 1 passed; 1 failed")
+        .unwrap_or_else(|| panic!("failing suite summary dropped:\n{out}"));
+    let passed = out
+        .find("test result: ok. 1 passed; 0 failed")
+        .unwrap_or_else(|| panic!("passing suite summary dropped:\n{out}"));
+    assert!(
+        failed < passed,
+        "suite summaries must stay in original order:\n{out}"
+    );
+}
+
+#[tokio::test]
+async fn test_runner_keeps_panic_location_and_assertion_values() {
+    // #7544: the panic line, the assertion message, and the left/right values
+    // matched none of the keep-list predicates and were dropped as noise.
+    let out = native_cargo_test(&two_suites_failed_then_passing()).await;
+    for needle in [
+        "panicked at crates/trusty-demo/src/lib.rs:42:9",
+        "assertion `left == right` failed: shunt budget must match the ledger",
+        "left: 1",
+        "right: 2",
+        "---- breaks stdout ----",
+        "test breaks ... FAILED",
+    ] {
+        assert!(out.contains(needle), "dropped {needle:?} from:\n{out}");
+    }
+}
+
+#[tokio::test]
+async fn test_runner_keeps_the_failing_test_name_list() {
+    // The `failures:` list names what to re-run; it is the one line an agent
+    // needs to narrow the next command.
+    let out = native_cargo_test(&two_suites_failed_then_passing()).await;
+    let tail = out
+        .rsplit("failures:")
+        .next()
+        .expect("rsplit always yields one element");
+    assert!(
+        tail.contains("breaks"),
+        "failing-test name list dropped:\n{out}"
+    );
+}
+
+#[tokio::test]
+async fn test_runner_still_reduces_passing_only_output() {
+    // The reduction this filter exists for must survive the fix: a green run
+    // is almost entirely `test <name> ... ok` lines.
+    let mut input = String::from("running 40 tests\n");
+    for i in 0..40 {
+        input.push_str(&format!("test suite::case_{i} ... ok\n"));
+    }
+    input.push_str("test result: ok. 40 passed; 0 failed; 0 ignored\n");
+    let out = native_cargo_test(&input).await;
+    assert!(
+        out.len() * 4 < input.len(),
+        "passing-only output barely shrank: {} -> {}",
+        input.len(),
+        out.len()
+    );
+    assert!(!out.contains("case_7 ... ok"), "kept a passing test line");
+    assert!(
+        out.contains("test result: ok. 40 passed"),
+        "lost the summary"
+    );
+}
+
+#[tokio::test]
+async fn test_runner_keeps_unrecognised_blocks() {
+    // Fail-open: a harness this filter has never seen must come back, not be
+    // discarded for matching no keep-list predicate (#7544).
+    // The fixture deliberately opens with a non-`key: value` line: a leading
+    // one routes the whole input through the structured-format passthrough
+    // instead of this filter, so the test would pass without proving anything.
+    let input = "\
+running 3 scenarios through the bespoke harness
+scenario budget ledger reconciliation
+  step seed ledger -> 3 rows
+  step reconcile -> amber
+  outcome pending (awaiting operator)
+a summary line nothing here recognises
+test result: ok. 3 passed; 0 failed; 0 ignored
+";
+    assert!(
+        !is_structured_format(input),
+        "fixture took the YAML passthrough"
+    );
+    let out = native_cargo_test(input).await;
+    for needle in [
+        "running 3 scenarios through the bespoke harness",
+        "scenario budget ledger reconciliation",
+        "step reconcile -> amber",
+        "outcome pending (awaiting operator)",
+        "a summary line nothing here recognises",
+    ] {
+        assert!(out.contains(needle), "dropped {needle:?} from:\n{out}");
+    }
+}
+
+#[tokio::test]
+async fn test_runner_drops_cargo_progress_lines() {
+    // The reduction side of the blocklist: cargo's indented progress verbs go,
+    // `Running` stays because it names the suite each summary belongs to.
+    let out = native_cargo_test(&two_suites_failed_then_passing()).await;
+    assert!(
+        !out.contains("Compiling trusty-demo"),
+        "kept Compiling:\n{out}"
+    );
+    assert!(
+        !out.contains("Finished `test` profile"),
+        "kept Finished:\n{out}"
+    );
+    assert!(
+        out.contains("Running unittests src/lib.rs"),
+        "dropped the suite attribution line:\n{out}"
+    );
+    assert!(
+        out.contains("Running tests/integration.rs"),
+        "dropped the second suite's attribution line:\n{out}"
+    );
+}
+
+#[test]
+fn test_runner_keeps_column_zero_lines_that_look_like_progress() {
+    // A test's own stdout is never cargo chatter, whatever word it starts with.
+    let input = "\
+running 1 test
+Compiling the shunt ledger in-process before the assertion
+Finished reconciling 3 rows
+test writes_progress_words ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored
+";
+    let out = filter_test_runner(input);
+    assert!(
+        out.contains("Compiling the shunt ledger"),
+        "dropped stdout:\n{out}"
+    );
+    assert!(
+        out.contains("Finished reconciling 3 rows"),
+        "dropped stdout:\n{out}"
+    );
+    assert!(!out.contains("... ok"), "kept a passing test line:\n{out}");
+}


### PR DESCRIPTION
## Outcome
Native `cargo test` compression keeps failure diagnostics (panic location, assertion left/right, multiline context) and every `test result:` summary in original order; a later passing suite no longer replaces an earlier failing one.

Refs #7544
Refs #7543

## Changes
`filter_test_runner` in `crates/trusty-agents-common/src/compress/tool_output/mod.rs` rewritten from allowlist to blocklist: drops only passing-test lines and cargo's indented progress verbs; `Running` and column-0 lines are kept. Six regression fixtures added through the native fallback entry point, four of which failed before the fix. Resolver, filter mapping, empty-output backstop, and exit logging (#7311 #7314 #7325 #7377 #7384) are untouched.

Out of scope: any change to the resolver/filter-mapping/exit-logging paths.

## Risk
Normal — rung 3 plus one dependent crate.

## Tests
- `cargo test -p trusty-agents-common --no-fail-fast`: 580 passed, 0 failed
- `cargo test -p trusty-mpm --test tm_compress_pipe --test tm_hook_pretooluse_rewrite --no-fail-fast`: 7 + 6 passed
- `fmt`, `check`, `clippy`, line-cap, test-pointers, sld, changelog-fragment, pr-version-bump: all exit 0

## Baseline
No pre-existing red encountered.

## Docs
Changelog fragment added for `trusty-agents-common`. No public API/doc-comment changes required.

## Review
No code-critic round owed at this rung. Security scan passed for 1523f4e91.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
