### PR TITLE
fix(trusty-agents): preserve extracted events beyond recent history, cap checkpoint state, surface history outages (Refs #7653)

### DIFF
--- a/crates/trusty-agents/changelog.d/7653-event-retention-and-state-guard.md
+++ b/crates/trusty-agents/changelog.d/7653-event-retention-and-state-guard.md
@@ -2,3 +2,4 @@ Fixed
 
 - Retain published event knowledge when unrelated incoming records move it outside a bounded processing batch; withdraw only on explicit exclusion or revoked source access.
 - Reject an oversized knowledge checkpoint before it replaces the file on disk, so the previous state stays readable and the next write recovers.
+- Report a transient chat-history outage on a turn carrying attachments as an outage instead of rejecting the send as a concurrently changed conversation.

--- a/crates/trusty-agents/changelog.d/7653-event-retention-and-state-guard.md
+++ b/crates/trusty-agents/changelog.d/7653-event-retention-and-state-guard.md
@@ -1,0 +1,4 @@
+Fixed
+
+- Retain published event knowledge when unrelated incoming records move it outside a bounded processing batch; withdraw only on explicit exclusion or revoked source access.
+- Reject an oversized knowledge checkpoint before it replaces the file on disk, so the previous state stays readable and the next write recovers.

--- a/crates/trusty-agents/changelog.d/7653-history-outage-notice.md
+++ b/crates/trusty-agents/changelog.d/7653-history-outage-notice.md
@@ -1,0 +1,3 @@
+Added
+
+- Report plaintext turns with unavailable saved image history as partial responses with an explicit API notice, displayed separately from the assistant reply in browser and desktop chat.

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -321,6 +321,7 @@ fn session_overrides_for(req: &TaskRequest) -> crate::ctrl::SessionOverrides {
         provider: req.provider_id.clone(),
         user: None,
         focused_workstream: req.focused_workstream.clone(),
+        ..Default::default()
     }
 }
 
@@ -545,6 +546,7 @@ pub(super) async fn submit_task(
                 // is captured for responder attribution — reflecting who
                 // actually ANSWERED, not who was asked.
                 let mut ev_rx = crate::events::subscribe();
+                let history_unavailable = overrides_bg.history_unavailable.clone();
                 let result = if let Some(agent_name) = agent_bg {
                     crate::ctrl::run_pm_task_with_persona(
                         &project_path,
@@ -587,6 +589,7 @@ pub(super) async fn submit_task(
                         r.status = PmStatus::Success;
                         r.narrative = content;
                         r.responder_agent = responder;
+                        crate::chat_attachments::apply_history_notice(&mut r, &history_unavailable);
                         r
                     }
                     Err(e) => {

--- a/crates/trusty-agents/src/api/server/knowledge_pipeline/event_retention_tests.rs
+++ b/crates/trusty-agents/src/api/server/knowledge_pipeline/event_retention_tests.rs
@@ -1,0 +1,155 @@
+//! Bounded event processing must not invent upstream deletion (#4283).
+use super::super::tests::{context, fixture};
+use super::*;
+use crate::listeners::store::{EventStore, StoredEvent};
+use std::sync::{Arc, Mutex};
+
+#[tokio::test]
+async fn published_event_survives_unrelated_event_batch_rollover() {
+    if std::env::var_os("TRUSTY_EVENT_RETENTION_CHILD").is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let status = tokio::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "api::server::knowledge_pipeline::execution::event_retention_tests::published_event_survives_unrelated_event_batch_rollover"])
+            .env("TRUSTY_EVENT_RETENTION_CHILD", "1").env("HOME", &root)
+            .env("TAGENT_PROJECT_DIR", &root).env("TAGENT_CONFIG_DIR", root.join("config"))
+            .env("TAGENT_ASSISTANTS_DIR", root.join("homes"))
+            .env("TRUSTY_DATA_DIR_OVERRIDE", root.join("data"))
+            .env("TRUSTY_MEMORY_SOCKET", root.join("absent-memory.sock"))
+            .env("TRUSTY_SEARCH_SOCKET", root.join("absent-search.sock"))
+            .env_remove("OPEN_MPM_CONFIG_DIR").env_remove("OPEN_MPM_PROJECT_DIR")
+            .status().await.unwrap();
+        assert!(status.success());
+        return;
+    }
+    let _home = crate::test_env::lock_home();
+    let (_tmp, dirs, homes) = fixture();
+    let manifest = dirs[0].join("twin.toml");
+    let raw = std::fs::read_to_string(&manifest).unwrap();
+    std::fs::write(
+        &manifest,
+        format!("{raw}\n[[listeners]]\nname='mail'\nenabled=true\n"),
+    )
+    .unwrap();
+    let mut ctx = context(&dirs, &homes, vec![]).await;
+    ctx.listeners.push(
+        toml::from_str("name='mail'\nconnector='gmail'\nenabled=true\nidentity='synthetic'\n")
+            .unwrap(),
+    );
+    let source = ctx.sources(&BTreeMap::new()).unwrap().remove(0);
+    let initial = ctx.store().initialize(Utc::now(), None).unwrap();
+    let state = ctx
+        .store()
+        .reconcile(&initial.revision, std::slice::from_ref(&source), Utc::now())
+        .unwrap();
+    let event = StoredEvent {
+        id: "mail:published".into(),
+        listener_id: "mail".into(),
+        provider: "gmail".into(),
+        event_type: "message.received".into(),
+        ts: Utc::now().to_rfc3339(),
+        from: None,
+        subject: Some("Atlas".into()),
+        snippet: Some("Maya leads Atlas.".into()),
+        included: true,
+        labels: vec![],
+    };
+    let dir = crate::listeners::store::events_dir().unwrap();
+    EventStore::append_at(&dir, &event).await.unwrap();
+    let state = ctx
+        .store()
+        .admit_event(
+            &state.revision,
+            &source.id,
+            &source.revision,
+            &event.id,
+            chrono::DateTime::parse_from_rfc3339(&event.ts)
+                .unwrap()
+                .with_timezone(&Utc),
+            Utc::now(),
+        )
+        .unwrap();
+    let root = state.store.root.clone();
+    let index = state.store.index_id.clone();
+    let published = Arc::new(Mutex::new(BTreeMap::<String, String>::new()));
+    let visible = published.clone();
+    let daemon = crate::uds_mock::spawn(move |method, params| {
+        let root = root.clone();
+        let index = index.clone();
+        let published = published.clone();
+        let method = method.to_owned();
+        Box::pin(async move {
+            match method.as_str() {
+                trusty_common::search_rpc::METHOD_INDEXES_LIST => {
+                    Ok(json!({"indexes":[{"id":index,"root_path":root}]}))
+                }
+                "search.index.config.get" => Ok(json!({"extensions":["md"]})),
+                trusty_common::search_rpc::METHOD_INDEX_STATUS => Ok(json!({"root_path":root})),
+                "search.index.file.put" => {
+                    published.lock().unwrap().insert(
+                        params["body"]["path"].as_str().unwrap().into(),
+                        params["body"]["content"].as_str().unwrap().into(),
+                    );
+                    Ok(json!({}))
+                }
+                "search.index.file.remove" => {
+                    published
+                        .lock()
+                        .unwrap()
+                        .remove(params["body"]["path"].as_str().unwrap());
+                    Ok(json!({}))
+                }
+                _ => Ok(params),
+            }
+        })
+    })
+    .await;
+    ctx.search_socket = Some(daemon.socket().to_path_buf());
+    let item = inputs(&ctx, &state, &source).await.unwrap().remove(0);
+    let key = catalog::digest(format!("{}:{}", source.id, item.item_id));
+    process_using(&ctx, &source, &item, &key, |_, _| async {
+        Ok((crate::knowledge::extraction::validate(r#"{"entities":[{"id":"maya","type":"person","name":"Maya","claims":[{"text":"Leads Atlas","evidence_quote":"Maya leads Atlas."}]}],"relationships":[]}"#,"Maya leads Atlas.")?, "fixture".into()))
+    }).await.unwrap();
+    assert!(
+        visible
+            .lock()
+            .unwrap()
+            .values()
+            .any(|text| text.contains("Maya"))
+    );
+    for n in 0..10000 {
+        let mut unrelated = event.clone();
+        unrelated.id = format!("other:{n}");
+        unrelated.listener_id = "other".into();
+        EventStore::append_at(&dir, &unrelated).await.unwrap();
+    }
+    assert!(inputs(&ctx, &state, &source).await.unwrap().is_empty());
+    sources::withdraw_missing(&ctx, &BTreeSet::new(), &BTreeSet::from([source.id.clone()]))
+        .await
+        .unwrap();
+    assert_eq!(ctx.store().checkpoints().unwrap()[&key].status, "completed");
+    assert!(
+        visible
+            .lock()
+            .unwrap()
+            .values()
+            .any(|text| text.contains("Maya"))
+    );
+    let kb = KbStore::new(state.store.root, Profile::default_profile());
+    for (_, path) in kb.entity_files("notes").unwrap() {
+        assert!(
+            !std::fs::read_to_string(path)
+                .unwrap()
+                .contains("source_status: deleted")
+        );
+    }
+    // Explicit exclusion remains withdrawal authority even after the event leaves the batch.
+    EventStore::set_filter_at(&dir, &event.event_type, false)
+        .await
+        .unwrap();
+    sources::withdraw_missing(&ctx, &BTreeSet::new(), &BTreeSet::from([source.id]))
+        .await
+        .unwrap();
+    assert_eq!(ctx.store().checkpoints().unwrap()[&key].status, "cancelled");
+    assert!(visible.lock().unwrap().is_empty());
+}

--- a/crates/trusty-agents/src/api/server/knowledge_pipeline/execution.rs
+++ b/crates/trusty-agents/src/api/server/knowledge_pipeline/execution.rs
@@ -282,3 +282,7 @@ async fn feed(
 #[cfg(test)]
 #[path = "execution_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "event_retention_tests.rs"]
+mod event_retention_tests;

--- a/crates/trusty-agents/src/api/server/knowledge_pipeline/execution_sources.rs
+++ b/crates/trusty-agents/src/api/server/knowledge_pipeline/execution_sources.rs
@@ -148,7 +148,13 @@ pub(super) async fn withdraw_missing(
     scanned: &BTreeSet<String>,
 ) -> anyhow::Result<()> {
     let checkpoints = context.store().checkpoints()?;
-    let event_ids = checkpoints.values().map(|c| c.item_id.clone()).collect();
+    // #7653: the lookup below is capped at 10000 IDs and 16 MiB, so only
+    // checkpoints whose source can reach it are collected. Project checkpoints
+    // are authorized by the scan above and never consult the event log.
+    let candidates: Vec<(String, String)> = checkpoints
+        .values()
+        .map(|c| (c.source_id.clone(), c.item_id.clone()))
+        .collect();
     let mut event_records: Option<BTreeMap<String, crate::listeners::store::StoredEvent>> = None;
     for (key, mut checkpoint) in checkpoints {
         if checkpoint.status == "cancelled" || !checkpoint.needs_withdrawal() || seen.contains(&key)
@@ -175,6 +181,16 @@ pub(super) async fn withdraw_missing(
             } else {
                 // #4283: a bounded batch cannot authorize deletion of an older event.
                 if event_records.is_none() {
+                    let event_sources: BTreeSet<&str> = eligible
+                        .iter()
+                        .filter(|s| s.kind != SourceKind::Project)
+                        .map(|s| s.id.as_str())
+                        .collect();
+                    let event_ids: BTreeSet<String> = candidates
+                        .iter()
+                        .filter(|(source_id, _)| event_sources.contains(source_id.as_str()))
+                        .map(|(_, item_id)| item_id.clone())
+                        .collect();
                     event_records =
                         Some(crate::listeners::store::EventStore::read_exact(&event_ids).await?);
                 }

--- a/crates/trusty-agents/src/api/server/knowledge_pipeline/execution_sources.rs
+++ b/crates/trusty-agents/src/api/server/knowledge_pipeline/execution_sources.rs
@@ -147,7 +147,10 @@ pub(super) async fn withdraw_missing(
     seen: &BTreeSet<String>,
     scanned: &BTreeSet<String>,
 ) -> anyhow::Result<()> {
-    for (key, mut checkpoint) in context.store().checkpoints()? {
+    let checkpoints = context.store().checkpoints()?;
+    let event_ids = checkpoints.values().map(|c| c.item_id.clone()).collect();
+    let mut event_records: Option<BTreeMap<String, crate::listeners::store::StoredEvent>> = None;
+    for (key, mut checkpoint) in checkpoints {
         if checkpoint.status == "cancelled" || !checkpoint.needs_withdrawal() || seen.contains(&key)
         {
             continue;
@@ -163,11 +166,28 @@ pub(super) async fn withdraw_missing(
             .sources(&state.project_selections())
             .map_err(api_error)?;
         let missing = if let Some(source) = eligible.iter().find(|s| s.id == checkpoint.source_id) {
-            scanned.contains(&source.id)
-                && !inputs(&current, &state, source)
-                    .await?
-                    .iter()
-                    .any(|i| i.item_id == checkpoint.item_id)
+            if source.kind == SourceKind::Project {
+                scanned.contains(&source.id)
+                    && !inputs(&current, &state, source)
+                        .await?
+                        .iter()
+                        .any(|i| i.item_id == checkpoint.item_id)
+            } else {
+                // #4283: a bounded batch cannot authorize deletion of an older event.
+                if event_records.is_none() {
+                    event_records =
+                        Some(crate::listeners::store::EventStore::read_exact(&event_ids).await?);
+                }
+                match event_records
+                    .as_ref()
+                    .and_then(|records| records.get(&checkpoint.item_id))
+                {
+                    Some(event) => {
+                        event_inputs(&current, &state, source, vec![event.clone()])?.is_empty()
+                    }
+                    None => false,
+                }
+            }
         } else {
             true
         };

--- a/crates/trusty-agents/src/chat_attachments.rs
+++ b/crates/trusty-agents/src/chat_attachments.rs
@@ -2,9 +2,27 @@
 use anyhow::{Context, Result};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use trusty_common::chat_attachments::{Attachment, ImageContent, ImageRef, InputAttachment};
 use trusty_common::memory_core::store::chat_sessions::ChatMessage;
 use trusty_common::memory_rpc::call_memory_tool_at_with_timeout;
+
+pub(crate) const HISTORY_UNAVAILABLE_NOTICE: &str = "Saved image history and chat persistence are unavailable for this turn. The response may lack earlier image context.";
+
+/// Why: a provider prompt cannot guarantee that the API discloses missing image context.
+/// What: mark otherwise successful responses partial with a fixed host-generated notice.
+/// Test: `history_outage_notice_preserves_success_and_failure_contracts`.
+pub(crate) fn apply_history_notice(
+    response: &mut crate::api::types::PmResponse,
+    unavailable: &AtomicBool,
+) {
+    if unavailable.load(Ordering::Relaxed)
+        && response.status == crate::api::types::PmStatus::Success
+    {
+        response.status = crate::api::types::PmStatus::Partial;
+        response.errors.push(HISTORY_UNAVAILABLE_NOTICE.into());
+    }
+}
 
 pub(crate) async fn rpc(socket: &Path, method: &str, args: Value) -> Result<Value> {
     let value = call_memory_tool_at_with_timeout(
@@ -88,6 +106,7 @@ pub(crate) async fn prepare(
     name: &str,
     input: &str,
     attachments: &[InputAttachment],
+    history_unavailable: &AtomicBool,
     validate: impl FnOnce(&AttachmentTurn) -> Result<()>,
 ) -> Result<Option<AttachmentTurn>> {
     trusty_common::chat_attachments::validate_inputs(attachments)?;
@@ -111,7 +130,10 @@ pub(crate) async fn prepare(
                 .cloned()
                 .context("Invalid chat history")?,
         )?,
-        Err(_) if attachments.is_empty() => return Ok(None),
+        Err(_) if attachments.is_empty() => {
+            history_unavailable.store(true, Ordering::Relaxed);
+            return Ok(None);
+        }
         Err(_) => vec![],
     };
     if attachments.is_empty() && !history.iter().any(|m| !m.attachments.is_empty()) {
@@ -317,6 +339,22 @@ pub(crate) async fn get_asset(name: &str, id: &str) -> Result<(String, Vec<u8>)>
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn history_outage_notice_preserves_success_and_failure_contracts() {
+        use crate::api::types::{PmResponse, PmStatus};
+        let mut response = PmResponse::running("fixture");
+        response.status = PmStatus::Success;
+        apply_history_notice(&mut response, &AtomicBool::new(false));
+        assert_eq!(response.status, PmStatus::Success);
+        assert!(response.errors.is_empty());
+        apply_history_notice(&mut response, &AtomicBool::new(true));
+        assert_eq!(response.status, PmStatus::Partial);
+        assert_eq!(response.errors, [HISTORY_UNAVAILABLE_NOTICE]);
+        let mut failed = PmResponse::error("fixture", "Explicit image failure");
+        apply_history_notice(&mut failed, &AtomicBool::new(true));
+        assert_eq!(failed.status, PmStatus::Failed);
+        assert_eq!(failed.errors, ["Explicit image failure"]);
+    }
     #[tokio::test]
     async fn attachment_rejection_is_read_only_and_pending_retries_are_idempotent() {
         if std::env::var_os("TRUSTY_ATTACHMENT_ACCEPT_CHILD").is_none() {
@@ -355,15 +393,21 @@ mod tests {
         let observed = history.clone();
         let writes = Arc::new(Mutex::new(Vec::<String>::new()));
         let observed_writes = writes.clone();
+        let fail_probe = Arc::new(AtomicBool::new(false));
+        let probe_control = fail_probe.clone();
         const PNG: &str = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==";
         let asset_id = uuid::Uuid::new_v4().to_string();
         let daemon = crate::uds_mock::spawn(move |method, params| {
+            let fail_probe = fail_probe.clone();
             let history = history.clone(); let writes = writes.clone();
             let namespace = namespace.clone(); let asset_id = asset_id.clone();
             let wrapped = method == "tools/call";
             let method = if wrapped { params["name"].as_str().unwrap().to_owned() } else { method.to_owned() };
             let args = if wrapped { params["arguments"].clone() } else { params };
             Box::pin(async move {
+                if method == "chat_session_get" && fail_probe.load(Ordering::Relaxed) {
+                    return Err(trusty_common::uds::server::RpcError::internal("synthetic history probe unavailable"));
+                }
                 let value = match method.as_str() {
                     "palace_list" => json!({"palaces":[namespace]}),
                     "chat_session_get" => json!({"history":history.lock().unwrap().clone()}),
@@ -386,10 +430,12 @@ mod tests {
         )
         .unwrap();
         let config = crate::agents::AgentConfig::by_name("fixture").unwrap();
+        let unavailable = AtomicBool::new(false);
         let rejected = prepare(
             "fixture",
             "Describe",
             std::slice::from_ref(&attachment),
+            &unavailable,
             |turn| turn.validate_provider(&config, "local", false),
         )
         .await;
@@ -403,28 +449,62 @@ mod tests {
         assert!(observed.lock().unwrap().is_empty());
         assert!(observed_writes.lock().unwrap().is_empty());
         assert!(
-            prepare("fixture", "Plain text still works", &[], |_| Ok(()))
-                .await
-                .unwrap()
-                .is_none()
+            prepare(
+                "fixture",
+                "Plain text still works",
+                &[],
+                &unavailable,
+                |_| Ok(())
+            )
+            .await
+            .unwrap()
+            .is_none()
         );
         prepare(
             "fixture",
             "Describe",
             std::slice::from_ref(&attachment),
+            &unavailable,
             |_| Ok(()),
         )
         .await
         .unwrap()
         .unwrap();
-        prepare("fixture", "Describe", &[attachment], |_| Ok(()))
-            .await
-            .unwrap()
-            .unwrap();
+        prepare(
+            "fixture",
+            "Describe",
+            std::slice::from_ref(&attachment),
+            &unavailable,
+            |_| Ok(()),
+        )
+        .await
+        .unwrap()
+        .unwrap();
         assert_eq!(observed.lock().unwrap().len(), 1);
         assert_eq!(
             *observed_writes.lock().unwrap(),
             ["chat_asset_put", "chat_session_add_turn"]
+        );
+        assert!(!unavailable.load(Ordering::Relaxed));
+        probe_control.store(true, Ordering::Relaxed);
+        assert!(
+            prepare("fixture", "Plain follow-up", &[], &unavailable, |_| Ok(()))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(unavailable.load(Ordering::Relaxed));
+        assert_eq!(observed_writes.lock().unwrap().len(), 2);
+        assert!(
+            prepare(
+                "fixture",
+                "Explicit image",
+                &[attachment],
+                &AtomicBool::new(false),
+                |_| Ok(())
+            )
+            .await
+            .is_err()
         );
     }
     #[tokio::test]

--- a/crates/trusty-agents/src/chat_attachments.rs
+++ b/crates/trusty-agents/src/chat_attachments.rs
@@ -123,6 +123,9 @@ pub(crate) async fn prepare(
     let session = crate::ctrl::pm_task::session_id_for(name);
     let args = json!({"palace":policy.namespace,"session_id":session});
     let previous = rpc(&socket, "chat_session_get", args.clone()).await;
+    // #7653: a failed probe leaves no baseline, so the re-read comparison below
+    // has nothing to compare against and must not run.
+    let mut history_probe_failed = false;
     let history: Vec<ChatMessage> = match previous {
         Ok(value) => serde_json::from_value(
             value
@@ -134,7 +137,11 @@ pub(crate) async fn prepare(
             history_unavailable.store(true, Ordering::Relaxed);
             return Ok(None);
         }
-        Err(_) => vec![],
+        Err(_) => {
+            history_unavailable.store(true, Ordering::Relaxed);
+            history_probe_failed = true;
+            vec![]
+        }
     };
     if attachments.is_empty() && !history.iter().any(|m| !m.attachments.is_empty()) {
         return Ok(None);
@@ -198,7 +205,7 @@ pub(crate) async fn prepare(
             .context("Invalid chat history")?,
     )?;
     anyhow::ensure!(
-        serde_json::to_value(&latest)? == serde_json::to_value(&history)?,
+        history_probe_failed || serde_json::to_value(&latest)? == serde_json::to_value(&history)?,
         "Conversation changed during attachment validation; retry the send"
     );
     if retry {
@@ -395,17 +402,27 @@ mod tests {
         let observed_writes = writes.clone();
         let fail_probe = Arc::new(AtomicBool::new(false));
         let probe_control = fail_probe.clone();
+        // #7653: a one-shot probe failure models a transient daemon blip, where
+        // the re-read below succeeds and returns the real prior history.
+        let probe_once = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let probe_once_control = probe_once.clone();
         const PNG: &str = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==";
         let asset_id = uuid::Uuid::new_v4().to_string();
         let daemon = crate::uds_mock::spawn(move |method, params| {
             let fail_probe = fail_probe.clone();
+            let probe_once = probe_once.clone();
             let history = history.clone(); let writes = writes.clone();
             let namespace = namespace.clone(); let asset_id = asset_id.clone();
             let wrapped = method == "tools/call";
             let method = if wrapped { params["name"].as_str().unwrap().to_owned() } else { method.to_owned() };
             let args = if wrapped { params["arguments"].clone() } else { params };
             Box::pin(async move {
-                if method == "chat_session_get" && fail_probe.load(Ordering::Relaxed) {
+                if method == "chat_session_get"
+                    && (fail_probe.load(Ordering::Relaxed)
+                        || probe_once
+                            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_sub(1))
+                            .is_ok())
+                {
                     return Err(trusty_common::uds::server::RpcError::internal("synthetic history probe unavailable"));
                 }
                 let value = match method.as_str() {
@@ -499,12 +516,45 @@ mod tests {
             prepare(
                 "fixture",
                 "Explicit image",
-                &[attachment],
+                std::slice::from_ref(&attachment),
                 &AtomicBool::new(false),
                 |_| Ok(())
             )
             .await
             .is_err()
+        );
+
+        // #7653: a TRANSIENT probe failure on the attachment path — the first
+        // read fails, the re-read succeeds and returns the real prior history.
+        // Before the fix the empty substituted baseline made that re-read look
+        // like a concurrent write, so the turn failed with "Conversation
+        // changed during attachment validation" instead of degrading.
+        probe_control.store(false, Ordering::Relaxed);
+        probe_once_control.store(1, Ordering::Relaxed);
+        assert_eq!(observed.lock().unwrap().len(), 1);
+        let transient = AtomicBool::new(false);
+        let degraded = prepare(
+            "fixture",
+            "Follow-up with image",
+            std::slice::from_ref(&attachment),
+            &transient,
+            |_| Ok(()),
+        )
+        .await
+        .expect("a transient history probe failure must not report a changed conversation");
+        assert!(degraded.is_some());
+        assert!(transient.load(Ordering::Relaxed));
+        // The turn was persisted, so the user's explicit attachment is never
+        // silently dropped by the degradation.
+        assert_eq!(observed.lock().unwrap().len(), 2);
+        assert_eq!(
+            *observed_writes.lock().unwrap(),
+            [
+                "chat_asset_put",
+                "chat_session_add_turn",
+                "chat_asset_put",
+                "chat_session_add_turn"
+            ]
         );
     }
     #[tokio::test]

--- a/crates/trusty-agents/src/ctrl/config.rs
+++ b/crates/trusty-agents/src/ctrl/config.rs
@@ -37,6 +37,8 @@ use crate::llm;
 /// sentinel and behave exactly as before. Wiring is verified by `cargo check`.
 #[derive(Debug, Clone, Default)]
 pub struct SessionOverrides {
+    /// Host-owned per-turn history health, shared with the response assembler.
+    pub history_unavailable: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub attachments: Vec<trusty_common::chat_attachments::InputAttachment>,
     pub model: Option<String>,
     pub provider: Option<String>,

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -102,24 +102,12 @@ pub async fn run_pm_task_with_persona(
         persona_cfg.override_model(m)?;
     }
 
-    let (creds, claude_cli_short_circuit) = prompt::resolve_provider(
-        &mut persona_cfg,
-        overrides.provider.as_deref(),
-        None,
-        persona_name,
-    )?;
-    let client = if claude_cli_short_circuit {
-        None
-    } else {
-        Some(llm::create_client_for_model(&persona_cfg.agent.model)?)
-    };
-    let attachment_turn = crate::chat_attachments::prepare(
-        persona_name,
-        user_input,
-        &overrides.attachments,
-        |turn| turn.validate_provider(&persona_cfg, creds.label(), claude_cli_short_circuit),
-    )
-    .await?;
+    let prompt::PreparedProvider {
+        creds,
+        client,
+        claude_cli_short_circuit,
+        attachment_turn,
+    } = prompt::prepare_provider(&mut persona_cfg, &overrides, persona_name, user_input).await?;
     if claude_cli_short_circuit {
         prompt::append_cli_context(&mut persona_cfg, project_path);
         // DOC-54 §9.6 note: the claude-cli subprocess path runs an entirely

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_prompt.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_prompt.rs
@@ -9,6 +9,44 @@ use async_openai::types::{
     ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
 };
 use std::path::Path;
+
+pub(super) struct PreparedProvider {
+    pub creds: crate::llm::credentials::LlmCredentials,
+    pub client: Option<async_openai::Client<async_openai::config::OpenAIConfig>>,
+    pub claude_cli_short_circuit: bool,
+    pub attachment_turn: Option<crate::chat_attachments::AttachmentTurn>,
+}
+/// Why: provider rejection must precede attachment persistence, while history outages stay visible.
+/// What: resolve the provider and client before preparing a validated turn and recording its health.
+/// Test: `attachment_rejection_is_read_only_and_pending_retries_are_idempotent`.
+pub(super) async fn prepare_provider(
+    config: &mut AgentConfig,
+    overrides: &crate::ctrl::SessionOverrides,
+    name: &str,
+    input: &str,
+) -> Result<PreparedProvider> {
+    let (creds, claude_cli_short_circuit) =
+        resolve_provider(config, overrides.provider.as_deref(), None, name)?;
+    let client = if claude_cli_short_circuit {
+        None
+    } else {
+        Some(crate::llm::create_client_for_model(&config.agent.model)?)
+    };
+    let attachment_turn = crate::chat_attachments::prepare(
+        name,
+        input,
+        &overrides.attachments,
+        &overrides.history_unavailable,
+        |turn| turn.validate_provider(config, creds.label(), claude_cli_short_circuit),
+    )
+    .await?;
+    Ok(PreparedProvider {
+        creds,
+        client,
+        claude_cli_short_circuit,
+        attachment_turn,
+    })
+}
 pub(super) fn system_prompt(
     persona_cfg: &AgentConfig,
     provider: &str,

--- a/crates/trusty-agents/src/knowledge/execution.rs
+++ b/crates/trusty-agents/src/knowledge/execution.rs
@@ -159,6 +159,71 @@ mod tests {
         drop(first);
         assert!(reopened.worker_lock().unwrap().is_some());
     }
+    #[test]
+    fn checkpoint_overflow_preserves_readable_state_and_allows_recovery() {
+        use super::*;
+        use crate::assistants::{AssistantHome, AssistantInstanceId};
+        use crate::knowledge::extraction;
+        let root = tempfile::tempdir().unwrap();
+        let home = AssistantHome::under(
+            root.path().canonicalize().unwrap(),
+            AssistantInstanceId::new("bounded").unwrap(),
+        );
+        let store = KnowledgeStore::new(home.clone());
+        persistence::private_dir(&store.directory()).unwrap();
+        let mut checkpoint = Checkpoint {
+            source_id: "source".into(),
+            item_id: "item".into(),
+            fingerprint: "v1".into(),
+            model: "fixture".into(),
+            status: "retryable".into(),
+            attempts: 1,
+            next_attempt_at: 0,
+            lease_owner: String::new(),
+            lease_until: 0,
+            output: None,
+            materialized_fingerprint: Some("v1".into()),
+            last_error: None,
+        };
+        let quote = "x".repeat(4096);
+        let output = extraction::Extraction {
+            entities: vec![extraction::Entity {
+                id: "maya".into(),
+                kind: "person".into(),
+                name: "Maya".into(),
+                claims: vec![
+                    extraction::Claim {
+                        text: "x".repeat(2048),
+                        evidence_quote: quote.clone()
+                    };
+                    16
+                ],
+            }],
+            relationships: vec![],
+        };
+        let raw = serde_json::to_string(&output).unwrap();
+        checkpoint.output = Some(extraction::validate(&raw, &format!("Maya {quote}")).unwrap());
+        let entry_size = serde_json::to_vec(&checkpoint).unwrap().len() + 20;
+        let count = (16 * 1024 * 1024 - 1024) / entry_size;
+        let mut seed = BTreeMap::new();
+        for index in 0..count {
+            seed.insert(format!("item-{index}"), checkpoint.clone());
+        }
+        let path = store.directory().join("extraction.json");
+        persistence::write_bytes(&path, &serde_json::to_vec(&seed).unwrap()).unwrap();
+        let previous = std::fs::read(&path).unwrap();
+        // Each output is valid; only the aggregate exceeds the persistent reader limit.
+        let mut overflow = seed.clone();
+        overflow.insert("overflow".into(), checkpoint.clone());
+        assert!(serde_json::to_vec(&overflow).unwrap().len() > 16 * 1024 * 1024);
+        assert!(store.checkpoint("overflow", checkpoint.clone()).is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), previous);
+        let reopened = KnowledgeStore::new(home);
+        assert_eq!(reopened.checkpoints().unwrap()["item-0"].fingerprint, "v1");
+        checkpoint.fingerprint = "v2".into();
+        reopened.checkpoint("item-0", checkpoint).unwrap();
+        assert_eq!(store.checkpoints().unwrap()["item-0"].fingerprint, "v2");
+    }
     #[tokio::test]
     async fn manifest_mutations_are_exclusive() {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/trusty-agents/src/knowledge/persistence.rs
+++ b/crates/trusty-agents/src/knowledge/persistence.rs
@@ -110,7 +110,16 @@ pub(super) fn write(path: &Path, state: &mut KnowledgeState) -> Result<()> {
     }
     write_bytes(path, &data)
 }
+/// Why: every persisted state must remain readable under the same byte limit.
+/// What: reject oversized bytes before creating or replacing a file, preserving prior state.
+/// Test: `checkpoint_overflow_preserves_readable_state_and_allows_recovery`.
 pub(crate) fn write_bytes(path: &Path, data: &[u8]) -> Result<()> {
+    // #4283: the atomic writer and bounded reader share one size contract.
+    if data.len() as u64 > MAX_STATE_BYTES {
+        return Err(KnowledgeError::InvalidState(
+            "Knowledge state exceeds size limit".into(),
+        ));
+    }
     safe_path(path)?;
     let parent = path
         .parent()

--- a/crates/trusty-agents/src/listeners/store.rs
+++ b/crates/trusty-agents/src/listeners/store.rs
@@ -694,3 +694,6 @@ mod tests {
         );
     }
 }
+
+#[path = "store_lookup.rs"]
+mod lookup;

--- a/crates/trusty-agents/src/listeners/store_lookup.rs
+++ b/crates/trusty-agents/src/listeners/store_lookup.rs
@@ -1,0 +1,145 @@
+//! Exact persisted event lookup for withdrawal authorization (#4283).
+use super::{EventStore, StoredEvent, events_dir, is_included};
+use anyhow::{Context, Result};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    io::BufRead,
+    path::Path,
+};
+
+const MAX_EVENT_BYTES: u64 = 1024 * 1024;
+const MAX_RETAINED_BYTES: usize = 16 * 1024 * 1024;
+impl EventStore {
+    /// Why: absence from a bounded processing batch is not evidence of upstream deletion.
+    /// What: stream the log and retain only requested IDs, using the newest record and current filters.
+    /// Retains at most 16 MiB across 10000 IDs. Missing IDs stay unknown;
+    /// oversized/malformed records fail without authorizing withdrawal.
+    /// Test: `published_event_survives_unrelated_event_batch_rollover`, `exact_lookup_bounds_and_latest_filter_are_enforced`.
+    pub(crate) async fn read_exact(
+        ids: &BTreeSet<String>,
+    ) -> Result<BTreeMap<String, StoredEvent>> {
+        Self::read_exact_at(&events_dir()?, ids).await
+    }
+    pub(crate) async fn read_exact_at(
+        dir: &Path,
+        ids: &BTreeSet<String>,
+    ) -> Result<BTreeMap<String, StoredEvent>> {
+        anyhow::ensure!(ids.len() <= 10000, "Exact event lookup exceeds 10000 IDs");
+        if ids.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+        let path = dir.join("events.jsonl");
+        let filters = Self::load_filters_at(dir).await?;
+        let ids = ids.clone();
+        tokio::task::spawn_blocking(move || scan(&path, &ids, &filters)).await?
+    }
+}
+fn scan(
+    path: &Path,
+    ids: &BTreeSet<String>,
+    filters: &HashMap<String, bool>,
+) -> Result<BTreeMap<String, StoredEvent>> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(error) => return Err(error).context("Open persisted event log"),
+    };
+    let mut reader = std::io::BufReader::new(file);
+    let mut found = BTreeMap::new();
+    let mut sizes = BTreeMap::new();
+    let mut retained = 0usize;
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        let mut limited = std::io::Read::take(&mut reader, MAX_EVENT_BYTES + 1);
+        if limited.read_until(b'\n', &mut line)? == 0 {
+            break;
+        }
+        anyhow::ensure!(
+            line.len() as u64 <= MAX_EVENT_BYTES,
+            "Stored event exceeds 1 MiB lookup limit"
+        );
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let mut event: StoredEvent =
+            serde_json::from_slice(&line).context("Invalid persisted event record")?;
+        if ids.contains(&event.id) {
+            retained = retained
+                .saturating_sub(sizes.insert(event.id.clone(), line.len()).unwrap_or(0))
+                .saturating_add(line.len());
+            anyhow::ensure!(
+                retained <= MAX_RETAINED_BYTES,
+                "Requested events exceed 16 MiB retained lookup limit"
+            );
+            event.included = is_included(filters, &event.event_type);
+            found.insert(event.id.clone(), event);
+        }
+    }
+    Ok(found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn exact_lookup_bounds_and_latest_filter_are_enforced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut event = StoredEvent {
+            id: "mail:one".into(),
+            listener_id: "mail".into(),
+            provider: "gmail".into(),
+            event_type: "message.received".into(),
+            ts: "2026-09-01T00:00:00Z".into(),
+            from: None,
+            subject: None,
+            snippet: Some("old".into()),
+            included: true,
+            labels: vec![],
+        };
+        EventStore::append_at(tmp.path(), &event).await.unwrap();
+        event.snippet = Some("new".into());
+        EventStore::append_at(tmp.path(), &event).await.unwrap();
+        EventStore::set_filter_at(tmp.path(), &event.event_type, false)
+            .await
+            .unwrap();
+        let ids = BTreeSet::from([event.id.clone(), "unknown".into()]);
+        let records = EventStore::read_exact_at(tmp.path(), &ids).await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[&event.id].snippet.as_deref(), Some("new"));
+        assert!(!records[&event.id].included);
+        std::fs::write(
+            tmp.path().join("events.jsonl"),
+            vec![b'x'; MAX_EVENT_BYTES as usize + 1],
+        )
+        .unwrap();
+        assert!(
+            EventStore::read_exact_at(tmp.path(), &ids)
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("1 MiB")
+        );
+        std::fs::write(tmp.path().join("events.jsonl"), "").unwrap();
+        let mut retained_ids = BTreeSet::new();
+        event.snippet = Some("x".repeat(MAX_EVENT_BYTES as usize / 2));
+        for n in 0..33 {
+            event.id = n.to_string();
+            retained_ids.insert(event.id.clone());
+            EventStore::append_at(tmp.path(), &event).await.unwrap();
+        }
+        assert!(
+            EventStore::read_exact_at(tmp.path(), &retained_ids)
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("16 MiB")
+        );
+        let too_many = (0..10001).map(|n| n.to_string()).collect();
+        assert!(
+            EventStore::read_exact_at(tmp.path(), &too_many)
+                .await
+                .is_err()
+        );
+    }
+}

--- a/crates/trusty-agents/src/repl/dispatch.rs
+++ b/crates/trusty-agents/src/repl/dispatch.rs
@@ -176,6 +176,7 @@ impl TrustyAgentsRepl {
             // are threaded only through the Slack transport.
             user: None,
             focused_workstream: self.focused_workstream.clone(),
+            ..Default::default()
         };
         if let Some(persona_name) = self.active_persona.as_deref() {
             let response = crate::ctrl::run_pm_task_with_persona(

--- a/crates/trusty-agents/tests/integration/chat_attachments.py
+++ b/crates/trusty-agents/tests/integration/chat_attachments.py
@@ -232,14 +232,17 @@ def http(method, path, body=None, status=200, auth='valid', binary=False, origin
     assert code == status, (path, code, str(value)[:1000])
     return (raw, response_headers) if binary and code == 200 else value
 
-def task(text, attachments=None, provider='openrouter', model='openai/gpt-4o-mini', success=True):
+def task(text, attachments=None, provider='openrouter', model='openai/gpt-4o-mini', success=True, expected_status=None):
     submit = http('POST', '/api/task', {'task': text, 'agent': 'assistant', 'provider_id': provider, 'model_id': model, 'attachments': attachments or []}, 202)
 
     def terminal():
         result = http('GET', '/api/task/' + submit['id'])
         return result if result['status'] not in ['running', 'pending'] else None
     result = wait('task ' + submit['id'], terminal, 120 if args.real_vision else 45)
-    assert (result['status'] == 'success') == success, result
+    if expected_status is not None:
+        assert result['status'] == expected_status, result
+    else:
+        assert (result['status'] == 'success') == success, result
     return result
 
 def assert_payload(index, image_bytes, table=None):
@@ -382,7 +385,9 @@ try:
         control['fail_assets'] = False
         control['fail_history_probe'] = True
         before = len(calls)
-        degraded = task('Synthetic history outage plaintext follow-up.')
+        degraded = task('Synthetic history outage plaintext follow-up.', expected_status='partial')
+        assert degraded['errors'] == ['Saved image history and chat persistence are unavailable for this turn. The response may lack earlier image context.']
+        assert 'data:image/png;base64,' not in json.dumps(calls[before])
         assert len(calls) > before
         record('plaintext_history_probe_outage', {'status': degraded['status'], 'narrative': degraded.get('narrative'), 'previous_image_sent': 'data:image/png;base64,' in json.dumps(calls[before]), 'task_response': degraded})
     record('integrated_assertions_passed', {'real_vision': args.real_vision, 'provider_requests': len(calls), 'raw_preparation_to_task_to_provider': True, 'typed_memory_history_and_asset_restart': True})

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -52,6 +52,7 @@
     id: string;
     narrative?: string;
     status?: string;
+    errors?: string[];
     /**
      * #3737: server-authoritative name of the specialist that actually
      * answered, present only when the turn delegated. When set, it overrides
@@ -123,7 +124,10 @@
         : /fail|error/i.test(p.status ?? '') ? 'The request failed without returning a response.' : '';
       const owner = conversationForTask(p.id);
       if (!owner) return;
-      updateMessageByTask(owner, p.id, text);
+      // #7370: keep partial-result notices outside the assistant's narrative.
+      const notices = p.status === 'partial' && Array.isArray(p.errors)
+        ? p.errors.filter((error): error is string => typeof error === 'string' && !!error.trim()) : [];
+      updateMessageByTask(owner, p.id, text, notices);
       // #3737: if the turn delegated, relabel the bubble to the agent that
       // actually answered (resolved to its display name via the roster).
       const responder = responderDisplayName(get(agentRoster), p.responder_agent);
@@ -365,6 +369,14 @@
       {:else}
         <div class="flex justify-center">
           <p class="max-w-[75%] text-center text-xs italic text-foundry-light-muted dark:text-foundry-text/50">{msg.content}</p>
+        </div>
+      {/if}
+      {#if msg.hostNotices?.length}
+        <div data-host-notice role="status" class="rounded-lg border border-foundry-amber/40 bg-foundry-amber/10 px-3 py-2 text-sm text-foundry-light-text dark:text-foundry-text">
+          <p class="mb-1 font-medium">Trusty Agents notice</p>
+          {#each msg.hostNotices as notice}
+            <p class="whitespace-pre-wrap break-words">{notice}</p>
+          {/each}
         </div>
       {/if}
     {/each}

--- a/crates/trusty-agents/ui/src/components/ChatView.test.ts
+++ b/crates/trusty-agents/ui/src/components/ChatView.test.ts
@@ -19,11 +19,11 @@
 // `ChatPane.test.ts`'s mounting pattern.
 // Test: this file.
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, unmount } from 'svelte';
 import ChatView from './ChatView.svelte';
 import { bridgeEventToWebBus } from '../lib/eventBridge';
-import { emitWebEvent, type AppEvent } from '../lib/transport';
+import { emitWebEvent, invoke, type AppEvent } from '../lib/transport';
 import { streamAccumulator } from '../lib/chatStream';
 import { resetWorkflow } from '../stores/workflow';
 import { activeProjectId, activeTaskId, addMessage, isRunning, messages } from '../stores/app';
@@ -126,9 +126,47 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   if (instance) unmount(instance);
   instance = null;
   target.remove();
+});
+
+// #7370: the same completion listener consumes browser polls and native payloads.
+it.each(['browser poll', 'native payload'])('shows partial errors as a host notice via %s', async (transport) => {
+  const warning = 'Saved image history is unavailable. <img src=x onerror=alert(1)>';
+  const response = { id: TASK, narrative: REAL, status: 'partial', errors: [warning] };
+  if (transport === 'browser poll') {
+    vi.stubGlobal('fetch', vi.fn(async (_url: unknown, init?: RequestInit) =>
+      new Response(JSON.stringify(init?.method === 'POST' ? { id: TASK, status: 'running' } : response), { status: 200 })));
+    await invoke('send_message', { content: 'Continue with text' });
+  } else {
+    emitWebEvent('task-complete', response);
+  }
+  await rendered();
+
+  const notice = target.querySelector('[data-host-notice]');
+  expect(notice?.textContent).toContain('Trusty Agents notice');
+  expect(notice?.textContent).toContain(warning);
+  expect(notice?.getAttribute('role')).toBe('status');
+  expect(notice?.querySelector('img,script')).toBeNull();
+  expect(notice?.closest('[data-assistant-body]')).toBeNull();
+  expect(bubbleText()).toContain(REAL);
+  expect(bubbleText()).not.toContain(warning);
+  expect(spinnerVisible()).toBe(false);
+
+  // Re-delivery updates the same turn, without duplicating notices.
+  emitWebEvent('task-complete', response);
+  await rendered();
+  expect(target.querySelectorAll('[data-host-notice]')).toHaveLength(1);
+});
+
+it('keeps successful completion free of partial host notices', async () => {
+  emitWebEvent('task-complete', { id: TASK, narrative: REAL, status: 'success', errors: [] });
+  await rendered();
+  expect(bubbleText()).toContain(REAL);
+  expect(target.querySelector('[data-host-notice]')).toBeNull();
+  expect(spinnerVisible()).toBe(false);
 });
 
 describe('task-complete race (#3759)', () => {

--- a/crates/trusty-agents/ui/src/lib/transport.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.ts
@@ -224,6 +224,8 @@ async function fetchFallback(command: string, args?: Record<string, unknown>): P
             id,
             narrative,
             status: resp.status,
+            // #7370: preserve host notices just as native completion does.
+            errors: resp.errors,
             // #3737: forward the server's responder attribution so the browser
             // fallback relabels a delegated bubble the same way the Tauri path
             // does (that path emits the full PmResponse, which already carries

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -50,6 +50,8 @@ export interface Project {
 import type { AttachmentRef } from '../lib/attachments';
 
 export interface Message {
+  /** #7370: server notices belong to the host, separately from model prose. */
+  hostNotices?: string[];
   /**
    * Prepared attachment bodies carried inline with the turn. Distinct from
    * `attachments` below, which holds #7370's id-addressed manifest rows.
@@ -536,18 +538,19 @@ export const canLoadOlderChat = derived(
  * placeholder for that task id and append/replace its content to grow the
  * bubble in place rather than spamming new messages.
  * What: Updates the first message matching `taskId` inside `projectId` with
- * the new content.
+ * the new content and optional host notices. Omitted notices clear old ones.
  * Test: Add a placeholder with `taskId='t1'`, call `updateMessageByTask` with
  * the same id and new content, assert the message content is replaced.
+ * `ChatView.test.ts` covers partial notices separately from model prose.
  */
-export function updateMessageByTask(projectId: string, taskId: string, content: string): void {
+export function updateMessageByTask(projectId: string, taskId: string, content: string, hostNotices?: string[]): void {
   messages.update((map) => {
     const list = map.get(projectId);
     if (!list) return map;
     const next = new Map(map);
     next.set(
       projectId,
-      list.map((m) => (m.taskId === taskId && (m.role === 'assistant' || m.role === 'pm') ? { ...m, content } : m)),
+      list.map((m) => (m.taskId === taskId && (m.role === 'assistant' || m.role === 'pm') ? { ...m, content, hostNotices } : m)),
     );
     return next;
   });


### PR DESCRIPTION
## Outcome

Refs #7653, #4283, #7396

- Event retention: extracted events now survive beyond recent checkpoint
  history via `EventStore::read_exact` before withdrawal, instead of being
  silently dropped once a checkpoint rolls past the window that produced them.
- Checkpoint state is now bounded: `MAX_STATE_BYTES` is enforced inside
  `persistence::write_bytes`, so a runaway checkpoint can no longer grow state
  without limit.
- History outages are now surfaced: `SessionOverrides.history_unavailable`
  propagates through to the UI as `hostNotices`, so a broken history backend is
  visible instead of silently degrading behavior.

## Changes

Ported from the diverged worktree lineage of PR #7396 (commit a8eadcb07 plus
uncommitted edits), with the reversions of #7454 and the fail-open filter
ruling dropped. Out of scope: no changes beyond the three items above — no
new event types, no history-backend swap.

## Risk

Rung 5 (persistence): touches checkpoint write/read paths and the event store
in `trusty-agents`. Blast radius is checkpoint durability and history-outage
visibility; no public API surface change.

## Tests

- `cargo fmt --check`
- `cargo check -p trusty-agents --all-targets`
- `cargo clippy -p trusty-agents --all-targets -- -D warnings`
- `cargo test -p trusty-agents --no-fail-fast` — 3970 passed, 0 failed, 16
  ignored, 19 targets
- `check_line_cap.sh`, `check_test_pointers.sh`, `check_teardown_guard.sh`,
  `check_rustdoc_links.sh`, `check_changelog_fragment.sh` — all EXIT=0
- UI: `pnpm test:unit` — 666 passed / 70 files; `pnpm check` — 0 errors

Fail-open evidence: three regression tests proven red with only their hunk
reverted — `checkpoint_overflow_preserves_readable_state_and_allows_recovery`,
`published_event_survives_unrelated_event_batch_rollover`, and the
transient-probe case in
`attachment_rejection_is_read_only_and_pending_retries_are_idempotent`.

## Baseline

No pre-existing failures observed on this branch; the full rung-5 gate list
above ran clean.

## Docs

Changelog fragment added for `trusty-agents`. No public-API or user-facing doc
change beyond the changelog entry.

## Review

code-critic WARN on aa8bf23e8 (HIGH attachment-path outage asymmetry, LOW
over-broad event id set) — both fixed here in 139389b18; a narrow re-check of
139389b18 is running. Security scan: PASS.

Narrow critic re-check of 139389b18: APPROVE (2026-09-12).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_011QDgQFCNMJnLLj2cZdLp6U
