### PR TITLE
fix(trusty-agents-common): BASE-ENGINEER names numeric escapes and the direct-write path; vercel-ops never lists env values

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7480-numeric-escapes-base-engineer.md
+++ b/crates/trusty-agents-common/changelog.d/7480-numeric-escapes-base-engineer.md
@@ -1,0 +1,3 @@
+Fixed
+
+- BASE-ENGINEER's escape-sensitive character list now names numeric escapes (`\uXXXX`, `\xXX`, octal `\NNN`) and states that the Edit/Write tool's own `new_string`/`content` argument is a direct-write corruption route, not only shell-routed edits (Refs #7480).

--- a/crates/trusty-agents-common/changelog.d/7500-vercel-env-json.md
+++ b/crates/trusty-agents-common/changelog.d/7500-vercel-env-json.md
@@ -1,0 +1,3 @@
+Fixed
+
+- vercel-ops no longer audits environment variables with `vercel env ls --json` / `--format json`, which prints values the redacted table view hides; audits now use the table form only, and a genuinely needed value routes through the secrets model (epic #7517) instead of the agent's own context (Refs #7500).

--- a/crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md
@@ -25,10 +25,15 @@ layer adds engineering discipline. Do not restate BASE-AGENT content here.
 ## Escape-Sensitive Edits — Write Verbatim, Verify Byte-Exact
 
 Content containing a regex character class (`\d`, `\s`, `[\w-]`), a literal
-backslash, or a comment delimiter (`*/`) is easy to corrupt through a layer
-that re-interprets escapes it should pass through unchanged — the corruption
-is invisible in a normal review pass and silently breaks `grep`/regex use
-against the file (issue #7121).
+backslash, a numeric escape (`\uXXXX`, `\xXX`, an octal `\NNN`), or a comment
+delimiter (`*/`) is easy to corrupt two ways: through a shell or interpreter
+layer that re-interprets escapes it should pass through unchanged, or
+directly through the Edit/Write tool's own `new_string`/`content` argument —
+a numeric escape there can be written as the literal byte it encodes (a
+`\x00`-shaped sequence became an actual NUL byte mid-file, #7480). Either
+route is invisible in a normal review pass; the shell-routed one silently
+breaks `grep`/regex use against the file (#7121), and the direct-write one
+corrupts the file outright (#7480).
 
 - Prefer the Write/Edit tool's own `content`/`new_string` argument over a
   shell one-liner for any change containing that kind of content.

--- a/crates/trusty-agents-common/src/assets/agents/vercel-ops.md
+++ b/crates/trusty-agents-common/src/assets/agents/vercel-ops.md
@@ -39,9 +39,22 @@ vercel env add FEATURE_FLAG preview staging --value="enabled"
 
 # Pre-deployment audit: check for public exposure of secrets
 grep -r "NEXT_PUBLIC_.*SECRET\|NEXT_PUBLIC_.*KEY\|NEXT_PUBLIC_.*TOKEN" .
-vercel env ls production --format json | \
-  jq '.[] | select(.type != "encrypted") | .key'
+vercel env ls production
 ```
+
+### Env Audits — Table Form Only, Never `--json`
+
+`vercel env ls --json` (and `--format json`) prints the stored `value` field
+for every variable, including ones marked Non-sensitive that the default
+table view redacts (#7500). A name- or status-only audit MUST use the plain
+`vercel env ls [environment]` table form — never `--json`, `--format json`,
+or any other raw-value output shape, even when the result is immediately
+piped through `jq` to select just a key or a type.
+
+When a value is genuinely needed (not just its name or encrypted status),
+route it through the secrets model (epic #7517) instead of a `--json` read —
+resolve it into the target process's env or stdin there, never into this
+agent's own context.
 
 ### Variable Classification
 - **`NEXT_PUBLIC_` prefix**: client-accessible, non-sensitive (API base URLs, feature flags)
@@ -100,7 +113,7 @@ Add to `package.json` for consistent developer experience:
   "scripts": {
     "dev": "vercel env pull .env.local --yes && next dev",
     "sync-env": "vercel env pull .env.local --environment=development --yes",
-    "audit-env": "vercel env ls --format json | jq '[.[] | {key: .key, encrypted: (.type == \"encrypted\")}]'"
+    "audit-env": "vercel env ls"
   }
 }
 ```


### PR DESCRIPTION
## Summary

BASE-ENGINEER's instruction text now names numeric escapes explicitly and
describes the direct-write path; the `vercel-ops` agent's instructions state it
never lists environment variable values in its output.

Refs #7480
Refs #7500

## What changed

- `trusty-agents-common` bundled agent instruction assets: BASE-ENGINEER guidance
  gains explicit coverage of numeric escapes and the direct-write path.
- `vercel-ops` agent instructions: add an explicit rule that env var values are
  never listed in output — only names/keys.
- Two changelog fragments added: `7480-numeric-escapes-base-engineer.md` and
  `7500-vercel-env-json.md`.

Out of scope: no behavior change to the runtime dispatch or tool-calling code —
this PR only changes agent instruction/prompt text and asset bundling.

## Risk / blast radius

Low — instruction-text-only change confined to `trusty-agents-common`'s bundled
agent asset text. No public API, schema, or runtime logic touched. Test ladder
rung 3 (localized change inside one crate).

## Test evidence

- `cargo fmt --check` — EXIT 0
- `cargo test -p trusty-agents-common --no-fail-fast` — 580 passed, 0 failed
- `cargo test -p trusty-mpm --no-fail-fast` — 59 targets, all ok; 6859 passed (lib)
- `bash scripts/check_sld.sh` — EXIT 0
- `bash scripts/check_doc_paths.sh` — EXIT 0
- `bash scripts/check_capabilities.sh` — EXIT 0

No pinning test exists for the asset body text itself (`bundle_tests` only
asserts non-empty content), so this PR relies on the crate test suite plus the
above script gates rather than a text-diff assertion.

## Baseline / pre-existing failures

None observed — all gates above are green on this branch.

## Documentation / changelog status

Two changelog fragments added:
- `crates/trusty-agents-common/changelog.d/7480-numeric-escapes-base-engineer.md`
- `crates/trusty-agents-common/changelog.d/7500-vercel-env-json.md`

`scripts/check-pr-version-bump.sh` — clear; `trusty-agents-common` is at 0.7.2,
not yet published, so no version bump is required for this change.

## Review-finding disposition

No prior review round on this branch; this is the initial PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01HEek73LSnk1zpsdBDLoPWW
