### PR TITLE
fix(trusty-common): SECRET_PREFIXES matches at any delimiter boundary, not only at token start (Refs #7549)

### DIFF
--- a/crates/trusty-common/changelog.d/7549-secret-prefixes-anywhere.md
+++ b/crates/trusty-common/changelog.d/7549-secret-prefixes-anywhere.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Secret detection now matches a known provider prefix (`sk-`, `ghp_`, `xoxb-`, …) at any delimiter boundary in a token, not only at its start, so a key written after a prepended segment, an `=`, a quote, or inside a JSON pair is redacted instead of being rescued as a segmented identifier (#7549).

--- a/crates/trusty-common/src/memory_core/filter/secret.rs
+++ b/crates/trusty-common/src/memory_core/filter/secret.rs
@@ -106,10 +106,11 @@ pub fn check_secret(content: &str) -> Result<(), FilterReject> {
 /// [`SECRET_MIN_LEN`] is sufficient protection for this list. AWS `AKIA`/`ASIA`
 /// used to live here and is not (issue #4898) — it is four bare letters, so it
 /// needs a shape check; see [`AWS_KEY_ID_PREFIXES`].
-/// What: lowercased prefix list checked case-insensitively in
-/// [`looks_like_secret`] (which lowercases the token before comparing), after
-/// the [`SECRET_MIN_LEN`] floor.
-/// Test: `known_key_prefixes_are_blocked`, `aws_access_key_ids_are_blocked`.
+/// What: lowercased prefix list matched case-insensitively by
+/// [`carries_secret_prefix`] (the caller lowercases the token), after the
+/// [`SECRET_MIN_LEN`] floor.
+/// Test: `known_key_prefixes_are_blocked`, `aws_access_key_ids_are_blocked`,
+/// `prefixed_provider_keys_are_blocked_after_7549`.
 pub(crate) const SECRET_PREFIXES: &[&str] = &[
     "sk-",
     "ghp_",
@@ -119,6 +120,66 @@ pub(crate) const SECRET_PREFIXES: &[&str] = &[
     "xoxb-",
     "xoxp-",
 ];
+
+/// True when `lower` carries a [`SECRET_PREFIXES`] entry at its start, or at an
+/// interior delimiter boundary with a credential-length run behind it.
+///
+/// Why (issue #7549): the test this replaced was `lower.starts_with(p)`, so one
+/// lowercase segment typed ahead of a real provider key defeated the entire
+/// prefix layer — `dpl_ghp_abcdefghijklmnopqrstuvwxyz0123456789` is a GitHub PAT
+/// wearing four characters of disguise and was not flagged. The miss compounds:
+/// the prefix layer is the FIRST thing [`looks_like_secret`] consults, so a
+/// no-answer there hands the token to [`is_structural_token`], whose
+/// segmented-identifier branch then rescues it outright because every segment of
+/// that token is lowercase-alphanumeric. A key written after `=`, after a quote,
+/// or inside a JSON pair lands in the same hole, since [`find_secret_token`]
+/// trims punctuation from a token's OUTER boundary only.
+///
+/// Why the preceding byte must be non-alphanumeric rather than anything at all,
+/// measured over this checkout (7,378 files, tokenised exactly as
+/// [`find_secret_token`] does): a bare substring match flags 46 distinct prose
+/// tokens, 32 of them ordinary English, because `sk-` is a substring of `disk-`,
+/// `risk-` and `task-` — `--disk-size`, `#6-risk-registers`,
+/// `feat/7313-disk-survey-by-session` and `single-primary-task-plus-secondaries`
+/// all become credentials. Requiring a delimiter in front takes that to 14 and
+/// removes every one of those shapes at no cost in detection: no issuer mints a
+/// key whose prefix begins mid-word.
+///
+/// Why the run behind an interior prefix must still reach [`SECRET_MIN_LEN`]:
+/// that is the floor offset 0 already answers to, applied by
+/// [`looks_like_secret`] to the whole token, so asking it of the interior suffix
+/// keeps one rule instead of two. Measured, it takes the 14 prose tokens to 1,
+/// and the 13 it drops are documentation placeholders too short to be keys
+/// (`GITHUB_TOKEN=ghp_xxx`, `SLACK_BOT_TOKEN=xoxb-`, `ANTHROPIC_API_KEY=sk-ant-`).
+/// The survivor is `OPENROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxx`, which is the shape
+/// this issue exists to catch.
+///
+/// Known accepted bound, unchanged in kind from offset 0 and now reachable at a
+/// boundary too: nothing is asked of the characters behind the prefix beyond
+/// their count, so a 20-character run opening with `sk-` is a credential here
+/// whether it is a key or a hyphenated phrase. `sk-eleton-key-for-the-front-door`
+/// was already flagged as a bare token before this change; the same run inside
+/// `notes/sk-eleton-key-for-the-front-door` is flagged after it. Pinned in
+/// `prose_prefix_substrings_are_not_flagged_after_7549`.
+/// What: byte-offset scan over the caller-lowercased token. Offset 0 matches
+/// exactly as before; an interior offset additionally requires the preceding
+/// byte to be non-ASCII-alphanumeric and the remaining suffix to be at least
+/// [`SECRET_MIN_LEN`] bytes.
+/// Test: `known_key_prefixes_are_blocked`,
+/// `prefixed_provider_keys_are_blocked_after_7549`,
+/// `prose_prefix_substrings_are_not_flagged_after_7549`,
+/// `known_accepted_bounds_after_7549`.
+pub(crate) fn carries_secret_prefix(lower: &str) -> bool {
+    SECRET_PREFIXES.iter().any(|p| {
+        lower.match_indices(p).any(|(at, _)| {
+            // #7549: an interior prefix counts only at a delimiter boundary and
+            // with a credential-length run behind it.
+            at == 0
+                || (lower.len() - at >= SECRET_MIN_LEN
+                    && !lower.as_bytes()[at - 1].is_ascii_alphanumeric())
+        })
+    })
+}
 
 /// AWS access key ID prefixes — long-term (`AKIA…`) and STS temporary
 /// credentials (`ASIA…`).
@@ -1065,7 +1126,9 @@ pub(crate) fn is_structural_token(token: &str) -> bool {
 /// What: returns `false` immediately for [`is_git_sha_like`] tokens (the
 /// allowlist) and for anything below [`SECRET_MIN_LEN`], then returns `true`
 /// when the token (a) carries a known [`SECRET_PREFIXES`] credential prefix
-/// (e.g. `sk-`, `ghp_`) or has the AWS key-id shape ([`is_aws_access_key_id`]),
+/// (e.g. `sk-`, `ghp_`) at its start or at an interior delimiter boundary
+/// ([`carries_secret_prefix`], issue #7549), or has the AWS key-id shape
+/// ([`is_aws_access_key_id`]),
 /// or (b) is not a structural token (see
 /// [`is_structural_token`]) AND mixes character classes in a way SHAs cannot
 /// — i.e. contains BOTH a lowercase and an uppercase letter plus a digit, or
@@ -1085,7 +1148,8 @@ pub(crate) fn is_structural_token(token: &str) -> bool {
 /// `git_sha_like_is_not_secret`, `ordinary_words_are_not_secret`,
 /// `aws_access_key_ids_are_blocked`, `mixed_case_no_digit_limitation`,
 /// `structural_tokens_are_not_flagged`,
-/// `vercel_deployment_ids_are_not_flagged`.
+/// `vercel_deployment_ids_are_not_flagged`,
+/// `prefixed_provider_keys_are_blocked_after_7549`.
 pub(crate) fn looks_like_secret(token: &str) -> bool {
     // Allowlist git SHAs first — the whole point of issue #1481.
     if is_git_sha_like(token) {
@@ -1102,7 +1166,9 @@ pub(crate) fn looks_like_secret(token: &str) -> bool {
         return false;
     }
     let lower = token.to_ascii_lowercase();
-    if SECRET_PREFIXES.iter().any(|p| lower.starts_with(p)) || is_aws_access_key_id(token) {
+    // #7549: a provider prefix counts at a delimiter boundary, not only at
+    // offset 0 — a lowercase segment typed in front used to hide the whole key.
+    if carries_secret_prefix(&lower) || is_aws_access_key_id(token) {
         return true;
     }
     // #7482: a vendor-issued PUBLIC resource id (a Vercel `dpl_` deployment id)

--- a/crates/trusty-common/src/memory_core/filter/secret.rs
+++ b/crates/trusty-common/src/memory_core/filter/secret.rs
@@ -102,10 +102,17 @@ pub fn check_secret(content: &str) -> Result<(), FilterReject> {
 /// regardless of their entropy profile. Matching the prefix is cheaper and more
 /// precise than entropy alone.
 ///
-/// Every entry here carries punctuation an English word never does, which is why
-/// [`SECRET_MIN_LEN`] is sufficient protection for this list. AWS `AKIA`/`ASIA`
-/// used to live here and is not (issue #4898) — it is four bare letters, so it
-/// needs a shape check; see [`AWS_KEY_ID_PREFIXES`].
+/// What a candidate entry must satisfy, restated since #7549 widened the match:
+/// an entry now fires at offset 0 OR at an interior delimiter boundary, so
+/// "carries punctuation an English word never does" is no longer the whole
+/// answer — `sk-` is the tail of `disk-`, `risk-` and `task-`, three of the most
+/// ordinary words in this project's prose. Vet a new entry against being a
+/// WORD-INTERNAL substring, not merely against containing punctuation. The two
+/// guards that make the list safe are the delimiter rule (a match beginning
+/// mid-word is declined) and the [`SECRET_MIN_LEN`] floor on the run the match
+/// opens; both live in [`carries_secret_prefix`] and are measured there. AWS
+/// `AKIA`/`ASIA` used to live here and is not (issue #4898) — it is four bare
+/// letters, so it needs a shape check; see [`AWS_KEY_ID_PREFIXES`].
 /// What: lowercased prefix list matched case-insensitively by
 /// [`carries_secret_prefix`] (the caller lowercases the token), after the
 /// [`SECRET_MIN_LEN`] floor.
@@ -122,7 +129,8 @@ pub(crate) const SECRET_PREFIXES: &[&str] = &[
 ];
 
 /// True when `lower` carries a [`SECRET_PREFIXES`] entry at its start, or at an
-/// interior delimiter boundary with a credential-length run behind it.
+/// interior delimiter boundary that opens a suffix of at least
+/// [`SECRET_MIN_LEN`] bytes (the prefix counted in).
 ///
 /// Why (issue #7549): the test this replaced was `lower.starts_with(p)`, so one
 /// lowercase segment typed ahead of a real provider key defeated the entire
@@ -145,10 +153,13 @@ pub(crate) const SECRET_PREFIXES: &[&str] = &[
 /// removes every one of those shapes at no cost in detection: no issuer mints a
 /// key whose prefix begins mid-word.
 ///
-/// Why the run behind an interior prefix must still reach [`SECRET_MIN_LEN`]:
-/// that is the floor offset 0 already answers to, applied by
-/// [`looks_like_secret`] to the whole token, so asking it of the interior suffix
-/// keeps one rule instead of two. Measured, it takes the 14 prose tokens to 1,
+/// Why the suffix an interior prefix OPENS — the prefix itself included, exactly
+/// as the code measures it at the `lower.len() - at` below — must still reach
+/// [`SECRET_MIN_LEN`]: that is the floor offset 0 already answers to, applied by
+/// [`looks_like_secret`] to the whole token, and at offset 0 the whole token IS
+/// that suffix. Measuring the same span keeps one rule instead of two: a match
+/// at a boundary is judged by what a match at offset 0 would have been judged by
+/// had the token started there. Measured, it takes the 14 prose tokens to 1,
 /// and the 13 it drops are documentation placeholders too short to be keys
 /// (`GITHUB_TOKEN=ghp_xxx`, `SLACK_BOT_TOKEN=xoxb-`, `ANTHROPIC_API_KEY=sk-ant-`).
 /// The survivor is `OPENROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxx`, which is the shape
@@ -172,8 +183,8 @@ pub(crate) const SECRET_PREFIXES: &[&str] = &[
 pub(crate) fn carries_secret_prefix(lower: &str) -> bool {
     SECRET_PREFIXES.iter().any(|p| {
         lower.match_indices(p).any(|(at, _)| {
-            // #7549: an interior prefix counts only at a delimiter boundary and
-            // with a credential-length run behind it.
+            // #7549: an interior prefix counts only at a delimiter boundary, and
+            // only when the suffix it opens (prefix included) is credential-length.
             at == 0
                 || (lower.len() - at >= SECRET_MIN_LEN
                     && !lower.as_bytes()[at - 1].is_ascii_alphanumeric())
@@ -1174,7 +1185,11 @@ pub(crate) fn looks_like_secret(token: &str) -> bool {
     // #7482: a vendor-issued PUBLIC resource id (a Vercel `dpl_` deployment id)
     // has a credential's character-class profile but is not a credential. Placed
     // BELOW the known-credential prefixes so a public-id prefix can never
-    // pre-empt one; both anchor at offset 0, so this is order-independent today.
+    // pre-empt one. #7549 note: the two anchor differently now (the prefix test
+    // also matches at an interior boundary), but the order still cannot matter —
+    // `is_public_resource_id` requires an all-ALPHANUMERIC tail of one exact
+    // length after `dpl_`, and every SECRET_PREFIXES entry carries a `-` or a
+    // second `_`, so no single token can satisfy both predicates.
     if is_public_resource_id(token) {
         return false;
     }

--- a/crates/trusty-common/src/memory_core/filter_tests.rs
+++ b/crates/trusty-common/src/memory_core/filter_tests.rs
@@ -3146,12 +3146,19 @@ fn prefixed_provider_keys_are_blocked_after_7549() {
 /// distinct prose tokens, 32 of them ordinary English; requiring the delimiter
 /// takes it to 14, and every token below is one the delimiter rule removes.
 ///
-/// The last two entries are real corpus tokens of a different shape: they clear
-/// the boundary rule (the prefix does follow a `=`) and are rejected by the
-/// second gate instead, the `SECRET_MIN_LEN` floor on the run behind the prefix.
-/// Both gates therefore have a reason to exist in this test, not just in the doc.
-/// What: asserts the token predicate declines each shape and that the end-to-end
-/// gate accepts prose carrying them.
+/// The trailing entries are a different shape: they clear the boundary rule (the
+/// prefix does follow a `=`) and the SECOND gate rejects them — the
+/// `SECRET_MIN_LEN` floor on the suffix the prefix opens, itself included. Both
+/// gates therefore have a reason to exist in this test, not only in the doc. Each
+/// such entry names the suffix length it actually presents, because a label that
+/// only said "short" carried a wrong number through review once.
+///
+/// The floor itself is then bracketed by a PAIR of assertions one filler byte
+/// apart, with the lengths asserted rather than eyeballed. A single
+/// under-the-floor case pins nothing: it passes just as well if the floor is 18,
+/// 19 or 25. The 19/20 pair is what fails the moment the floor moves.
+/// What: asserts the token predicate declines each shape, brackets the floor,
+/// and asserts the end-to-end gate accepts prose carrying these tokens.
 /// Test: itself.
 #[test]
 fn prose_prefix_substrings_are_not_flagged_after_7549() {
@@ -3176,12 +3183,23 @@ fn prose_prefix_substrings_are_not_flagged_after_7549() {
             "trusty-mpm/INSTRUCTIONS.md#macOS-Full-Disk-Access",
         ),
         ("compound with `risk-`", "2026-Q3-risk-register-rollup"),
-        // Prefix at a real boundary, but the run behind it is shorter than
-        // SECRET_MIN_LEN — a documentation placeholder, not a key.
-        ("docs placeholder, short body", "GITHUB_TOKEN=ghp_xxx"),
+        // Prefix at a real boundary, but the suffix it opens (prefix counted in,
+        // as `carries_secret_prefix` measures it) is under SECRET_MIN_LEN — a
+        // documentation placeholder, not a key. The length each one actually
+        // presents is named, because "short" alone let a wrong number sit here.
+        ("docs placeholder, suffix 7", "GITHUB_TOKEN=ghp_xxx"),
         (
-            "docs placeholder, body one short of the floor",
+            "docs placeholder, suffix 17",
             "SLACK_BOT_TOKEN=xoxb-xxxxxxxxxxxx",
+        ),
+        // THE FLOOR'S LOWER EDGE, load-bearing: `xoxb-` plus 14 filler is a
+        // 19-byte suffix, one under SECRET_MIN_LEN. Paired with the 20-byte case
+        // in the positive direction below — neither assertion pins the boundary
+        // alone, and without the pair the floor could drift to 18 or 19 with the
+        // whole corpus still green.
+        (
+            "suffix one byte under the floor",
+            "SLACK_BOT_TOKEN=xoxb-xxxxxxxxxxxxxx",
         ),
     ] {
         assert!(
@@ -3191,6 +3209,26 @@ fn prose_prefix_substrings_are_not_flagged_after_7549() {
              SECRET_MIN_LEN floor on the interior run was dropped: {tok}"
         );
     }
+
+    // The floor's two sides, measured rather than eyeballed. `at` differs from
+    // `under` by ONE filler byte, so the pair brackets SECRET_MIN_LEN exactly:
+    // move the floor either way and one of the two assertions fails.
+    let boundary_at = "SLACK_BOT_TOKEN=".len();
+    let under = "SLACK_BOT_TOKEN=xoxb-xxxxxxxxxxxxxx";
+    let at = "SLACK_BOT_TOKEN=xoxb-xxxxxxxxxxxxxxx";
+    assert_eq!(under.len() - boundary_at, SECRET_MIN_LEN - 1);
+    assert_eq!(at.len() - boundary_at, SECRET_MIN_LEN);
+    assert!(
+        find_secret_token(under).is_none(),
+        "#7549: a {}-byte suffix is one under SECRET_MIN_LEN and must not flag",
+        SECRET_MIN_LEN - 1
+    );
+    assert!(
+        find_secret_token(at).is_some(),
+        "#7549: a suffix of exactly SECRET_MIN_LEN bytes at a delimiter boundary \
+         must flag. With the assertion above, this pins the floor at \
+         {SECRET_MIN_LEN} — if only this one fails, the floor rose."
+    );
 
     let cfg = FilterConfig::default();
     for content in [

--- a/crates/trusty-common/src/memory_core/filter_tests.rs
+++ b/crates/trusty-common/src/memory_core/filter_tests.rs
@@ -2980,18 +2980,19 @@ fn real_secrets_still_blocked_after_7482_public_id_exemption() {
          FLAGS, something separated them; delete this assertion and say how."
     );
 
-    // KNOWN MISS 2, pre-existing and unrelated to #7482: an all-lowercase
-    // `_`-segmented token is a segmented identifier, so a provider key with ANY
-    // lowercase prefix typed in front of it is rescued by `is_structural_token`
-    // branch (c) before the prefix test can see it. The exemption is not
-    // involved — that tail carries a second `_` and is 40 characters, so
-    // `is_public_resource_id` declines it twice over.
+    // WAS KNOWN MISS 2, CLOSED by #7549. #7482 recorded it as accepted: an
+    // all-lowercase `_`-segmented token is a segmented identifier, so a provider
+    // key with any lowercase segment typed in front of it was rescued by
+    // `is_structural_token` branch (c) before the prefix test could see it. The
+    // prefix test now matches at a delimiter boundary as well as at offset 0, so
+    // the rescue never runs. Kept here, with the assertion inverted, because the
+    // shape belongs to this corpus: the exemption must not re-open it.
     assert!(
-        find_secret_token("dpl_ghp_abcdefghijklmnopqrstuvwxyz0123456789").is_none(), // pragma: allowlist secret
-        "KNOWN MISS (pre-existing, re-pinned by #7482): the structural rescue \
-         for `_`-segmented lowercase tokens hides a prefixed provider key. If \
-         this now FLAGS, that bypass was closed elsewhere — delete this \
-         assertion rather than widening anything."
+        find_secret_token("dpl_ghp_abcdefghijklmnopqrstuvwxyz0123456789").is_some(), // pragma: allowlist secret
+        "#7549: a provider key behind a prepended lowercase segment must be \
+         flagged. This was #7482's KNOWN MISS 2; if it is missed again, the \
+         boundary arm of `carries_secret_prefix` regressed or the public-id \
+         exemption grew in front of it."
     );
 
     // KNOWN REJECTION, and the bound on what #7482 fixed: a deployment id inside
@@ -3052,5 +3053,205 @@ fn known_accepted_bounds_after_7482() {
         "KNOWN ACCEPTED BOUND (#7482): a Vercel PROJECT id (`prj_`) is not on \
          the exemption list and still flags. If it now passes, the list grew — \
          add it to the assertion above."
+    );
+}
+
+// ---- Issue #7549: SECRET_PREFIXES match at a delimiter boundary, not only at
+// ---- the start of the token.
+
+/// Why (issue #7549): the prefix layer tested `lower.starts_with(p)`, so one
+/// lowercase segment typed ahead of a real provider key defeated it entirely —
+/// and because the prefix layer runs FIRST, its miss then handed the token to
+/// `is_structural_token`, whose segmented-identifier branch rescued it outright.
+/// Every entry below was MISSED before this change, each for a different reason
+/// in the same family, so the set pins the fix by placement rather than by one
+/// representative shape:
+///
+/// - prepended segment: rescued by `is_segmented_identifier` (the `dpl_ghp_…`
+///   reproduction the issue reports).
+/// - after `=`: rescued by branch (a), a word-shaped LHS plus a word-shaped RHS.
+/// - behind a quote: not rescued at all — the `"` fails
+///   `is_plausible_b64_charset`, and an all-lowercase body fails the mixed-case
+///   branch, so nothing was left to flag it.
+/// - inside a JSON pair: rescued by `is_segmented_identifier` again, because the
+///   quote and colon sit INSIDE a segment, where `is_human_word_segment` ignores
+///   them.
+/// - after a hyphen: rescued by `is_segmented_identifier`.
+///
+/// What: asserts each placement is flagged by `find_secret_token`, then that the
+/// end-to-end gate rejects the same key written into ordinary prose.
+/// Test: itself.
+#[test]
+fn prefixed_provider_keys_are_blocked_after_7549() {
+    let mut missed: Vec<String> = Vec::new();
+    for (label, tok) in [
+        (
+            "prepended lowercase segment",
+            "dpl_ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+        ), // pragma: allowlist secret
+        (
+            "after an `=` in an env-var assignment",
+            "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+        ), // pragma: allowlist secret
+        (
+            "behind a quote",
+            "token=\"ghp_abcdefghijklmnopqrstuvwxyz0123456789\"",
+        ), // pragma: allowlist secret
+        (
+            "inside a JSON pair",
+            "{\"token\":\"ghp_abcdefghijklmnopqrstuvwxyz0123456789\"}",
+        ), // pragma: allowlist secret
+        (
+            "after a hyphen, mid-token",
+            "backup-sk-abcdefghijklmnopqrstuvwxyz01234567890123",
+        ), // pragma: allowlist secret
+    ] {
+        // Collected, not asserted per iteration: each entry is a DIFFERENT
+        // rescue path, so a report naming only the first missed placement hides
+        // how many of them a regression reopened.
+        if find_secret_token(tok).is_none() {
+            missed.push(format!("{label} ({tok})"));
+        }
+    }
+    assert!(
+        missed.is_empty(),
+        "#7549: a provider key carrying a {SECRET_MIN_LEN}+ character run \
+         behind its prefix must be flagged wherever the prefix sits in the \
+         token. Missed placements: {missed:#?}"
+    );
+
+    // End-to-end, not just the token predicate: the gate is what a write hits.
+    let cfg = FilterConfig::default();
+    for content in [
+        "Rotate GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789 before the release", // pragma: allowlist secret
+        "The deploy log printed dpl_ghp_abcdefghijklmnopqrstuvwxyz0123456789 in plain text", // pragma: allowlist secret
+    ] {
+        assert!(
+            matches!(
+                cfg.apply(content, false),
+                Err(FilterReject::PotentialSecret { .. })
+            ),
+            "#7549: the gate must REJECT prose carrying a boundary-prefixed key; \
+             got {:?}",
+            cfg.apply(content, false)
+        );
+    }
+}
+
+/// Why (issue #7549): widening the prefix test to interior matches is only safe
+/// because the match must sit at a delimiter boundary. `sk-` is a substring of
+/// `disk-`, `risk-` and `task-`, three of the most ordinary words in this
+/// project's own prose. Measured over this checkout — 7,378 files, tokenised
+/// exactly as `find_secret_token` does — a boundary-free interior match flags 46
+/// distinct prose tokens, 32 of them ordinary English; requiring the delimiter
+/// takes it to 14, and every token below is one the delimiter rule removes.
+///
+/// The last two entries are real corpus tokens of a different shape: they clear
+/// the boundary rule (the prefix does follow a `=`) and are rejected by the
+/// second gate instead, the `SECRET_MIN_LEN` floor on the run behind the prefix.
+/// Both gates therefore have a reason to exist in this test, not just in the doc.
+/// What: asserts the token predicate declines each shape and that the end-to-end
+/// gate accepts prose carrying them.
+/// Test: itself.
+#[test]
+fn prose_prefix_substrings_are_not_flagged_after_7549() {
+    for (label, tok) in [
+        // `sk-` inside `disk-`, `risk-`, `task-` — rejected by the boundary rule,
+        // because the character before the prefix is a letter.
+        (
+            "branch name with `disk-`",
+            "feat/7313-disk-survey-by-session",
+        ),
+        (
+            "hyphenated phrase with `task-`",
+            "single-primary-task-plus-secondaries",
+        ),
+        (
+            "slash-joined flags with `disk-`",
+            "--cpu/--memory/--disk-size",
+        ),
+        ("path with `task-`", "autonomous/task-dispatch-for-autonomy"),
+        (
+            "anchor link with `Disk-`",
+            "trusty-mpm/INSTRUCTIONS.md#macOS-Full-Disk-Access",
+        ),
+        ("compound with `risk-`", "2026-Q3-risk-register-rollup"),
+        // Prefix at a real boundary, but the run behind it is shorter than
+        // SECRET_MIN_LEN — a documentation placeholder, not a key.
+        ("docs placeholder, short body", "GITHUB_TOKEN=ghp_xxx"),
+        (
+            "docs placeholder, body one short of the floor",
+            "SLACK_BOT_TOKEN=xoxb-xxxxxxxxxxxx",
+        ),
+    ] {
+        assert!(
+            find_secret_token(tok).is_none(),
+            "#7549 ({label}): an ordinary token carrying a prefix SUBSTRING must \
+             NOT be flagged. If it now flags, the boundary rule or the \
+             SECRET_MIN_LEN floor on the interior run was dropped: {tok}"
+        );
+    }
+
+    let cfg = FilterConfig::default();
+    for content in [
+        "The disk-survey work landed on feat/7313-disk-survey-by-session this week",
+        "Set GITHUB_TOKEN=ghp_xxx in the example env file and move on",
+    ] {
+        assert!(
+            cfg.apply(content, false).is_ok(),
+            "#7549: the gate must ACCEPT prose carrying a prefix substring; got \
+             {:?}",
+            cfg.apply(content, false)
+        );
+    }
+}
+
+/// Why (issue #7549): the widened prefix test asks nothing of the characters
+/// BEHIND the prefix beyond how many there are. That was already true at offset
+/// 0 — `known_accepted_bounds_after_4898` pins `sk-eleton-key-for-the-front-door`
+/// as flagged — and making an interior boundary count carries the same bound to
+/// every delimiter in the token. Pinning both halves is what makes a later
+/// tightening or loosening visible instead of silent.
+/// What: pins the predicate's two arms directly (offset 0, and a boundary with
+/// the length floor), then the accepted cost of the length-only rule.
+/// Test: itself.
+#[test]
+fn known_accepted_bounds_after_7549() {
+    // The predicate's own contract, asserted on the lowercased form the caller
+    // passes it, so a change to either arm shows up here and not only through
+    // `looks_like_secret`'s later branches.
+    assert!(
+        carries_secret_prefix("ghp_abcdefghijklmnopqrstuvwxyz0123456789"), // pragma: allowlist secret
+        "#7549: offset 0 must match exactly as it did before the change"
+    );
+    assert!(
+        carries_secret_prefix("dpl_ghp_abcdefghijklmnopqrstuvwxyz0123456789"), // pragma: allowlist secret
+        "#7549: a prefix after a delimiter, with a long run behind it, matches"
+    );
+    assert!(
+        !carries_secret_prefix("feat/7313-disk-survey-by-session"),
+        "#7549: a prefix substring beginning mid-word does not match"
+    );
+    assert!(
+        !carries_secret_prefix("github_token=ghp_xxx"),
+        "#7549: a prefix at a boundary with a sub-SECRET_MIN_LEN run does not match"
+    );
+
+    // KNOWN ACCEPTED BOUND: the interior arm inherits the length-only rule from
+    // offset 0, so a hyphenated English phrase behind `sk-` is a credential here
+    // too. The two assertions are a PAIR: the first shows the bare token was
+    // ALREADY flagged before this change (#4898 pins it), the second shows the
+    // boundary arm carries that verdict to the same run inside a path. Widening
+    // this is not a #7549 regression; narrowing it means narrowing offset 0 too.
+    assert!(
+        find_secret_token("sk-eleton-key-for-the-front-door").is_some(),
+        "the bare form must be flagged, or the bound below proves nothing"
+    );
+    assert!(
+        find_secret_token("notes/sk-eleton-key-for-the-front-door").is_some(),
+        "KNOWN ACCEPTED BOUND (#7549): the prefix test is length-gated, not \
+         shape-gated, at an interior boundary exactly as it is at offset 0. If \
+         this stops flagging, the interior arm grew a shape check that offset 0 \
+         does not have — make both arms agree."
     );
 }


### PR DESCRIPTION
## Outcome

`SECRET_PREFIXES` redaction only matched when a known prefix (`sk-`, `ghp_`,
etc.) started a token, so the same secret placed after a delimiter — an
env-var `KEY=sk-...`, a quoted JSON value, a prepended segment, or a
mid-token hyphen boundary — passed through unredacted. This widens the
predicate to match at any delimiter boundary, not only at token start.

Refs bobmatnyc/trusty-tools#7549

## What changed / out of scope

- `crates/trusty-common`: widened the `SECRET_PREFIXES` match predicate so a
  known prefix is recognized after `=`, quotes, JSON key/value punctuation,
  and other non-alphanumeric delimiters, not only at the very start of a
  token.
- Corrected four doc-comment claims that the widened predicate invalidated,
  and bracketed the interior-match length floor with an exact edge-case
  pair, in the follow-up review commit.
- Out of scope: no change to which prefixes are recognized, no change to the
  redaction output format, no change to callers.

## Risk / blast radius

Rung 4 — shared library (`trusty-common`) on a security-sensitive path
(secret redaction). Widening the match predicate can only make redaction
MORE aggressive (matches at more boundaries), which is the safe direction
for a redaction false-negative; the added tests pin the false-positive
bound so prose containing prefix-like substrings (`disk-`, `risk-`,
`task-`) is not over-redacted.

## Test evidence

- `cargo fmt --check` — clean.
- `cargo check -p trusty-common` — clean.
- `cargo clippy -p trusty-common --features memory-core,embedder-test-support --all-targets -- -D warnings` — clean.
- `cargo test -p trusty-common --features memory-core,embedder-test-support --no-fail-fast` — 1414 passed, 0 failed (lib), 12 targets all ok.
- `cargo check --workspace` — clean.
- Consumers (rung 4 dependent testing): `cargo test -p trusty-memory --no-fail-fast` — 878 passed, 35 targets ok; `cargo test -p trusty-agents --no-fail-fast` — 3981 passed, 14 targets ok.
- Regression tests added:
  - `prefixed_provider_keys_are_blocked_after_7549` — fails against the origin/main predicate on all five placements (env-var `=`, quote, JSON pair, prepended segment, mid-token hyphen); passes with this fix.
  - `prose_prefix_substrings_are_not_flagged_after_7549` — pins the false-positive bound (`disk-`, `risk-`, `task-` substrings stay clean).
  - `known_accepted_bounds_after_7549` — pins the interior-match arm's length floor with an exact edge pair.

## Baseline / pre-existing failures

None observed. All gates above are green on this branch.

## Documentation / changelog status

Changelog fragment added under `crates/trusty-common/changelog.d/`. Doc
comments touched by the widened predicate were corrected in the review-round
commit (56d1b7815) rather than left stale.

## Review-finding disposition

`code-critic` returned APPROVE on the initial fix commit (11fa2aba4). Three
doc-invariant corrections and the interior-match length-floor edge-case pair
it flagged were addressed directly in this PR (56d1b7815), not deferred.
Security scan (credential/secret diff scan) PASS on both commits.

Refs #7549

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
