### PR TITLE
chore(trusty-mpm): bump to 1.5.35 for owner-authorized reinstall (Refs #7569)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11930,7 +11930,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.34"
+version = "1.5.35"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -64,7 +64,7 @@ name = "trusty-mpm"
 # edits `src/**`, so the `PR version bump vs crates.io` gate (#4421) requires
 # the bump here. Patch because the change is a bug fix inside the existing
 # savings producer and compiled-prompt writer.
-version = "1.5.34"
+version = "1.5.35"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/changelog.d/7569-bump-1-5-35.md
+++ b/crates/trusty-mpm/changelog.d/7569-bump-1-5-35.md
@@ -1,0 +1,3 @@
+Changed
+
+- Bump to 1.5.35 for an owner-authorized reinstall carrying the #7569 `tm repair savings-ledger` fix (PR #7591).


### PR DESCRIPTION
## Summary

Rung 1 (metadata) — bump `trusty-mpm` from 1.5.34 to 1.5.35 for an
owner-authorized reinstall. Every reinstall carries a patch bump so
`--version` identifies the build. This build carries the `tm repair
savings-ledger` change from PR #7591.

Refs #7569

## Changes

- `crates/trusty-mpm/Cargo.toml`: `version = "1.5.34"` -> `"1.5.35"`
- `Cargo.lock`: matching single `trusty-mpm` entry
- `crates/trusty-mpm/changelog.d/7569-bump-1-5-35.md`: changelog fragment

Out of scope: no source or behavior change beyond the version string.

## Risk

Low. Version-string-only change with no source edits; nothing to regress
beyond the version reported by `tm --version`.

## Tests

- `cargo check -p trusty-mpm`: OK
- `scripts/check-pr-version-bump.sh`: OK — 3 changed paths, none under
  `crates/<crate>/src/**`
- `scripts/check_workspace_dep_versions.sh`: OK — `trusty-mpm` req 1.0.0
  accepts crate 1.5.35

## Baseline

No known pre-existing failures touch this change; the diff is limited to
the version bump, the matching lockfile entry, and the changelog fragment.

## Docs

`crates/trusty-mpm/changelog.d/7569-bump-1-5-35.md` added;
`scripts/check_changelog_fragment.sh`: OK.

## Review

No review findings yet raised against this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
