### PR TITLE
fix(trusty-mpm): savings-recording paths name their ledger root so unit tests stop writing the operator's ledger; bump to 1.5.34 for reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.33"
+version = "1.5.34"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -60,7 +60,11 @@ name = "trusty-mpm"
 # #7479 #7499 #7185 #7487 #7518 #7504): patch, version-only — 1.5.32 is
 # already published and this bump exists solely so `tm --version` identifies
 # the reinstalled build.
-version = "1.5.33"
+# 1.5.34 (#7514): patch — 1.5.33 is already published on crates.io and this PR
+# edits `src/**`, so the `PR version bump vs crates.io` gate (#4421) requires
+# the bump here. Patch because the change is a bug fix inside the existing
+# savings producer and compiled-prompt writer.
+version = "1.5.34"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/7514-compiled-prompt-short-write.md
+++ b/crates/trusty-mpm/changelog.d/7514-compiled-prompt-short-write.md
@@ -1,3 +1,4 @@
 Fixed
 
+- `tm compress`'s savings write now takes its framework root and session id from the caller, and the `tm compress` pipeline tests clear `CLAUDE_CODE_SESSION_ID` from the spawned child, so a test run no longer appends a `compress` row keyed by the developer's own live session (refs [#7514](https://github.com/bobmatnyc/trusty-tools/issues/7514))
 - the instruction-compression savings row no longer describes a test fixture as an operator's session: writing a compiled prompt is now a pure write, the ledger the fold is recorded in is named by the launch path instead of resolved from the process home directory, and a destination that is not a `<root>/.trusty-mpm/sessions/<id>/INSTRUCTIONS-COMPILED.md` path declines with a warning rather than attributing a row to a directory that is not a session (refs [#7514](https://github.com/bobmatnyc/trusty-tools/issues/7514))

--- a/crates/trusty-mpm/changelog.d/7514-compiled-prompt-short-write.md
+++ b/crates/trusty-mpm/changelog.d/7514-compiled-prompt-short-write.md
@@ -1,0 +1,3 @@
+Fixed
+
+- the instruction-compression savings row no longer describes a test fixture as an operator's session: writing a compiled prompt is now a pure write, the ledger the fold is recorded in is named by the launch path instead of resolved from the process home directory, and a destination that is not a `<root>/.trusty-mpm/sessions/<id>/INSTRUCTIONS-COMPILED.md` path declines with a warning rather than attributing a row to a directory that is not a session (refs [#7514](https://github.com/bobmatnyc/trusty-tools/issues/7514))

--- a/crates/trusty-mpm/changelog.d/7544-reinstall-1-5-34.md
+++ b/crates/trusty-mpm/changelog.d/7544-reinstall-1-5-34.md
@@ -1,0 +1,3 @@
+Changed
+
+- Bump to 1.5.34 for an owner-authorized reinstall carrying the #7544 native test-compression fix (PR #7546) and the #7514 ledger fix.

--- a/crates/trusty-mpm/src/bin/tm/commands/compress.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/compress.rs
@@ -266,25 +266,68 @@ async fn compress_with_raw_fallback(
 /// [`trusty_mpm::core::savings_compress::record_compress`], which declines a
 /// passthrough run rather than writing a zero-saving row. Declines quietly with
 /// no session id or no resolvable root; never fails the compression.
-/// Test: the producer's own suite in `savings_compress_tests.rs`.
+///
+/// #7514: the two ambient reads are ISOLATED here and nowhere else, so the only
+/// way a caller reaches the operator's ledger is by going through this function.
+/// `run_compress` is the one that does; every test drives
+/// [`record_compress_savings_with`] or the producer directly, and the
+/// `tests/tm_compress_pipe.rs` helpers — which spawn the real binary and so
+/// cannot be given a Rust parameter — clear `CLAUDE_CODE_SESSION_ID` from the
+/// CHILD's environment instead. A test that appends a row keyed by the
+/// developer's own live session id is the defect #7514 names.
+/// Test: `record_compress_savings_with_declines_without_a_session_id`.
 fn record_compress_savings(bytes_before: usize, bytes_after: usize, compression_path: &str) {
-    let Some(session_id) = trusty_mpm::core::savings::claude_code_session_id() else {
-        tracing::debug!("no claude session id: writing no compress savings row");
-        return;
-    };
     let root = match crate::commands::managed_root::resolve_managed_paths(None) {
-        Ok(paths) => paths.root,
+        Ok(paths) => Some(paths.root),
         Err(source) => {
             tracing::warn!(
                 %source,
                 "cannot resolve the framework root: writing no compress savings row"
             );
-            return;
+            None
         }
     };
+    record_compress_savings_with(
+        root.as_deref(),
+        trusty_mpm::core::savings::claude_code_session_id().as_deref(),
+        bytes_before,
+        bytes_after,
+        compression_path,
+    );
+}
+
+/// [`record_compress_savings`] with the framework root and session id supplied.
+///
+/// Why (#7514): `resolve_managed_paths` reads the operator's `--root` /
+/// `TRUSTY_MPM_ROOT` / config chain and `claude_code_session_id` reads the
+/// harness variable, so a test that reached this code wrote a real row into the
+/// operator's real ledger under the developer's own live session id. Injecting
+/// both — rather than setting them, which the `src/bin/tm/**` env ratchet
+/// (#5544) forbids — keeps the decision testable and leaves exactly one
+/// ambient call site.
+/// What: declines with no session id, a blank one, or no resolvable root;
+/// otherwise defers to
+/// [`trusty_mpm::core::savings_compress::record_compress`], which declines a
+/// passthrough run itself.
+/// Test: `record_compress_savings_with_declines_without_a_session_id`,
+/// `record_compress_savings_with_writes_under_the_named_root`.
+fn record_compress_savings_with(
+    root: Option<&std::path::Path>,
+    session_id: Option<&str>,
+    bytes_before: usize,
+    bytes_after: usize,
+    compression_path: &str,
+) {
+    let Some(session_id) = session_id.map(str::trim).filter(|id| !id.is_empty()) else {
+        tracing::debug!("no claude session id: writing no compress savings row");
+        return;
+    };
+    let Some(root) = root else {
+        return;
+    };
     trusty_mpm::core::savings_compress::record_compress(
-        &root,
-        &session_id,
+        root,
+        session_id,
         bytes_before,
         bytes_after,
         compression_path,
@@ -637,6 +680,42 @@ mod tests {
             "expected compression to shrink repetitive passing-test output"
         );
         assert!(compressed.contains("test result"));
+    }
+
+    /// Why (#7514): `tm compress`'s savings write read the operator's framework
+    /// root and the live `CLAUDE_CODE_SESSION_ID`, so a test that reached it
+    /// appended a real `compress` row to the operator's ledger keyed by the
+    /// developer's own session. The decline must be a property of the injected
+    /// inputs, not of the machine.
+    /// Test: itself.
+    #[test]
+    fn record_compress_savings_with_declines_without_a_session_id() {
+        let root = tempfile::tempdir().expect("temp root");
+        for id in [None, Some(""), Some("   ")] {
+            record_compress_savings_with(Some(root.path()), id, 10_000, 1_000, "native");
+        }
+        record_compress_savings_with(None, Some("c1"), 10_000, 1_000, "native");
+        assert!(
+            !root.path().join("usage").exists(),
+            "no session id, or no root, must write nothing at all"
+        );
+    }
+
+    /// Why (#7514): the other half — with both inputs supplied the row must land
+    /// under the root the CALLER named, or the injection would be decoration.
+    /// Test: itself.
+    #[test]
+    fn record_compress_savings_with_writes_under_the_named_root() {
+        let root = tempfile::tempdir().expect("temp root");
+
+        record_compress_savings_with(Some(root.path()), Some("c-7514"), 10_000, 1_000, "native");
+
+        let ledger = trusty_mpm::core::savings::savings_log_in(root.path());
+        let written = std::fs::read_to_string(&ledger).expect("the named root must hold the row");
+        assert!(
+            written.contains("c-7514") && written.contains("\"technique\":\"compress\""),
+            "the row must be keyed by the supplied session id: {written}"
+        );
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -400,7 +400,7 @@ pub fn write_compiled_prompt_to(dest: &std::path::Path, prompt: &str) -> std::io
 /// [`crate::core::savings_instructions::record_instruction_compression_in`].
 /// Recording is best-effort by contract — a write failure returns before it, so
 /// no row can describe a prompt that never landed.
-/// Test: `prepare_session_writes_the_compiled_prompt_before_returning`.
+/// Test: `a_recording_compiled_write_reaches_the_named_framework_root`.
 pub(crate) fn write_compiled_prompt_recording_in(
     framework_root: &std::path::Path,
     dest: &std::path::Path,
@@ -413,25 +413,6 @@ pub(crate) fn write_compiled_prompt_recording_in(
         prompt,
     );
     Ok(())
-}
-
-/// [`write_compiled_prompt_to`], then record the fold against the operator's
-/// own framework root.
-///
-/// Why (#7514): the two launch paths that do not carry a
-/// [`crate::core::paths::FrameworkPaths`] — the spawn's `build_prompt_file` and
-/// [`refresh_compiled_prompt`] — still need the row, and the ambient root is
-/// correct for them because they only ever run inside a real launch. Naming that
-/// choice in the function name is what keeps it out of the pure writer.
-/// What: [`write_compiled_prompt_recording_in`] against
-/// [`crate::core::paths::FrameworkPaths::default`]'s root.
-/// Test: `refresh_compiled_prompt_writes_the_project_local_file`.
-pub fn write_compiled_prompt_and_record(
-    dest: &std::path::Path,
-    prompt: &str,
-) -> std::io::Result<()> {
-    let root = crate::core::paths::FrameworkPaths::default().root;
-    write_compiled_prompt_recording_in(&root, dest, prompt)
 }
 
 /// Compose a project's prompt and refresh its compiled prompt on disk — fatally.
@@ -453,15 +434,44 @@ pub fn write_compiled_prompt_and_record(
 /// the `effective_style` it just resolved (flag > config > manifest), which this
 /// helper hardcodes to `None`, and routing it through here would silently drop
 /// the operator's chosen output style from the compiled copy. All three still
-/// share the actual write via [`write_compiled_prompt_to`] and the same fatal
-/// policy; what differs is only which text they compose.
-/// What: composes the project-resolved prompt through the same seam the launcher
-/// uses, with no explicit output style, writes it to [`compiled_prompt_path`],
-/// and on failure returns the operator-facing string from
-/// [`instructions_failure_message`] — callers refuse the launch with it.
+/// share the actual write via [`write_compiled_prompt_recording_in`] and the
+/// same fatal policy; what differs is only which text they compose.
+/// What: [`refresh_compiled_prompt_in`] against
+/// [`crate::core::paths::FrameworkPaths::default`]'s root, which is correct for
+/// both callers because both are real launches on the operator's own machine.
+///
+/// PRECONDITION: `session_id` must be a session SCOPE — a managed session id or
+/// [`crate::core::harness_root::UNMANAGED_SESSION_SCOPE`] — because
+/// [`compiled_prompt_path`] uses it verbatim as a directory name and
+/// `savings_instructions::session_and_root` reads it back as the row's fallback
+/// key. Both production callers pass a `ManagedSessionId`'s string form.
 /// Test: `refresh_compiled_prompt_writes_the_project_local_file`,
 /// `refresh_compiled_prompt_reports_an_actionable_failure`.
 pub fn refresh_compiled_prompt(
+    project_dir: &std::path::Path,
+    session_id: &str,
+) -> Result<(), String> {
+    // #7514: a real launch, so the ambient framework root is the right ledger.
+    let root = crate::core::paths::FrameworkPaths::default().root;
+    refresh_compiled_prompt_in(&root, project_dir, session_id)
+}
+
+/// [`refresh_compiled_prompt`] against a caller-named framework root.
+///
+/// Why (#7514): the entry point above resolves its ledger from the process home
+/// directory, so the two unit tests that drive it wrote a savings row — or a
+/// `no-fold-warned` marker — into the operator's own `~/.trusty-mpm/usage/`.
+/// Naming the root is what lets those tests stay on a tempdir without mutating
+/// `$HOME`.
+/// What: composes the project-resolved prompt through the same seam the launcher
+/// uses, with no explicit output style, writes it to [`compiled_prompt_path`]
+/// and records the fold against `framework_root`; on failure returns the
+/// operator-facing string from [`instructions_failure_message`] — callers refuse
+/// the launch with it.
+/// Test: `refresh_compiled_prompt_writes_the_project_local_file`,
+/// `refresh_compiled_prompt_reports_an_actionable_failure`.
+pub fn refresh_compiled_prompt_in(
+    framework_root: &std::path::Path,
     project_dir: &std::path::Path,
     session_id: &str,
 ) -> Result<(), String> {
@@ -472,8 +482,7 @@ pub fn refresh_compiled_prompt(
         native,
     );
     let dest = compiled_prompt_path(project_dir, session_id);
-    // #7514: a real launch, so the ambient framework root is the right ledger.
-    write_compiled_prompt_and_record(&dest, &prompt)
+    write_compiled_prompt_recording_in(framework_root, &dest, &prompt)
         .map_err(|source| instructions_failure_message(&dest, &source))
 }
 

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -368,17 +368,70 @@ pub fn instructions_failure_message(path: &std::path::Path, source: &std::io::Er
 /// What: creates `dest`'s parent directory if absent, then writes `prompt`
 /// verbatim. Returns the underlying IO error unchanged; pair it with
 /// [`instructions_failure_message`] when surfacing to an operator.
-/// Test: `write_compiled_prompt_to_creates_parent_dirs`.
+///
+/// #7514: this write is PURE — it touches `dest` and nothing else. The
+/// instruction-compression savings row used to be recorded here, against
+/// [`crate::core::paths::FrameworkPaths::default`], which resolves under the
+/// operator's real home. That made the operator's ledger reachable from any
+/// unit test that wrote a compiled prompt into a tempdir: 228 of the 229
+/// `instruction-compression` rows on the owner's host were this function's own
+/// 13-byte fixture. Recording is now an explicit choice of the caller —
+/// [`write_compiled_prompt_and_record`] for a launch, or
+/// [`write_compiled_prompt_recording_in`] where the caller already holds the
+/// framework root.
+/// Test: `write_compiled_prompt_to_creates_parent_dirs`,
+/// `a_bare_compiled_write_records_no_savings_row`.
 pub fn write_compiled_prompt_to(dest: &std::path::Path, prompt: &str) -> std::io::Result<()> {
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(dest, prompt)?;
-    // #6958: this is the one choke point that knows both halves of the
-    // instruction fold, so the savings row is recorded here rather than at each
-    // of the three launch paths. Best-effort by contract — see the producer.
-    crate::core::savings_instructions::record_instruction_compression(dest, prompt);
+    std::fs::write(dest, prompt)
+}
+
+/// [`write_compiled_prompt_to`], then record the fold against `framework_root`.
+///
+/// Why (#6958, re-seamed by #7514): one choke point still knows both halves of
+/// the instruction fold, so the savings row is recorded here rather than at each
+/// launch path — but the LEDGER it lands in is now named by the caller instead
+/// of resolved from the process's home directory. `prepare_session_inner`
+/// already holds a [`crate::core::paths::FrameworkPaths`], so threading its root
+/// keeps a launch prepared under a temp root recording under that same root.
+/// What: the pure write, then
+/// [`crate::core::savings_instructions::record_instruction_compression_in`].
+/// Recording is best-effort by contract — a write failure returns before it, so
+/// no row can describe a prompt that never landed.
+/// Test: `prepare_session_writes_the_compiled_prompt_before_returning`.
+pub(crate) fn write_compiled_prompt_recording_in(
+    framework_root: &std::path::Path,
+    dest: &std::path::Path,
+    prompt: &str,
+) -> std::io::Result<()> {
+    write_compiled_prompt_to(dest, prompt)?;
+    crate::core::savings_instructions::record_instruction_compression_in(
+        framework_root,
+        dest,
+        prompt,
+    );
     Ok(())
+}
+
+/// [`write_compiled_prompt_to`], then record the fold against the operator's
+/// own framework root.
+///
+/// Why (#7514): the two launch paths that do not carry a
+/// [`crate::core::paths::FrameworkPaths`] — the spawn's `build_prompt_file` and
+/// [`refresh_compiled_prompt`] — still need the row, and the ambient root is
+/// correct for them because they only ever run inside a real launch. Naming that
+/// choice in the function name is what keeps it out of the pure writer.
+/// What: [`write_compiled_prompt_recording_in`] against
+/// [`crate::core::paths::FrameworkPaths::default`]'s root.
+/// Test: `refresh_compiled_prompt_writes_the_project_local_file`.
+pub fn write_compiled_prompt_and_record(
+    dest: &std::path::Path,
+    prompt: &str,
+) -> std::io::Result<()> {
+    let root = crate::core::paths::FrameworkPaths::default().root;
+    write_compiled_prompt_recording_in(&root, dest, prompt)
 }
 
 /// Compose a project's prompt and refresh its compiled prompt on disk — fatally.
@@ -419,7 +472,8 @@ pub fn refresh_compiled_prompt(
         native,
     );
     let dest = compiled_prompt_path(project_dir, session_id);
-    write_compiled_prompt_to(&dest, &prompt)
+    // #7514: a real launch, so the ambient framework root is the right ledger.
+    write_compiled_prompt_and_record(&dest, &prompt)
         .map_err(|source| instructions_failure_message(&dest, &source))
 }
 

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -1042,6 +1042,30 @@ fn a_bare_compiled_write_records_no_savings_row() {
     );
 }
 
+/// Why (#7514): the other half of the split — the recording write must land its
+/// measurement in the root the CALLER named, or threading the root through
+/// `prepare_session_inner` would be decoration. The fixture is LARGER than the
+/// source set on purpose: the producer then takes the "folded nothing" branch,
+/// which writes its marker before any model pricing, so the assertion does not
+/// depend on whether this host's configured PM model is in the price table.
+/// Test: itself.
+#[test]
+fn a_recording_compiled_write_reaches_the_named_framework_root() {
+    let root = TempDir::new().expect("framework root");
+    let project = TempDir::new().expect("project");
+    let dest = compiled_prompt_path(project.path(), "sess-7514");
+    let sources: usize = SECTION_SOURCES.iter().map(|(_, body)| body.len()).sum();
+    let bulky = "x".repeat(sources + 1);
+
+    write_compiled_prompt_recording_in(root.path(), &dest, &bulky).expect("write succeeds");
+
+    assert_eq!(fs::read_to_string(&dest).unwrap(), bulky);
+    assert!(
+        root.path().join("usage").join("no-fold-warned").exists(),
+        "the fold must be measured against the framework root the caller named"
+    );
+}
+
 #[test]
 fn compiled_prompt_write_is_the_full_assembled_prompt_never_a_stub() {
     // Why (#383 regression guard, retained through #4752's path move): the
@@ -1273,13 +1297,17 @@ fn refresh_compiled_prompt_writes_the_project_local_file() {
     //
     // FIXTURE: a stale sentinel is pre-seeded so "the file exists" cannot pass;
     // only a real refresh overwrites it.
+    //
+    // #7514: driven through the root-taking seam, so the fold this composes is
+    // recorded under `root` rather than the operator's own `~/.trusty-mpm`.
+    let root = TempDir::new().expect("framework root");
     let tmp = TempDir::new().expect("tempdir");
     let dest = compiled_prompt_path(tmp.path(), "sess-1");
     fs::create_dir_all(dest.parent().expect("has a parent")).expect("create parent");
     const STALE: &str = "STALE-FROM-A-PREVIOUS-LAUNCH";
     fs::write(&dest, STALE).expect("seed stale");
 
-    refresh_compiled_prompt(tmp.path(), "sess-1").expect("refresh must succeed");
+    refresh_compiled_prompt_in(root.path(), tmp.path(), "sess-1").expect("refresh must succeed");
 
     let on_disk = fs::read_to_string(&dest).expect("readable");
     assert_ne!(
@@ -1305,11 +1333,14 @@ fn refresh_compiled_prompt_reports_an_actionable_failure() {
     //
     // FIXTURE: a directory planted at the exact destination, so only this write
     // fails and nothing else in the compose path does.
+    // #7514: root-taking seam, so a failed refresh cannot touch the operator's
+    // ledger on its way to the error.
+    let root = TempDir::new().expect("framework root");
     let tmp = TempDir::new().expect("tempdir");
     let dest = compiled_prompt_path(tmp.path(), "sess-1");
     fs::create_dir_all(&dest).expect("plant a directory at the compiled path");
 
-    let msg = refresh_compiled_prompt(tmp.path(), "sess-1")
+    let msg = refresh_compiled_prompt_in(root.path(), tmp.path(), "sess-1")
         .expect_err("a failed compiled write must be reported as an error");
     assert!(
         msg.contains(&dest.display().to_string()),

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -65,6 +65,12 @@ impl RosterTiers {
         self.tmp.path().join("project")
     }
 
+    /// The temp `$HOME` this guard installed — where an ambient
+    /// [`crate::core::paths::FrameworkPaths::default`] resolves while it is held.
+    fn home(&self) -> PathBuf {
+        self.tmp.path().join("home")
+    }
+
     /// Tier 1 — `<project>/.claude/agents`, the operator's hand-placed agents.
     fn project_tier(&self) -> PathBuf {
         self.project().join(".claude").join("agents")
@@ -1006,6 +1012,34 @@ fn write_compiled_prompt_to_creates_parent_dirs() {
     let dest = tmp.path().join("a").join("b").join(COMPILED_PROMPT_FILE);
     write_compiled_prompt_to(&dest, "COMPILED-BODY").expect("write succeeds");
     assert_eq!(fs::read_to_string(&dest).unwrap(), "COMPILED-BODY");
+}
+
+/// Why (#7514): this write used to append an instruction-compression savings row
+/// against `FrameworkPaths::default()` — which resolves under the operator's own
+/// home — so every unit test that wrote a compiled prompt into a tempdir put a
+/// synthetic row in the operator's real ledger and a marker in its
+/// `usage/no-fold-warned/`. The `💸` statusline segment then reported a figure no
+/// launch produced. A bare write must touch its destination and nothing else.
+/// FAILS BEFORE THIS CHANGE: `<home>/.trusty-mpm/usage/` existed afterwards.
+/// Test: itself.
+#[test]
+#[serial_test::serial]
+fn a_bare_compiled_write_records_no_savings_row() {
+    let tiers = RosterTiers::new();
+    let project = tiers.project();
+    let dest = compiled_prompt_path(&project, "sess-7514");
+    // Above the #7491 floor and below the source set, so the producer WOULD
+    // have recorded a row: what is asserted is that it is never asked to.
+    let plausible =
+        "x".repeat(crate::core::savings_instructions::min_plausible_compiled_bytes() + 137);
+
+    write_compiled_prompt_to(&dest, &plausible).expect("write succeeds");
+
+    assert_eq!(fs::read_to_string(&dest).unwrap(), plausible);
+    assert!(
+        !tiers.home().join(".trusty-mpm").join("usage").exists(),
+        "a bare compiled write must not reach the operator's savings ledger"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/savings_instructions.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions.rs
@@ -8,13 +8,12 @@
 //! by hand — means the figure re-derives itself when the instruction corpus
 //! changes, and it goes to zero honestly when nothing was folded.
 //!
-//! What: [`record_instruction_compression`] and its root-taking sibling
-//! [`record_instruction_compression_in`], called from the compiled-prompt
-//! writer's recording entry points
-//! ([`crate::core::instruction_pipeline::write_compiled_prompt_and_record`] and
-//! [`crate::core::instruction_pipeline::write_compiled_prompt_recording_in`]).
-//! #7514 split those off the bare write, which now records nothing. It compares
-//! the folded source set against the
+//! What: [`record_instruction_compression_in`], called from
+//! [`crate::core::instruction_pipeline::write_compiled_prompt_recording_in`].
+//! #7514 split that off the bare write, which now records nothing, and made the
+//! ledger's root a parameter rather than a read of the process home directory —
+//! each launch path resolves the ambient root once, in its own named wrapper.
+//! It compares the folded source set against the
 //! delivered prompt and appends one [`crate::core::savings::SavingsRow`] per
 //! session launch when, and only when, the delivered prompt is smaller.
 //!
@@ -92,31 +91,17 @@ use crate::core::savings_sidecar::{stage_row, warn_no_fold_once};
 /// Append one `instruction-compression` row for a session whose compiled prompt
 /// came out smaller than the sources that fed it.
 ///
-/// Why: called from the compiled-prompt writer so every launch path — fresh
-/// start, daemon resume, in-place relaunch — records the same way without each
-/// one growing its own call.
-/// What: reads the Claude Code session id the statusline folds by, then defers
-/// to [`record_instruction_compression_to`] against the default framework root.
-/// Test: `the_row_is_keyed_by_the_claude_session_id`,
-/// `no_claude_id_stages_the_row_instead_of_writing_an_unfoldable_one`.
-pub fn record_instruction_compression(dest: &Path, prompt: &str) {
-    record_instruction_compression_in(
-        &crate::core::paths::FrameworkPaths::default().root,
-        dest,
-        prompt,
-    );
-}
-
-/// [`record_instruction_compression`] against a caller-named framework root.
-///
-/// Why (#7514): the entry point above resolves its root from the operator's home
-/// directory, so every caller reachable from a test wrote into the operator's
-/// own ledger. A launch path that already holds a
-/// [`crate::core::paths::FrameworkPaths`] can name the root instead, and then a
-/// launch prepared under a temp root records under that temp root.
+/// Why: called from the compiled-prompt writer's recording entry points so every
+/// launch path — fresh start, daemon resume, in-place relaunch — records the same
+/// way without each one growing its own call. #7514 removed the ambient
+/// `record_instruction_compression` that resolved `framework_root` from the
+/// process home directory: every caller reachable from a test wrote into the
+/// operator's own ledger through it. Each launch path now resolves the ambient
+/// root once, in its own named wrapper, and passes it down.
 /// What: reads the Claude Code session id the statusline folds by, then defers to
 /// [`record_instruction_compression_to`] against `framework_root`.
-/// Test: `a_bare_compiled_write_records_no_savings_row`.
+/// Test: `a_bare_compiled_write_records_no_savings_row`,
+/// `a_recording_compiled_write_reaches_the_named_framework_root`.
 pub(crate) fn record_instruction_compression_in(framework_root: &Path, dest: &Path, prompt: &str) {
     // #7209: the row's key is the Claude Code session id, not the directory name.
     record_instruction_compression_to(

--- a/crates/trusty-mpm/src/core/savings_instructions.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions.rs
@@ -8,9 +8,13 @@
 //! by hand — means the figure re-derives itself when the instruction corpus
 //! changes, and it goes to zero honestly when nothing was folded.
 //!
-//! What: [`record_instruction_compression`], called from
-//! [`crate::core::instruction_pipeline::write_compiled_prompt_to`] — the single
-//! writer of the compiled prompt. It compares the folded source set against the
+//! What: [`record_instruction_compression`] and its root-taking sibling
+//! [`record_instruction_compression_in`], called from the compiled-prompt
+//! writer's recording entry points
+//! ([`crate::core::instruction_pipeline::write_compiled_prompt_and_record`] and
+//! [`crate::core::instruction_pipeline::write_compiled_prompt_recording_in`]).
+//! #7514 split those off the bare write, which now records nothing. It compares
+//! the folded source set against the
 //! delivered prompt and appends one [`crate::core::savings::SavingsRow`] per
 //! session launch when, and only when, the delivered prompt is smaller.
 //!
@@ -77,6 +81,8 @@
 
 use std::path::Path;
 
+use crate::core::harness_root::{HARNESS_DIR, SESSIONS_DIR};
+use crate::core::instruction_pipeline::COMPILED_PROMPT_FILE;
 use crate::core::savings::{
     BYTES_PER_TOKEN, SavingsRow, TECHNIQUE_INSTRUCTION_COMPRESSION, append_row,
     claude_code_session_id, now_ts, savings_log_in,
@@ -94,9 +100,27 @@ use crate::core::savings_sidecar::{stage_row, warn_no_fold_once};
 /// Test: `the_row_is_keyed_by_the_claude_session_id`,
 /// `no_claude_id_stages_the_row_instead_of_writing_an_unfoldable_one`.
 pub fn record_instruction_compression(dest: &Path, prompt: &str) {
+    record_instruction_compression_in(
+        &crate::core::paths::FrameworkPaths::default().root,
+        dest,
+        prompt,
+    );
+}
+
+/// [`record_instruction_compression`] against a caller-named framework root.
+///
+/// Why (#7514): the entry point above resolves its root from the operator's home
+/// directory, so every caller reachable from a test wrote into the operator's
+/// own ledger. A launch path that already holds a
+/// [`crate::core::paths::FrameworkPaths`] can name the root instead, and then a
+/// launch prepared under a temp root records under that temp root.
+/// What: reads the Claude Code session id the statusline folds by, then defers to
+/// [`record_instruction_compression_to`] against `framework_root`.
+/// Test: `a_bare_compiled_write_records_no_savings_row`.
+pub(crate) fn record_instruction_compression_in(framework_root: &Path, dest: &Path, prompt: &str) {
     // #7209: the row's key is the Claude Code session id, not the directory name.
     record_instruction_compression_to(
-        &crate::core::paths::FrameworkPaths::default().root,
+        framework_root,
         dest,
         prompt,
         claude_code_session_id(),
@@ -134,6 +158,14 @@ fn record_instruction_compression_to(
     price: impl FnOnce() -> Option<(String, f64)>,
 ) {
     let Some((compiled_prompt_id, harness_root)) = session_and_root(dest) else {
+        // #7514: a destination that is not a compiled-prompt path has no session
+        // and no harness root to measure against, so there is nothing to record.
+        tracing::warn!(
+            compiled_prompt = %dest.display(),
+            "not a <root>/.trusty-mpm/sessions/<id>/INSTRUCTIONS-COMPILED.md path, so \
+             neither the session nor the source set it would be measured against is \
+             known; writing no instruction-compression savings row"
+        );
         return;
     };
     let source_bytes = folded_source_bytes(&harness_root);
@@ -239,16 +271,34 @@ pub(crate) fn rederive_from_compiled_prompt(
 /// harness root is three directories above that (`sessions/`, `.trusty-mpm/`,
 /// the root).
 /// Returns `None` for any path not of that shape.
+///
+/// #7514: it now CHECKS that shape. It used to take the parent as a session id
+/// and count three directories up for the root without looking at what those
+/// directories were called, so `<tmp>/a/b/INSTRUCTIONS-COMPILED.md` resolved to
+/// session `b` under root `<tmp>` — which is exactly the
+/// `session_id":"b" … compiled 13 B` row the owner's ledger carried, produced by
+/// this crate's own `write_compiled_prompt_to_creates_parent_dirs` fixture. A
+/// path that is not a compiled prompt now declines, so no row can be attributed
+/// to a directory that is not a session.
 /// Test: `session_and_root_reads_the_compiled_prompt_path`,
-/// `session_and_root_rejects_a_short_path`.
+/// `session_and_root_rejects_a_short_path`,
+/// `session_and_root_rejects_a_path_that_is_not_under_sessions`,
+/// `a_malformed_compiled_prompt_path_records_no_row`.
 fn session_and_root(dest: &Path) -> Option<(String, std::path::PathBuf)> {
-    let session_dir = dest.parent()?;
-    let session_id = session_dir.file_name()?.to_str()?.to_string();
-    if session_id.is_empty() {
+    if dest.file_name()? != std::ffi::OsStr::new(COMPILED_PROMPT_FILE) {
         return None;
     }
-    let harness_root = session_dir.parent()?.parent()?.parent()?.to_path_buf();
-    Some((session_id, harness_root))
+    let session_dir = dest.parent()?;
+    let session_id = session_dir.file_name()?.to_str()?.to_string();
+    let sessions_dir = session_dir.parent()?;
+    if sessions_dir.file_name()? != std::ffi::OsStr::new(SESSIONS_DIR) {
+        return None;
+    }
+    let harness_dir = sessions_dir.parent()?;
+    if harness_dir.file_name()? != std::ffi::OsStr::new(HARNESS_DIR) {
+        return None;
+    }
+    Some((session_id, harness_dir.parent()?.to_path_buf()))
 }
 
 /// Total bytes of every instruction body the composer read for this project.

--- a/crates/trusty-mpm/src/core/savings_instructions_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions_tests.rs
@@ -149,6 +149,85 @@ fn session_and_root_rejects_a_short_path() {
     assert!(session_and_root(std::path::Path::new("/a/b/INSTRUCTIONS-COMPILED.md")).is_none());
 }
 
+/// Why (#7514): the resolver counted directories instead of checking their
+/// names, so any path four segments deep resolved to a session. The owner's
+/// ledger carried 228 rows reading `"session_id":"b" … compiled 13 B` — `b` is
+/// the second directory of `<tmp>/a/b/INSTRUCTIONS-COMPILED.md`, this crate's
+/// own `write_compiled_prompt_to_creates_parent_dirs` fixture, and 13 B is that
+/// fixture's `COMPILED-BODY` body.
+/// FAILS BEFORE THIS CHANGE: every path below resolved to a session id.
+/// Test: itself.
+#[test]
+fn session_and_root_rejects_a_path_that_is_not_under_sessions() {
+    for not_a_compiled_prompt in [
+        "/tmp/x/a/b/INSTRUCTIONS-COMPILED.md",
+        "/repos/t/.trusty-mpm/framework/sess-1/INSTRUCTIONS-COMPILED.md",
+        "/repos/t/other/sessions/sess-1/INSTRUCTIONS-COMPILED.md",
+        "/repos/t/.trusty-mpm/sessions/sess-1/last-instructions.md",
+    ] {
+        assert!(
+            session_and_root(std::path::Path::new(not_a_compiled_prompt)).is_none(),
+            "{not_a_compiled_prompt} is not a compiled-prompt path"
+        );
+    }
+}
+
+/// Why (#7514): the producer's whole input is a destination path, so a
+/// destination that is not a compiled prompt must produce nothing at all —
+/// neither a ledger row nor a staged one. The body here is deliberately ABOVE
+/// the #7491 floor, so what the assertion pins is the PATH check and not the
+/// floor; the floor's own guards are unchanged and still cover a short file.
+/// FAILS BEFORE THIS CHANGE: the ledger gained a row keyed `b`.
+/// Test: itself.
+#[test]
+fn a_malformed_compiled_prompt_path_records_no_row() {
+    let framework_root = tempfile::tempdir().expect("temp framework root");
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let dest = tmp
+        .path()
+        .join("a")
+        .join("b")
+        .join("INSTRUCTIONS-COMPILED.md");
+    std::fs::create_dir_all(dest.parent().expect("parent")).expect("fixture dirs");
+    let plausible = plausible_prompt_above_the_floor();
+    std::fs::write(&dest, &plausible).expect("fixture");
+    let ledger = crate::core::savings::savings_log_in(framework_root.path());
+
+    record_instruction_compression_to(
+        framework_root.path(),
+        &dest,
+        &plausible,
+        Some("c-7514".to_string()),
+        sonnet_price,
+    );
+
+    assert!(
+        !ledger.exists(),
+        "a destination that is not a compiled prompt must append no row: {}",
+        std::fs::read_to_string(&ledger).unwrap_or_default()
+    );
+    assert!(
+        !crate::core::savings_sidecar::pending_row_path_in(framework_root.path(), &dest).exists(),
+        "nor stage one"
+    );
+    assert!(
+        !framework_root
+            .path()
+            .join("usage")
+            .join("no-fold-warned")
+            .exists(),
+        "nor leave a no-fold marker behind"
+    );
+}
+
+/// A compiled-prompt body that clears the #7491 floor and still folds.
+///
+/// Why: a fixture below the floor would make every assertion about the floor
+/// rather than about the property under test.
+fn plausible_prompt_above_the_floor() -> String {
+    "x".repeat(min_plausible_compiled_bytes() + 137)
+}
+
 /// Why: the bundled sections are the floor of the source set, and a count that
 /// silently dropped them would make every fold look like a saving.
 /// Test: itself.

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -1258,11 +1258,16 @@ fn prepare_session_inner(
 
     let scope = crate::core::harness_root::session_scope(session_id);
     let compiled = crate::core::instruction_pipeline::compiled_prompt_path(project_dir, &scope);
-    crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &resolved_prompt)
-        .map_err(|source| PrepError::Instructions {
-            path: compiled.clone(),
-            source,
-        })?;
+    // #7514: record the fold against THIS preparation's framework root.
+    crate::core::instruction_pipeline::write_compiled_prompt_recording_in(
+        &fw.root,
+        &compiled,
+        &resolved_prompt,
+    )
+    .map_err(|source| PrepError::Instructions {
+        path: compiled.clone(),
+        source,
+    })?;
 
     // #6649: computed LAST so the skill tier it reads is the one this launch
     // leaves behind, not the one it inherited.

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_prep.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_prep.rs
@@ -114,12 +114,33 @@ pub(super) fn refresh_resume_compiled_prompt(
     workspace: &std::path::Path,
     session_id: &ManagedSessionId,
 ) -> Result<(), String> {
-    // #4752: delegates to the shared entry point so the daemon-resume,
-    // fresh-start, and bare-`tm` in-place relaunch paths cannot drift apart.
-    // #4832: the write is per-session, so the resumed session's own id selects
-    // the directory — a resume must refresh the file the spawn will read, not
-    // a sibling session's.
-    crate::core::instruction_pipeline::refresh_compiled_prompt(workspace, &session_id.to_string())
+    // #7514: a real resume, so the ambient framework root is the right ledger.
+    let root = crate::core::paths::FrameworkPaths::default().root;
+    refresh_resume_compiled_prompt_in(&root, workspace, session_id)
+}
+
+/// [`refresh_resume_compiled_prompt`] against a caller-named framework root.
+///
+/// Why (#7514): the entry point above resolves its savings ledger from the
+/// process home directory, so the two tests that drive it left a
+/// `no-fold-warned` marker in the operator's own `~/.trusty-mpm/usage/`.
+/// What: [`crate::core::instruction_pipeline::refresh_compiled_prompt_in`] with
+/// the resumed session's own id as the scope — #4752's shared entry point, so
+/// the daemon-resume, fresh-start and bare-`tm` in-place relaunch paths cannot
+/// drift apart, and #4832's per-session write, so a resume refreshes the file
+/// the spawn will read rather than a sibling session's.
+/// Test: `refresh_resume_compiled_prompt_writes_the_project_local_file`,
+/// `refresh_resume_compiled_prompt_reports_an_actionable_failure`.
+pub(super) fn refresh_resume_compiled_prompt_in(
+    framework_root: &std::path::Path,
+    workspace: &std::path::Path,
+    session_id: &ManagedSessionId,
+) -> Result<(), String> {
+    crate::core::instruction_pipeline::refresh_compiled_prompt_in(
+        framework_root,
+        workspace,
+        &session_id.to_string(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_prep_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_prep_tests.rs
@@ -30,7 +30,10 @@ fn refresh_resume_compiled_prompt_writes_the_project_local_file() {
     const STALE: &str = "STALE-FROM-A-PREVIOUS-START";
     std::fs::write(&dest, STALE).expect("seed stale");
 
-    refresh_resume_compiled_prompt(tmp.path(), &id).expect("refresh succeeds");
+    // #7514: root-taking seam, so the fold lands under `root` and not in the
+    // operator's own `~/.trusty-mpm/usage/`.
+    let root = tempfile::tempdir().expect("framework root");
+    refresh_resume_compiled_prompt_in(root.path(), tmp.path(), &id).expect("refresh succeeds");
 
     let on_disk = std::fs::read_to_string(&dest).expect("readable");
     assert_ne!(
@@ -56,7 +59,9 @@ fn refresh_resume_compiled_prompt_reports_an_actionable_failure() {
     let dest = crate::core::instruction_pipeline::compiled_prompt_path(tmp.path(), &id.to_string());
     std::fs::create_dir_all(&dest).expect("plant a directory at the compiled path");
 
-    let msg = refresh_resume_compiled_prompt(tmp.path(), &id)
+    // #7514: root-taking seam — see the sibling test above.
+    let root = tempfile::tempdir().expect("framework root");
+    let msg = refresh_resume_compiled_prompt_in(root.path(), tmp.path(), &id)
         .expect_err("a failed compiled write must refuse the resume");
     assert!(
         msg.contains(&dest.display().to_string()),

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -429,10 +429,14 @@ fn build_prompt_file(project_dir: &Path, session_id: Option<&str>) -> Option<std
     // two provisioning steps and not here.
     let scope = crate::core::harness_root::session_scope(session_id);
     let compiled = crate::core::instruction_pipeline::compiled_prompt_path(project_dir, &scope);
-    // #7514: a real spawn, so the ambient framework root is the right ledger.
-    if let Err(err) =
-        crate::core::instruction_pipeline::write_compiled_prompt_and_record(&compiled, &prompt)
-    {
+    // #7514: a real spawn, so the ambient framework root is the right ledger —
+    // read once, here, and passed down rather than resolved inside the writer.
+    let framework_root = crate::core::paths::FrameworkPaths::default().root;
+    if let Err(err) = crate::core::instruction_pipeline::write_compiled_prompt_recording_in(
+        &framework_root,
+        &compiled,
+        &prompt,
+    ) {
         tracing::warn!(
             project = %project_dir.display(),
             path = %compiled.display(),

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -429,8 +429,9 @@ fn build_prompt_file(project_dir: &Path, session_id: Option<&str>) -> Option<std
     // two provisioning steps and not here.
     let scope = crate::core::harness_root::session_scope(session_id);
     let compiled = crate::core::instruction_pipeline::compiled_prompt_path(project_dir, &scope);
+    // #7514: a real spawn, so the ambient framework root is the right ledger.
     if let Err(err) =
-        crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &prompt)
+        crate::core::instruction_pipeline::write_compiled_prompt_and_record(&compiled, &prompt)
     {
         tracing::warn!(
             project = %project_dir.display(),

--- a/crates/trusty-mpm/tests/tm_compress_pipe.rs
+++ b/crates/trusty-mpm/tests/tm_compress_pipe.rs
@@ -55,6 +55,10 @@ fn run_tm_compress_with(env: &[(&str, &str)], tool: &str, input: &str) -> (bool,
     let mut child = Command::new(bin)
         .args(["compress", "--tool", tool])
         .env_remove(ENV_COMPRESS_NO_RTK)
+        // #7514: the child would otherwise inherit the developer's live
+        // CLAUDE_CODE_SESSION_ID and append a real `compress` savings row to
+        // their own ledger. Cleared on the CHILD, never on this process.
+        .env_remove(trusty_mpm::core::savings::CLAUDE_CODE_SESSION_ID_ENV)
         .envs(env.iter().copied())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -125,6 +129,9 @@ fn run_wrapped_pipeline(inner: &str, tool: &str) -> (String, String) {
         .arg("-c")
         .arg(&script)
         .env(ENV_COMPRESS_NO_RTK, "1")
+        // #7514: see `run_tm_compress_with` — the `tm compress` at the tail of
+        // this pipeline must not key a savings row by the developer's session.
+        .env_remove(trusty_mpm::core::savings::CLAUDE_CODE_SESSION_ID_ENV)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Summary

Rung 3 (trusty-mpm), escalated to a critic round because it touches persisted
state (the savings ledger).

Root cause: the 13-byte compiled-prompt "writes" reported in #7514 never
existed on disk. 13 bytes is the string `COMPILED-BODY`, a fixture in
`instruction_pipeline_tests.rs`. `write_compiled_prompt_to` recorded a savings
row through `record_instruction_compression`, which resolved the ambient
framework root and keyed by the ambient `CLAUDE_CODE_SESSION_ID` — so every
`cargo test -p trusty-mpm` inside a Claude session appended a row to the
operator's real `~/.trusty-mpm/usage/savings.jsonl` (228 of 229
instruction-compression rows polluted, 99.8% of that technique's "tokens
saved"). `session_and_root` took `dest.parent()` as the session id with no
name check, so a tempdir path became session "b".

Fix: `write_compiled_prompt_to` is now a pure write.
`write_compiled_prompt_recording_in(framework_root, …)`,
`refresh_compiled_prompt_in`, `refresh_resume_compiled_prompt_in`,
`record_instruction_compression_in`, and
`record_compress_savings_with(root, session_id, …)` take explicit roots;
ambient wrappers are deleted where callerless. `session_and_root` now requires
`<root>/.trusty-mpm/sessions/<id>/INSTRUCTIONS-COMPILED.md` and `warn!`s the
path on decline. The #7491 floor is untouched.

Refs #7514
Refs #7544

## What changed

- `write_compiled_prompt_to` — pure write, no ledger side effect.
- New explicit-root variants: `write_compiled_prompt_recording_in`,
  `refresh_compiled_prompt_in`, `refresh_resume_compiled_prompt_in`,
  `record_instruction_compression_in`, `record_compress_savings_with`.
- `session_and_root` requires the compiled-prompt path to sit under
  `<root>/.trusty-mpm/sessions/<id>/INSTRUCTIONS-COMPILED.md`; a
  non-conforming path is declined with a `warn!` naming the path, and records
  no row.
- Ambient (ledger-writing) wrappers deleted where they had no remaining
  caller.
- Version bump: trusty-mpm 1.5.33 -> 1.5.34, carrying the owner-authorized
  reinstall for #7544 (whose fix PR #7546 merged after the 1.5.33 bump).

Out of scope: the one-shot ledger repair for the already-polluted
`savings.jsonl` (#7569, owner decision) and the two-write append
interleaving hazard (#7579).

## Risk / blast radius

Rung 3, localized to `trusty-mpm`'s compiled-prompt write path and savings
recording, escalated one critic round for touching persisted operator state
(the savings ledger).

## Test evidence

Regression tests that fail on `origin/main` and pass here:
- `session_and_root_rejects_a_path_that_is_not_under_sessions`
- `a_malformed_compiled_prompt_path_records_no_row`
- `a_bare_compiled_write_records_no_savings_row`
- `a_recording_compiled_write_reaches_the_named_framework_root`
- two compress-arm tests

Ledger-isolation evidence: scoped
`cargo test --lib -- instruction_pipeline savings_instructions compress`
(99 passed) leaves `~/.trusty-mpm/usage/no-fold-warned` at 3809 -> 3809 and the
ledger flat; the same run on b3fc202fd moved it.

Gates:
- `cargo fmt --check` — 0
- `cargo check -p trusty-mpm` — 0
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — 0
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4` — 59 targets,
  12742 passed, 0 failed, 18 ignored
- `scripts/check_line_cap.sh` — 0 violations
- `scripts/check_test_pointers.sh` — 0 dangling
- `scripts/check_changelog_fragment.sh` — OK
  (`7514-compiled-prompt-short-write.md`, `7544-reinstall-1-5-34.md`)
- `scripts/check-pr-version-bump.sh` — clear (1.5.33 -> 1.5.34)

## Baseline / pre-existing failures

None observed in scope; all gates above are green on this branch.

## Documentation / changelog status

Two fragments added under `crates/trusty-mpm/changelog.d/`:
`7514-compiled-prompt-short-write.md`, `7544-reinstall-1-5-34.md`.

## Review-finding disposition

`code-critic` WARN'd b3fc202fd: HIGH — `refresh_compiled_prompt` still
ambient; HIGH — `tm compress` bin wrapper writes real rows from tests. Both
closed in ec7437727 (this branch's second commit).

Security three-dot scan (`git diff origin/main...HEAD`): PASS, 14 files
(+433/-58).

Known residual, tracked in #7568: integration tests that spawn the real `tm`
binary inherit the real `$HOME`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01HEek73LSnk1zpsdBDLoPWW
