### PR TITLE
fix(ci): rustdoc features lane builds on the runner (libdbus-1-dev; exclude trusty-audit-ui)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,13 +548,23 @@ jobs:
         if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@stable
 
+      # `libdbus-1-dev` is this job's alone (#7466). The `features` lane enables
+      # `trusty-common/keyring-store`, and `keyring`'s Linux target section
+      # resolves that to `dbus-secret-service` -> `libdbus-sys`, whose build.rs
+      # pkg-config-probes `dbus-1 >= 1.6` and panics without the headers. macOS
+      # resolves `keyring/apple-native` instead and never compiles that chain, so
+      # the lane exits 0 locally and 101 on the runner: trusty-common failed to
+      # build, so rustdoc documented 2 crates and the gate failed closed with
+      # nine LANE-NOT-EXAMINED rows. No other job enables `keyring-store` — no
+      # crate depends on it — so no other apt list needs this.
       - name: Install system dependencies
         if: needs.changes.outputs.docs_only != 'true'
         run: |
           bash scripts/ci-apt-install.sh \
             build-essential \
             pkg-config \
-            libssl-dev
+            libssl-dev \
+            libdbus-1-dev
 
       # Its own cache key, for the same reason every other job has one: a doc
       # build's target dir is not interchangeable with clippy's or test's.

--- a/.github/workflows/pre-publish.yml
+++ b/.github/workflows/pre-publish.yml
@@ -305,11 +305,18 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # `libdbus-1-dev` for the same reason ci.yml's `rustdoc-links` job carries
+      # it (#7466): the script's `features` lane enables
+      # `trusty-common/keyring-store`, which on Linux resolves to
+      # `dbus-secret-service` -> `libdbus-sys`, whose build.rs pkg-config-probes
+      # `dbus-1 >= 1.6`. Without it trusty-common does not build, rustdoc
+      # documents almost nothing, and this gate fails at the release boundary —
+      # the exact timing #7466 exists to stop.
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config libssl-dev
+            build-essential pkg-config libssl-dev libdbus-1-dev
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2

--- a/scripts/check_rustdoc_links.sh
+++ b/scripts/check_rustdoc_links.sh
@@ -193,11 +193,18 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-# The three Tauri GUI crates are excluded for the same reason every other
-# workspace-wide job in this repo excludes them: they need WebKit2GTK, which no
+# The four Tauri GUI crates are excluded for the same reason every other
+# workspace-wide job in this repo excludes them (ci.yml's clippy, test, doctest
+# and MSRV jobs all carry the same four flags): they need WebKit2GTK, which no
 # headless CI runner has. They are not published to crates.io, so they have no
 # docs.rs page for a broken link to land on.
-EXCLUDES=(--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui)
+#
+# trusty-audit-ui was missing from this list until #7466. It lives at
+# crates/trusty-audit/ui/src-tauri, so its diagnostics attribute to the
+# `trusty-audit` directory, which trusty-audit itself documents — the crate
+# failing to build on Linux was therefore invisible in the crate count and
+# surfaced only as `cargo exited 101` on a lane the scorer does not score.
+EXCLUDES=(--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --exclude trusty-audit-ui)
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/rustdoc-links.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
@@ -291,6 +298,18 @@ else
     fi
     printf '%s\t%s\t%s\t%s\n' "$lane" "$out" "$rc" "$feats" >> "$DESC"
     echo "check_rustdoc_links: lane ${lane}: cargo exited ${rc}" >&2
+    # A cargo that dies before invoking rustdoc says WHY on stderr, and the
+    # JSON stream the scorer reads carries none of it: a build-script panic is
+    # not a `compiler-message`. That stream was discarded with $WORK, so the
+    # #7466 cause — libdbus-sys's build.rs failing a `dbus-1` pkg-config probe
+    # on the runner — was unrecoverable from the CI log and had to be inferred
+    # from the dependency graph. Bounded, so a lane with 200 broken links does
+    # not paste 200 spans a second time.
+    if [ "$rc" -ne 0 ]; then
+      echo "check_rustdoc_links: lane ${lane}: last stderr lines from cargo:" >&2
+      grep -vE '^ *(Compiling|Checking|Documenting|Downloaded|Downloading|Updating|Locking|Blocking|Finished|Fresh|Generated) ' "$err" \
+        | tail -n 30 | sed 's/^/       /' >&2 || true
+    fi
   }
 
   run_lane default ""
@@ -456,7 +475,12 @@ for lane_id, json_path, lane_rc, _lane_feats in lanes:
 # ---- The lane declaration (#7466) --------------------------------------
 # Parsed AFTER the streams so a malformed row is reported beside whatever the
 # run found, not instead of it.
-EXCLUDED_CRATES = {"trusty-mpm-gui", "trusty-code-gui", "trusty-agents-ui"}
+EXCLUDED_CRATES = {
+    "trusty-mpm-gui",
+    "trusty-code-gui",
+    "trusty-agents-ui",
+    "trusty-audit-ui",
+}
 
 lane_members = collections.defaultdict(set)   # lane id -> {crate}
 declared = collections.defaultdict(set)       # crate -> {feature} placed by a row

--- a/scripts/rustdoc-doc-lanes.tsv
+++ b/scripts/rustdoc-doc-lanes.tsv
@@ -40,8 +40,11 @@
 #       Same bar as scripts/semver-checks-feature-exclusions.tsv, which carries
 #       the matching rows for the same features.
 #
-# The three Tauri GUI crates the gate excludes outright (trusty-mpm-gui,
-# trusty-code-gui, trusty-agents-ui) need no rows: they are never documented.
+# The four Tauri GUI crates the gate excludes outright (trusty-mpm-gui,
+# trusty-code-gui, trusty-agents-ui, trusty-audit-ui) need no rows: they are
+# never documented. trusty-audit-ui joined that list in #7466 — it needs
+# WebKit2GTK exactly as its three siblings do, and carrying a row for a crate
+# the run excludes is a claim about documentation that never happens.
 #
 # Regenerate the inventory this file must cover:
 #   cargo metadata --no-deps --format-version 1
@@ -78,7 +81,6 @@ LANE	features	trusty-search/candle,trusty-search/clustering,trusty-search/ner,tr
 # feature it enables is itself a declared feature and carries its own row, so
 # the coverage check reaches it either way.
 # ---------------------------------------------------------------------------
-NO-CFG	trusty-audit-ui	custom-protocol
 NO-CFG	trusty-common	embedder-bundled-ort
 NO-CFG	trusty-common	embedder-coreml
 NO-CFG	trusty-common	embedder-load-dynamic


### PR DESCRIPTION
## Outcome

Fixes the `Rustdoc intra-doc links` job red on `main`.

Refs #7466

Refs #7351

## What changed

Fixes the `Rustdoc intra-doc links` job red on `main` since PR #7559
(2c17dbb7b). Two Linux-only causes, invisible on macOS:

1. The `features` lane enables `trusty-common/keyring-store`. On Linux that
   resolves to `keyring` -> `dbus-secret-service` -> `libdbus-sys`, whose
   `build.rs` pkg-config-probes `dbus-1 >= 1.6`. The runner has no
   `libdbus-1-dev`, so `trusty-common` fails to build and the lane exits 101
   almost unscored. Reproduced in a `rust:1` container: "The system library
   `dbus-1` required by crate `libdbus-sys` was not found."
2. `trusty-audit-ui` (`crates/trusty-audit/ui/src-tauri`, `publish = false`)
   was never in `check_rustdoc_links.sh`'s Tauri exclude list, unlike every
   other workspace-wide `ci.yml` job. Its gdk-sys/javascriptcore-rs-sys/soup3-sys
   build failures made the default lane exit 101 unscored too.

Changes:

- `libdbus-1-dev` added to the `rustdoc-links` apt list in `ci.yml` and to
  Gate 1 in `pre-publish.yml`.
- `--exclude trusty-audit-ui` added to `check_rustdoc_links.sh`'s Tauri
  exclusion set, plus the matching `EXCLUDED_CRATES` entry in the scorer.
- A bounded 30-line stderr tail printed on a failed lane, to make the next
  build-script-panic case diagnosable from the CI log instead of inferred
  from the dependency graph.
- The stale `NO-CFG trusty-audit-ui` row dropped from `rustdoc-doc-lanes.tsv`
  now that the crate is excluded outright.

Out of scope: the default lane's own exit code still going unscored (see
"Baseline / pre-existing" below).

## Risk / blast radius

CI-only. No production or library source changed. Rung 1 (docs/CI-only) —
no Rust test gate owed.

## Test evidence

- In a Linux (`rust:1`) container with both fixes applied: the `features`
  lane command exits 0 (`Documenting trusty-mpm v1.5.33 ... Finished in
  2m 23s`), and the default lane exits 0.
- Locally (macOS): both lanes exit 0 — `25 crate(s) examined by rustdoc,
  0 broken link(s)` (default), 23 examined (features).
- `scripts/check_rustdoc_links.sh` self-test: 14/14 passing.
- `scripts/check-ci-helpers-selftest.sh`: 251/251 passing.
- `scripts/check-red-main-coverage.sh`: 22 workflows covered.
- `shellcheck` on `check_rustdoc_links.sh`: clean.
- `ci.yml` / `pre-publish.yml`: YAML parses.

Gate still fails closed on its two other arms — `LANE-NOT-EXAMINED` and
`LANE-ERROR` are unchanged.

## Baseline / pre-existing

Residual gap, filed separately: the default lane's own exit code is unscored
by the Python summarizer (follow-up filed by `ticketing`; no number yet at
push time).

## Documentation / changelog

CI-only change — no changelog fragment (docs/CI-only PRs are exempt per
`check_changelog_fragment.sh`).

## Review-finding disposition

N/A — first pass on this PR.

---

Red-main record: comment on #7351.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01HEek73LSnk1zpsdBDLoPWW
