### PR TITLE
test(trusty-mpm): spawned tm binaries get a temp $HOME through one helper; ratchet forbids raw CARGO_BIN_EXE_tm outside it (Refs #7568)

### DIFF
--- a/crates/trusty-mpm/tests/commit_stats_hook_budget.rs
+++ b/crates/trusty-mpm/tests/commit_stats_hook_budget.rs
@@ -16,6 +16,8 @@
 //! answer: `merge`, `squash`, and `commit` with and without a session.
 //! Test: this file IS the test module.
 
+mod common;
+
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -77,9 +79,12 @@ impl Fixture {
     /// Put the real `tm` binary on the hook's `PATH`, as a shim rather than a
     /// copy: it keeps the test off any code-signing question and costs nothing.
     fn real_tm(&self) {
+        // #7568: the hook finds `tm` by name on `PATH`, so this needs the path
+        // rather than a `Command`. The isolation goes on the `/bin/sh` that
+        // runs the hook, in `run_sourced` below, and the shim inherits it.
         write_executable(
             &self.bin.join("tm"),
-            &format!("#!/bin/sh\nexec {:?} \"$@\"\n", env!("CARGO_BIN_EXE_tm")),
+            &format!("#!/bin/sh\nexec {:?} \"$@\"\n", common::tm_bin()),
         );
     }
 
@@ -107,12 +112,14 @@ impl Fixture {
             std::env::var("PATH").unwrap_or_default()
         );
         let mut cmd = Command::new("/bin/sh");
+        // #7568: applied first, so the caller's `TRUSTY_MPM_ROOT` and session
+        // id below survive it and only the inherited ones are scrubbed.
+        common::isolate_spawned_tm(&mut cmd, common::tm_spawn_home());
         cmd.arg(&self.hook)
             .arg(&self.message)
             .env("PATH", path)
             .env("TM_COMMIT_STATS_TIMEOUT", budget)
-            .env_remove("TM_SKIP_COMMIT_STATS")
-            .env_remove("CLAUDE_CODE_SESSION_ID");
+            .env_remove("TM_SKIP_COMMIT_STATS");
         if let Some(source) = source {
             cmd.arg(source);
         }

--- a/crates/trusty-mpm/tests/common/mod.rs
+++ b/crates/trusty-mpm/tests/common/mod.rs
@@ -20,8 +20,18 @@
 //! Test: every test in `manager_routes`, `project_registry_routes`,
 //! `manager_cli_client`, `manager_inference` and `mcp_spawn_gate`. Each now
 //! asserts against a registry the host machine cannot reach.
+//!
+//! #7568 adds the second half of the same concern: a target that spawns the
+//! built `tm` binary hands the CHILD an environment, and a child that inherits
+//! `$HOME` resolves the operator's own `~/.trusty-mpm`. [`tm_command`],
+//! [`tm_command_in`] and [`isolate_spawned_tm`] are the one seam every such
+//! spawn goes through; `tests/spawned_tm_home_isolation.rs` is the ratchet that
+//! keeps them the only one.
+
+#![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::OnceLock;
 
 /// Redirect this test process's `$HOME` to a scratch directory, once (#6671).
@@ -49,4 +59,103 @@ pub fn scratch_home() -> &'static Path {
         dir
     })
     .as_path()
+}
+
+/// The `tm` binary cargo built for this integration target (#7568).
+///
+/// Why: this is the ONE place `CARGO_BIN_EXE_tm` is named. Every other spawn
+/// site reaches the binary through [`tm_command`] / [`tm_command_in`], which
+/// also isolate the child; the two targets that need the raw PATH (a `sh -c`
+/// pipeline, a `PATH` shim) are ratcheted by
+/// `tests/spawned_tm_home_isolation.rs` and isolate the outer process
+/// themselves with [`isolate_spawned_tm`].
+pub fn tm_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_tm")
+}
+
+/// Variables that would point a spawned `tm` back at the operator's own state.
+///
+/// Why (#7568): redirecting `$HOME` alone is not enough. `TRUSTY_MPM_ROOT` and
+/// the XDG config file both outrank the home-relative default in the framework
+/// root chain (`--root` > `TRUSTY_MPM_ROOT` > XDG config > `~/.trusty-mpm`),
+/// `CLAUDE_CONFIG_DIR` is absolute and survives a `$HOME` repoint (#5544), and
+/// `CLAUDE_CODE_SESSION_ID` is what made a spawned child append a real row to
+/// the operator's savings ledger (#7514). `TRUSTY_MPM_URL`, `TMUX` and the
+/// managed-session ids make a child adopt the developer's live daemon, tmux
+/// server and session rather than the fixture's.
+///
+/// What: cleared on the CHILD only. Nothing here touches this process's
+/// environment, so the `#5544` hazard — a `set_var` visible to every parallel
+/// sibling in the same test binary — does not arise.
+/// Test: `the_helper_clears_every_state_pointing_var`.
+const CHILD_STATE_ENV: &[&str] = &[
+    "TRUSTY_MPM_ROOT",
+    "TRUSTY_MPM_URL",
+    "XDG_CONFIG_HOME",
+    "CLAUDE_CONFIG_DIR",
+    trusty_mpm::core::savings::CLAUDE_CODE_SESSION_ID_ENV,
+    "CLAUDE_SESSION_ID",
+    "TM_MANAGED_SESSION_ID",
+    "TRUSTY_MPM_MANAGED_SESSION_ID",
+    "TMUX",
+    "TMUX_PANE",
+    "REPOS_ROOT",
+    "GH_CONFIG_DIR",
+];
+
+/// Point `cmd`'s child at `home` and strip every other state-pointing variable.
+///
+/// Why (#7568): a spawned `tm` resolves `~/.trusty-mpm` from the `$HOME` it
+/// inherits, so an integration target that spawns the binary writes into the
+/// operator's own framework root — observed as `migrations.json`,
+/// `compression.jsonl` and `usage/` markers appearing under a real `$HOME`
+/// during `cargo test -p trusty-mpm`.
+/// What: one `env("HOME", …)` plus an `env_remove` per [`CHILD_STATE_ENV`]
+/// entry, applied to the child's environment block. A caller that needs its own
+/// value for one of these chains `.env(…)` afterwards — the later call for a key
+/// wins — and a caller that needs `$HOME` absent chains `.env_remove("HOME")`.
+/// Test: `a_spawned_tm_resolves_the_helper_home_and_leaves_the_operators_alone`,
+/// `the_helper_clears_every_state_pointing_var`.
+pub fn isolate_spawned_tm<'a>(cmd: &'a mut Command, home: &Path) -> &'a mut Command {
+    cmd.env("HOME", home);
+    for key in CHILD_STATE_ENV {
+        cmd.env_remove(key);
+    }
+    cmd
+}
+
+/// A `tm` command whose child is confined to `home`.
+pub fn tm_command_in(home: &Path) -> Command {
+    let mut cmd = Command::new(tm_bin());
+    isolate_spawned_tm(&mut cmd, home);
+    cmd
+}
+
+/// The scratch `$HOME` this test process hands its spawned children (#7568).
+///
+/// Why: most spawn sites never inspect what the child wrote — they assert on
+/// stdout — so one scratch home per PROCESS is enough isolation and avoids
+/// leaking a directory per spawn. A test that reads the child's writes back
+/// calls [`tm_command_in`] with a home it owns.
+/// What: a `OnceLock` scratch directory under `/tmp`, `keep()`-ed for the same
+/// reason [`scratch_home`] keeps its own and carrying the same `tm-test-`
+/// prefix, so `test_support::sweep_stale_test_dirs` reaps it after a day.
+/// Unlike [`scratch_home`] this NEVER calls `set_var` — the path is handed to
+/// spawned children and to nothing else.
+pub fn tm_spawn_home() -> &'static Path {
+    static SPAWN_HOME: OnceLock<PathBuf> = OnceLock::new();
+    SPAWN_HOME
+        .get_or_init(|| {
+            tempfile::Builder::new()
+                .prefix("tm-test-spawn-home-")
+                .tempdir_in("/tmp")
+                .expect("create scratch spawn $HOME")
+                .keep()
+        })
+        .as_path()
+}
+
+/// A `tm` command confined to [`tm_spawn_home`].
+pub fn tm_command() -> Command {
+    tm_command_in(tm_spawn_home())
 }

--- a/crates/trusty-mpm/tests/config_mount.rs
+++ b/crates/trusty-mpm/tests/config_mount.rs
@@ -5,20 +5,16 @@
 //! on every primary binary; this asserts the mount actually wired up HERE by
 //! driving the real built binary — `config --help` parses and `config keys
 //! list` runs fully offline (no key required, no value is ever printed).
-//! What: spawns the binary via the Cargo-provided `CARGO_BIN_EXE_*` path and
-//! checks the two offline invocations exit success with the expected surface
-//! text.
+//! What: spawns the real built binary through `common::tm_command` — which
+//! confines the child to a scratch `$HOME` (#7568) — and checks the two offline
+//! invocations exit success with the expected surface text.
 //! Test: this file IS the test.
 
-use std::process::Command;
-
-/// Absolute path to the freshly built binary (Cargo sets this for integration
-/// tests). Using it guarantees we exercise the real mounted CLI, not a stub.
-const BIN: &str = env!("CARGO_BIN_EXE_tm");
+mod common;
 
 #[test]
 fn config_help_advertises_keys_feature() {
-    let out = Command::new(BIN)
+    let out = common::tm_command()
         .args(["config", "--help"])
         .output()
         .expect("spawn `config --help`");
@@ -36,7 +32,7 @@ fn config_help_advertises_keys_feature() {
 
 #[test]
 fn config_keys_list_runs_offline() {
-    let out = Command::new(BIN)
+    let out = common::tm_command()
         .args(["config", "keys", "list"])
         .output()
         .expect("spawn `config keys list`");

--- a/crates/trusty-mpm/tests/meta_demo_e2e.rs
+++ b/crates/trusty-mpm/tests/meta_demo_e2e.rs
@@ -7,11 +7,13 @@
 //! `#[ignore]`-gated; the CI-runnable coverage is the pure poll/verify unit tests
 //! in the `tm` binary's `commands::meta::{launch,verify}` modules. This file is
 //! the documented local-validation entry point for the POC success criterion.
-//! What: runs the built `tm` binary (`CARGO_BIN_EXE_tm`) as
+//! What: runs the built `tm` binary (via `common::tm_bin`) as
 //! `meta run --demo --project <tmp> --timeout-secs <n>` against a throwaway dir
 //! and asserts the process exits 0 (the #1051 acceptance criterion) and the
 //! artifact exists with the expected marker.
 //! Test: this file (run with `cargo test -p trusty-mpm --test meta_demo_e2e -- --include-ignored`).
+
+mod common;
 
 use std::process::Command;
 
@@ -32,7 +34,10 @@ fn meta_run_demo_writes_and_verifies_artifact() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let project = tmp.path();
 
-    let bin = env!("CARGO_BIN_EXE_tm");
+    // #7568: deliberately NOT confined to a scratch `$HOME`. This is a live,
+    // `#[ignore]`d run against the framework the operator actually installed —
+    // a scratch home would make it untestable rather than hermetic.
+    let bin = common::tm_bin();
     let output = Command::new(bin)
         .args([
             "meta",

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -10,6 +10,8 @@
 //! cache-hit test proving the LLM is skipped on repeated identical content.
 //! Test: this file IS the test; run with `cargo test -p trusty-mpm`.
 
+mod common;
+
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -1176,8 +1178,8 @@ async fn front_gate_answer_unblocks_spawn() {
 /// to exit 75. Pointing the command at a dead loopback port forces the transport
 /// (unreachable) branch deterministically without standing up a daemon.
 /// What: spawns `tm --url http://127.0.0.1:<dead> sessions prune-idle --json` and
-/// asserts the process exits with status code 75. Uses `CARGO_BIN_EXE_tm`
-/// (set by Cargo for integration tests) so no extra dev-dependency is needed.
+/// asserts the process exits with status code 75. The command comes from
+/// `common::tm_command_in`, so no extra dev-dependency is needed.
 /// A hermetic HOME is planted with a lock file that anchors the lock-file
 /// fallback in `resolve_daemon_url_probing` (#1731) to the same dead port,
 /// preventing a live daemon on the default port from intercepting resolution.
@@ -1199,8 +1201,6 @@ async fn front_gate_answer_unblocks_spawn() {
 /// Test: this test.
 #[test]
 fn cli_prune_idle_unreachable_exit_code() {
-    use std::process::Command;
-
     // Plant a hermetic HOME so `resolve_daemon_url_probing` (#1731) cannot fall
     // back to a real daemon's `~/.trusty-mpm/daemon.lock`. The fake lock file
     // points at the same dead port with our PID (alive) so the staleness check
@@ -1218,8 +1218,9 @@ fn cli_prune_idle_unreachable_exit_code() {
 
     // 127.0.0.1:1 is a reserved/dead port: connecting there fails fast with a
     // transport error, which is exactly the SM-unavailable (exit 75) path.
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let output = Command::new(bin)
+    // #7568: `tm_command_in` pins that same hermetic HOME on the child and
+    // strips the rest of the operator's state pointers with it.
+    let output = common::tm_command_in(fake_home.path())
         .args([
             "--url",
             "http://127.0.0.1:1",
@@ -1227,7 +1228,6 @@ fn cli_prune_idle_unreachable_exit_code() {
             "prune-idle",
             "--json",
         ])
-        .env("HOME", fake_home.path())
         .output()
         .expect("spawn tm binary");
 

--- a/crates/trusty-mpm/tests/spawned_tm_home_isolation.rs
+++ b/crates/trusty-mpm/tests/spawned_tm_home_isolation.rs
@@ -1,0 +1,493 @@
+//! A spawned `tm` never reaches the operator's `$HOME` (#7568).
+//!
+//! Why: an integration target that runs the built binary hands the CHILD an
+//! environment, and a child that inherits `$HOME` resolves the operator's own
+//! `~/.trusty-mpm`. Measured on `origin/main` by running each spawn-site target
+//! under a scratch `$HOME`: nine of them created `<HOME>/.trusty-mpm/`, and
+//! `tm_compress_pipe` additionally appended to `compression.jsonl` — the
+//! savings ledger #7514 fixed for the unit-test path. Redirecting `$HOME`
+//! inside the test PROCESS is not the answer either: that is the #5544 hazard,
+//! a process-global write visible to every parallel sibling in the same binary.
+//! The child's own environment block is the injection point.
+//!
+//! What: three live tests and two source rules.
+//!   - [`an_unisolated_spawn_writes_into_whatever_home_it_inherits`] pins the
+//!     hazard — the pre-fix shape, proving the marker file this file asserts on
+//!     is a real signal rather than something that appears unconditionally.
+//!   - [`a_spawned_tm_resolves_the_helper_home_and_leaves_the_operators_alone`]
+//!     is the regression guard: the same spawn through `common::isolate_spawned_tm`
+//!     writes under the confined home, writes nothing under the home it would
+//!     have inherited, and leaves the operator's framework root untouched.
+//!   - [`the_helper_clears_every_state_pointing_var`] covers the escape hatches
+//!     a `$HOME` redirect alone does not close.
+//!   - [`no_test_source_names_the_bin_env_outside_the_helper`] — HARD rule, no
+//!     allowlist. `tests/common/mod.rs` is the only source that may name the
+//!     cargo-provided binary-path variable, so every other spawn site must come
+//!     through the helper to reach the binary at all.
+//!   - [`raw_binary_path_use_does_not_grow`] — RATCHET. Two targets need the
+//!     PATH rather than a `Command` (a `sh -c` pipeline, a `PATH` shim) and one
+//!     is a deliberately live `#[ignore]` test; each is counted against
+//!     [`RAW_BIN_BUDGET`] so the population cannot grow unreviewed.
+//!
+//! The scan is line-based over `crates/trusty-mpm/tests/**`, not a Rust parser.
+//! The lib target cannot host this defect at all — cargo sets the binary-path
+//! variable only for integration and bench targets — so `src/**` is out of
+//! scope by construction rather than by omission.
+//! Test: this file IS the test module.
+
+mod common;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::SystemTime;
+
+/// An invocation that reaches `main`'s body and writes the framework root.
+///
+/// Why: `--help` exits inside clap, before the one-time skill migration that
+/// creates `<framework root>/migrations.json` — so it proves nothing about
+/// which `$HOME` the child resolved. A real subcommand against a dead port
+/// runs that block, fails fast on the transport, and never needs a daemon.
+const PROBE_ARGS: &[&str] = &["--url", "http://127.0.0.1:1", "sessions", "list"];
+
+/// The file a `tm` run leaves in whichever framework root it resolved.
+const MIGRATION_MARKER: &str = "migrations.json";
+
+/// Run the probe and return the framework root it should have written.
+fn framework_root_of(home: &Path) -> PathBuf {
+    home.join(".trusty-mpm")
+}
+
+/// The operator's own framework root, when this process has a `$HOME` at all.
+fn operator_framework_root() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| framework_root_of(Path::new(&home)))
+}
+
+/// Direct children of `root`, plus the migration marker's size and mtime.
+///
+/// Why: the harm #7568 reports is new FILES under the operator's framework root
+/// — `migrations.json`, `compression.jsonl`, a `usage/` marker tree. A name set
+/// catches exactly that. A recursive mtime comparison would not: on a developer
+/// machine a live daemon writes under `~/.trusty-mpm/` throughout the run, so
+/// mtime equality would report a flake rather than a finding. The marker file
+/// is exempt from that reasoning — it is written at most once per machine, so
+/// its size and mtime are a stable equality check.
+/// What: `(sorted direct child names, Some((len, mtime)) for the marker)`. A
+/// missing root is an empty snapshot, which is the CI case.
+/// Test: the two live tests below take it before and after.
+fn snapshot(root: &Path) -> (Vec<String>, Option<(u64, SystemTime)>) {
+    let mut names: Vec<String> = std::fs::read_dir(root)
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    let marker = std::fs::metadata(root.join(MIGRATION_MARKER))
+        .ok()
+        .and_then(|m| Some((m.len(), m.modified().ok()?)));
+    (names, marker)
+}
+
+/// The hazard, pinned: a spawned `tm` writes into the `$HOME` it is given.
+///
+/// Why: this is the pre-fix shape every spawn site had, and it is what makes
+/// the regression guard below meaningful — without it, a `migrations.json` that
+/// never appeared for an unrelated reason would read as a pass.
+/// What: spawns the binary with `$HOME` pointed at a decoy directory standing
+/// in for the operator's, with no isolation, and asserts the child created the
+/// decoy's framework root.
+/// Test: this function IS the test.
+#[test]
+fn an_unisolated_spawn_writes_into_whatever_home_it_inherits() {
+    let decoy = tempfile::tempdir().expect("decoy $HOME");
+
+    // #7568: deliberately NOT routed through `common::tm_command_in` — this
+    // test exists to show what that helper prevents.
+    let output = Command::new(common::tm_bin())
+        .args(PROBE_ARGS)
+        .env("HOME", decoy.path())
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("spawn the tm binary");
+
+    assert!(
+        framework_root_of(decoy.path())
+            .join(MIGRATION_MARKER)
+            .is_file(),
+        "an unisolated `tm` must write its framework root under the `$HOME` it was \
+         handed — if this stops holding, the regression guard below is asserting on \
+         a file nothing creates any more and must be re-pointed. stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The helper confines the child and leaves the operator's root untouched.
+///
+/// Why: the closure condition of #7568. The child must resolve the home the
+/// helper named, not the one the test process would have passed down.
+/// What: sets a decoy `$HOME` on the child FIRST — indistinguishable, from the
+/// child's side, from an inherited one — then applies `isolate_spawned_tm`,
+/// which must win. Asserts the confined home gained the marker, the decoy gained
+/// nothing at all, and the operator's framework root has no new direct child and
+/// an unchanged marker.
+/// Test: this function IS the test.
+#[test]
+fn a_spawned_tm_resolves_the_helper_home_and_leaves_the_operators_alone() {
+    let decoy = tempfile::tempdir().expect("decoy $HOME");
+    let confined = tempfile::tempdir().expect("confined $HOME");
+    let operator = operator_framework_root();
+    let before = operator.as_deref().map(snapshot);
+
+    let mut cmd = Command::new(common::tm_bin());
+    cmd.env("HOME", decoy.path());
+    common::isolate_spawned_tm(&mut cmd, confined.path());
+    let output = cmd
+        .args(PROBE_ARGS)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("spawn the tm binary");
+
+    assert!(
+        framework_root_of(confined.path())
+            .join(MIGRATION_MARKER)
+            .is_file(),
+        "the child must resolve the helper's `$HOME`; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !framework_root_of(decoy.path()).exists(),
+        "the child must not touch the `$HOME` it would otherwise have inherited"
+    );
+
+    if let (Some(root), Some(before)) = (operator.as_deref(), before) {
+        let after = snapshot(root);
+        let added: Vec<&String> = after.0.iter().filter(|n| !before.0.contains(n)).collect();
+        assert!(
+            added.is_empty(),
+            "a spawned `tm` added {added:?} under the operator's own {} (#7568). Cargo runs \
+             integration targets as parallel PROCESSES, so a concurrent target's unisolated \
+             spawn can be the writer — that is the same defect, reported here rather than \
+             silently tolerated.",
+            root.display()
+        );
+        assert_eq!(
+            after.1, before.1,
+            "the operator's {MIGRATION_MARKER} changed size or mtime across the run"
+        );
+    }
+}
+
+/// Every state-pointing variable is cleared on the child.
+///
+/// Why: `$HOME` alone does not confine the child — `TRUSTY_MPM_ROOT` outranks
+/// the home-relative default outright, and `CLAUDE_CONFIG_DIR` is absolute, so
+/// either one inherited from the operator's shell re-escapes a redirected home.
+/// What: hands the child a `TRUSTY_MPM_ROOT` pointing at a directory the helper
+/// must strip, then asserts the marker landed under the helper's home rather
+/// than that root.
+/// Test: this function IS the test.
+#[test]
+fn the_helper_clears_every_state_pointing_var() {
+    let confined = tempfile::tempdir().expect("confined $HOME");
+    let escape = tempfile::tempdir().expect("escape root");
+
+    let mut cmd = Command::new(common::tm_bin());
+    cmd.env("TRUSTY_MPM_ROOT", escape.path())
+        .env("CLAUDE_CONFIG_DIR", escape.path());
+    common::isolate_spawned_tm(&mut cmd, confined.path());
+    let output = cmd
+        .args(PROBE_ARGS)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("spawn the tm binary");
+
+    assert!(
+        !escape.path().join(MIGRATION_MARKER).is_file(),
+        "an inherited TRUSTY_MPM_ROOT must be stripped, not honoured; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        framework_root_of(confined.path())
+            .join(MIGRATION_MARKER)
+            .is_file(),
+        "with the escape hatches stripped the child falls back to the helper's `$HOME`"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Source rules
+// ---------------------------------------------------------------------------
+
+/// The cargo variable naming the built binary, spelled in two halves.
+///
+/// Why: this file's own scan reads every `tests/**` source. Writing the name as
+/// one literal here would make the gate fire on itself, and skipping this file
+/// from the scan to avoid that would leave a hole any future edit could widen.
+/// Splitting it keeps the file inside its own scan.
+const BIN_ENV_HALVES: (&str, &str) = ("CARGO_BIN_", "EXE_tm");
+
+/// The only source permitted to name [`BIN_ENV_HALVES`].
+const HELPER_SUFFIX: &str = "tests/common/mod.rs";
+
+/// This file, skipped by rule 2 only.
+///
+/// Why: rule 1 still reads this file — that is what [`BIN_ENV_HALVES`]'s split
+/// spelling buys. Rule 2 counts a bare `tm_bin(` token, which this file's own
+/// assertion messages and detector sample carry as ordinary string data, so a
+/// budget number here would track its prose rather than its spawns.
+const SELF_SUFFIX: &str = "tests/spawned_tm_home_isolation.rs";
+
+/// Per-file budget of `tm_bin()` call sites — spawns that take the raw PATH.
+///
+/// Why: a `Command` built by the helper is isolated by construction; a caller
+/// that takes the PATH string builds its own process and must apply
+/// `common::isolate_spawned_tm` itself. That is a reviewable claim per site, so
+/// the population is ratcheted rather than banned. Lowering a number is always
+/// welcome; raising one says a new raw-PATH spawn was reviewed.
+/// What: `(path suffix, sites)`, counted after comment stripping.
+const RAW_BIN_BUDGET: &[(&str, usize)] = &[
+    // A `PATH` shim: the hook under test finds `tm` by name, so it needs the
+    // path, and the isolation goes on the `/bin/sh` that runs the hook.
+    ("tests/commit_stats_hook_budget.rs", 1),
+    // A `sh -c` pipeline with `tm compress` at its tail; the isolation goes on
+    // the shell.
+    ("tests/tm_compress_pipe.rs", 1),
+    // `#[ignore]`d live test (#1053): it drives a real `claude` session against
+    // the framework the operator actually installed, so a scratch `$HOME` would
+    // make it untestable rather than hermetic. Never run in CI.
+    ("tests/meta_demo_e2e.rs", 1),
+];
+
+/// `crates/trusty-mpm/tests`.
+fn tests_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests")
+}
+
+/// Every `.rs` file under `tests/`.
+fn test_sources() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir)
+            .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+            .filter_map(Result::ok)
+        {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(&tests_root(), &mut out);
+    assert!(
+        out.len() > 20,
+        "the tests/ walk found only {} files — a broken walk reports a clean tree \
+         regardless of its contents",
+        out.len()
+    );
+    out.sort();
+    out
+}
+
+/// Offset of the first `//` in `segment` that opens a comment.
+///
+/// Why: these targets spawn `tm` against `http://127.0.0.1:1` on the same line
+/// as the command they build. Treating that `//` as a comment would truncate
+/// the line and hide whatever follows, which for a one-line spawn is the whole
+/// detection. `prefix` is what the line already contributed, so a `://` split
+/// across a block-comment boundary still reads as a URL.
+fn line_comment_at(prefix: &str, segment: &str) -> Option<usize> {
+    let mut from = 0;
+    while let Some(rel) = segment[from..].find("//") {
+        let at = from + rel;
+        let preceding = if at == 0 {
+            prefix.chars().last()
+        } else {
+            segment[..at].chars().last()
+        };
+        if preceding == Some(':') {
+            from = at + 2;
+            continue;
+        }
+        return Some(at);
+    }
+    None
+}
+
+/// `text` with `/* … */` and `// …` comments removed.
+///
+/// Why: several targets discuss the binary-path variable in their module docs,
+/// and this file's own prose names the raw-PATH helper. Counting prose would
+/// make both rules fire on documentation. The two comment forms must be read in
+/// the order they APPEAR, not one kind and then the other: a doc comment
+/// carrying a glob such as `src/bin/tm/**` contains `/*`, so a block-comment
+/// pass that ran first would hunt for a `*/` that never comes and discard the
+/// rest of the file — silently reporting a clean target, which is the one
+/// outcome a guard must never produce.
+/// What: one pass per line carrying a block-comment flag, taking whichever of
+/// `//` (see [`line_comment_at`]) and `/*` comes first. Lines are preserved, so
+/// the result stays line-addressable.
+/// Test: `comment_stripping_keeps_code_and_drops_prose`.
+fn code_only(text: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let mut in_block = false;
+    for line in text.lines() {
+        let mut kept = String::new();
+        let mut rest = line;
+        loop {
+            if in_block {
+                match rest.find("*/") {
+                    Some(at) => {
+                        rest = &rest[at + 2..];
+                        in_block = false;
+                    }
+                    None => break,
+                }
+            }
+            let comment = line_comment_at(&kept, rest);
+            let block = rest.find("/*");
+            match (comment, block) {
+                (Some(c), Some(b)) if b < c => {
+                    kept.push_str(&rest[..b]);
+                    rest = &rest[b + 2..];
+                    in_block = true;
+                }
+                (Some(c), _) => {
+                    kept.push_str(&rest[..c]);
+                    break;
+                }
+                (None, Some(b)) => {
+                    kept.push_str(&rest[..b]);
+                    rest = &rest[b + 2..];
+                    in_block = true;
+                }
+                (None, None) => {
+                    kept.push_str(rest);
+                    break;
+                }
+            }
+        }
+        lines.push(kept);
+    }
+    lines.join("\n")
+}
+
+/// Rule 1 — only the helper names the cargo binary-path variable.
+///
+/// Why: it is the one thing every spawn site needs, so gating it routes every
+/// site through `tests/common/mod.rs`, where the isolation lives. The allowlist
+/// is a single path and is deliberately not extendable by a table: a target
+/// that genuinely needs the raw PATH calls `common::tm_bin()` and answers to
+/// rule 2 instead.
+/// Test: this function IS the test; `the_rules_detect_what_they_are_shown`
+/// proves the detection fires.
+#[test]
+fn no_test_source_names_the_bin_env_outside_the_helper() {
+    let needle = format!("{}{}", BIN_ENV_HALVES.0, BIN_ENV_HALVES.1);
+    let mut findings = Vec::new();
+    for path in test_sources() {
+        let display = path.display().to_string();
+        if display.ends_with(HELPER_SUFFIX) {
+            continue;
+        }
+        if code_only(&std::fs::read_to_string(&path).expect("read source")).contains(&needle) {
+            findings.push(display);
+        }
+    }
+    assert!(
+        findings.is_empty(),
+        "a test source names the cargo binary-path variable directly (#7568). A spawned `tm` \
+         that inherits `$HOME` resolves the OPERATOR's `~/.trusty-mpm`. Build the command with \
+         `common::tm_command()` / `common::tm_command_in(home)`, or — if you need the PATH \
+         rather than a `Command` — `common::tm_bin()` plus `common::isolate_spawned_tm` on the \
+         process you do spawn.\n  {}",
+        findings.join("\n  ")
+    );
+}
+
+/// Rule 2 — the raw-PATH spawn population does not grow.
+///
+/// Why: `common::tm_bin()` hands back a path with no isolation attached, so each
+/// use is a place the confinement is applied by hand and could be forgotten.
+/// What: counts `tm_bin(` per file against [`RAW_BIN_BUDGET`], reporting both
+/// over-budget (a regression) and under-budget (a stale row to lower).
+/// Test: this function IS the test.
+#[test]
+fn raw_binary_path_use_does_not_grow() {
+    let mut over = Vec::new();
+    let mut stale = Vec::new();
+    for path in test_sources() {
+        let display = path.display().to_string();
+        if display.ends_with(HELPER_SUFFIX) || display.ends_with(SELF_SUFFIX) {
+            continue;
+        }
+        let code = code_only(&std::fs::read_to_string(&path).expect("read source"));
+        let count = code.matches("tm_bin(").count();
+        let budget = RAW_BIN_BUDGET
+            .iter()
+            .find(|(suffix, _)| display.ends_with(suffix))
+            .map_or(0, |(_, n)| *n);
+        if count > budget {
+            over.push(format!(
+                "{display}: {count} raw-PATH spawns, budget {budget}"
+            ));
+        } else if count < budget {
+            stale.push(format!(
+                "{display}: {count} raw-PATH spawns, budget {budget}"
+            ));
+        }
+    }
+    assert!(
+        over.is_empty(),
+        "a new raw-PATH spawn of the `tm` binary (#7568). Prefer `common::tm_command()`; if the \
+         PATH really is what you need, apply `common::isolate_spawned_tm` to the process you \
+         spawn and raise this file's `RAW_BIN_BUDGET` row, saying why in the PR.\n  {}",
+        over.join("\n  ")
+    );
+    assert!(
+        stale.is_empty(),
+        "`RAW_BIN_BUDGET` is stale — lower these rows so the ratchet keeps its grip.\n  {}",
+        stale.join("\n  ")
+    );
+}
+
+/// The scanner reads code and ignores prose.
+///
+/// Why: a scan that matches nothing passes forever and protects nothing, which
+/// is the same outcome as the defect it guards. This shows it fires on the real
+/// shapes and stays quiet on the documented ones.
+/// Test: this function IS the test.
+#[test]
+fn comment_stripping_keeps_code_and_drops_prose() {
+    let needle = format!("{}{}", BIN_ENV_HALVES.0, BIN_ENV_HALVES.1);
+    let raw = format!("tm_{}", "bin(");
+    let sample = format!(
+        "//! Runs the built binary (`{needle}`) as a child.\n\
+         //! Keeps the `src/bin/tm/**` ratchet intact.\n\
+         /* {needle} in a block comment */\n\
+         fn a() {{ Command::new(env!(\"{needle}\")) }}\n\
+         // let bin = common::{raw});\n\
+         fn b() {{ let bin = common::{raw}); }}\n\
+         fn c() {{ run(\"http://127.0.0.1:1\", env!(\"{needle}\")); }}\n"
+    );
+    let code = code_only(&sample);
+
+    assert_eq!(
+        code.matches(&needle).count(),
+        2,
+        "the two live call sites must survive stripping — including the one \
+         behind a `http://` URL on the same line; got:\n{code}"
+    );
+    assert_eq!(
+        code.matches(&raw).count(),
+        1,
+        "the commented-out raw-PATH use must not be counted; got:\n{code}"
+    );
+    assert!(
+        code.contains("fn c()"),
+        "a `/*`-shaped glob inside a doc comment must not swallow the rest of \
+         the file — that shape reports a clean target regardless of its \
+         contents; got:\n{code}"
+    );
+}

--- a/crates/trusty-mpm/tests/tm_compress_pipe.rs
+++ b/crates/trusty-mpm/tests/tm_compress_pipe.rs
@@ -7,7 +7,7 @@
 //! compressed result to stdout, exit 0. Unit tests inside `commands::compress`
 //! cover the compression logic directly; this file proves the actual binary
 //! honors that stdin/stdout contract end to end.
-//! What: Runs the built `tm` binary (`CARGO_BIN_EXE_tm`) as
+//! What: Runs the built `tm` binary (via `common::tm_command`) as
 //! `tm compress --tool <name>` with piped stdin. The three
 //! native-chain tests force `TRUSTY_COMPRESS_NO_RTK=1` on the child so their
 //! assertions hold on any host (#7325);
@@ -24,6 +24,8 @@
 //! that a tool name outside the dispatch table's coverage (whether that's
 //! literally `"bash"` or any other unmatched name) is always a safe,
 //! byte-for-byte passthrough — never a corruption or crash.
+
+mod common;
 
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -50,15 +52,13 @@ fn run_tm_compress(tool: &str, input: &str) -> (bool, String, String) {
 /// process's environment, so `TRUSTY_COMPRESS_NO_RTK` is cleared first and
 /// then re-set only from `env` — otherwise an operator who exported it would
 /// silently force the native chain on the rtk-arm test below (#7325).
+/// `common::tm_command` clears `CLAUDE_CODE_SESSION_ID` (#7514) and points the
+/// child at a scratch `$HOME` (#7568) — the ledger it writes is the scratch
+/// home's, not the developer's.
 fn run_tm_compress_with(env: &[(&str, &str)], tool: &str, input: &str) -> (bool, String, String) {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut child = Command::new(bin)
+    let mut child = common::tm_command()
         .args(["compress", "--tool", tool])
         .env_remove(ENV_COMPRESS_NO_RTK)
-        // #7514: the child would otherwise inherit the developer's live
-        // CLAUDE_CODE_SESSION_ID and append a real `compress` savings row to
-        // their own ledger. Cleared on the CHILD, never on this process.
-        .env_remove(trusty_mpm::core::savings::CLAUDE_CODE_SESSION_ID_ENV)
         .envs(env.iter().copied())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -120,18 +120,21 @@ fn strip_ansi(text: &str) -> String {
 /// filter's stdout plus its ANSI-stripped stderr. `inner` must not contain a
 /// single quote.
 fn run_wrapped_pipeline(inner: &str, tool: &str) -> (String, String) {
-    let bin = env!("CARGO_BIN_EXE_tm");
+    // #7568: a shell pipeline needs the PATH, not a `Command`, so the isolation
+    // goes on the `sh` that runs it — the `tm compress` at the tail inherits it.
+    // That also covers #7514: the scrubbed environment carries no live
+    // CLAUDE_CODE_SESSION_ID to key a savings row by.
+    let bin = common::tm_bin();
     let script = format!(
         "{{ sh -c '{inner}'; printf '\\n__tm_compress_exit=%s__\\n' \"$?\"; }} \
          | '{bin}' compress --tool '{tool}'"
     );
-    let output = Command::new("sh")
+    let mut command = Command::new("sh");
+    common::isolate_spawned_tm(&mut command, common::tm_spawn_home());
+    let output = command
         .arg("-c")
         .arg(&script)
         .env(ENV_COMPRESS_NO_RTK, "1")
-        // #7514: see `run_tm_compress_with` — the `tm compress` at the tail of
-        // this pipeline must not key a savings row by the developer's session.
-        .env_remove(trusty_mpm::core::savings::CLAUDE_CODE_SESSION_ID_ENV)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/trusty-mpm/tests/tm_doctor_standalone.rs
+++ b/crates/trusty-mpm/tests/tm_doctor_standalone.rs
@@ -12,21 +12,20 @@
 //! ONE row saying "not running", and that no output names a port.
 //! Test: `cargo test -p trusty-mpm --test tm_doctor_standalone`.
 
-use std::process::Command;
+mod common;
 
 /// Run `tm doctor` against an address nothing listens on.
 ///
-/// The scratch HOME keeps the run off the operator's real framework root, and
-/// port 1 on loopback is the same never-listening address the `tm hook`
-/// fail-open suite uses — the connect is refused rather than timing out.
+/// The scratch HOME keeps the run off the operator's real framework root —
+/// `common::tm_command_in` applies it along with the rest of the #7568 scrub —
+/// and port 1 on loopback is the same never-listening address the `tm hook`
+/// fail-open suite uses, so the connect is refused rather than timing out.
 fn run_doctor_with_no_daemon() -> (bool, String, String) {
     let home = tempfile::tempdir().expect("scratch home");
     let cwd = tempfile::tempdir().expect("scratch cwd");
-    let output = Command::new(env!("CARGO_BIN_EXE_tm"))
+    let output = common::tm_command_in(home.path())
         .args(["--url", "http://127.0.0.1:1", "doctor"])
         .current_dir(cwd.path())
-        .env("HOME", home.path())
-        .env_remove("TRUSTY_MPM_URL")
         .output()
         .expect("failed to spawn `tm doctor`");
     (

--- a/crates/trusty-mpm/tests/tm_guided_default_explicit_url.rs
+++ b/crates/trusty-mpm/tests/tm_guided_default_explicit_url.rs
@@ -16,21 +16,20 @@
 //! that fallback-prone logic runs) and errors with exit code 75 instead.
 //! What: spawns `tm --url http://127.0.0.1:1` (bare, no subcommand) with
 //! stdin closed and asserts exit 75 plus a stderr message naming the failed
-//! URL and stating no fallback occurred. Uses `CARGO_BIN_EXE_tm` (set by
-//! Cargo for integration tests) so no extra dev-dependency is needed. Runs
-//! from a hermetic, non-git temp directory so the test never depends on this
-//! repo's own git/GitHub-remote structure (`derive_project` never needs to
+//! URL and stating no fallback occurred. The command comes from
+//! `common::tm_command`, so the child also gets a scratch `$HOME` (#7568).
+//! Runs from a hermetic, non-git temp directory so the test never depends on
+//! this repo's own git/GitHub-remote structure (`derive_project` never needs to
 //! run — the explicit-URL guard fires before it).
 //! Test: this test.
 
-use std::process::Command;
+mod common;
 
 #[test]
 fn bare_tm_explicit_unreachable_url_errors_not_silent_fallback() {
     let tmp = tempfile::tempdir().expect("create temp cwd");
 
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let output = Command::new(bin)
+    let output = common::tm_command()
         .args(["--url", "http://127.0.0.1:1"])
         .current_dir(tmp.path())
         .stdin(std::process::Stdio::null())

--- a/crates/trusty-mpm/tests/tm_hook_delegation_payload.rs
+++ b/crates/trusty-mpm/tests/tm_hook_delegation_payload.rs
@@ -13,9 +13,11 @@
 //! live Claude Code 2.1.220 captures (the #2864 Step-0 probe).
 //! Test: `cargo test -p trusty-mpm --test tm_hook_delegation_payload`.
 
+mod common;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 /// Read one HTTP request off `stream` and return its body.
 ///
@@ -73,8 +75,9 @@ fn capture_hook_post(stdin_json: &str) -> (serde_json::Value, bool, String) {
         body
     });
 
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut child = Command::new(bin)
+    // #7568: the child gets a scratch `$HOME`, so the hook's own state writes
+    // land there rather than in the operator's `~/.trusty-mpm`.
+    let mut child = common::tm_command()
         .args(["--url", &format!("http://127.0.0.1:{port}"), "hook"])
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")

--- a/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
+++ b/crates/trusty-mpm/tests/tm_hook_idle_parking.rs
@@ -15,6 +15,8 @@
 //! (<https://code.claude.com/docs/en/hooks>).
 //! Test: `cargo test -p trusty-mpm --test tm_hook_idle_parking`.
 
+mod common;
+
 use std::io::Write;
 use std::process::{Command, Stdio};
 
@@ -23,10 +25,10 @@ use std::process::{Command, Stdio};
 /// #7278: `config_dir` becomes the child's `CLAUDE_CONFIG_DIR`, which is the
 /// boundary the parking detector screens `transcript_path` against. Set on the
 /// spawned process, never on this one — a `std::env::set_var` here would leak
-/// into every other test in the binary.
+/// into every other test in the binary. It is chained AFTER
+/// `common::tm_command`, whose scrub would otherwise clear it (#7568).
 fn run_hook_in(stdin_json: &str, config_dir: &std::path::Path) -> (bool, String) {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut child = Command::new(bin)
+    let mut child = common::tm_command()
         .args(["--url", "http://127.0.0.1:1", "hook"])
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")
@@ -241,8 +243,7 @@ fn rejects_fifo_without_blocking() {
         .expect("failed to spawn mkfifo");
     assert!(mkfifo_status.success(), "mkfifo must succeed");
 
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut child = Command::new(bin)
+    let mut child = common::tm_command()
         .args(["--url", "http://127.0.0.1:1", "hook"])
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -34,6 +34,8 @@
 //! share (and race on) the same counter file, and would also pollute the
 //! real developer `$HOME`.
 
+mod common;
+
 use std::io::Write;
 use std::process::{Command, Stdio};
 
@@ -128,24 +130,22 @@ fn spawn_pm_guard(
     extra_env: &[(&str, &str)],
     unset: &[&str],
 ) -> std::process::Child {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut command = Command::new(bin);
+    // #7497: point the child at a config home whose `disk.max_usage_pct` is
+    // 100, so the disk gate can never deny an ordinary `git worktree add`
+    // payload below on a runner whose volume happens to be full. An EXPLICIT
+    // threshold is the only thing that moves this gate — there is deliberately
+    // no env var that disables it — and a caller passing its own `HOME` in
+    // `extra_env` (the two disk cases, and every budget-eligible case)
+    // overrides it, since a later `.env` for the same key wins.
+    // #7568: `tm_command_in` is also what keeps the child off the operator's
+    // own `~/.trusty-mpm`.
+    let mut command = common::tm_command_in(default_hook_home());
     command
         .args(["--url", url, "hook", "--pm-guard"])
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")
         .env_remove("TRUSTY_MPM_PM_UNRESTRICTED")
         .env_remove("TRUSTY_MPM_PM_DENY_BY_DEFAULT")
-        .env_remove("TM_MANAGED_SESSION_ID")
-        // #7497: point the child at a config home whose `disk.max_usage_pct` is
-        // 100, so the disk gate can never deny an ordinary `git worktree add`
-        // payload below on a runner whose volume happens to be full. An
-        // EXPLICIT threshold is the only thing that moves this gate — there is
-        // deliberately no env var that disables it — and a caller passing its
-        // own `HOME` in `extra_env` (the two disk cases, and every
-        // budget-eligible case) overrides this line, since a later `.env` for
-        // the same key wins.
-        .env("HOME", default_hook_home())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard_false_positives.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard_false_positives.rs
@@ -16,8 +16,10 @@
 //! reported command verbatim plus the deny that bounds the fix.
 //! Test: `cargo test -p trusty-mpm --test tm_hook_pm_guard_false_positives`.
 
+mod common;
+
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 /// The daemon URL every spawn here pins: nothing listens on port 1, so the
 /// best-effort audit POST on a deny path fails fast on a refused connection
@@ -38,11 +40,9 @@ const UNREACHABLE_DAEMON: &str = "http://127.0.0.1:1";
 /// counter can never touch the developer's real `$HOME`.
 /// Test: every assertion below routes through it.
 fn run_pm_guard(stdin_json: &str, home: &std::path::Path) -> String {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut command = Command::new(bin);
+    let mut command = common::tm_command_in(home);
     command
         .args(["--url", UNREACHABLE_DAEMON, "hook", "--pm-guard"])
-        .env("HOME", home)
         .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
         .env_remove("CLAUDE_MPM_SUB_AGENT")
         .env_remove("TRUSTY_MPM_PM_UNRESTRICTED")

--- a/crates/trusty-mpm/tests/tm_hook_pretooluse_rewrite.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pretooluse_rewrite.rs
@@ -7,7 +7,7 @@
 //! stdin-read → rewrite → stdout-print path end to end through the real
 //! binary, which is the behavior Claude Code will actually depend on. This
 //! file closes that gap.
-//! What: Runs the built `tm` binary (`CARGO_BIN_EXE_tm`) as
+//! What: Runs the built `tm` binary (via `common::tm_command`) as
 //! `tm --url http://127.0.0.1:1 hook` with `CLAUDE_HOOK_EVENT=PreToolUse` and
 //! a `{"tool_name":"Bash","tool_input":{"command":"..."}}` stdin payload,
 //! then asserts the printed `hookSpecificOutput.updatedInput.command` matches
@@ -27,6 +27,8 @@
 //! consistent with the documented protocol, not a substitute for testing
 //! against a real running Claude Code session.
 
+mod common;
+
 use std::io::Write;
 
 /// What `tm hook` rewrites `cargo test` into.
@@ -38,13 +40,15 @@ use std::io::Write;
 /// spelling is repeated here — the unit tests build theirs from the producer,
 /// which is what keeps the two from drifting apart unnoticed.
 const EXPECTED_CARGO_TEST_REWRITE: &str = "{ cargo test; printf '\\n__tm_compress_exit=%s__\\n' \"$?\"; } | tm compress --tool \"cargo test\"";
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 /// Spawn `tm hook` with the given `CLAUDE_HOOK_EVENT` and stdin JSON,
 /// returning stdout as a string.
+///
+/// The command comes from `common::tm_command`, so the child runs against a
+/// scratch `$HOME` (#7568).
 fn run_hook_with_stdin(event: &str, stdin_json: &str) -> String {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut child = Command::new(bin)
+    let mut child = common::tm_command()
         .args(["--url", "http://127.0.0.1:1", "hook"])
         .env("CLAUDE_HOOK_EVENT", event)
         .env("CLAUDE_SESSION_ID", "test-session")
@@ -144,8 +148,7 @@ fn hook_rewrite_stdout_contains_only_the_json_object() {
 /// live hooks reference (confirmed 2026-07-03): Claude Code does not set
 /// those as environment variables for hook subprocesses.
 fn run_hook_with_stdin_only(stdin_json: &str) -> String {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut child = Command::new(bin)
+    let mut child = common::tm_command()
         .args(["--url", "http://127.0.0.1:1", "hook"])
         .env_remove("CLAUDE_HOOK_EVENT")
         .env_remove("CLAUDE_SESSION_ID")

--- a/crates/trusty-mpm/tests/tm_session_disk_cli.rs
+++ b/crates/trusty-mpm/tests/tm_session_disk_cli.rs
@@ -16,8 +16,9 @@
 //! Test: this file; run with
 //! `cargo test -p trusty-mpm --test tm_session_disk_cli`.
 
+mod common;
+
 use std::future::IntoFuture;
-use std::process::Command;
 use std::sync::{Arc, Mutex};
 
 use axum::routing::{get, post};
@@ -170,9 +171,11 @@ async fn serve_stub() -> (String, Arc<Mutex<Vec<Value>>>) {
 ///
 /// The cwd is outside any managed workspace root, so the project filter
 /// declines and the survey covers everything — which is what makes the
-/// assertions independent of the developer's own machine.
+/// assertions independent of the developer's own machine. `common::tm_command`
+/// does the same for the child's `$HOME` (#7568); the `TRUSTY_MPM_URL` below is
+/// set after it, so it survives the helper's scrub.
 fn run_tm(url: &str, cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
-    Command::new(env!("CARGO_BIN_EXE_tm"))
+    common::tm_command()
         .env("TRUSTY_MPM_URL", url)
         .args(args)
         .current_dir(cwd)

--- a/crates/trusty-mpm/tests/tm_sessions_alias_notice.rs
+++ b/crates/trusty-mpm/tests/tm_sessions_alias_notice.rs
@@ -16,15 +16,15 @@
 //! is unaffected by the subsequent failure.
 //! Test: `cargo test -p trusty-mpm --test tm_sessions_alias_notice`.
 
-use std::process::Command;
+mod common;
 
 /// Deterministic never-listening address (reserved port), so the daemon round
 /// trip fails immediately instead of hanging or requiring a live daemon.
 const DEAD_URL: &str = "http://127.0.0.1:1";
 
+/// Run `tm`, with the child confined to a scratch `$HOME` (#7568).
 fn run_tm(args: &[&str]) -> (String, String) {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let output = Command::new(bin)
+    let output = common::tm_command()
         .args(args)
         .output()
         .expect("failed to spawn `tm`");

--- a/crates/trusty-mpm/tests/tm_sessions_instructions_diagnostics.rs
+++ b/crates/trusty-mpm/tests/tm_sessions_instructions_diagnostics.rs
@@ -18,17 +18,16 @@
 //!
 //! Test: `cargo test -p trusty-mpm --test tm_sessions_instructions_diagnostics`.
 
-use std::process::Command;
+mod common;
 
 /// Run `tm` with `args` and `RUST_LOG`, returning `(stdout, stderr)` separately.
 ///
 /// Capturing the two streams independently is the whole point: this binary's
 /// daemon and MCP modes need stdout free for JSON-RPC framing, and this command
 /// prints the resolved prompt to stdout. A diagnostic that reached stdout would
-/// corrupt both.
+/// corrupt both. `common::tm_command` confines the child's `$HOME` (#7568).
 fn run_tm(args: &[&str], rust_log: Option<&str>) -> (String, String) {
-    let bin = env!("CARGO_BIN_EXE_tm");
-    let mut cmd = Command::new(bin);
+    let mut cmd = common::tm_command();
     cmd.args(args);
     match rust_log {
         Some(value) => cmd.env("RUST_LOG", value),


### PR DESCRIPTION
## Summary

Spawned `tm` binaries in `trusty-mpm` integration tests now get a temp `$HOME`
through one shared helper, so a spawn-site test can no longer write into the
operator's real `~/.trusty-tools` state. A new ratchet test forbids raw
`CARGO_BIN_EXE_tm` usage outside the helper in `tests/common/mod.rs`.

Refs #7568

## What changed / out of scope

- Added `crates/trusty-mpm/tests/spawned_tm_home_isolation.rs` (6 tests),
  including an empty-allowlist ratchet that fails if any test file outside
  `tests/common/mod.rs` references `CARGO_BIN_EXE_tm` directly instead of
  going through the shared temp-`$HOME` helper.
- Updated the 14 existing spawn-site test files under
  `crates/trusty-mpm/tests/` to route every spawned `tm` invocation through
  that helper.
- Test-only change: no `crates/trusty-mpm/src/**` files touched.
- Out of scope: any change to the helper's production counterpart (there is
  none — this is purely test-harness isolation) and any change to `tm`'s
  runtime `$HOME` resolution itself.

## Risk / blast radius

Rung 2 (test-only stabilization). 17 files changed, all under
`crates/trusty-mpm/tests/`. No production code path is affected.

## Test evidence

- `cargo fmt --check` — OK
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — OK
- `scripts/check_line_cap.sh` — OK
- `scripts/check_test_pointers.sh` — OK
- `scripts/check_sld.sh` — OK
- `scripts/check_changelog_fragment.sh --staged` — OK (test-only diff, fragment
  not required)
- `cargo test -p trusty-mpm --no-fail-fast -- --test-threads=4`:
  - First full run at the commit SHA: 60 targets, 12764 passed / 0 failed.
  - A later run at the same SHA showed 12 failures, all in the six
    `src/bin/tm/**` unit tests across two bin targets, refusing worktree
    provisioning because the host disk crossed the `disk.max_usage_pct` 90%
    gate mid-session (`df` read 92%). `git diff --name-only
    origin/main...HEAD -- crates/trusty-mpm/src/` is empty, so these are
    environmental/pre-existing per the baseline-failure protocol, not
    branch-caused.
- Regression evidence for the fix itself: on `origin/main`, each of the 14
  probed spawn-site targets wrote `migrations.json`/`compression.jsonl` into a
  scratch `$HOME` (state leakage). On this branch all 14 write 0 such files.
  `a_spawned_tm_resolves_the_helper_home_and_leaves_the_operators_alone` and
  `the_helper_clears_every_state_pointing_var` fail when the helper body is
  neutered, confirming the tests exercise the real guarantee.
- Security scan (credential diff over `git diff origin/main...HEAD`): PASS.

## Baseline / pre-existing failures

`src/bin/tm/**` unit tests (6 tests x 2 bin targets) intermittently fail under
disk pressure (host `df` at 92%, over the 90% `disk.max_usage_pct` gate) when
worktree provisioning is attempted concurrently with other builds. Confirmed
pre-existing: `git diff --name-only origin/main...HEAD --
crates/trusty-mpm/src/` is empty for this branch.

## Documentation / changelog status

Test-only PR; changelog fragment gate confirms no fragment is required
(`crates/trusty-mpm/src/**` untouched).

## Review-finding disposition

PM-reviewed at rung 2 (test-only, no architectural impact) — no `code-critic`
round required.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
