### PR TITLE
fix(trusty-mpm): trim the #7626 skill additions back under the resident-skill budget (Refs #4642 #7626)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7626-resident-skill-budget.md
+++ b/crates/trusty-mpm/changelog.d/7626-resident-skill-budget.md
@@ -1,0 +1,9 @@
+Fixed
+
+- Trimmed the `documentation-style` and `test-driven-development` bundled
+  skills back under the rust-family resident-skill budget, which #7626 pushed
+  353 bytes over and reddened main. Every fact those additions carried is
+  kept — the doctest and `doc_lazy_continuation` continuation pitfalls with
+  their worked examples, and the concurrency-test RED-run rule — the prose is
+  shorter and the duplicated per-language cart example collapsed to one
+  (Refs #4642 #7626).

--- a/crates/trusty-mpm/src/assets/skills/documentation-style.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style.md
@@ -68,18 +68,14 @@ pub fn cwd(&self) -> &Path { … }
 
 **Two `///` continuation pitfalls compile clean but fail a separate gate:**
 
-- A blank `///` line followed by an indented continuation line compiles as a
-  rustdoc doctest — rustdoc reads the indented block as a code fence, not
-  prose, and the crate's test suite then fails with `` unknown start of token:
-  ` `` instead of a doc build. Never follow a blank `///` line with an
-  indented continuation. Fixed worked example:
-  `crates/trusty-common/src/host_metrics.rs::mount_for_path` — its `Why:`/
-  `What:` continuation lines run on with no blank line inserted.
-- `Test:` placed directly after a numbered or bulleted list in `What:` fails
+- A blank `///` line then an indented continuation compiles as a doctest —
+  rustdoc reads the indented block as a code fence, not prose — and the suite
+  fails with `` unknown start of token: ` ``. Never indent after a blank `///`.
+  Fixed: `crates/trusty-common/src/host_metrics.rs::mount_for_path`.
+- `Test:` directly after a numbered or bulleted list in `What:` fails
   `clippy::doc_lazy_continuation` under `-D warnings` ("doc list item without
   indentation"). Insert a blank `///` line between the list and `Test:`.
-  Fixed worked example:
-  `crates/trusty-mpm/src/bin/tm/commands/pm_guard_secret_read.rs:967-969`.
+  Fixed: `crates/trusty-mpm/src/bin/tm/commands/pm_guard_secret_read.rs:967-969`.
 
 **Never fabricate a spec link.** Add `# Spec References` (inline) or
 `spec_refs:` (Markdown frontmatter) only when a spec genuinely governs the

--- a/crates/trusty-mpm/src/assets/skills/test-driven-development.md
+++ b/crates/trusty-mpm/src/assets/skills/test-driven-development.md
@@ -8,8 +8,6 @@ effort: high
 ---
 # Test-Driven Development (TDD)
 
-Comprehensive TDD patterns and practices for all programming languages. This skill eliminates ~500-800 lines of redundant testing guidance per agent.
-
 ## When to Use
 
 Apply TDD for:
@@ -29,14 +27,12 @@ Write a test that:
 - Is focused on a single behavior
 ```
 
-🔴 **A concurrency regression test's RED run against the pre-fix commit is
-not optional — it is the test's own correctness check.** A test written as a
-plain `Promise.all` (or equivalent) over two racing calls can pass against the
-exact racy commit it was meant to catch, when connection setup happens to
-serialize the pair and mask the race. Run it RED before trusting it green.
-Evidence: adaptive-crm issue #222 — first run against the racy store showed
-10 pass, 0 fail; only after warming the connection pool and looping eight
-attempts did attempt 0 fail with two creates.
+🔴 **Run a concurrency regression test RED against the pre-fix commit — that
+run is the test's own correctness check.** A plain `Promise.all` (or
+equivalent) over two racing calls can pass against the exact racy commit it
+was meant to catch, when connection setup serializes the pair and masks the
+race. Evidence: adaptive-crm #222 — 10 pass, 0 fail at first; only a warmed
+connection pool and eight looped attempts made attempt 0 fail with two creates.
 
 ### 2. Green Phase: Make It Pass
 ```
@@ -103,38 +99,13 @@ def test_should_calculate_total_when_items_added():
     assert total == 11.50
 ```
 
-**JavaScript (Jest):**
-```javascript
-describe('ShoppingCart', () => {
-  test('should calculate total when items added', () => {
-    const cart = new ShoppingCart();
-    cart.addItem({ name: 'Book', price: 10.00 });
-    cart.addItem({ name: 'Pen', price: 1.50 });
+Same AAA body, one naming shape per language:
 
-    const total = cart.calculateTotal();
+**JavaScript (Jest):** `test('should calculate total when items added', …)`
+inside `describe('ShoppingCart', …)`.
 
-    expect(total).toBe(11.50);
-  });
-});
-```
-
-**Go:**
-```go
-func TestShouldCalculateTotalWhenItemsAdded(t *testing.T) {
-    // Arrange
-    cart := NewShoppingCart()
-    cart.AddItem(Item{Name: "Book", Price: 10.00})
-    cart.AddItem(Item{Name: "Pen", Price: 1.50})
-
-    // Act
-    total := cart.CalculateTotal()
-
-    // Assert
-    if total != 11.50 {
-        t.Errorf("Expected 11.50, got %f", total)
-    }
-}
-```
+**Go:** `func TestShouldCalculateTotalWhenItemsAdded(t *testing.T)`, asserting
+with `t.Errorf` on mismatch.
 
 ## Test Types and Scope
 


### PR DESCRIPTION
## Outcome

Refs #4642 #7626

PR #7626 added 24 lines to `documentation-style.md` and
`test-driven-development.md` and pushed the rust-engineer/tauri-engineer
resident-skill set to 34,353 B against the 34,000 B budget enforced by
`bundled_agent_resident_skill_cost_stays_within_budget`. That test runs only on
push to `main`, so #7626's own PR checks were green and main went red (tracker
#7351). This PR tightens the three additions from #7566, #7531 and #7372
(facts kept) and adjacent prose in the same two files to 33,425 B, 575 under
budget. Per the owner's starting-context ruling the budget itself is untouched
and no skill leaves a `skills:` list.

## Changes

- `crates/trusty-mpm/src/assets/skills/documentation-style.md` — 16 lines
  tightened, facts preserved.
- `crates/trusty-mpm/src/assets/skills/test-driven-development.md` — 51 lines
  condensed to prose that keeps the same guidance.
- `crates/trusty-mpm/changelog.d/7626-resident-skill-budget.md` — fragment for
  this fix.

Out of scope: the 34,000 B budget constant and the resident-skill list itself
are unchanged.

## Risk

Low. Docs-class prose edits inside two bundled skill files; no runtime code
path touched, no critic run requested.

## Tests

Failing at base:
```
resident skill-body cost exceeds the per-dispatch budget … rust-engineer: 34353 bytes (budget 34000)
```
Passing after this change: 1 passed.

- `cargo fmt --check`: 0
- `cargo test -p trusty-mpm --no-fail-fast`: 61 targets, 12805 passed / 0
  failed / 18 ignored
- Bundled-skill deploy tests `documentation_style_lands_in_deployed_dot_claude_skills`
  and `install_then_deploy_deploys_skills`: 1 passed each
- Changelog gate (`--file`, `--staged`, post-commit): OK
- `scripts/check_sld.sh`: 0

## Baseline

`main` also fails shard 7 on
`tm_compress_reports_unknown_for_an_unwrapped_invocation` in the same run;
that failure is unrelated to this change and is being triaged separately
under its own tracker, not addressed here.

## Docs

Changelog fragment present:
`crates/trusty-mpm/changelog.d/7626-resident-skill-budget.md`.

## Review

No code-critic round requested for this PR (low risk, docs-class prose,
security scan clear). No findings to disposition.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
