### PR TITLE
fix(trusty-console): rebuild the saver's WKWebView after three failed loads, and stop retries cancelling themselves (Refs #7606)

### DIFF
--- a/crates/trusty-console/changelog.d/7606-saver-recreate-webview.md
+++ b/crates/trusty-console/changelog.d/7606-saver-recreate-webview.md
@@ -1,0 +1,23 @@
+Fixed
+- The screen saver rebuilds its `WKWebView` after three consecutive failed
+  loads, instead of reloading forever into a WebContent process the OS has
+  frozen. A reload lands in the same process, so a page macOS has marked
+  NotVisible comes back hidden and the recovery reloads it again: the owner's
+  saver ran that loop for three days, showing the bundled offline preview while
+  `/ui/screensaver` answered in under a millisecond throughout. The rebuild is
+  decided on the failure COUNT alone, never on what the page reports about its
+  own visibility — a page reporting itself hidden inside a saver the host is
+  animating is not evidence of occlusion. It logs the count and the reason to
+  `com.trusty.console.saver` and is rate-limited to one a minute, widening to
+  one per ten minutes once the console has been down longer than the fast-retry
+  window, so a genuinely dead daemon does not turn into process churn
+  ([#7606](https://github.com/bobmatnyc/trusty-tools/issues/7606)).
+- A retry no longer cancels the load it is retrying. The retry delay was a flat
+  5 s against a 6 s load deadline, so every retry issued a `load` over an
+  attempt WebKit had not finished with; WebKit reported that supersession as
+  `NSURLErrorCancelled` (-999), the view read its own cancellation as a fresh
+  network failure and armed another 5 s retry, and the loop fed itself — 139 of
+  those in two hours of the owner's log. The delay is now derived from the
+  deadline rather than chosen, and the view cancels any attempt it abandons and
+  recognises the cancellation that comes back, so a -999 it counts can only have
+  come from outside ([#7606](https://github.com/bobmatnyc/trusty-tools/issues/7606)).

--- a/crates/trusty-console/macos/saver/PaintHarness.swift
+++ b/crates/trusty-console/macos/saver/PaintHarness.swift
@@ -7,7 +7,7 @@
 //   "whatever the view paints when there is no live page", and all three were
 //   reported as a black screen. Nothing measured them, because measuring them
 //   means reading pixels, not navigation callbacks.
-// What: seven modes, each instantiating the bundle's principal class offscreen
+// What: nine modes, each instantiating the bundle's principal class offscreen
 //   and reading its rendered bitmap through
 //   `bitmapImageRepForCachingDisplay` / `cacheDisplay`:
 //     offline — points the view at a closed port; asserts the frame is not black
@@ -37,6 +37,15 @@
 //               never reloaded — which is what fails a view that reloads on
 //               every probe tick. `suspend-cold` serves one hidden from its
 //               first answer, and measures the bounded forced-recovery deadline.
+//     recreate  #7606: the never-answering listener again, so every load fails
+//               the same way and the failure COUNT is the variable. Asserts the
+//               view stops reloading into the same WebContent process and
+//               replaces the `WKWebView` instance after three consecutive
+//               failures, and that the replacement loads.
+//     one-      the same endpoint, watched only as far as the first failure and
+//     failure   its retry. Asserts the instance is NOT replaced there — the
+//               assertion that fails a view which spends a process on every
+//               brief console restart.
 //   Every mode takes the frame it runs at — `--frame WxH`, default 1280x800 —
 //   so the ultrawide geometry #6871 was reported on is reachable.
 // Test: it IS the test. README.md, "Paint harness", has the invocations;
@@ -98,10 +107,15 @@ let minInkRatio = 0.02
 /// and the `slow` mode's retry count are the real gates.
 let firstPaintDeadline: TimeInterval = 1.0
 /// How long the `slow` mode watches its listener for retry attempts. The fixed
-/// view attempts at roughly 0 s, 11 s, 22 s and 33 s (a 5 s request timeout with
-/// a 1 s watchdog grace, plus a 5 s retry delay), so this window holds four
-/// attempts and demands three.
-let retryObservationSeconds: TimeInterval = 34
+/// view attempts at roughly 0 s, 14 s, 28 s and 42 s — a 5 s request timeout
+/// with a 1 s watchdog grace, plus an 8 s retry delay — so this window holds
+/// four attempts and demands three.
+///
+/// #7606 moved the retry delay from 5 s to 8 s and this window from 34 s with
+/// it. The cadence is no longer a free number: a retry that lands before the 6 s
+/// deadline supersedes the attempt in flight, and WebKit reports that
+/// supersession as -999. The view now derives the delay from the deadline.
+let retryObservationSeconds: TimeInterval = 45
 /// Connection attempts the `slow` mode expects inside that window: the initial
 /// load plus at least two retries. Without a request timeout the view issues
 /// one connection and waits out `URLRequest`'s 60 s default, so this is the
@@ -120,7 +134,7 @@ let minSlowModeAttempts = 3
 /// wait, a synchronous XPC round trip, or a run-loop spin into the stop path.
 let stopReturnBudget: TimeInterval = 0.5
 /// How long after the stop the listener is watched for traffic that must not
-/// come. The unfixed view's re-armed retry lands about 5 s after the stop
+/// come. The unfixed view's re-armed retry lands about 8 s after the stop
 /// (`about:blank` supersedes the in-flight load, WebKit reports the
 /// cancellation, `enterOffline` re-arms `scheduleRetryTimer`'s 5 s delay), and
 /// each subsequent attempt about 11 s after that, so 20 s holds two or three of
@@ -186,6 +200,32 @@ let suspendColdObservationSeconds: TimeInterval = 90
 /// about that long and every sample in the window must carry drawn content.
 let suspendSampleSeconds: TimeInterval = 3
 
+// MARK: - Web-view rebuild thresholds (#7606)
+
+/// Consecutive failed loads the view is expected to absorb before it rebuilds
+/// its `WKWebView`. Mirrors `recreateAfterFailures` in `TrustyConsoleSaver.swift`
+/// — the two must move together, and `one-failure` mode below is what catches a
+/// view that rebuilds sooner.
+let recreateAfterFailures = 3
+/// How long `recreate` mode watches for that rebuild. Against a listener that
+/// never answers, the view fails on its own 6 s watchdog and waits 8 s before
+/// the next attempt, so the three failures land at roughly 6 s, 20 s and 34 s.
+/// Sixty seconds holds the third with slack and is far short of the hourly
+/// reload, which could produce a fresh load for a reason that is not this one.
+let recreateObservationSeconds: TimeInterval = 60
+/// How long `recreate` mode then watches for the load the rebuilt web view must
+/// issue. A rebuild that replaces the instance and loads nothing is the same
+/// black screen with an extra process behind it.
+let recreateFreshLoadWait: TimeInterval = 10
+/// How long `one-failure` mode waits for the retry that proves the FIRST failure
+/// was counted and answered. Without it the mode would pass on a view that never
+/// failed at all.
+let oneFailureRetryWait: TimeInterval = 20
+/// How much longer it then watches the instance. The second failure lands at
+/// about 20 s and the rebuild at about 34 s, so this stays inside the window
+/// where exactly one failure has been counted.
+let oneFailureSettleSeconds: TimeInterval = 3
+
 // MARK: - Arguments
 
 func note(_ message: String) {
@@ -246,9 +286,10 @@ let bundlePath = positional.count > 1
     ? positional[1]
     : NSHomeDirectory() + "/Library/Screen Savers/TrustyConsole.saver"
 
-guard ["offline", "slow", "preview", "resize", "stop", "suspend", "suspend-cold"].contains(mode) else {
-    note("usage: paintharness <offline|slow|preview|resize|stop|suspend|suspend-cold> [bundlePath]"
-        + " [--frame WxH] [--start WxH]")
+guard ["offline", "slow", "preview", "resize", "stop", "suspend", "suspend-cold",
+       "recreate", "one-failure"].contains(mode) else {
+    note("usage: paintharness <offline|slow|preview|resize|stop|suspend|suspend-cold"
+        + "|recreate|one-failure> [bundlePath] [--frame WxH] [--start WxH]")
     note("  --frame  the frame to run at (default 1280x800; env SAVER_HARNESS_FRAME)")
     note("  --start  resize mode only: the frame to construct at (default 320x200)")
     exit(64)
@@ -608,10 +649,12 @@ case "suspend", "suspend-cold":
     }
     page = listener
     pointView(atPort: listener.port)
-case "slow", "stop":
+case "slow", "stop", "recreate", "one-failure":
     // #6900 wants the same endpoint `slow` uses: a load that is in flight and
     // stays there is the state the stop has to interrupt, and every connection
-    // the view opens is counted.
+    // the view opens is counted. #7606's two modes want it for a third reason —
+    // it is the only endpoint that makes every load fail the same way, so the
+    // failure COUNT is the variable under test.
     guard let listener = SilentListener() else {
         note("could not start the silent listener")
         finish(6)
@@ -808,6 +851,112 @@ case "slow":
         }
     } else {
         failures.append("could not read the view's bitmap after the stall")
+    }
+
+case "recreate", "one-failure":
+    guard let listener = silent else { break }
+    let expectsRebuild = mode == "recreate"
+
+    /// The view's timers and WebKit's callbacks all land on the main run loop,
+    /// so a plain sleep would stop the machinery under test.
+    func pump(_ seconds: TimeInterval, until condition: () -> Bool = { false }) {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline && !condition() {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    func currentWebView() -> WKWebView? {
+        view.subviews.compactMap { $0 as? WKWebView }.first
+    }
+
+    // The ORIGINAL instance, held strongly for the length of the run. Identity
+    // is the assertion, and a released object's address can be handed to its
+    // replacement — holding it makes `!==` mean what it reads as.
+    guard let original = currentWebView() else {
+        failures.append("the view built no web view to replace")
+        break
+    }
+    note("original web view: \(ObjectIdentifier(original))")
+
+    if expectsRebuild {
+        // --- N consecutive failures must replace the instance ---------------
+        // Every load against this listener times out, so the only variable is
+        // how many the view takes before it stops reloading into the same
+        // WebContent process and builds a new one. #7606's owner report is
+        // three days of a view that never did.
+        note("watching for the rebuild for \(Int(recreateObservationSeconds))s"
+            + " (\(recreateAfterFailures) failures expected first)")
+        var acceptedBeforeRebuild = listener.accepted
+        var lowestInk = Double.greatestFiniteMagnitude
+        let deadline = Date().addingTimeInterval(recreateObservationSeconds)
+        while Date() < deadline && currentWebView() === original {
+            // Sampled BEFORE the identity check, so this holds the connection
+            // count from the last poll at which the instance was still the old
+            // one — the count the rebuild's own load has to exceed.
+            acceptedBeforeRebuild = listener.accepted
+            if let rep = capture(view), let frame = stats(of: rep) {
+                lowestInk = min(lowestInk, frame.inkRatio)
+                if frame.nonBlackRatio < minNonBlackRatio {
+                    failures.append(String(format: "frame went black while failing: nonBlack=%.4f",
+                                           frame.nonBlackRatio))
+                    break
+                }
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+
+        guard let rebuilt = currentWebView(), rebuilt !== original else {
+            failures.append("the web view was never replaced:"
+                + " \(listener.accepted) failed load(s) in \(Int(recreateObservationSeconds))s,"
+                + " expected a rebuild after \(recreateAfterFailures)")
+            break
+        }
+        note("web view replaced: \(ObjectIdentifier(original)) → \(ObjectIdentifier(rebuilt))"
+            + " after \(acceptedBeforeRebuild) connection attempt(s)")
+        if acceptedBeforeRebuild < recreateAfterFailures {
+            failures.append("rebuilt too early: \(acceptedBeforeRebuild) attempt(s) before the"
+                + " swap, expected at least \(recreateAfterFailures)")
+        }
+
+        // --- and the replacement must actually load -------------------------
+        note("watching for the rebuilt view's own load for \(Int(recreateFreshLoadWait))s")
+        pump(recreateFreshLoadWait, until: { listener.accepted > acceptedBeforeRebuild })
+        note("connection attempts after the swap: \(listener.accepted) (was \(acceptedBeforeRebuild))")
+        if listener.accepted <= acceptedBeforeRebuild {
+            failures.append("the rebuilt web view never loaded:"
+                + " no connection in \(Int(recreateFreshLoadWait))s after the swap")
+        }
+
+        // #6838 must not regress across the swap: the fallback keeps drawing
+        // while the web view underneath it is replaced.
+        note(String(format: "lowest ink while failing: %.4f", lowestInk))
+        if lowestInk < minInkRatio, lowestInk != Double.greatestFiniteMagnitude {
+            failures.append(String(format: "fallback stopped drawing while failing: ink=%.4f < %.4f",
+                                   lowestInk, minInkRatio))
+        }
+    } else {
+        // --- ONE failure must replace nothing --------------------------------
+        // The counterpart assertion, and the one that fails a view that rebuilds
+        // on every failure: a single timed-out load is an outage the retry
+        // backoff already answers, and spending a WebContent process on it would
+        // turn a brief console restart into process churn.
+        note("waiting up to \(Int(oneFailureRetryWait))s for the retry that follows the first failure")
+        pump(oneFailureRetryWait, until: { listener.accepted >= 2 })
+        note("connection attempts: \(listener.accepted)")
+        if listener.accepted < 2 {
+            failures.append("the first load never failed and retried:"
+                + " \(listener.accepted) connection attempt(s) in \(Int(oneFailureRetryWait))s,"
+                + " so this run proves nothing about the rebuild threshold")
+            break
+        }
+        pump(oneFailureSettleSeconds)
+        if let now = currentWebView(), now !== original {
+            failures.append("rebuilt the web view after a single failure —"
+                + " \(listener.accepted) connection attempt(s), threshold is \(recreateAfterFailures)")
+        } else {
+            note("web view unchanged after one failure: \(ObjectIdentifier(original))")
+        }
     }
 
 case "stop":

--- a/crates/trusty-console/macos/saver/README.md
+++ b/crates/trusty-console/macos/saver/README.md
@@ -148,7 +148,7 @@ daemon**: each mode builds its own endpoint.
 swiftc -O -swift-version 5 -o target/console-saver/harness/paintharness \
   crates/trusty-console/macos/saver/PaintHarness.swift
 
-for mode in offline slow preview resize stop suspend suspend-cold; do
+for mode in offline slow preview resize stop suspend suspend-cold recreate one-failure; do
   ./target/console-saver/harness/paintharness "$mode" \
     target/console-saver/TrustyConsole.saver || echo "FAILED: $mode"
 done
@@ -160,12 +160,14 @@ unoptimised build spends over a second in it.
 | Mode | Endpoint | Asserts |
 |---|---|---|
 | `offline` | a closed port | ≥98% of pixels non-black and ≥2% carrying drawn content, both before `startAnimation()` and after |
-| `slow` | a listener that accepts and never answers | the same, plus ≥3 connection attempts in 34 s — i.e. the load timed out and retried instead of hanging on `URLRequest`'s 60 s default |
+| `slow` | a listener that accepts and never answers | the same, plus ≥3 connection attempts in 45 s — i.e. the load timed out and retried instead of hanging on `URLRequest`'s 60 s default |
 | `preview` | none (`isPreview: true`) | the bundled asset draws, and no `WKWebView` is built for a tile |
 | `resize` | the real console (7788, or `SAVER_HARNESS_PORT`) | after a late growth: `webView.frame == view.bounds`, the page's own `innerWidth`×`innerHeight` equals those bounds, and none of five edge samples is black (#6871) |
 | `stop` | the same never-answering listener | `stopAnimation()` returns inside 500 ms and the listener sees **zero** further connections for 20 s — twice, once with a load in flight and once from inside a render tick (#6900) |
 | `suspend` | a listener that **answers**, serving a page that reports `document.visibilityState` as `visible` for three reads then `hidden` | three re-entrant `startAnimation()` calls over the live page produce **zero** further requests; the page then goes 35 s reporting itself visible with **zero** requests, so a view that reloaded on every probe tick fails here; then the flip to `hidden` produces exactly one reload, and every frame captured while the web view is off screen carries ≥2% ink (#7112) |
 | `suspend-cold` | the same listener, serving a page that is `hidden` from its **first** read | the same re-entrant assertion, then the view recovers inside 90 s with no visible-then-hidden history to reason from — the bounded forced-recovery deadline, measured at 69 s (#7112) |
+| `recreate` | the never-answering listener again | after three consecutive failed loads the `WKWebView` **instance** is replaced and the replacement opens its own connection; the fallback keeps drawing across the swap (#7606) |
+| `one-failure` | the same listener, watched only as far as the first failure and its retry | the instance is **not** replaced — the assertion that fails a view which spends a WebContent process on every brief console restart (#7606) |
 
 ### Stop path (#6900)
 
@@ -246,6 +248,27 @@ the exact symptom this issue is about.
 `recoveryCooldown` caps the reload rate at one a minute, so none of the four
 grounds can turn into a treadmill.
 
+**And when reloading is not enough, the web view itself goes (#7606).** A reload
+lands in the same WebContent process, so a page macOS has parked at
+`running-suspended-NotVisible` comes back hidden and the recovery above reloads
+it again. The owner's saver ran that loop for three days while the console
+answered `/ui/screensaver` in under a millisecond throughout. After three
+consecutive failures to get a live page on screen — a failed or timed-out load,
+or a visibility recovery — the view tears down its `WKWebView` and builds a
+fresh one, which is a fresh WebContent and network process, and loads into that.
+The decision is made on the COUNT alone and never on what the page says about
+its own visibility: a page reporting itself hidden inside a saver the host is
+animating is not evidence of occlusion, and treating it as such is what let this
+run for days. Only a probe answering `visible` clears the count —
+`didFinish` does not, because every reload in that three-day loop finished. The
+rebuild is capped at one a minute, widening to one per ten minutes once the
+console has been down longer than `fastRetryWindow`, so a dead daemon overnight
+does not become process churn. The same issue derived the retry delay from the
+6 s load deadline rather than leaving it a flat 5 s underneath it: every retry
+used to `load` over an attempt WebKit had not finished with, WebKit reported the
+supersession as `NSURLErrorCancelled` (-999), and the view counted its own
+cancellation as a fresh failure — 139 of them in two hours of the same log.
+
 Every decision names its trigger and its ground at `.default`, so `log show`
 separates them:
 
@@ -256,6 +279,8 @@ visibility lost, recovering — document.visibilityState=hidden (was visible)
 visibility lost, recovering — document.visibilityState=hidden (unhealthy for 69s)
 visibility lost, waiting — occluded window, page never reported visible (…)
 window occlusion changed — visible=false
+rebuilding the web view — 3 consecutive failed load(s): visibility recovery: …
+rebuild held off — 3 consecutive failure(s), inside the 60s cooldown (…)
 ```
 
 Against a bundle built from the pre-fix `main` (951d46b6b) both modes report
@@ -408,8 +433,10 @@ configuration sheet this phase (`hasConfigureSheet` is `false`).
   view paints `Resources/ConsolePreview.png` scaled to fit at 35% over the
   Foundry dark background (`#201612`), with a `TRUSTY CONSOLE · OFFLINE` banner
   over a scrim so a photograph of old numbers cannot read as live ones. Retries
-  every 5 s for the first 3 minutes of an outage, then every 30 s, and switches
-  to the live page the moment one succeeds — no saver restart.
+  every 8 s for the first 3 minutes of an outage, then every 30 s, and switches
+  to the live page the moment one succeeds — no saver restart. The 8 s is
+  derived from the 6 s deadline, not chosen: a retry that lands inside it
+  supersedes the attempt in flight and WebKit reports that as -999 (#7606).
 - **Preview** — the System Settings thumbnail (`isPreview == true`) never
   constructs a web view; it paints the same asset at full opacity, with no
   banner.
@@ -432,6 +459,13 @@ configuration sheet this phase (`hasConfigureSheet` is `false`).
   is reachable) and reloaded, on any of four grounds and after at most 60 s. This
   is the only exit from `.live` when the OS discards the page's layers without
   terminating its process (#7112).
+- **Rebuilt** — after three consecutive failures to get a live page on screen
+  (a failed or timed-out load, or a visibility recovery), the `WKWebView` is torn
+  down and replaced, which is the only way to leave a frozen WebContent process
+  behind. Decided on the count, never on what the page reports about its own
+  visibility; cleared only by a probe answering `visible`; capped at one a
+  minute, or one per ten minutes once the console has been down past the
+  fast-retry window (#7606).
 - **Multi-display** — the framework instantiates one view per screen, so each
   display gets its own web view and timers. No coordination is attempted.
 - **Tracks the frame** — the web view is sized from `bounds` in

--- a/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
+++ b/crates/trusty-console/macos/saver/TrustyConsoleSaver.swift
@@ -14,7 +14,10 @@
 //   the way into `startAnimation()`, so a preview-sized or 0x0 init frame never
 //   survives to the first paint (#6871). While the page is live the view asks it
 //   every 10 s whether WebKit still considers it visible, because the OS can
-//   discard the page's layers without terminating its process (#7112).
+//   discard the page's layers without terminating its process (#7112). After
+//   three consecutive attempts fail to put a live page on screen, the web view
+//   itself is torn down and rebuilt, because a reload cannot leave the frozen
+//   WebContent process a fresh one replaces (#7606).
 // Test: `LoadHarness.swift` in this directory resolves the principal class,
 //   instantiates the view outside the screen-saver host and asserts `didFinish`
 //   fires; `PaintHarness.swift` reads the rendered bitmap in the offline,
@@ -24,7 +27,9 @@
 //   `suspend-cold` states asserts a re-entrant `startAnimation()` reloads
 //   nothing, a page that goes from visible to hidden is reloaded, and a page
 //   hidden from its first answer under an unoccluded window is reloaded too —
-//   without either reloading a healthy page (#7112). The in-host run is manual — see
+//   without either reloading a healthy page (#7112), and in the `recreate` and
+//   `one-failure` states asserts three consecutive failed loads replace the web
+//   view instance while one does not (#7606). The in-host run is manual — see
 //   README.md, "Manual verification".
 //
 // Two constraints below are load-tested spike findings, not preference:
@@ -139,8 +144,23 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     /// lets WebKit's error callback win the ordinary race, so the log carries
     /// the real `NSError` rather than the watchdog's generic reason.
     private static let loadWatchdogGrace: TimeInterval = 1
+    /// #7606: how long one load attempt may stay outstanding before this view
+    /// gives up on it. Named once so the retry cadence below cannot drift back
+    /// under it — see [`retryGap`].
+    private static let loadDeadline: TimeInterval = loadTimeout + loadWatchdogGrace
+    /// #7606: how long after that deadline the next attempt starts. Any positive
+    /// value satisfies the invariant this constant exists for; two seconds keeps
+    /// a console that comes back mid-cycle picked up quickly.
+    private static let retryGap: TimeInterval = 2
     /// Retry cadence for the first [`fastRetryWindow`] of an outage.
-    private static let fastRetryInterval: TimeInterval = 5
+    ///
+    /// #7606: DERIVED from [`loadDeadline`], not chosen. At a flat 5 s it sat
+    /// UNDER the 6 s deadline, so every retry issued a `load` over an attempt
+    /// WebKit had not finished with; WebKit reported that supersession as
+    /// `NSURLErrorCancelled` (-999), [`enterOffline`] read its own cancellation
+    /// as a fresh failure and armed another 5 s retry, and the loop fed itself.
+    /// The owner's log carried 139 of those in two hours.
+    private static let fastRetryInterval: TimeInterval = loadDeadline + retryGap
     /// Retry cadence once the console has been down longer than that.
     private static let slowRetryInterval: TimeInterval = 30
     /// How long retries stay fast. A daemon reinstall is back inside a minute,
@@ -168,6 +188,22 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     /// never reported visible" branch is unbounded and [`reloadInterval`] is the
     /// only exit — an hour of the black screen this issue is about.
     private static let forcedRecoveryDeadline: TimeInterval = 60
+    /// #7606: consecutive failed attempts to get a live page on screen after
+    /// which the `WKWebView` itself is torn down and rebuilt. Three, because a
+    /// single failure is an outage the retry backoff already answers and this
+    /// costs a WebContent and a network XPC child; three consecutive ones say
+    /// the processes behind THIS web view are the thing that is wrong.
+    private static let recreateAfterFailures = 3
+    /// #7606: minimum gap between two rebuilds while the console has been
+    /// reachable recently. Matched to [`recoveryCooldown`] deliberately: a
+    /// rebuild is the heavier form of the same remedy and must not run at a
+    /// tighter rate than the reload it escalates from.
+    private static let recreateCooldown: TimeInterval = 60
+    /// #7606: the same gap once the console has been down longer than
+    /// [`fastRetryWindow`]. A dead daemon can fail every attempt all night, and
+    /// nothing about spawning WebContent processes at the 60 s floor would make
+    /// it answer.
+    private static let slowRecreateCooldown: TimeInterval = 600
 
     private var webView: WKWebView?
     private var retryTimer: Timer?
@@ -208,6 +244,20 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     /// jobs are to log the transition an operator needs to correlate against
     /// RunningBoard's own rows, and to re-probe the instant the window comes back.
     private var occlusionObserver: NSObjectProtocol?
+    /// #7606: when the load in flight started; `nil` when none is. What lets
+    /// [`abandonInFlightLoad`] tell a load it must cancel from one that already
+    /// ended, so `expectingCancellation` is never set speculatively.
+    private var loadStartedAt: Date?
+    /// #7606: whether the next `NSURLErrorCancelled` belongs to a load THIS view
+    /// abandoned. Without it a cancellation the view asked for arrives at
+    /// [`webView(_:didFailProvisionalNavigation:withError:)`] indistinguishable
+    /// from a real network failure and is counted as one.
+    private var expectingCancellation = false
+    /// #7606: failed attempts to get a live page on screen since the last one
+    /// that provably worked. Drives [`recreateAfterFailures`].
+    private var consecutiveLoadFailures = 0
+    /// #7606: when the web view was last rebuilt, for the recreate cooldown.
+    private var lastRecreateAt: Date?
     private var state: DisplayState
     private let config = SaverConfig.current()
     /// #6839: the bundled render of the dashboard, drawn whenever the live page
@@ -240,14 +290,24 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         // cost. #6839: preview draws the bundled render of that dashboard
         // instead, which is what the tile was missing.
         guard !isPreview else { return }
+        webView = makeWebView()
+    }
 
+    /// Why: #7606 rebuilds the web view at runtime, and two copies of this
+    ///   configuration would drift — a rebuilt view that drew its own background
+    ///   or arrived unhidden would look like a different bug entirely.
+    /// What: one hidden, full-bounds, delegate-attached `WKWebView`, added as a
+    ///   subview. The caller owns the [`webView`] reference.
+    /// Test: `PaintHarness.swift`'s `recreate` mode asserts the rebuilt instance
+    ///   loads and paints the same way the original did.
+    private func makeWebView() -> WKWebView {
         let web = WKWebView(frame: bounds, configuration: WKWebViewConfiguration())
         web.autoresizingMask = [.width, .height]
         web.navigationDelegate = self
         web.setValue(false, forKey: "drawsBackground")
         web.isHidden = true
         addSubview(web)
-        webView = web
+        return web
     }
 
     @available(*, unavailable)
@@ -327,6 +387,13 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         sawVisiblePage = false
         lastRecoveryAt = nil
         unhealthySince = nil
+        // #7606: the failure count and the rebuild cooldown are deliberately NOT
+        // reset here. `WallpaperAgent` re-arms a running view every 20 s to
+        // 3.5 min, and an offline view falls through to the load below on every
+        // one of those calls — clearing the count there would stop it ever
+        // reaching the threshold, and clearing the cooldown would let the host's
+        // cadence drive the rebuild rate. `stopAnimation()` owns both resets,
+        // and a view that has never run holds their initial values anyway.
         webView?.navigationDelegate = self
         loadConsole()
         scheduleReloadTimer()
@@ -404,6 +471,13 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         sawVisiblePage = false
         lastRecoveryAt = nil
         unhealthySince = nil
+        // #7606: nothing may rebuild the web view after the host's stop, and the
+        // cancellation the `about:blank` navigation below produces belongs to no
+        // attempt this view is still counting.
+        loadStartedAt = nil
+        expectingCancellation = false
+        consecutiveLoadFailures = 0
+        lastRecreateAt = nil
         if let occlusionObserver {
             NotificationCenter.default.removeObserver(occlusionObserver)
             self.occlusionObserver = nil
@@ -467,11 +541,18 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         // `evaluateJavaScript` fails on the navigation, and that failure reads as
         // a suspension and issues a second, redundant reload. `didFinish` re-arms.
         cancelVisibilityProbe()
+        // #7606: a `load` over an attempt WebKit has not finished with is a
+        // supersession, and WebKit reports it as -999. Cancelling here rather
+        // than letting the new request do it implicitly is what makes that -999
+        // attributable: every one this view can provoke passes through
+        // [`abandonInFlightLoad`] first and is recognised on the way back.
+        abandonInFlightLoad()
         os_log("loading %{public}@", log: saverLog, type: .info, config.url.absoluteString)
         var request = URLRequest(url: config.url)
         request.cachePolicy = .reloadIgnoringLocalCacheData
         // #6838: without this the request inherits URLRequest's 60 s default.
         request.timeoutInterval = Self.loadTimeout
+        loadStartedAt = Date()
         webView.load(request)
         // Only while the fallback is what the operator can see. An hourly reload
         // of a page already on screen has its own failure callbacks, and pulling
@@ -489,13 +570,39 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     ///   against a listener that accepts and never answers.
     private func startLoadWatchdog() {
         loadTimer?.invalidate()
-        let deadline = Self.loadTimeout + Self.loadWatchdogGrace
+        let deadline = Self.loadDeadline
         loadTimer = Timer.scheduledTimer(withTimeInterval: deadline, repeats: false) { [weak self] _ in
             guard let self else { return }
             self.loadTimer = nil
             guard self.state != .live else { return }
+            // #7606: giving up on an attempt means cancelling it. Left running,
+            // it stays outstanding until the next `load` supersedes it, and the
+            // -999 that comes back then is indistinguishable from a real one.
+            self.abandonInFlightLoad()
             self.enterOffline("load did not finish within \(Int(deadline))s")
         }
+    }
+
+    /// Why: the view abandons a load in two places — the watchdog above and the
+    ///   #7606 rebuild — and WebKit answers both by delivering
+    ///   `NSURLErrorCancelled` to the navigation delegate. Read as a network
+    ///   failure that error arms another retry, and the retry abandons another
+    ///   load: the -999 treadmill the owner's log carried 139 times in two hours.
+    /// What: cancels the attempt in flight, if there is one, and records that the
+    ///   cancellation coming back is this view's own doing. A no-op when nothing
+    ///   is outstanding, so the flag is never set speculatively — a -999 with no
+    ///   abandonment behind it came from outside and is still counted.
+    /// Test: `PaintHarness.swift`'s `recreate` mode counts the failures the view
+    ///   reaches before it rebuilds; a self-inflicted -999 doubles that count and
+    ///   trips the rebuild early.
+    private func abandonInFlightLoad() {
+        guard let startedAt = loadStartedAt else { return }
+        loadStartedAt = nil
+        expectingCancellation = true
+        webView?.stopLoading()
+        os_log("abandoned the load in flight after %{public}@s",
+               log: saverLog, type: .info,
+               String(format: "%.1f", Date().timeIntervalSince(startedAt)))
     }
 
     private func scheduleReloadTimer() {
@@ -512,7 +619,9 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     ///   dead daemon overnight must not retry at 5 s forever.
     /// What: one-shot rather than repeating, rescheduled per attempt, so the
     ///   cadence can widen: [`fastRetryInterval`] for the first
-    ///   [`fastRetryWindow`] of an outage, then [`slowRetryInterval`].
+    ///   [`fastRetryWindow`] of an outage, then [`slowRetryInterval`]. Both
+    ///   exceed [`loadDeadline`], so the attempt this fires is never the thing
+    ///   that cancels the attempt before it (#7606).
     ///   Invalidating first makes two stacked timers unreachable. The fired
     ///   closure reloads only in `.offline`, which is what keeps `.stopped`
     ///   terminal (#6900) — a timer already in flight when the host stops runs
@@ -544,6 +653,7 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         webView?.isHidden = true
         loadTimer?.invalidate()
         loadTimer = nil
+        loadStartedAt = nil
         // #7112: there is no live page left to probe.
         cancelVisibilityProbe()
         // Only the FIRST failure of a run sets the clock, so the backoff widens
@@ -552,6 +662,102 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         needsDisplay = true
         os_log("offline — %{public}@", log: saverLog, type: .error, reason)
         scheduleRetryTimer()
+        // #7606: last, so the retry above is armed as a backstop whether or not
+        // the rebuild runs. A rebuild that does run loads immediately and that
+        // load re-arms the timer from its own outcome.
+        noteLoadFailure(reason)
+    }
+
+    // MARK: - Web-view rebuild (#7606)
+
+    /// Why: reloading inside a `WKWebView` whose WebContent process the OS has
+    ///   parked cannot undo the parking — the reload lands in the same process,
+    ///   the page comes back `hidden`, and #7112's recovery reloads it again. The
+    ///   owner's saver ran that loop for three days: the console answered
+    ///   `/ui/screensaver` in under a millisecond throughout while the screen
+    ///   showed the bundled offline preview.
+    /// What: counts consecutive failed attempts to get a live page on screen and,
+    ///   at [`recreateAfterFailures`], schedules the rebuild. Judged on the
+    ///   COUNT, never on what the page said about its own visibility: a page
+    ///   reporting itself hidden inside a saver the host is animating is not
+    ///   evidence of occlusion, which is the inference that let this run for
+    ///   days. Returns whether a rebuild is now on its way, so a caller that
+    ///   would otherwise reload can stand down.
+    /// Test: `PaintHarness.swift`'s `recreate` mode asserts the instance is
+    ///   replaced after three failures and a fresh load follows; its `one-failure`
+    ///   mode asserts a single failure replaces nothing.
+    @discardableResult
+    private func noteLoadFailure(_ reason: String) -> Bool {
+        guard state != .stopped, state != .preview else { return false }
+        consecutiveLoadFailures += 1
+        guard consecutiveLoadFailures >= Self.recreateAfterFailures else { return false }
+
+        let cooldown = currentRecreateCooldown()
+        if let lastRecreateAt, Date().timeIntervalSince(lastRecreateAt) < cooldown {
+            os_log("rebuild held off — %{public}@ consecutive failure(s), inside the %{public}@s cooldown (%{public}@)",
+                   log: saverLog, type: .info,
+                   String(consecutiveLoadFailures), String(Int(cooldown)), reason)
+            return false
+        }
+
+        let failures = consecutiveLoadFailures
+        // Claimed BEFORE the rebuild runs, so a second failure landing in the
+        // same turn of the run loop cannot queue a second one behind it.
+        lastRecreateAt = Date()
+        consecutiveLoadFailures = 0
+        // Every caller reaches this from a navigation-delegate callback or from a
+        // timer that ran one, so WebKit is on the stack. Releasing a `WKWebView`
+        // under its own callback is not a supported teardown; the next turn is.
+        DispatchQueue.main.async { [weak self] in
+            self?.recreateWebView(reason, afterFailures: failures)
+        }
+        return true
+    }
+
+    /// The cooldown in force right now. A console that has been down longer than
+    /// [`fastRetryWindow`] fails every attempt by definition, and spawning
+    /// WebContent children at the 60 s floor all night would not make it answer.
+    private func currentRecreateCooldown() -> TimeInterval {
+        let downFor = offlineSince.map { Date().timeIntervalSince($0) } ?? 0
+        return downFor < Self.fastRetryWindow ? Self.recreateCooldown : Self.slowRecreateCooldown
+    }
+
+    /// Why: a fresh `WKWebView` is a fresh WebContent and network process, which
+    ///   is the only thing that clears a page the OS has frozen in place. This is
+    ///   the escalation #7112's reload could not reach.
+    /// What: detaches the old web view's delegate BEFORE tearing it down — the
+    ///   #6900 ordering, for the same reason, so a callback from the process
+    ///   being discarded reaches nothing — swaps in a replacement from
+    ///   [`makeWebView`], and loads. The state is left as the caller set it, so a
+    ///   rebuild reached from `.suspended` keeps the dimmed no-banner frame and
+    ///   one reached from `.offline` keeps the OFFLINE banner.
+    /// Test: `PaintHarness.swift`'s `recreate` mode.
+    private func recreateWebView(_ reason: String, afterFailures failures: Int) {
+        // Re-checked rather than assumed: this runs a turn of the run loop after
+        // the decision, and the host may have stopped the saver in between.
+        guard state != .stopped, state != .preview else {
+            os_log("rebuild abandoned — the host stopped the saver first", log: saverLog, type: .info)
+            return
+        }
+        os_log("rebuilding the web view — %{public}@ consecutive failed load(s): %{public}@",
+               log: saverLog, type: .default, String(failures), reason)
+
+        cancelVisibilityProbe()
+        loadTimer?.invalidate()
+        loadTimer = nil
+        loadStartedAt = nil
+        expectingCancellation = false
+        sawVisiblePage = false
+        unhealthySince = nil
+
+        if let old = webView {
+            old.navigationDelegate = nil
+            old.stopLoading()
+            old.removeFromSuperview()
+        }
+        webView = makeWebView()
+        needsDisplay = true
+        loadConsole()
     }
 
     // MARK: - Visibility recovery (#7112)
@@ -609,6 +815,11 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
             if let answer = value as? String, answer == "visible" {
                 self.sawVisiblePage = true
                 self.unhealthySince = nil
+                // #7606: the ONE signal that a load actually worked. `didFinish`
+                // is not it — every reload in the owner's three-day loop finished,
+                // and the page it produced was hidden each time. A page that
+                // answers `visible` is on screen, and only that clears the count.
+                self.consecutiveLoadFailures = 0
                 return
             }
             let answer = (value as? String)
@@ -670,6 +881,10 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         needsDisplay = true
         os_log("visibility lost, recovering — %{public}@ (%{public}@)",
                log: saverLog, type: .default, reason, ground)
+        // #7606: a recovery is a failed attempt to keep a live page on screen,
+        // and counts as one. Three in a row mean the reload is not working and
+        // the process behind the page goes instead — the rebuild loads for us.
+        if noteLoadFailure("visibility recovery: \(reason)") { return }
         loadConsole()
     }
 
@@ -831,6 +1046,8 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
         // successful console load would put a blank page on screen.
         guard webView.url?.absoluteString != "about:blank" else { return }
         state = .live
+        loadStartedAt = nil
+        expectingCancellation = false
         retryTimer?.invalidate()
         retryTimer = nil
         loadTimer?.invalidate()
@@ -853,7 +1070,19 @@ public final class TrustyConsoleSaverView: ScreenSaverView, WKNavigationDelegate
     public func webView(_ webView: WKWebView,
                         didFailProvisionalNavigation navigation: WKNavigation!,
                         withError error: Error) {
-        enterOffline("didFailProvisionalNavigation " + Self.describe(error as NSError))
+        let nsError = error as NSError
+        // #7606: a cancellation this view asked for in [`abandonInFlightLoad`] is
+        // not a failure to count and not a reason to retry — the attempt that
+        // replaces it is already accounted for. Counting it is what turned one
+        // failure into two and halved the effective retry interval.
+        if expectingCancellation, nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            expectingCancellation = false
+            os_log("ignored own cancellation — %{public}@", log: saverLog, type: .info,
+                   Self.describe(nsError))
+            return
+        }
+        expectingCancellation = false
+        enterOffline("didFailProvisionalNavigation " + Self.describe(nsError))
     }
 
     public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {


### PR DESCRIPTION
## Outcome

Fixes the console screensaver getting stuck on a cached page for days, unable
to reconnect to the console. Refs #7606

## Changes

- Problem: the legacyScreenSaver process stayed on a cached page for three
  days. `enterOffline` abandoned a load without `stopLoading()`, so the next
  retry's `webView.load()` superseded it and WebKit reported `-999`; the
  watchdog at 6 s and WebKit's own `-1001` each armed a retry, so one attempt
  counted as two failures on an 11 s cycle, and `recoverVisibility` refused to
  reload because the page reported hidden.
- Fix: `fastRetryInterval` is derived as `loadDeadline (6) + retryGap (2) = 8 s`;
  `abandonInFlightLoad()` cancels explicitly and sets `expectingCancellation` so
  `didFailProvisionalNavigation` does not count the saver's own `-999`;
  `noteLoadFailure` counts failed loads and visibility recoveries and rebuilds
  the `WKWebView` at 3 (`makeWebView()` extracted so init and rebuild share one
  path); the count clears only on a probe answering `visible`; the counters
  reset in `stopAnimation()`, not `startAnimation()`, because WallpaperAgent
  re-arms a running view every 20 s to 3.5 min.
- Out of scope: RunningBoard suspension handling itself is unchanged, only the
  failure-counting/rebuild path around it.

## Risk

UI surface, non-Rust — no crate `src/**` touched, so no cargo test-ladder gate
applies (rung 6). Blast radius is confined to
`crates/trusty-console/macos/saver/{TrustyConsoleSaver,PaintHarness}.swift`.

## Tests

Test ladder rung 6 (UI surface, non-Rust). Evidence:
- PaintHarness sweep of all nine modes PASS (offline / slow / preview / resize
  / stop / suspend / suspend-cold / recreate / one-failure), `ALL MODES DONE
  rc=0`.
- The new `recreate` mode against a bundle built from origin/main's saver
  source FAILS with `the web view was never replaced: 6 failed load(s) in
  60s, expected a rebuild after 3`, exit 9 — confirms the harness catches the
  pre-fix defect.
- LoadHarness against the live console PASS (`title=Trusty Console`).
- Build: zero warnings.
- Doc gates: `check_changelog_fragment.sh`, `check_sld.sh`,
  `check_doc_paths.sh`, `check_line_cap.sh` all pass.

## Baseline

Not reachable by the harness: three visibility recoveries under a real
RunningBoard suspension; the in-host run after install is the proof, as for
#7112. No pre-existing red gates on this branch.

## Docs

Changelog fragment added:
`crates/trusty-console/changelog.d/7606-saver-recreate-webview.md`. README
updated. Install after merge is a separate local-ops step
(`scripts/install-console-saver.sh`), followed by a trusty-console patch bump
per the owner's reinstall ruling.

## Review

No review findings yet — this is the initial PR for #7606.

Refs #7606

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
