### PR TITLE
fix(trusty-mpm): compile and document cleanly under the feature union

### DIFF
--- a/crates/trusty-mpm/changelog.d/7466-feature-union-rustdoc.md
+++ b/crates/trusty-mpm/changelog.d/7466-feature-union-rustdoc.md
@@ -1,0 +1,8 @@
+Fixed
+
+- The crate now compiles and documents cleanly under its full feature union. The
+  `sm-memory` and `manager-memory` call sites read `Drawer::content` through its
+  `content()` accessor (the field became private in #5902 and no default build
+  compiles those modules), and the five intra-doc links to `ProviderRegistry`,
+  `PalaceRegistry` and `PalaceId` resolve by explicit path, so the per-lane
+  rustdoc gate is green for `trusty-mpm` (#7466).

--- a/crates/trusty-mpm/src/core/sm/agent/chat.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/chat.rs
@@ -201,7 +201,9 @@ impl SessionManagerAgent {
             Ok(hits) if !hits.is_empty() => {
                 let joined = hits
                     .iter()
-                    .map(|h| h.drawer.content.trim())
+                    // #7466: `Drawer::content` is a private field behind the
+                    // `content()` accessor (#5902 keeps the digest in agreement).
+                    .map(|h| h.drawer.content().trim())
                     .filter(|c| !c.is_empty())
                     .collect::<Vec<_>>()
                     .join("\n");

--- a/crates/trusty-mpm/src/core/sm/agent/mod.rs
+++ b/crates/trusty-mpm/src/core/sm/agent/mod.rs
@@ -140,7 +140,8 @@ impl SessionManagerAgent {
     /// Construct an SM agent wired for inference (the daemon path, SM-7).
     ///
     /// Why: the daemon builds the agent once at startup with a credential-aware
-    /// [`ProviderRegistry`] (from the process environment), the storage root for
+    /// [`ProviderRegistry`](crate::core::sm::ProviderRegistry) (from the
+    /// process environment), the storage root for
     /// context-engine state, and — under `sm-memory` — the SM palace handle.
     /// Keeping construction side-effect-free (the registry is just resolved
     /// credentials; no provider is built until a chat turn) means wiring it up
@@ -276,7 +277,9 @@ impl SessionManagerAgent {
             Ok(hits) if !hits.is_empty() => {
                 let joined = hits
                     .iter()
-                    .map(|h| h.drawer.content.trim())
+                    // #7466: `Drawer::content` is a private field behind the
+                    // `content()` accessor (#5902 keeps the digest in agreement).
+                    .map(|h| h.drawer.content().trim())
                     .filter(|c| !c.is_empty())
                     .collect::<Vec<_>>()
                     .join("\n");

--- a/crates/trusty-mpm/src/core/sm/memory.rs
+++ b/crates/trusty-mpm/src/core/sm/memory.rs
@@ -20,6 +20,8 @@
 //! "never writes to a non-SM palace" guard.
 //!
 //! [`SmMemory`]: crate::core::sm::memory::SmMemory
+//! [`PalaceRegistry`]: trusty_common::memory_core::registry::PalaceRegistry
+//! [`PalaceId`]: trusty_common::memory_core::palace::PalaceId
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -393,7 +395,12 @@ impl SmMemory {
                  truncated on rebuild — revisit the cap"
             );
         }
-        Ok(drawers.into_iter().map(|d| d.content).collect())
+        // #7466: `Drawer::content` is a private field behind the `content()`
+        // accessor (#5902), which borrows — so copy the body out per drawer.
+        Ok(drawers
+            .into_iter()
+            .map(|d| d.content().to_string())
+            .collect())
     }
 
     /// Number of palaces currently persisted under the SM data root.

--- a/crates/trusty-mpm/src/core/sm/memory_tests.rs
+++ b/crates/trusty-mpm/src/core/sm/memory_tests.rs
@@ -212,7 +212,7 @@ async fn ensure_palace_falls_back_to_open_when_palace_already_exists() {
         .expect("recall from second instance");
     assert!(
         hits.iter()
-            .any(|h| h.drawer.content.contains("TOCTOU_MARKER")),
+            .any(|h| h.drawer.content().contains("TOCTOU_MARKER")),
         "second SM must open the EXISTING palace (seeing prior content), not a fresh one; got {hits:?}"
     );
 }
@@ -236,8 +236,10 @@ async fn remember_then_recall_round_trips() {
         .expect("recall");
 
     assert!(
-        hits.iter()
-            .any(|h| h.drawer.content.contains("delegates all engineering work")),
+        hits.iter().any(|h| h
+            .drawer
+            .content()
+            .contains("delegates all engineering work")),
         "recall must surface the remembered SM fact; got {hits:?}"
     );
 }
@@ -261,7 +263,7 @@ async fn recall_deep_round_trips() {
 
     assert!(
         hits.iter()
-            .any(|h| h.drawer.content.contains("worktree-per-ticket")),
+            .any(|h| h.drawer.content().contains("worktree-per-ticket")),
         "recall_deep must surface the remembered SM fact; got {hits:?}"
     );
 }
@@ -279,7 +281,8 @@ async fn note_stores_short_fact() {
 
     let hits = mem.recall("what is the goal").await.expect("recall");
     assert!(
-        hits.iter().any(|h| h.drawer.content.contains("ship SM-4")),
+        hits.iter()
+            .any(|h| h.drawer.content().contains("ship SM-4")),
         "note must store a short curated fact retrievable via recall; got {hits:?}"
     );
 }
@@ -317,7 +320,7 @@ async fn recall_is_scoped_to_sm_palace() {
     assert!(
         sm_hits
             .iter()
-            .all(|h| !h.drawer.content.contains("OTHER_PALACE_SECRET")),
+            .all(|h| !h.drawer.content().contains("OTHER_PALACE_SECRET")),
         "SM recall must never surface another palace's content; got {sm_hits:?}"
     );
 
@@ -326,7 +329,7 @@ async fn recall_is_scoped_to_sm_palace() {
     assert!(
         other_hits
             .iter()
-            .all(|h| !h.drawer.content.contains("SM_PALACE_SECRET")),
+            .all(|h| !h.drawer.content().contains("SM_PALACE_SECRET")),
         "non-SM recall must never surface SM content; got {other_hits:?}"
     );
 }
@@ -364,7 +367,7 @@ async fn data_survives_fresh_construction() {
         .expect("recall after restart");
     assert!(
         hits.iter()
-            .any(|h| h.drawer.content.contains("SM-3 merged to main")),
+            .any(|h| h.drawer.content().contains("SM-3 merged to main")),
         "remembered data must survive a fresh SmMemory construction; got {hits:?}"
     );
 }

--- a/crates/trusty-mpm/src/daemon/manager/memory.rs
+++ b/crates/trusty-mpm/src/daemon/manager/memory.rs
@@ -274,12 +274,15 @@ pub enum PortfolioMemoryError {
 /// The live portfolio palace binding (opt-in `manager-memory` feature).
 ///
 /// Why: mirrors [`crate::core::sm::memory::SmMemory`] — a DIRECT `memory-core`
-/// library call (not over MCP) scoped to a single [`PalaceId`] so the manager
+/// library call (not over MCP) scoped to a single
+/// [`PalaceId`](trusty_common::memory_core::palace::PalaceId) so the manager
 /// can never touch another namespace. Binding one id for the struct's lifetime
 /// makes "manager only ever reads/writes its own portfolio palace" a structural
 /// invariant, not caller discipline (the DOC-36 §3.4 "never duplicates project
 /// state" guarantee).
-/// What: owns the open-handle [`PalaceRegistry`], the on-disk `data_root`, and
+/// What: owns the open-handle
+/// [`PalaceRegistry`](trusty_common::memory_core::registry::PalaceRegistry),
+/// the on-disk `data_root`, and
 /// the bound `palace_id`. Built via [`Self::open`], which idempotently ensures
 /// exactly one palace. Phase 1a exposes the minimal remember/recall surface
 /// later phases extend; it deliberately does NOT reimplement the SM palace's


### PR DESCRIPTION
## Outcome

Refs bobmatnyc/trusty-tools#7466

`trusty-mpm` compiles and documents cleanly under the feature union
(`bedrock,daemon,manager-memory,mcp,slack,sm-memory,swagger-ui,telegram,tui`),
fixing the `Drawer::content` field-privacy break from #5902 that no
default build path ever exercised.

## Changes

`trusty-mpm` did not compile or document cleanly under the feature union
(`bedrock,daemon,manager-memory,mcp,slack,sm-memory,swagger-ui,telegram,tui`)
because no default build path exercises `sm-memory`/`manager-memory`. Root
cause: #5902 made `Drawer::content` a private field behind an accessor
method, and every call site outside the default feature set still touched
the field directly.

- `crates/trusty-mpm/src/core/sm/agent/chat.rs`,
  `crates/trusty-mpm/src/core/sm/agent/mod.rs`,
  `crates/trusty-mpm/src/core/sm/memory.rs`,
  `crates/trusty-mpm/src/daemon/manager/memory.rs`,
  `crates/trusty-mpm/src/core/sm/memory_tests.rs`: switch `drawer.content`
  field access to `drawer.content()`, and resolve two `E0282` type-inference
  failures that only surfaced under this feature combination.
- Fixed the rustdoc build under the same feature set: 5 unresolved
  intra-doc links (`ProviderRegistry`, `PalaceRegistry` x3, `PalaceId` x2).
- `crates/trusty-mpm/changelog.d/7466-feature-union-rustdoc.md` — changelog
  fragment.

Out of scope: the per-lane rustdoc CI gate itself (tracked separately on
`fix/7466-7435-ci-scripts`, to open after this merges) and any broader
refactor of `Drawer`'s API.

## Risk / blast radius

Rung 3 — localized to `trusty-mpm`, no public API change (accessor already
existed; only internal call sites moved to it).

## Test evidence

Default feature set:
- `cargo fmt --check` — 0
- `cargo check -p trusty-mpm` — 0
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — 0
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — 59 targets,
  all ok, 0 failed

Feature union (`bedrock,daemon,manager-memory,mcp,slack,sm-memory,
swagger-ui,telegram,tui`):
- `cargo check` — was EXIT 101 before (5x `E0616` field `content` of struct
  `Drawer` is private, 2x `E0282`); 0 after
- `cargo clippy --all-targets` — 0 after (7 more sites fixed in
  `memory_tests.rs`)
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p trusty-mpm
  --no-deps --features <set>` — was EXIT 101 (5 unresolved links:
  `ProviderRegistry`, `PalaceRegistry` x2, `PalaceId` x2); 0 after
- `cargo test -p trusty-mpm --features <set> --no-fail-fast --
  --test-threads=4` — 12755 passed, 0 failed

Prerequisite check: with the two files from the pending per-lane rustdoc
gate (`fix/7466-7435-ci-scripts`) copied in locally,
`check_rustdoc_links.sh` reports `25 crate(s) examined, 0 broken link(s)`,
no FAIL rows.

Security: three-dot diff scan PASS (6 files, +40/-14; two string matches
are test placeholder markers `OTHER_PALACE_SECRET`/`SM_PALACE_SECRET`, not
credentials).

## Baseline / pre-existing failures

None encountered on this branch.

## Documentation / changelog status

Changelog fragment added: `crates/trusty-mpm/changelog.d/
7466-feature-union-rustdoc.md`. Doc gates (`check_line_cap`,
`check_changelog_fragment`, `check_test_pointers`, `check_sld`,
`check_doc_paths`) all 0. `trusty-mpm` is at 1.5.33, not yet published —
version gate clear.

## Review-finding disposition

No review round yet; this is the initial PR.

---

Refs #7466

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01HEek73LSnk1zpsdBDLoPWW
