### PR TITLE
docs: nineteen documentation quick wins across docs/reference, bundled skills and agent assets (Refs #7566 #7531 #7534 #7508 #7465 #7604 #7551 #7578 #7595 #7515 #7243 #7240 #7387 #7373 #7372 #7337 #7335 #7333 #7252)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,9 @@ what a pasted count then proves:
   runs otherwise. Run `UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden`, then
   read the diff of the three `crates/trusty-mpm/src/core/testdata/pm-prompt-*.md`
   goldens and confirm it carries only your edit.
-- 🟡 An exit 137 with no output from `cargo test -p <crate>` is a SIGKILL under
-  memory pressure (several agent worktrees building at once), not a test
-  failure; re-run with `-- --test-threads=4`.
+- 🟡 An exit 137 with no output from any gate command is usually a SIGKILL
+  under memory pressure, not a real failure — retry once before digging
+  further: [common-pitfalls.md](docs/reference/common-pitfalls.md).
 
 🔴 **`trusty-common` takes `--features` on every test run (#4901)** — its
 `default` set is empty, so a bare `cargo test -p trusty-common` is a

--- a/crates/trusty-agents-common/changelog.d/7620-doc-quick-wins.md
+++ b/crates/trusty-agents-common/changelog.d/7620-doc-quick-wins.md
@@ -1,0 +1,9 @@
+Documentation
+
+- `BASE-ENGINEER.md`'s regression-test-first section now names the
+  `git restore --source=HEAD --staged --worktree` substitute for
+  `git checkout HEAD --`, refused inside a Claude Code isolation worktree
+  (#7508).
+- The bundled `documentation` agent asset states that a spec edit driven by
+  an owner ruling must carry a dated cross-reference at the change site
+  (#7337).

--- a/crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-agents-common/src/assets/agents/BASE-ENGINEER.md
@@ -73,7 +73,10 @@ restore is where the work gets lost.
    reads back; with no commit there is nothing to restore from.
 2. Revert only the files under test — `git checkout origin/main -- <paths>` —
    run the test, and confirm it fails for the reason you expect.
-3. Restore with `git checkout HEAD -- <paths>`, naming `HEAD`.
+3. Restore with `git checkout HEAD -- <paths>`, naming `HEAD`. Inside a
+   Claude Code isolation worktree this form is refused as unverifiable; use
+   `git restore --source=HEAD --staged --worktree <paths>` there instead
+   (#7508).
 4. **Never restore with `git checkout <branch> -- <paths>` on a branch with no
    commit yet.** Its tip IS the base branch, so that checkout discards every
    uncommitted edit and prints nothing — an engineer lost a finished fix this

--- a/crates/trusty-agents-common/src/assets/agents/documentation.md
+++ b/crates/trusty-agents-common/src/assets/agents/documentation.md
@@ -90,6 +90,10 @@ and the "Policy" note in its README — follow it when writing or editing docs:
   pass; find it by reading the project's CLAUDE.md and listing its `scripts/`
   rather than assuming a filename. Specs predating the policy are usually
   grandfathered through an allowlist file the lint itself names.
+- **A spec edit driven by an owner ruling carries a dated cross-reference at
+  the change site** — the date the ruling was made plus a DOC/issue number,
+  mirroring the `// #NNNN:` ticket-attribution convention used for code. A
+  spec change from an owner ruling with no dated cross-reference is incomplete.
 
 ## Commit Discipline
 

--- a/crates/trusty-audit/changelog.d/7252-watchdog-sigint-doc.md
+++ b/crates/trusty-audit/changelog.d/7252-watchdog-sigint-doc.md
@@ -1,0 +1,6 @@
+Documentation
+
+- `stop_clones_on_interrupt`'s doc comment now states who installs the
+  `SIGINT` handler and what happens when a host binary also awaits its own
+  `tokio::signal::ctrl_c()` — both listeners are notified, since tokio fans
+  the signal out rather than claiming it exclusively.

--- a/crates/trusty-audit/src/clone/watchdog.rs
+++ b/crates/trusty-audit/src/clone/watchdog.rs
@@ -127,6 +127,16 @@ impl Drop for Detached {
 /// `SIGINT` stops killing the process on its own from the first poll onwards;
 /// the re-raise is what puts that back. Never returns.
 ///
+/// This function is what installs the `SIGINT` handler, via
+/// `tokio::signal::ctrl_c()` — the crate does not register one at load time,
+/// only when this is awaited, and only for as long as it stays pending.
+/// `tokio::signal::ctrl_c()` fans one OS signal out to every concurrent
+/// listener rather than claiming it exclusively, so a host binary that also
+/// awaits its own `tokio::signal::ctrl_c()` gets notified alongside this one,
+/// not instead of it — both run. A host binary that installs a signal handler
+/// by any OTHER means (a raw `sigaction`, the `signal-hook` crate) is
+/// untested against this function and may race it for the disposition.
+///
 /// This belongs to the BINARY, not to [`super::clone_all`]: it ends the process,
 /// and a front end embedding this crate owns that decision itself.
 /// Test: `super::watchdog::watchdog_tests::an_interrupt_kills_a_detached_clone_group`.

--- a/crates/trusty-mpm/changelog.d/7620-doc-quick-wins.md
+++ b/crates/trusty-mpm/changelog.d/7620-doc-quick-wins.md
@@ -1,0 +1,11 @@
+Documentation
+
+- Nineteen bundled-skill and doc-quick-win fixes across `documentation-style`,
+  `tm-ticketing`, `tm-delegation-patterns`, `webapp-testing`,
+  `test-driven-development`, `tm-workflow`, `code-review-standards`, and
+  `contract-driven-testing`: rustdoc/clippy doc-comment pitfalls, a reopen-
+  comment evidence rule, a docs-only close exception, a dead-worktree salvage
+  pattern, headless-screenshot verification, a concurrency-test RED-run rule,
+  a dated spec cross-reference rule, a third Fail-Open Check outcome, and
+  invariant-named/hermetic-fixture/pinned-clock test rules (Refs #7566 #7531
+  #7515 #7243 #7240 #7387 #7373 #7372 #7337 #7335 #7333).

--- a/crates/trusty-mpm/src/assets/skills/code-review-standards.md
+++ b/crates/trusty-mpm/src/assets/skills/code-review-standards.md
@@ -96,6 +96,15 @@ CRITICAL or HIGH by construction: silent data loss, or a broken contract.
    "done" marker, or success return that moves forward when the operation
    failed puts the lost item outside every future window. **Fail closed** —
    hold the state, propagate the error.
+   - A third outcome is also acceptable: **reported degradation** — the
+     failure is carried to the caller in the response body (e.g. a
+     `{"connected": false, "reason": ...}` field), and that field is under
+     test. This is distinct from silently failing open; the caller can see
+     and act on the degraded state. Contrast within one branch:
+     `knowledge_pipeline.rs::search_socket` discards its error via `.ok()`
+     (undocumented fail-open) while `knowledge_pipeline/indexing.rs` turns
+     the same missing-socket case into an explicit, tested response field
+     (reported degradation).
 2. **Name the alarm, then break it.** Identify which check is supposed to catch
    this loss, then ask whether it can report healthy while the loss occurs.
    Aggregates, tallies and summaries hide single-item failures by construction.

--- a/crates/trusty-mpm/src/assets/skills/contract-driven-testing.md
+++ b/crates/trusty-mpm/src/assets/skills/contract-driven-testing.md
@@ -200,3 +200,19 @@ When reviewing contracts written by the engineer:
 - [ ] Pre-call state is captured (`old()` or the language's equivalent) where
       a mutation postcondition needs to reference it.
 - [ ] Every precondition has a corresponding Level 3 violation test.
+- [ ] **Test name states the invariant that would be violated** — not the
+      function under test or a generic action. Worked examples:
+      `symlink_store_and_state_are_rejected`,
+      `concurrent_writers_have_exactly_one_revision_winner`,
+      `corrupt_or_cross_assistant_state_fails_closed`,
+      `index_collision_never_reindexes_a_foreign_root`,
+      `stale_inbox_replay_cannot_restore_detached_source`.
+- [ ] **Fixtures are hermetic** — built from `tempfile::tempdir()` (or the
+      language equivalent), never a fixed path, and never a read of `HOME` or
+      any other ambient env var.
+- [ ] **The clock is pinned** to a fixed timestamp rather than read from the
+      system clock, so a time-dependent assertion is reproducible.
+- A misleadingly-named test is a citable rejection: two tests in
+  `tools/listener_config.rs` and `tools/channel.rs` asserted on a field the
+  schema doesn't have, caught only because the review flagged the name/intent
+  mismatch (landed fix: PR #7323).

--- a/crates/trusty-mpm/src/assets/skills/documentation-style.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style.md
@@ -66,6 +66,21 @@ pub fn my_function() { … }
 pub fn cwd(&self) -> &Path { … }
 ```
 
+**Two `///` continuation pitfalls compile clean but fail a separate gate:**
+
+- A blank `///` line followed by an indented continuation line compiles as a
+  rustdoc doctest — rustdoc reads the indented block as a code fence, not
+  prose, and the crate's test suite then fails with `` unknown start of token:
+  ` `` instead of a doc build. Never follow a blank `///` line with an
+  indented continuation. Fixed worked example:
+  `crates/trusty-common/src/host_metrics.rs::mount_for_path` — its `Why:`/
+  `What:` continuation lines run on with no blank line inserted.
+- `Test:` placed directly after a numbered or bulleted list in `What:` fails
+  `clippy::doc_lazy_continuation` under `-D warnings` ("doc list item without
+  indentation"). Insert a blank `///` line between the list and `Test:`.
+  Fixed worked example:
+  `crates/trusty-mpm/src/bin/tm/commands/pm_guard_secret_read.rs:967-969`.
+
 **Never fabricate a spec link.** Add `# Spec References` (inline) or
 `spec_refs:` (Markdown frontmatter) only when a spec genuinely governs the
 item. An item with no governing spec simply omits the block — that is the

--- a/crates/trusty-mpm/src/assets/skills/test-driven-development.md
+++ b/crates/trusty-mpm/src/assets/skills/test-driven-development.md
@@ -29,6 +29,15 @@ Write a test that:
 - Is focused on a single behavior
 ```
 
+🔴 **A concurrency regression test's RED run against the pre-fix commit is
+not optional — it is the test's own correctness check.** A test written as a
+plain `Promise.all` (or equivalent) over two racing calls can pass against the
+exact racy commit it was meant to catch, when connection setup happens to
+serialize the pair and mask the race. Run it RED before trusting it green.
+Evidence: adaptive-crm issue #222 — first run against the racy store showed
+10 pass, 0 fail; only after warming the connection pool and looping eight
+attempts did attempt 0 fail with two creates.
+
 ### 2. Green Phase: Make It Pass
 ```
 Write the minimum code to:

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -323,6 +323,25 @@ regardless of wording.
 time, each waited for before the next. Serializing always works. Hand-rolling to
 parallelize anyway is what this forbids.
 
+## Salvaging a Dead Agent's Worktree
+
+A dispatch that names an existing worktree left behind by a stopped or dead
+agent cannot be followed directly — `tm hook --pm-guard` refuses cross-tree
+git from a differently-pinned worktree. Reach for `tm session
+adopt-worktree <tree> --as <session>` FIRST, before hand-porting files or
+rebuilding the branch from scratch: it is the documented verb for exactly
+this case (#6497, live-verified 2026-09-02). The refusal text to search on:
+`already used by worktree at .../<agent-dir>`, or a guard denial naming a
+tree pinned to a different, gone session. `tm session adopt-worktree` is
+distinct from `git worktree remove` (#5791, cleanup of an already-merged
+tree) — adoption is for a tree still holding unmerged work.
+
+Declaring `isolation: "worktree"` on a dispatch always mints a FRESH tree;
+there is no parameter that says "adopt this existing one instead." A PM that
+knows the target tree is a live, un-reclaimed worktree from an earlier round
+still has to let the dispatched agent land in the guard refusal and run
+`adopt-worktree` itself — there is no way to wire adoption in up front.
+
 ## Cross-Workstream Coordination (memory claim drawers, DOC-53)
 
 Memory is awareness only — never a lock, never a message channel. git/GitHub

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -83,6 +83,15 @@ root cause; file a new regression when the recurrence has a different cause, a
 different symptom class, or arrives after a verified fix that a reader would need
 to see as separate work.
 
+**A reopen comment on a previously-verified issue must carry the observed
+command and its actual stderr/output, never a restated prior cause.** #7185's
+reopen comment repeated the original causal claim ("tm's guard counts the
+marker") instead of the real failure: git's own `fatal: 'wt' contains
+modified or untracked files, use --force` in a project that does not
+gitignore the marker. One quoted stderr line would have named the real gate
+immediately. Quote what actually ran and what it printed; do not assume the
+old diagnosis still applies.
+
 ### 2. Promote only an independently prioritizable outcome
 
 File a standalone issue only when at least one of these holds:
@@ -464,6 +473,15 @@ live verification stays open — at `status:merged` while nobody is working it, 
 back at `status:coded` once a follow-up fix PR is open (owner ruling 2026-09-07;
 the model declares `status:merged -> status:coded`). A fix PR carries `Refs #N`,
 never `Closes #N`, so a merge cannot auto-close something nobody has verified.
+
+**Docs-only exception (owner ruling 2026-09-09).** A docs-only issue may close
+directly from `status:merged` on merged-text evidence — a squash-merge SHA
+plus confirmation the merged text is present on `origin/main` at the cited
+file/symbol — since there is no installed binary or run to point at. First
+application: #7190, closed on squash SHA `0024aa7af6a0cbab6fbe12b35ef5c6e26e312c46`
+with the text verified present at `destructive_delete.rs` lines 73-74 on
+`origin/main`. Every other issue class keeps the `status:tested` +
+live-verification bar unchanged.
 
 **Comments along the way.** A progress comment at each meaningful transition —
 diagnosis confirmed, fix pushed, review verdict received, blocked — carrying

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -137,6 +137,12 @@ Use: think/deepthink for analysis
 Return: Approval status with specific recommendations
 ```
 
+Both `code-analyzer` and `code-critic` run the Fail-Open Check
+(`code-review-standards`) against every failure branch touched, and name
+which of its three outcomes each branch lands in: fail-open (defect),
+fail-closed (correct), or reported degradation — the failure carried to the
+caller in a tested response field (also correct, distinct from fail-open).
+
 Decision: APPROVED → Implementation. NEEDS_IMPROVEMENT → back to Research.
 BLOCKED → escalate to the user.
 
@@ -148,7 +154,11 @@ described below. Skip only for docs-only/CI-only changes.
 The gate itself is `tm-verification-protocols`.
 
 **Phase 5 — Documentation** (`documentation`). Skipped for an internal refactor
-with no public API change.
+with no public API change. A spec edit driven by an owner ruling carries a
+dated cross-reference at the change site — `// <date>: <owner ruling
+summary>, see #<DOC-or-issue>` — mirroring the `// #NNNN:` ticket-attribution
+convention for code. A spec change from an owner ruling with no dated
+cross-reference fails review.
 
 ### Running the Phases
 

--- a/crates/trusty-mpm/src/assets/skills/webapp-testing.md
+++ b/crates/trusty-mpm/src/assets/skills/webapp-testing.md
@@ -423,6 +423,29 @@ page.set_viewport_size({'width': 1920, 'height': 1080})
 page.screenshot(path='/tmp/desktop.png')
 ```
 
+### Headless CLI Screenshots (`chrome --headless --screenshot`)
+
+A raw `chrome --headless --screenshot` run can exit 0 or 1 and write NO file,
+with no error naming the missing output — Chrome 153 has been observed doing
+this silently (adaptive-crm, issue #210, ~20 minutes lost diagnosing it).
+**Verify the output file exists after every headless-screenshot command**;
+treat a missing file as a failure even when the exit code looks clean.
+
+`--screenshot` alone cannot set a cookie first, so it cannot shoot a
+session-gated app. The supported fallback is CDP: launch with
+`--remote-debugging-port`, list targets at `/json/list`, then drive
+`Page.captureScreenshot` over the CDP websocket — the same connection can set
+the cookie before capturing.
+
+Run the dev server, a health check, the browser launch, and the capture
+inside ONE foreground script, rather than backgrounding the server and
+capturing in a later, separate tool call — a backgrounded server is not
+guaranteed to survive between tool calls, and a capture against a dead server
+photographs Chrome's own `ERR_CONNECTION_REFUSED` page instead of failing
+loudly (adaptive-crm PM session 2026-09-10: three of four captures showed the
+error page). Assert the server answers 200 immediately before AND after each
+shot, inside that same script.
+
 ### Video Recording
 ```python
 browser = p.chromium.launch(headless=True)

--- a/docs/reference/ci-scripts.md
+++ b/docs/reference/ci-scripts.md
@@ -60,6 +60,49 @@ gate that cannot fail makes its own green meaningless:
 own. Both carry a frozen baseline or a fetch that can fail open, which is the
 shape a self-test exists to pin, so both are candidates if either is edited.
 
+**The `--gate <path>` self-test convention.** Some `scripts/*_selftest.sh`
+scripts — `check_rustdoc_links_selftest.sh`,
+`check_changelog_attribution_selftest.sh`,
+`check_changelog_staged_selftest.sh` — accept `--gate <path>` to run their
+fixture cases against an alternate copy of the gate script instead of the real
+one. This is the mutation-demonstration convention: pointing `--gate` at a
+deliberately broken copy proves the fixtures can still fail, the same property
+"Self-tests" above states for the gate/self-test pairing itself. Not every
+self-test in this file supports the flag; check the individual script's own
+`--gate` handling before assuming it does.
+
+**Reading a GitHub Actions job log from this harness.** `gh api
+repos/OWNER/REPO/actions/jobs/<id>/logs` and a raw log piped through BSD `sed`
+both fail here — the Bash tool refuses terminal escape sequences, and BSD
+`sed`'s regex engine chokes on the raw ESC byte. Working form:
+
+```
+gh run view <run> --job <id> --log 2>&1 | LC_ALL=C tr -d '\033' | LC_ALL=C sed 's/\[[0-9;]*m//g' > <file>
+```
+
+then Read the file. `LC_ALL=C` keeps both `tr` and `sed` in byte mode so
+neither trips on the ESC byte or non-UTF-8 log content.
+
+**Bin-target doc links need the explicit-target form.** A `` [`Name`] `` doc
+link under a `src/bin/**` target that points at a library item resolves
+against the bin crate's own scope, not the library's, and silently ships as
+dead link text — a crate-scoped build does not catch it, only
+`check_rustdoc_links.sh`'s workspace-wide run does. Spell the target
+explicitly instead: `` [`Name`](trusty_mpm::path::Name) ``. Worked example:
+`crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs:84-85`, both forms
+spelled out explicitly. (Adding a `-p <crate>` passthrough to the script so a
+crate-scoped run can serve as a pre-commit gate is a separate, code-level
+change, out of scope here.)
+
+A source-scanning guard that strips comments before matching must consume
+`//` and `/* */` in appearance order — stripping block comments first lets a
+`src/bin/tm/**` glob inside a `//` doc line open an unterminated block
+comment and silently discard the rest of the file, a false-clean ratchet.
+`env_isolation_tests.rs::strip_comments` in
+`crates/trusty-mpm/src/bin/tm/env_isolation_tests.rs` already does this
+correctly; point any new comment-stripping guard at that precedent rather
+than re-deriving the order (Refs #7568).
+
 ## Gated in a workflow, but not CI-only
 
 `scripts/check_doc_paths.sh` (issue #5147) is deliberately NOT in the table

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -101,6 +101,14 @@ and issue #2222. On a mismatched host, `trusty-embedderd`'s startup now fails
 fast with an explicit glibc-version error instead of hanging for up to
 `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` (default 180 s).
 
+🟡 **An unexplained exit 137 from any gate command is usually a SIGKILL under
+memory pressure, not a real failure** — several agent worktrees building or
+testing concurrently exhaust host memory. First response is a single retry
+before investigating further. Moved here from CLAUDE.md and generalized
+(#7465): the original guidance named only `cargo test -p <crate>`, but the
+same kill hits `./scripts/check_line_cap.sh` and any other gate command; when
+retrying `cargo test -p <crate>` specifically, add `-- --test-threads=4`.
+
 🟢 **MSRV drift** — the workspace pins `rust-version = "1.94"`. Running
 `rustup update` and picking up a new nightly may introduce syntax that
 compiles locally but fails on CI. Prefer stable channel toolchains.

--- a/docs/reference/test-ladder-baseline.md
+++ b/docs/reference/test-ladder-baseline.md
@@ -50,6 +50,13 @@ was exercised.
 `cargo test --workspace` is absent from rungs 1–3 on purpose; "scope down, never
 scope away" above is what constrains picking a lower rung.
 
+🔴 **Editing `crates/trusty-console/ui*/index.html` owes the crate's
+`*_ui_mount` tests, in addition to rung 6's other gates** —
+`cargo test -p trusty-console --test '*_ui_mount'` (`analyze_ui_mount.rs`,
+`memory_ui_mount.rs`, `search_ui_mount.rs`). These pin the served shell's
+`<title>` and asset references; an `index.html` edit that misses them can pass
+every other UI gate green and still fail here (#7593).
+
 ### Every rung carries `--no-fail-fast`, and the reason is not politeness
 
 Cargo runs each test target as its own binary and, by default, stops issuing

--- a/docs/reference/worktree-discipline.md
+++ b/docs/reference/worktree-discipline.md
@@ -166,6 +166,9 @@ substitutes as the reliable spelling rather than as a workaround for one shape.
 | `cd <worktree> && git diff …` | `git -C <absolute worktree path> diff …` |
 | a git command wrapped in the redirect-then-`echo` gate idiom | run the git command bare, one per Bash call |
 | a pathspec whose basename starts `tm-`, or a `$(git …)` substitution as a pathspec | quote a glob: `git --no-pager diff -- 'crates/*/src/assets/skills/tm-capa*'` |
+| `git checkout HEAD -- <paths>` | `git restore --source=HEAD --staged --worktree <paths>` |
+| a `grep` pattern with no `git` in it at all — `grep -n caller_session <file>` refused, `grep -n 'caller' <same file>` allowed, same file both times | re-spell the pattern shorter, or read the file with the Read tool instead |
+| `gh pr create` / `tm pr open` refused because the PR body text carries an env-sample filename substring (a dotenv-style `.example` suffix) | reword the body text to avoid that literal substring, or pass the body via `--body-file <path>` |
 
 ### Running a script or an interpreter
 
@@ -176,6 +179,8 @@ substitutes as the reliable spelling rather than as a workaround for one shape.
 | `python3 - <<'PY'`, `cat >> <file> <<'EOF'`, a heredoc piped into a runner | the Write tool, or Edit for a multi-hunk change |
 | `node -e` whose script path is built from a variable | a literal path |
 | an `awk` program over a log file | `grep` |
+| `grep -n <pattern> <file>` | multi-file/line-number `grep` results are unreliable here — read the file with the Read tool and search visually, or narrow to the one line with `sed -n '<N>p' <file>` on a literal address |
+| a helper script written with the Write tool to the scratchpad directory, then run from there (`python3 <scratchpad>/name.py`) — refused even quoted, because the scratchpad sits outside the worktree | write the script INSIDE the worktree with the Write tool and invoke it as `./name.py`, not from the scratchpad path |
 
 This repo's docs spell every gate `bash scripts/<name>.sh`, so the first row
 above applies to the whole test ladder, not only to the line-cap check.
@@ -191,6 +196,9 @@ above applies to the whole test ladder, not only to the line-cap check.
 | `export VAR=$PWD/… && cargo …`, `CARGO_TARGET_DIR=$PWD/… cargo …` | spell the absolute path literally in the assignment |
 | `$(pgrep …)` or any command substitution supplying an argument | a literal value, captured in a previous call |
 | an argument whose TEXT contains `git` — a grep pattern, a `perl -pi` regex, a filename | none; re-spell the pattern, or use the Write-a-script route |
+| a directory argument with a trailing `/` (`find crates/<crate>/ -name …`) | drop the trailing slash: `find crates/<crate> -name …` |
+| a pattern or path containing the literal token `worktree` (`grep -n worktree <file>`) | re-spell around the literal token, or read the file with the Read tool |
+| `grep` over more than one file (`grep -rn <pattern> <dir1> <dir2>`, or a glob matching several files) | one `grep` call per file, or `git grep -l <pattern>` to list matches first |
 
 One reported shape is refused HERE too, for a reason of our own: `$'…'` quoting
 (`grep -n $'\tfixture' README.md`). The guard's lexer cannot decode it, so it


### PR DESCRIPTION
## Outcome
Nineteen open docs-only issues each asked for a small addition; all land here so each can close from status:merged per the #7243 owner ruling recorded in this same PR. Per today's #7620 ruling CLAUDE.md received only pointer edits; the content went to the docs/reference file or skill that owns the topic.

## Changes
docs/reference/{ci-scripts,common-pitfalls,test-ladder-baseline,worktree-discipline}.md; bundled skills under crates/trusty-mpm/src/assets/skills/ (documentation-style, tm-ticketing, tm-delegation-patterns, webapp-testing, test-driven-development, tm-workflow, code-review-standards, contract-driven-testing); crates/trusty-agents-common/src/assets/agents/{BASE-ENGINEER,documentation}.md; crates/trusty-audit/src/clone/watchdog.rs doc comment; CLAUDE.md pointer lines; fragments for trusty-mpm, trusty-agents-common, trusty-audit.

## Risk
Low.

## Tests
`scripts/check_sld.sh` 0 errors; `scripts/check_doc_paths.sh` 66 files resolve; `scripts/check_line_cap.sh` 0 violations; changelog gate all 3 crates recorded; context-budget gate OK (67122 B vs baseline 67104, within allowance); `cargo test -p trusty-audit --doc` ok; bundled-skill deploy tests code_critic_skills_land_in_deployed_dot_claude_skills, install_then_deploy_deploys_skills, documentation_style_lands_in_deployed_dot_claude_skills all 1 passed.

## Baseline
None.

## Docs
This PR is docs.

## Review
None.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
