### PR TITLE
chore(trusty-console): bump to 0.11.2 for owner-authorized reinstall (Refs #7606 #7589 #7590)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6644,7 +6644,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11723,7 +11723,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-console"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/trusty-console/Cargo.toml
+++ b/crates/trusty-console/Cargo.toml
@@ -25,7 +25,7 @@ name        = "trusty-console"
 # (src/connector.rs:100) and `enum_variant_added` for
 # `machine_history::events::HistoryEvent::Services`. Both are the shape the
 # console's per-service graphs are read from, so neither is avoidable.
-version     = "0.11.1"
+version     = "0.11.2"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Outcome
The installed trusty-console daemon is 0.11.0 and predates #7593 (Foundry
dashboards, one favicon) and #7614 (saver rebuild). This bump lets
`--version` identify the reinstalled build, per the owner's ruling that every
reinstall carries a patch bump. Tracks #7606, #7589, #7590.

## Changes
PATCH bump `crates/trusty-console/Cargo.toml` 0.11.1 -> 0.11.2, plus the
matching `Cargo.lock` update. No source changes.

## Risk
Low — metadata only.

## Tests
Rung 1 (version-only change).
- `cargo check -p trusty-console`: clean, exit 0.
- `bash scripts/check_workspace_dep_versions.sh`: OK — the `trusty-console`
  row (`req 0.11`) accepts crate `0.11.2`.
- `bash scripts/check_changelog_fragment.sh`: scanned 2 changed paths,
  attributed 0 crate-source paths — no fragment owed (docs-only / metadata).

## Baseline
None — no test failures encountered.

## Docs
None.

## Review
None needed — mechanical version bump.

Refs #7606

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
