### PR TITLE
fix(trusty-mpm,trusty-agents-common): pre-pull untracked-collision check; 128+N exit codes read as signals; local-ops blocks on its own waits (Refs #7558 #7561 #7612)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/7612-local-ops-blocks-on-its-own-waits.md
+++ b/crates/trusty-agents-common/changelog.d/7612-local-ops-blocks-on-its-own-waits.md
@@ -1,0 +1,19 @@
+Fixed
+
+- `local-ops.md`'s "Long Waits" section now names the blocking verb for the two
+  task shapes the agent kept parking on. A deploy script and a reachability poll
+  are the agent's own commands, so the section states they run in the
+  foreground and that the wait goes through `tm wait --for run --pid` (or
+  `--for file --path` for a probe that writes a sentinel), never through a
+  notification the agent expects to wake it. The two narrations observed —
+  "I'll wait for the deploy monitor notification before proceeding" and
+  "Standing by" — are quoted as the shapes that end a turn with the goal unmet
+  (#7612).
+- The same section now states a margin rule for any bounded polling loop: bound
+  it ~10-15% under the harness's foreground ceiling rather than at it. The Bash
+  tool caps at 600000ms and a loop written to a nominal 600s overran that on
+  per-iteration overhead and auto-backgrounded; ~480s is the budget, re-issued
+  in the same turn when the condition has not met yet. #2501 and #2610 closed
+  this failure class on version-control and merge-release; this is the
+  recurrence on local-ops, whose task shapes the earlier fix did not reach
+  (#7612).

--- a/crates/trusty-agents-common/src/assets/agents/local-ops.md
+++ b/crates/trusty-agents-common/src/assets/agents/local-ops.md
@@ -97,6 +97,28 @@ hangs until a human resumes you.
 cargo build --release -p <crate>         # long build: run it, wait for exit
 ```
 
+**A deploy script and a reachability poll are your commands too (#7612).** Run
+the script in the foreground and let it hold the turn. Wait on the thing itself
+with `tm wait --for run`, never on a notification you expect to wake you:
+
+```bash
+./scripts/<deploy-script>.sh                        # deploy: foreground, wait for exit
+tm wait --for run --pid <pid> --timeout 480         # a process you backgrounded
+tm wait --for file --path <sentinel> --timeout 480  # a probe that writes its result
+```
+
+A reachability poll is the same shape: have the probe write its verdict to a
+sentinel file and wait on that file, or run a bounded loop under the margin
+rule below. "I'll wait for the deploy monitor notification before proceeding"
+and "Standing by" both end the turn with the goal unmet and strand the deploy
+until a human resumes you.
+
+🔴 **Bound a polling loop ~10-15% under the harness's foreground ceiling, never
+at it.** The Bash tool caps at 600000ms, and a loop written to a nominal 600s
+overran that on per-iteration overhead and auto-backgrounded — the margin is
+what per-iteration cost is paid out of. Budget ~480s, and re-issue the wait in
+the SAME turn when the condition has not met yet (#7612).
+
 **CI is the opposite.** Never wait on it and never use `gh pr checks --watch` —
 `--watch` streams check output into your context for the whole run (546k tokens
 over 54 minutes on one PR). Push, take a ONE-SHOT `gh pr checks <pr>` /

--- a/crates/trusty-mpm/changelog.d/7558-pre-pull-untracked-collision-check.md
+++ b/crates/trusty-mpm/changelog.d/7558-pre-pull-untracked-collision-check.md
@@ -1,0 +1,13 @@
+Fixed
+
+- The bundled `git-workflow` skill now states a pre-pull untracked-collision
+  check, so a `git pull --ff-only` that would abort with "The following
+  untracked working tree files would be overwritten by merge" is caught before
+  it runs rather than improvised around afterwards. The guidance names the
+  exact check — `git status --porcelain` for the `??` rows, then
+  `git show origin/<base>:<path> | diff - <path>` per colliding path — and its
+  two outcomes: identical content resolves itself by deleting the untracked
+  copy, differing content is reported with the diff. Deleting an untracked path
+  to clear the abort without diffing it first is called out as the thing not to
+  do, since the abort only says two writers produced one path, never that
+  either copy is disposable (#7558).

--- a/crates/trusty-mpm/changelog.d/7558-pre-pull-untracked-collision-check.md
+++ b/crates/trusty-mpm/changelog.d/7558-pre-pull-untracked-collision-check.md
@@ -11,3 +11,8 @@ Fixed
   to clear the abort without diffing it first is called out as the thing not to
   do, since the abort only says two writers produced one path, never that
   either copy is disposable (#7558).
+- `tm-workflow`'s main-checkout refresh instructions now point at that check.
+  The refresh is where `pull --ff-only` is actually prescribed, and it already
+  named one cause of the command failing — another session's uncommitted work —
+  so the untracked-path collision is recorded there as the other cause, with a
+  cross-reference rather than a second copy of the procedure (#7558).

--- a/crates/trusty-mpm/changelog.d/7561-signal-exit-is-not-a-failure.md
+++ b/crates/trusty-mpm/changelog.d/7561-signal-exit-is-not-a-failure.md
@@ -1,0 +1,12 @@
+Fixed
+
+- The bundled `verification-before-completion` skill now teaches how to read a
+  `128 + N` exit status beside its own "check exit code" step, so an agent stops
+  reading its own `kill <pid>` as a crash. A dev server stopped on purpose was
+  reported four times in one task as "failed with exit code 143"; 143 is
+  `128 + 15`, a `SIGTERM` delivery, and the skill now maps 130 / 137 / 143 to
+  their signals and says to report a deliberate stop as terminated by signal N
+  rather than failed. The one `128 + N` value that is still a real failure —
+  a 137 on a build or test run nobody killed, which is the OOM killer — is
+  carved out explicitly so the rule cannot be used to wave off a genuine kill
+  (#7561).

--- a/crates/trusty-mpm/src/assets/skills/git-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/git-workflow.md
@@ -118,6 +118,39 @@ git checkout feature-branch
 git merge origin/main
 ```
 
+### Pulling After a Merge — Check Untracked Collisions First
+
+<!-- #7558: the post-merge pull aborted blind on an untracked research doc the
+     incoming branch also committed, and the recovery was improvised by hand. -->
+
+`git pull --ff-only` refuses to run when the incoming commits add a path that
+already exists in your checkout as an untracked file:
+
+```
+error: The following untracked working tree files would be overwritten by merge:
+        docs/research/some-plan.md
+```
+
+The abort names the path and nothing else. Check for the collision before you
+pull rather than improvising a recovery after it fails:
+
+```bash
+git fetch origin
+git status --porcelain                        # untracked paths are the `??` rows
+git show origin/<base>:<path> | diff - <path> # one per colliding path
+```
+
+There are exactly two outcomes:
+
+- **Identical content** — the untracked copy is byte-for-byte what the branch
+  commits, so nothing is lost. Delete the untracked copy and pull.
+- **Differing content** — stop and report the diff. That copy holds work the
+  branch does not have, and the pull is not the thing to force.
+
+Never delete an untracked path to clear the abort without diffing it first: a
+`--ff-only` abort says two writers produced the same path, not that one of them
+is disposable.
+
 ### Undoing Changes
 
 ```bash

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -302,8 +302,17 @@ auto-merging docs-only PR. So run the fetch and `pull --ff-only` above after a
 pause PR lands, the same as after any other merge, and the snapshot is visible
 locally again.
 
-🔴 **If `--ff-only` fails, never clear the way by discarding.** The usual cause
-is another session's uncommitted work. Do not `git stash` — repo-level and
+🟡 **One cause is an untracked path the incoming commits also add.** `--ff-only`
+then aborts with "The following untracked working tree files would be
+overwritten by merge", naming the path and nothing else. Diff that untracked
+copy against the incoming one BEFORE pulling rather than improvising a recovery
+after the abort: identical content resolves itself, differing content is
+reported with the diff. The check and both outcomes are in
+`Skill(skill="git-workflow")`, under the heading
+"Pulling After a Merge — Check Untracked Collisions First" (#7558).
+
+🔴 **If `--ff-only` fails, never clear the way by discarding.** The other usual
+cause is another session's uncommitted work. Do not `git stash` — repo-level and
 shared across every worktree, so it yanks state out from under sessions running
 right now. Do not `git checkout --`, `restore`, `reset --hard`, or `clean`: the
 main-checkout guard blocks these, correctly, and hunting for an unblocked

--- a/crates/trusty-mpm/src/assets/skills/verification-before-completion.md
+++ b/crates/trusty-mpm/src/assets/skills/verification-before-completion.md
@@ -61,6 +61,33 @@ The five-step gate function:
 
 Skip any step = lying, not verifying.
 
+## Reading an Exit Code
+
+<!-- #7561: a `kill <pid>` stop of a dev server was reported four times as
+     "failed with exit code 143". -->
+
+Step 3 says "check exit code". A non-zero exit is not automatically a failure.
+A process stopped by a signal reaches the shell as `128 + N`, so a kill you
+issued yourself lands in the same numeric range as a real crash:
+
+| Exit | Meaning |
+|---|---|
+| `0` | Success |
+| `1`–`125` | The command's own failure status |
+| `130` (128+2) | `SIGINT` — Ctrl-C |
+| `137` (128+9) | `SIGKILL` — `kill -9`, or the OOM killer |
+| `143` (128+15) | `SIGTERM` — the ordinary `kill <pid>` |
+
+When you or the harness stopped the process on purpose — `kill <pid>` on a dev
+server you started, a monitor tearing down a background task — a `128 + N` exit
+is **terminated by signal N**, which is the outcome you asked for. Report it
+that way and never as "failed with exit code 143". Do not file a bug or start
+debugging a failure that did not happen.
+
+The one exception is `137` on a build or test run nobody killed: that is the
+OOM killer, a real failure, and it is diagnosed rather than read as a clean
+stop.
+
 ## Key Patterns
 
 **Correct Pattern:**

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1661,3 +1661,51 @@ fn base_agent_prose_rules_survive_composition() {
         "graduated-verbosity rule must not reuse the optimizer's `Caveman` term"
     );
 }
+
+/// 🔴 #7558 REGRESSION: `git pull --ff-only` aborts naming only the colliding
+/// path, so the recovery gets improvised — once by hand-diffing two copies of
+/// an untracked research doc. The bundled `git-workflow` skill must state the
+/// pre-pull check and BOTH of its outcomes, so the identical-content case
+/// resolves itself and the differing-content case is reported rather than
+/// deleted.
+#[test]
+fn git_workflow_skill_states_the_pre_pull_untracked_collision_check_7558() {
+    for needle in [
+        "### Pulling After a Merge — Check Untracked Collisions First",
+        "git status --porcelain",
+        "git show origin/<base>:<path>",
+        "**Identical content**",
+        "**Differing content**",
+        "Never delete an untracked path to clear the abort without diffing it",
+    ] {
+        assert!(
+            GIT_WORKFLOW.contains(needle),
+            "git-workflow skill is missing the #7558 pre-pull untracked-collision \
+             guidance: {needle:?}"
+        );
+    }
+}
+
+/// 🔴 #7561 REGRESSION: a `kill <pid>` the agent issued itself surfaced four
+/// times as "failed with exit code 143", because a `128 + signal` exit shares
+/// the numeric range of a real failure. `verification-before-completion` owns
+/// the "check exit code" step, so the signal reading must live beside it —
+/// including the one `128 + N` value that IS a failure (137 nobody killed).
+#[test]
+fn verification_skill_reads_128_plus_signal_as_terminated_not_failed_7561() {
+    for needle in [
+        "## Reading an Exit Code",
+        "`128 + N`",
+        "`143` (128+15)",
+        "`SIGTERM` — the ordinary `kill <pid>`",
+        "**terminated by signal N**",
+        "never as \"failed with exit code 143\"",
+        "The one exception is `137`",
+    ] {
+        assert!(
+            VERIFICATION_BEFORE_COMPLETION.contains(needle),
+            "verification-before-completion skill is missing the #7561 \
+             signal-exit reading: {needle:?}"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1716,6 +1716,32 @@ fn git_workflow_skill_states_the_pre_pull_untracked_collision_check_7558() {
     }
 }
 
+/// 🔴 #7558 REGRESSION, second home: `tm-workflow` owns the main-checkout
+/// `pull --ff-only` refresh and already names ONE cause of its failure
+/// (another session's uncommitted work). The untracked-path collision is a
+/// second cause of the same command failing, so the refresh instructions must
+/// point at the check rather than leaving the reader to improvise — a
+/// cross-reference, not a second copy of the block.
+#[test]
+fn tm_workflow_points_at_the_pre_pull_untracked_collision_check_7558() {
+    for needle in [
+        "untracked path the incoming commits also add",
+        "Pulling After a Merge — Check Untracked Collisions First",
+        "#7558",
+    ] {
+        assert!(
+            TM_WORKFLOW.contains(needle),
+            "tm-workflow is missing the #7558 cross-reference to the pre-pull \
+             untracked-collision check: {needle:?}"
+        );
+    }
+    // A pointer, not a duplicate: the procedure itself stays in one place.
+    assert!(
+        !TM_WORKFLOW.contains("git show origin/<base>:<path> | diff - <path>"),
+        "tm-workflow must cross-reference the check, not restate its commands (#7558)"
+    );
+}
+
 /// 🔴 #7561 REGRESSION: a `kill <pid>` the agent issued itself surfaced four
 /// times as "failed with exit code 143", because a `128 + signal` exit shares
 /// the numeric range of a real failure. `verification-before-completion` owns

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -1662,6 +1662,36 @@ fn base_agent_prose_rules_survive_composition() {
     );
 }
 
+/// 🔴 #7612 REGRESSION: `local-ops` parked on a narrated wait twice in one
+/// session — once on a reachability poll, once after starting a deploy script —
+/// despite BASE-AGENT's inherited rule, and a 600s bounded loop overran the
+/// Bash tool's 600000ms ceiling. #2501/#2610 closed the same class on
+/// version-control; the persona text must name the blocking verb for ITS task
+/// shapes and the margin a bounded loop owes.
+#[test]
+fn local_ops_names_tm_wait_for_deploys_and_a_loop_margin_7612() {
+    use crate::core::agent_builder::compose_agent;
+    use std::path::Path;
+
+    let assets_dir = Path::new(trusty_agents_common::agent_assets::AGENT_ASSETS_DIR);
+    let local_ops =
+        compose_agent("local-ops", assets_dir).expect("compose_agent(local-ops) must succeed");
+
+    for needle in [
+        "A deploy script and a reachability poll are your commands too",
+        "`tm wait --for run`",
+        "tm wait --for run --pid <pid> --timeout 480",
+        "tm wait --for file --path <sentinel>",
+        "10-15% under the harness's foreground ceiling",
+        "600000ms",
+    ] {
+        assert!(
+            local_ops.contains(needle),
+            "composed local-ops is missing the #7612 blocking-wait guidance: {needle:?}"
+        );
+    }
+}
+
 /// 🔴 #7558 REGRESSION: `git pull --ff-only` aborts naming only the colliding
 /// path, so the recovery gets improvised — once by hand-diffing two copies of
 /// an untracked research doc. The bundled `git-workflow` skill must state the


### PR DESCRIPTION
## Outcome

Refs #7558 #7561 #7612

#7558 — `git pull --ff-only` aborts on an untracked path the incoming commits
also add, and nothing told agents to check first. The `git-workflow` skill
gains "Pulling After a Merge — Check Untracked Collisions First", and
`tm-workflow`'s main-checkout refresh section now cross-references it.

#7561 — a self-issued `kill` surfaces as exit 143 and was read as a failure.
`verification-before-completion` gains "Reading an Exit Code", mapping
130/137/143 to signals, with the one carve-out that a 137 nobody sent on a
build/test run is the OOM killer (the fail-open guard, pinned by test).

#7612 — `local-ops` inherited "never narrate a wait" only for gates/CI. Its
Long Waits section now names deploy scripts and reachability polls as its own
commands, routes them through `tm wait --for run --pid` / `--for file --path`,
and bounds polling loops 10-15% under the 600000 ms Bash ceiling.

#7607 is deferred to batch 2b — it shares `compress.rs` with #7618.

## Changes

- `crates/trusty-mpm/src/assets/skills/git-workflow.md`
- `crates/trusty-mpm/src/assets/skills/verification-before-completion.md`
- `crates/trusty-mpm/src/assets/skills/tm-workflow.md`
- `crates/trusty-agents-common/src/assets/agents/local-ops.md`
- `crates/trusty-mpm/src/core/bundle_tests.rs` — four content-pinning tests,
  one per issue, each shown failing pre-fix
- `crates/trusty-mpm/changelog.d/7558-pre-pull-untracked-collision-check.md`
- `crates/trusty-mpm/changelog.d/7561-signal-exit-is-not-a-failure.md`
- `crates/trusty-agents-common/changelog.d/7612-local-ops-blocks-on-its-own-waits.md`

Out of scope: #7607 (deferred to batch 2b, shares `compress.rs` with #7618).

## Risk

Normal — skill and agent prose plus tests, no runtime code paths changed.

## Tests

Rung 3.

- `cargo fmt --check`: 0
- `cargo check` / `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: 0
- `cargo check` / `cargo clippy -p trusty-agents-common --all-targets -- -D warnings`: 0
- `cargo test -p trusty-agents-common --no-fail-fast`: 580 passed, 0 failed
- `cargo test -p trusty-mpm --no-fail-fast`: 59/60 targets ok; the one failure
  is `bundled_agent_resident_skill_cost_stays_within_budget`, pre-existing on
  `origin/main` since #7626 (empty three-dot diff for every input file;
  9244+4642+9897+10570 = 34353 B vs a 34000 B budget); a hotfix is in flight
- `scripts/check_line_cap.sh`, `check_test_pointers.sh`, `check_sld.sh`,
  `check_agent_assets.sh` (42 single-copy assets, `local-ops` not a pinned
  deviation), changelog gate: all 0

## Baseline

`bundled_agent_resident_skill_cost_stays_within_budget` is red on
`origin/main` from #7626, unrelated to this PR's changes.
`worktrees_exclude_entry_protects_against_double_force_clean` flaked once and
passed on rerun.

## Docs

Changelog fragments present for `trusty-mpm` (#7558, #7561) and
`trusty-agents-common` (#7612).

## Review

None — sprint mode, no critic round for this batch.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
