### PR TITLE
fix(trusty-mpm): one instruction-compression row per session — append_row_once under a cross-process lock; the sweep dedupes against the ledger; tm repair collapses existing duplicates (Refs #7658)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7658-dedupe-instruction-compression-rows.md
+++ b/crates/trusty-mpm/changelog.d/7658-dedupe-instruction-compression-rows.md
@@ -1,0 +1,8 @@
+Fixed
+- The savings ledger no longer accumulates duplicate `instruction-compression`
+  rows: every producer now appends through one choke point that reads the ledger
+  first and writes only when no row with the same session, technique and basis is
+  already recorded. One live session had 312 byte-identical rows. An unreadable
+  ledger skips the write and logs it rather than appending blind, and
+  `tm repair savings-ledger` collapses existing duplicates to the earliest copy
+  of each measurement (dry run by default, `--apply` to quarantine and rewrite).

--- a/crates/trusty-mpm/changelog.d/7658-dedupe-instruction-compression-rows.md
+++ b/crates/trusty-mpm/changelog.d/7658-dedupe-instruction-compression-rows.md
@@ -2,7 +2,11 @@ Fixed
 - The savings ledger no longer accumulates duplicate `instruction-compression`
   rows: every producer now appends through one choke point that reads the ledger
   first and writes only when no row with the same session, technique and basis is
-  already recorded. One live session had 312 byte-identical rows. An unreadable
-  ledger skips the write and logs it rather than appending blind, and
-  `tm repair savings-ledger` collapses existing duplicates to the earliest copy
-  of each measurement (dry run by default, `--apply` to quarantine and rewrite).
+  already recorded. One live session had 312 byte-identical rows. The read and
+  the append are held under the workspace's cross-process advisory file lock, so
+  two hooks racing in separate processes cannot both observe an absent row and
+  both write. An unreadable ledger skips the write and logs it rather than
+  appending blind, and stops being retried once the staged row passes the
+  stranded threshold. `tm repair savings-ledger` collapses existing duplicates to
+  the earliest copy of each measurement (dry run by default, `--apply` to
+  quarantine and rewrite).

--- a/crates/trusty-mpm/src/bin/tm/commands/repair_savings_ledger.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/repair_savings_ledger.rs
@@ -9,8 +9,12 @@
 //! for a one-shot, back-up-then-rewrite recovery of a persisted file.
 //! What: [`repair_savings_ledger`] resolves the framework root, plans the
 //! repair, prints the verdict, and — only with `--apply` — performs it.
+//! Since #7658 the same plan/apply pair also collapses exact-duplicate
+//! `instruction-compression` rows — one live session accumulated 312 copies of
+//! one measurement — keeping the earliest copy of each `(session_id, basis)`.
 //! Test: `repair_savings_ledger_dry_run_writes_nothing`,
-//! `repair_savings_ledger_applies_and_is_idempotent`.
+//! `repair_savings_ledger_applies_and_is_idempotent`; the collapse rule itself
+//! is `plan_collapses_duplicate_rows`.
 
 use std::path::PathBuf;
 
@@ -122,10 +126,13 @@ fn report(ledger: &std::path::Path, planned: &LedgerPlan) {
         kept + quarantined
     );
     println!("  would keep:       {kept} row(s)");
+    // #7658: `duplicate` is the third class — repeats of one
+    // instruction-compression measurement, collapsed to the earliest copy.
     println!(
-        "  would quarantine: {quarantined} row(s) — {} test-fixture, {} malformed",
+        "  would quarantine: {quarantined} row(s) — {} test-fixture, {} malformed, {} duplicate",
         planned.count_of(Reason::TestFixture),
-        planned.count_of(Reason::Malformed)
+        planned.count_of(Reason::Malformed),
+        planned.count_of(Reason::Duplicate)
     );
     // #7569: these lines held more or less than one parseable row, which is a
     // different finding from the `malformed` row count two lines above — most

--- a/crates/trusty-mpm/src/core/savings.rs
+++ b/crates/trusty-mpm/src/core/savings.rs
@@ -320,6 +320,132 @@ pub fn append_row(ledger: &Path, row: &SavingsRow) -> std::io::Result<()> {
     write_row_line(&mut file, row)
 }
 
+/// Whether the ledger already carries a given measurement — or could not be
+/// asked (#7658).
+///
+/// Why: a two-valued answer forces an unreadable ledger to be reported as one
+/// of "present" or "absent", and both are wrong in a way that costs something.
+/// Reporting it absent is the FAIL-OPEN: every producer then appends, and an
+/// unreadable ledger becomes an unbounded one — which is the failure this whole
+/// change exists to stop. Reporting it present would silently discard a genuine
+/// measurement. The third value lets the caller do neither: skip the write and
+/// say so in the log.
+/// What: `Unreadable` covers every read error EXCEPT `NotFound`, because a
+/// ledger that does not exist yet is the ordinary state on a machine no
+/// producer has run on, not a fault.
+/// Test: `row_presence_distinguishes_a_different_basis`,
+/// `append_row_once_skips_an_unreadable_ledger`,
+/// `row_presence_of_a_missing_ledger_is_absent`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowPresence {
+    /// The ledger holds a row with this `(session_id, technique, basis)`.
+    Present,
+    /// The ledger was read and holds no such row.
+    Absent,
+    /// The ledger could not be read, so the question was not answered.
+    Unreadable,
+}
+
+/// Does the ledger already carry this exact measurement?
+///
+/// Why (#7658): [`has_row`] answers "does this session have a row of this
+/// technique", which is the right question for the re-derivation guard and the
+/// wrong one for an append — a session whose prompt genuinely changed mid-run
+/// owes a second, DIFFERENT row. Keying on `basis` as well is what separates
+/// "the same measurement again" from "a new measurement", so the guard
+/// suppresses only the former.
+/// What: scans every parseable row, whatever its values. Deliberately NOT
+/// [`for_each_accepted_row`]: a row the fold rejects is still on the file, and
+/// treating it as absent would let a producer re-append it on every invocation
+/// forever.
+/// Test: `row_presence_distinguishes_a_different_basis`,
+/// `row_presence_finds_a_row_the_fold_rejects`,
+/// `append_row_once_skips_an_unreadable_ledger`.
+pub fn row_presence(ledger: &Path, session_id: &str, technique: &str, basis: &str) -> RowPresence {
+    let text = match std::fs::read_to_string(ledger) {
+        Ok(text) => text,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return RowPresence::Absent,
+        Err(source) => {
+            tracing::warn!(
+                ledger = %ledger.display(),
+                %source,
+                "could not read the savings ledger to check for an existing row"
+            );
+            return RowPresence::Unreadable;
+        }
+    };
+    let found = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<SavingsRow>(line).ok())
+        .any(|row| {
+            row.session_id == session_id && row.technique == technique && row.basis == basis
+        });
+    if found {
+        RowPresence::Present
+    } else {
+        RowPresence::Absent
+    }
+}
+
+/// What [`append_row_once`] did.
+///
+/// Test: `append_row_once_writes_one_row_for_n_attempts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppendOnce {
+    /// The row was not on the ledger and is now.
+    Appended,
+    /// An identical measurement was already recorded; nothing was written.
+    AlreadyPresent,
+    /// The ledger could not be read, so nothing was written (#7658).
+    LedgerUnreadable,
+}
+
+/// Append `row` unless the ledger already carries the same measurement.
+///
+/// Why (#7658): THE choke point. The ledger grew 312 byte-identical
+/// `instruction-compression` rows for one live session because both producers
+/// that write this technique — the compose-time append in
+/// [`crate::core::savings_instructions`] and the sweep's append in
+/// [`crate::core::savings_sidecar`] — called [`append_row`] without ever
+/// consulting the file. Guarding each producer separately would leave the next
+/// producer free to re-open the hole, so the check lives HERE, below every one
+/// of them: a caller that reaches the ledger at all reaches it through this.
+/// What: [`row_presence`] on `(session_id, technique, basis)`, then
+/// [`append_row`] only for [`RowPresence::Absent`]. An unreadable ledger skips
+/// the write and reports it — never treated as "no row exists", which would
+/// make an unreadable ledger append on every invocation.
+/// Test: `append_row_once_writes_one_row_for_n_attempts`,
+/// `append_row_once_skips_an_unreadable_ledger`,
+/// `append_row_once_still_records_a_different_basis`.
+pub fn append_row_once(ledger: &Path, row: &SavingsRow) -> std::io::Result<AppendOnce> {
+    match row_presence(ledger, &row.session_id, &row.technique, &row.basis) {
+        RowPresence::Present => {
+            tracing::debug!(
+                ledger = %ledger.display(),
+                session_id = %row.session_id,
+                technique = %row.technique,
+                "the ledger already carries this measurement; appending nothing"
+            );
+            Ok(AppendOnce::AlreadyPresent)
+        }
+        RowPresence::Unreadable => {
+            tracing::warn!(
+                ledger = %ledger.display(),
+                session_id = %row.session_id,
+                technique = %row.technique,
+                "the savings ledger could not be read, so whether this row is already \
+                 recorded is unknown; skipping the append rather than risking a duplicate"
+            );
+            Ok(AppendOnce::LedgerUnreadable)
+        }
+        RowPresence::Absent => {
+            append_row(ledger, row)?;
+            Ok(AppendOnce::Appended)
+        }
+    }
+}
+
 /// Write one row and its terminator to `sink` in a single `write_all`.
 ///
 /// Why (#7579): `writeln!` expands to `write_fmt`, which hands the formatter's

--- a/crates/trusty-mpm/src/core/savings.rs
+++ b/crates/trusty-mpm/src/core/savings.rs
@@ -412,13 +412,45 @@ pub enum AppendOnce {
 /// producer free to re-open the hole, so the check lives HERE, below every one
 /// of them: a caller that reaches the ledger at all reaches it through this.
 /// What: [`row_presence`] on `(session_id, technique, basis)`, then
-/// [`append_row`] only for [`RowPresence::Absent`]. An unreadable ledger skips
-/// the write and reports it — never treated as "no row exists", which would
-/// make an unreadable ledger append on every invocation.
+/// [`append_row`] only for [`RowPresence::Absent`] — the pair held under
+/// `trusty_common::file_lock::with_exclusive_lock` on the ledger, because a
+/// read-then-append that is not atomic is the SAME duplicate class bounded by
+/// the number of racers: two hooks in separate processes both observe `Absent`
+/// and both append. That lock is the workspace's one advisory-locking primitive
+/// (#5344) and it serialises threads and processes alike, so no second
+/// implementation is introduced here. An unreadable ledger skips the write and
+/// reports it — never treated as "no row exists", which would make an
+/// unreadable ledger append on every invocation.
+///
+/// Only the instruction-compression producers route through this. `divert` and
+/// `compress` keep [`append_row`]: a second diversion of the same file is a
+/// second real saving, so suppressing it would delete data, and neither pays the
+/// lock.
+///
+/// NOT reentrant, inheriting `with_exclusive_lock`'s contract — never call this
+/// from inside another lock on the same ledger.
 /// Test: `append_row_once_writes_one_row_for_n_attempts`,
+/// `racing_threads_append_exactly_one_row`,
 /// `append_row_once_skips_an_unreadable_ledger`,
 /// `append_row_once_still_records_a_different_basis`.
 pub fn append_row_once(ledger: &Path, row: &SavingsRow) -> std::io::Result<AppendOnce> {
+    // #7658: the ledger's parent must exist before the lock sidecar can be
+    // created beside it. `append_row` creates it too, but that is inside the
+    // critical section and too late for the lock file itself.
+    if let Some(parent) = ledger.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    trusty_common::file_lock::with_exclusive_lock(ledger, || append_row_once_locked(ledger, row))?
+}
+
+/// [`append_row_once`]'s critical section, with the lock already held.
+///
+/// Why: separating it keeps the lock acquisition one line and makes the
+/// read-then-append pair readable as the single indivisible step it has to be.
+/// What: see [`append_row_once`].
+/// Test: `append_row_once_writes_one_row_for_n_attempts`,
+/// `racing_threads_append_exactly_one_row`.
+fn append_row_once_locked(ledger: &Path, row: &SavingsRow) -> std::io::Result<AppendOnce> {
     match row_presence(ledger, &row.session_id, &row.technique, &row.basis) {
         RowPresence::Present => {
             tracing::debug!(

--- a/crates/trusty-mpm/src/core/savings_instructions.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions.rs
@@ -93,8 +93,8 @@ use std::path::Path;
 use crate::core::harness_root::{HARNESS_DIR, SESSIONS_DIR};
 use crate::core::instruction_pipeline::COMPILED_PROMPT_FILE;
 use crate::core::savings::{
-    BYTES_PER_TOKEN, SavingsRow, TECHNIQUE_INSTRUCTION_COMPRESSION, append_row,
-    claude_code_session_id, now_ts, savings_log_in,
+    BYTES_PER_TOKEN, SavingsRow, TECHNIQUE_INSTRUCTION_COMPRESSION, claude_code_session_id, now_ts,
+    savings_log_in,
 };
 use crate::core::savings_sidecar::{stage_row, warn_no_fold_once};
 
@@ -244,7 +244,12 @@ fn record_instruction_compression_to(
         return;
     }
     let ledger = savings_log_in(framework_root);
-    if let Err(source) = append_row(&ledger, &row) {
+    // #7658: this append fires on every compose that runs with the harness's
+    // session id exported, which a `tm` subprocess of a live Claude session
+    // inherits — 312 byte-identical rows for one session. `append_row_once`
+    // consults the ledger first; see `savings::append_row_once` for why the
+    // guard lives there rather than here.
+    if let Err(source) = crate::core::savings::append_row_once(&ledger, &row) {
         tracing::warn!(
             ledger = %ledger.display(),
             %source,

--- a/crates/trusty-mpm/src/core/savings_instructions_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions_tests.rs
@@ -850,3 +850,40 @@ fn the_fold_measurement_reads_the_newest_compiled_prompt() {
         "the source side must carry the bundled corpus"
     );
 }
+
+/// Why (#7658): the live regression's own producer. A `tm` subprocess of a live
+/// Claude session inherits `CLAUDE_CODE_SESSION_ID`, so every compose takes the
+/// append branch below — with no read of the ledger, 26 composes of one unchanged
+/// prompt wrote 26 identical rows. The measurement, not the number of composes,
+/// bounds the ledger.
+/// Test: itself.
+#[test]
+fn n_composes_under_one_session_id_append_exactly_one_row() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let project = tmp.path().join("project");
+    let dest = crate::core::instruction_pipeline::compiled_prompt_path(&project, "local");
+    std::fs::create_dir_all(dest.parent().expect("session dir")).expect("session dir");
+    let ledger = savings_log_in(&root);
+    // Far below the source set so the fold is genuinely positive, and at or above
+    // the #7491 plausibility floor so the producer does not refuse it.
+    let prompt = "x".repeat(min_plausible_compiled_bytes().max(1));
+
+    for _ in 0..26 {
+        record_instruction_compression_to(
+            &root,
+            &dest,
+            &prompt,
+            Some("claude-7658".to_string()),
+            no_roster,
+            sonnet_price,
+        );
+    }
+
+    let text = std::fs::read_to_string(&ledger).expect("the first compose must write a ledger");
+    assert_eq!(
+        text.lines().filter(|line| !line.trim().is_empty()).count(),
+        1,
+        "26 composes of one unchanged prompt must leave one row, got:\n{text}"
+    );
+}

--- a/crates/trusty-mpm/src/core/savings_repair.rs
+++ b/crates/trusty-mpm/src/core/savings_repair.rs
@@ -77,24 +77,30 @@ pub const MARKER_DIR: &str = crate::core::savings_sidecar::NO_FOLD_WARNED_DIR;
 /// Why: the sidecar records the rule that matched each row, because a repair
 /// that cannot say why it took a row is one an operator cannot audit.
 /// What: `TestFixture` for [`is_test_fixture_row`]; `Malformed` for a fragment
-/// that is not parseable JSON at all.
-/// Test: `plan_classifies_a_mixed_ledger`.
+/// that is not parseable JSON at all; `Duplicate` for a repeat of an
+/// `instruction-compression` measurement already seen earlier in the file
+/// (#7658).
+/// Test: `plan_classifies_a_mixed_ledger`, `plan_collapses_duplicate_rows`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Reason {
     /// The row carries [`FIXTURE_COMPILED_BASIS`] — written by a unit test.
     TestFixture,
     /// The text does not parse as a [`SavingsRow`].
     Malformed,
+    /// A later copy of an `instruction-compression` measurement already on the
+    /// ledger, matched on `(session_id, technique, basis)` (#7658).
+    Duplicate,
 }
 
 impl Reason {
     /// The stable string written into the sidecar and printed by the command.
     ///
-    /// Test: `plan_classifies_a_mixed_ledger`.
+    /// Test: `plan_classifies_a_mixed_ledger`, `plan_collapses_duplicate_rows`.
     pub fn label(self) -> &'static str {
         match self {
             Self::TestFixture => "test-fixture",
             Self::Malformed => "malformed",
+            Self::Duplicate => "duplicate",
         }
     }
 }
@@ -238,6 +244,32 @@ pub fn is_test_fixture_row(row: &SavingsRow) -> bool {
     row.technique == TECHNIQUE_INSTRUCTION_COMPRESSION && row.basis.contains(FIXTURE_COMPILED_BASIS)
 }
 
+/// Has this `instruction-compression` measurement already been seen on this
+/// ledger (#7658)?
+///
+/// Why: the producer-side guard stops NEW duplicates; a ledger that already
+/// carries 312 copies of one measurement needs them collapsed, and the repair
+/// is the only surface that may remove a row. Keying on `basis` alongside
+/// `session_id` is what separates "the same fold recorded again" from "a second,
+/// genuinely different fold in the same session" — the latter is real data and
+/// must survive. Only `instruction-compression` is keyed this way because it is
+/// the only technique whose producers re-run against an unchanged input; a
+/// `divert` row repeating its basis is a second real diversion.
+/// What: records the key on first sight and reports `true` on every sight after
+/// that. A row of any other technique is never a duplicate here.
+/// Test: `plan_collapses_duplicate_rows`,
+/// `plan_keeps_rows_whose_basis_differs`,
+/// `plan_keeps_a_repeated_divert_row`.
+fn is_repeat_measurement(
+    row: &SavingsRow,
+    seen: &mut std::collections::HashSet<(String, String)>,
+) -> bool {
+    if row.technique != TECHNIQUE_INSTRUCTION_COMPRESSION {
+        return false;
+    }
+    !seen.insert((row.session_id.clone(), row.basis.clone()))
+}
+
 /// Split one physical ledger line into the row fragments it actually holds.
 ///
 /// Why (#7579): the ledger's writer issued a row and its newline as two
@@ -300,6 +332,10 @@ pub fn plan(ledger: &Path) -> std::io::Result<LedgerPlan> {
         bytes_read: text.len() as u64,
         ..LedgerPlan::default()
     };
+    // #7658: the measurements already seen, in ledger order. The FIRST copy of
+    // each is kept — it carries the earliest `ts`, which is when the fold that
+    // produced it actually happened.
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
     for (index, line) in text.lines().enumerate() {
         let number = index + 1;
         planned.lines_read += 1;
@@ -315,6 +351,8 @@ pub fn plan(ledger: &Path) -> std::io::Result<LedgerPlan> {
             let quarantine = match &row {
                 None => Some(Reason::Malformed),
                 Some(row) if is_test_fixture_row(row) => Some(Reason::TestFixture),
+                // #7658: a repeat of a measurement already on the file.
+                Some(row) if is_repeat_measurement(row, &mut seen) => Some(Reason::Duplicate),
                 Some(_) => None,
             };
             planned.fragments.push(Fragment {

--- a/crates/trusty-mpm/src/core/savings_repair_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_repair_tests.rs
@@ -604,3 +604,90 @@ fn a_brace_pair_inside_a_string_is_not_a_row_boundary() {
     );
     assert!(planned.is_clean(), "such a ledger is already clean");
 }
+
+/// The same genuine fold as [`KEEP_REAL_FOLD`], re-recorded a second later —
+/// the exact shape the live producers appended 312 times (#7658). Only `ts`
+/// differs.
+const DUP_REAL_FOLD: &str = r#"{"ts":"2026-09-11T09:12:01Z","session_id":"33333333-3333-4333-8333-333333333333","technique":"instruction-compression","tokens_saved":611,"tokens_before":6702,"cost_saved_usd":0.0018,"basis":"sources 26810 B - compiled 24363 B, at 4 B/token, priced at claude-sonnet-4-5 input $3/Mtok","model_source":"statusline"}"#;
+
+/// The same SESSION with a genuinely different fold — its prompt changed, so
+/// this is real data and must survive the collapse (#7658).
+const KEEP_SECOND_FOLD: &str = r#"{"ts":"2026-09-11T09:30:00Z","session_id":"33333333-3333-4333-8333-333333333333","technique":"instruction-compression","tokens_saved":900,"tokens_before":6702,"cost_saved_usd":0.0027,"basis":"sources 26810 B - compiled 23163 B, at 4 B/token, priced at claude-sonnet-4-5 input $3/Mtok","model_source":"statusline"}"#;
+
+/// Write `lines` as a ledger under a fresh temp root and return both.
+fn ledger_of(lines: &[&str]) -> (tempfile::TempDir, std::path::PathBuf) {
+    let root = tempfile::tempdir().expect("temp root");
+    let ledger = savings_log_in(root.path());
+    std::fs::create_dir_all(ledger.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&ledger, format!("{}\n", lines.join("\n"))).expect("write");
+    (root, ledger)
+}
+
+/// Why (#7658): the producer-side guard stops NEW duplicates; the operator's
+/// ledger already carries 312 copies of one measurement, and the repair is the
+/// only surface allowed to remove a row. Five copies collapse to the earliest.
+/// Test: itself.
+#[test]
+fn plan_collapses_duplicate_rows() {
+    let (_root, ledger) = ledger_of(&[
+        KEEP_REAL_FOLD,
+        DUP_REAL_FOLD,
+        DUP_REAL_FOLD,
+        DUP_REAL_FOLD,
+        DUP_REAL_FOLD,
+    ]);
+
+    let planned = plan(&ledger).expect("plan");
+    assert_eq!(
+        planned.count_of(Reason::Duplicate),
+        4,
+        "four of the five copies are repeats"
+    );
+    let kept: Vec<&str> = planned.kept().map(|f| f.text.as_str()).collect();
+    assert_eq!(
+        kept,
+        vec![KEEP_REAL_FOLD],
+        "the EARLIEST copy is the one kept"
+    );
+
+    let applied = apply(&ledger, &planned, chrono::Utc::now()).expect("apply");
+    assert_eq!(applied.kept, 1);
+    assert_eq!(applied.quarantined, 4);
+    assert_eq!(
+        std::fs::read_to_string(&ledger).expect("read").trim(),
+        KEEP_REAL_FOLD,
+        "the repaired ledger holds exactly one copy"
+    );
+    assert!(
+        plan(&ledger).expect("re-plan").is_clean(),
+        "a second run must find nothing"
+    );
+}
+
+/// Why (#7658): `basis` is what separates a repeat from a second genuine fold.
+/// A collapse keyed on the session alone would delete real measurements.
+/// Test: itself.
+#[test]
+fn plan_keeps_rows_whose_basis_differs() {
+    let (_root, ledger) = ledger_of(&[KEEP_REAL_FOLD, KEEP_SECOND_FOLD, KEEP_ODDITY]);
+
+    let planned = plan(&ledger).expect("plan");
+    assert_eq!(planned.count_of(Reason::Duplicate), 0);
+    assert!(
+        planned.is_clean(),
+        "a ledger of distinct measurements needs no repair"
+    );
+}
+
+/// Why (#7658): only `instruction-compression` has producers that re-run
+/// against an unchanged input. A repeated `divert` row is a second real
+/// diversion, so the collapse must not reach it.
+/// Test: itself.
+#[test]
+fn plan_keeps_a_repeated_divert_row() {
+    let (_root, ledger) = ledger_of(&[KEEP_DIVERT, KEEP_DIVERT]);
+
+    let planned = plan(&ledger).expect("plan");
+    assert_eq!(planned.count_of(Reason::Duplicate), 0);
+    assert_eq!(planned.kept().count(), 2, "both diversions are real");
+}

--- a/crates/trusty-mpm/src/core/savings_sidecar.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar.rs
@@ -295,11 +295,16 @@ pub fn emit_staged_row(
 /// a claim of a measurement the ledger already carries deletes the staged file
 /// and reports `false` — the row is accounted for, and leaving the file would
 /// only have it claimed again on the next hook. A ledger that cannot be READ
-/// leaves the row staged, exactly as a failed append does.
+/// leaves the row staged, exactly as a failed append does — but only until the
+/// staged file passes [`STRANDED_AFTER`], after which the retry stops: the file
+/// stays under its claim name, which the sweep skips, and one `error!` names it
+/// for `tm repair` or the operator. Without that bound a persistently unreadable
+/// ledger warns and re-stages on every sweep forever.
 /// Test: `two_racing_claims_append_exactly_one_row`,
 /// `a_failed_append_leaves_the_row_staged_for_the_next_hook`,
 /// `n_hooks_sweeping_a_restaged_row_append_exactly_one`,
-/// `an_unreadable_ledger_leaves_the_staged_row_alone`.
+/// `an_unreadable_ledger_leaves_the_staged_row_alone`,
+/// `a_stranded_row_stops_being_restaged_against_an_unreadable_ledger`.
 fn claim_staged_row(ledger: &Path, path: &Path, claude_session_id: &str) -> bool {
     let session_id = claude_session_id.trim();
     if session_id.is_empty() {
@@ -355,8 +360,28 @@ fn claim_staged_row(ledger: &Path, path: &Path, claude_session_id: &str) -> bool
         }
         // #7658: nothing was written and nothing is known, so the staged row
         // goes back for a hook that can read the ledger — the same treatment a
-        // failed append gets, for the same reason.
+        // failed append gets, for the same reason. Bounded by
+        // [`STRANDED_AFTER`], because a ledger that is PERSISTENTLY unreadable
+        // would otherwise warn and re-stage on every sweep for the life of the
+        // machine.
         Ok(AppendOnce::LedgerUnreadable) => {
+            // The rename preserves the staged file's mtime, so the claim path
+            // still carries the age the bound is measured against.
+            if age_of(&claim).is_some_and(|age| age >= STRANDED_AFTER) {
+                // Not renamed back: the sweep only picks up `*.json`, so leaving
+                // the file under its claim name is what stops the retry. The row
+                // is still on disk for `tm repair` or the operator.
+                tracing::error!(
+                    ledger = %ledger.display(),
+                    path = %claim.display(),
+                    stranded_hours = STRANDED_AFTER.as_secs() / 3600,
+                    "the savings ledger has been unreadable since this instruction-compression \
+                     row was staged, for longer than the stranded threshold; giving up on it \
+                     rather than re-staging it on every sweep. The measurement is still at the \
+                     path named here"
+                );
+                return false;
+            }
             let restored = std::fs::rename(&claim, &path).is_ok();
             tracing::warn!(
                 ledger = %ledger.display(),

--- a/crates/trusty-mpm/src/core/savings_sidecar.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar.rs
@@ -18,7 +18,9 @@
 //!   [`crate::core::savings::SavingsRow`], written by the compiling process
 //!   because it cannot key it. [`emit_staged_row`] claims it and appends it
 //!   under the Claude session id through
-//!   [`crate::core::savings::append_row`], which stays the ledger's one writer.
+//!   [`crate::core::savings::append_row_once`], which stays the ledger's one
+//!   writer for this technique and, since #7658, appends only a measurement the
+//!   ledger does not already carry.
 //!   The claim is an atomic rename onto a per-attempt path, so of two racing
 //!   hook processes only the one whose rename succeeds appends. The claim file
 //!   is deleted once the append has landed, and renamed back to the staging
@@ -87,7 +89,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-use crate::core::savings::{SavingsRow, append_row};
+use crate::core::savings::{AppendOnce, SavingsRow};
 
 /// Directory holding staged rows, under the framework root's `usage/`.
 const PENDING_DIR: &str = "pending-savings";
@@ -252,7 +254,9 @@ fn claim_path_for(staged: &Path) -> PathBuf {
 /// What: renames the staged file onto a per-attempt claim path — the rename is
 /// the claim, and the racer whose rename fails reads nothing and appends
 /// nothing — then replaces the row's `session_id` and appends through
-/// [`append_row`]. The claim file is removed only once the append has landed;
+/// [`crate::core::savings::append_row_once`], which since #7658 appends only a
+/// measurement the ledger does not already carry. The claim file is removed once
+/// the append has landed — or once the ledger is found to hold the row already;
 /// an append that fails goes back to the staging path for the next hook, and
 /// the warning carries the row's JSON so the measurement survives in the log
 /// even if the rename back also fails. Returns whether a row was appended:
@@ -286,9 +290,16 @@ pub fn emit_staged_row(
 /// the directory, so the atomic rename lives here — one claim primitive, still
 /// the only writer, so two hooks racing on one staged file still produce one
 /// ledger row.
-/// What: see [`emit_staged_row`], which is this against a digested path.
+/// What: see [`emit_staged_row`], which is this against a digested path. The
+/// append goes through [`crate::core::savings::append_row_once`] since #7658, so
+/// a claim of a measurement the ledger already carries deletes the staged file
+/// and reports `false` — the row is accounted for, and leaving the file would
+/// only have it claimed again on the next hook. A ledger that cannot be READ
+/// leaves the row staged, exactly as a failed append does.
 /// Test: `two_racing_claims_append_exactly_one_row`,
-/// `a_failed_append_leaves_the_row_staged_for_the_next_hook`.
+/// `a_failed_append_leaves_the_row_staged_for_the_next_hook`,
+/// `n_hooks_sweeping_a_restaged_row_append_exactly_one`,
+/// `an_unreadable_ledger_leaves_the_staged_row_alone`.
 fn claim_staged_row(ledger: &Path, path: &Path, claude_session_id: &str) -> bool {
     let session_id = claude_session_id.trim();
     if session_id.is_empty() {
@@ -328,20 +339,46 @@ fn claim_staged_row(ledger: &Path, path: &Path, claude_session_id: &str) -> bool
         }
     };
     row.session_id = session_id.to_string();
-    if let Err(source) = append_row(ledger, &row) {
-        let restored = std::fs::rename(&claim, &path).is_ok();
-        let row_json = serde_json::to_string(&row).unwrap_or(text);
-        tracing::warn!(
-            ledger = %ledger.display(),
-            %source,
-            restored,
-            row = %row_json,
-            "could not append the staged instruction-compression savings row"
-        );
-        return false;
+    // #7658: the sweep re-runs on every hook, and a producer that re-stages
+    // hands it the same measurement again. `append_row_once` is what makes a
+    // second claim of an identical row a no-op instead of a second ledger line.
+    match crate::core::savings::append_row_once(ledger, &row) {
+        Ok(AppendOnce::Appended) => {
+            let _ = std::fs::remove_file(&claim);
+            true
+        }
+        // The measurement is already on the ledger, so this staged copy is
+        // redundant: drop it rather than leave it to be claimed again forever.
+        Ok(AppendOnce::AlreadyPresent) => {
+            let _ = std::fs::remove_file(&claim);
+            false
+        }
+        // #7658: nothing was written and nothing is known, so the staged row
+        // goes back for a hook that can read the ledger — the same treatment a
+        // failed append gets, for the same reason.
+        Ok(AppendOnce::LedgerUnreadable) => {
+            let restored = std::fs::rename(&claim, &path).is_ok();
+            tracing::warn!(
+                ledger = %ledger.display(),
+                restored,
+                "left the staged instruction-compression savings row unwritten because \
+                 the ledger could not be read"
+            );
+            false
+        }
+        Err(source) => {
+            let restored = std::fs::rename(&claim, &path).is_ok();
+            let row_json = serde_json::to_string(&row).unwrap_or(text);
+            tracing::warn!(
+                ledger = %ledger.display(),
+                %source,
+                restored,
+                row = %row_json,
+                "could not append the staged instruction-compression savings row"
+            );
+            false
+        }
     }
-    let _ = std::fs::remove_file(&claim);
-    true
 }
 
 /// Every compiled prompt that exists under `project_dir`, newest first.

--- a/crates/trusty-mpm/src/core/savings_sidecar_sweep_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar_sweep_tests.rs
@@ -105,6 +105,66 @@ fn the_sweep_claims_a_row_staged_under_another_session_scope() {
     assert_eq!(rows_in(&ledger), 1, "the row must land exactly once");
 }
 
+/// Why (#7658): THE live regression — 312 byte-identical
+/// `instruction-compression` rows for one Claude session. The sweep runs before
+/// the re-derivation's `has_row` guard and consults nothing itself, so a
+/// producer that re-stages the same measurement got it appended on every hook.
+/// The row's identity, not the staging file's presence, is what must bound the
+/// ledger.
+/// Test: itself.
+#[test]
+fn n_hooks_sweeping_a_restaged_row_append_exactly_one() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let compiled = project_with_compiled_prompt(tmp.path(), "project", "managed-7658");
+    let project = tmp.path().join("project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+
+    // 26 hooks, each preceded by a re-stage — the shape the live ledger shows,
+    // whichever producer does the re-staging.
+    for _ in 0..26 {
+        stage_row(&root, &compiled, &a_row("managed-7658"));
+        emit_staged_row_for_session_in(&root, &project, "claude-7658");
+    }
+
+    assert_eq!(
+        rows_in(&ledger),
+        1,
+        "26 hooks over one re-staged measurement must leave one row, got:\n{}",
+        std::fs::read_to_string(&ledger).unwrap_or_default()
+    );
+    assert!(
+        !pending_row_path_in(&root, &compiled).exists(),
+        "a redundant staged row must be dropped, not left to be claimed again"
+    );
+}
+
+/// Why (#7658) — the Fail-Open Check at the sweep. A ledger that cannot be READ
+/// answers neither "present" nor "absent", so the claim must put the row back
+/// rather than append blind. The opposite reading is the fail-open that makes an
+/// IO fault an unbounded append loop.
+/// Test: itself.
+#[test]
+fn an_unreadable_ledger_leaves_the_staged_row_alone() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let compiled = project_with_compiled_prompt(tmp.path(), "project", "managed-7658b");
+    let project = tmp.path().join("project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+    // A directory at the ledger path: readable as a path, unreadable as a file.
+    std::fs::create_dir_all(&ledger).expect("occupy the ledger path");
+
+    stage_row(&root, &compiled, &a_row("managed-7658b"));
+    assert!(
+        !emit_staged_row_for_session_in(&root, &project, "claude-7658b"),
+        "no row can be reported against a ledger that cannot be read"
+    );
+    assert!(
+        pending_row_path_in(&root, &compiled).exists(),
+        "the measurement must stay staged for a hook that can read the ledger"
+    );
+}
+
 /// Why (#7411): staging is the only route this producer has to the ledger, so a
 /// staged file that was never written — an unwritable directory, a `tm`
 /// upgraded between the compile and the hook — left the session with a blank

--- a/crates/trusty-mpm/src/core/savings_sidecar_sweep_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar_sweep_tests.rs
@@ -165,6 +165,66 @@ fn an_unreadable_ledger_leaves_the_staged_row_alone() {
     );
 }
 
+/// Why (#7658, code-critic round 1): the re-stage above is correct for a
+/// transient read fault and unbounded for a permanent one — a ledger that is
+/// never readable warns and re-stages on every sweep for the life of the
+/// machine. Past [`STRANDED_AFTER`] the retry stops: the file keeps its claim
+/// name, which the sweep skips, so the measurement is preserved without being
+/// reattempted.
+/// Test: itself.
+#[test]
+fn a_stranded_row_stops_being_restaged_against_an_unreadable_ledger() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let root = tmp.path().join("framework");
+    let compiled = project_with_compiled_prompt(tmp.path(), "project", "managed-7658c");
+    let project = tmp.path().join("project");
+    let ledger = crate::core::savings::savings_log_in(&root);
+    std::fs::create_dir_all(&ledger).expect("occupy the ledger path");
+
+    let staged = pending_row_path_in(&root, &compiled);
+    stage_row(&root, &compiled, &a_row("managed-7658c"));
+    backdate(&staged, STRANDED_AFTER.as_secs() / 3600 + 1);
+
+    assert!(!emit_staged_row_for_session_in(
+        &root,
+        &project,
+        "claude-7658c"
+    ));
+    assert!(
+        !staged.exists(),
+        "a stranded row against an unreadable ledger must not be re-staged"
+    );
+
+    // The measurement is still on disk under the claim name, and a second sweep
+    // does not pick it back up.
+    let leftovers: Vec<PathBuf> = std::fs::read_dir(root.join("usage").join(PENDING_DIR))
+        .expect("pending dir")
+        .flatten()
+        .map(|entry| entry.path())
+        .collect();
+    assert_eq!(leftovers.len(), 1, "the row's bytes must survive");
+    assert!(
+        leftovers[0]
+            .extension()
+            .is_none_or(|extension| extension != "json"),
+        "the leftover must not be swept again: {}",
+        leftovers[0].display()
+    );
+
+    assert!(!emit_staged_row_for_session_in(
+        &root,
+        &project,
+        "claude-7658c"
+    ));
+    assert_eq!(
+        std::fs::read_dir(root.join("usage").join(PENDING_DIR))
+            .expect("pending dir")
+            .count(),
+        1,
+        "a second sweep must neither claim nor duplicate it"
+    );
+}
+
 /// Why (#7411): staging is the only route this producer has to the ledger, so a
 /// staged file that was never written — an unwritable directory, a `tm`
 /// upgraded between the compile and the hook — left the session with a blank

--- a/crates/trusty-mpm/src/core/savings_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_tests.rs
@@ -500,3 +500,153 @@ fn a_row_and_its_newline_leave_in_one_write() {
         "exactly one terminator: {written:?}"
     );
 }
+
+/// Why (#7658): the live regression. The operator's ledger carried 312
+/// byte-identical `instruction-compression` rows for one session because both
+/// producers called [`append_row`] without ever reading the file. N attempts at
+/// one measurement must leave exactly one row.
+/// Test: itself.
+#[test]
+fn append_row_once_writes_one_row_for_n_attempts() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let ledger = savings_log_in(dir.path());
+    let measurement = row("sess-dup", 183, 0.000_549);
+
+    let mut appended = 0usize;
+    for _ in 0..26 {
+        match append_row_once(&ledger, &measurement).expect("append") {
+            AppendOnce::Appended => appended += 1,
+            AppendOnce::AlreadyPresent => {}
+            AppendOnce::LedgerUnreadable => panic!("the ledger is readable in this test"),
+        }
+    }
+
+    assert_eq!(appended, 1, "only the first attempt may write");
+    let text = std::fs::read_to_string(&ledger).expect("read");
+    assert_eq!(
+        text.lines().filter(|line| !line.trim().is_empty()).count(),
+        1,
+        "26 attempts at one measurement must leave one row, got:\n{text}"
+    );
+}
+
+/// Why (#7658): a session whose prompt genuinely changes mid-run folds a second,
+/// DIFFERENT measurement, and suppressing that would lose real data. The key is
+/// `(session_id, technique, basis)`, never the session alone.
+/// Test: itself.
+#[test]
+fn append_row_once_still_records_a_different_basis() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let ledger = savings_log_in(dir.path());
+    let first = row("sess-a", 183, 0.000_549);
+    let mut second = first.clone();
+    second.basis = "sources 30000 B - compiled 20000 B".to_string();
+
+    assert_eq!(
+        append_row_once(&ledger, &first).expect("append"),
+        AppendOnce::Appended
+    );
+    assert_eq!(
+        append_row_once(&ledger, &second).expect("append"),
+        AppendOnce::Appended,
+        "a different basis is a different measurement"
+    );
+    assert_eq!(fold_session(&ledger, "sess-a").rows, 2);
+}
+
+/// Why (#7658) — the Fail-Open Check. An unreadable ledger must NOT read as "no
+/// row exists": that is exactly the fail-open that turns a read fault into an
+/// unbounded append loop. The write is skipped and the caller is told.
+/// Test: itself.
+#[test]
+fn append_row_once_skips_an_unreadable_ledger() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let ledger = savings_log_in(dir.path());
+    // A DIRECTORY at the ledger path reads back as an error that is not
+    // `NotFound` — the same shape as every other unreadable ledger this guard
+    // has to survive, and the one a test can create portably.
+    std::fs::create_dir_all(&ledger).expect("occupy the ledger path");
+
+    assert_eq!(
+        row_presence(&ledger, "sess-a", TECHNIQUE_INSTRUCTION_COMPRESSION, "b"),
+        RowPresence::Unreadable,
+        "an unreadable ledger must never report Absent"
+    );
+    assert_eq!(
+        append_row_once(&ledger, &row("sess-a", 183, 0.000_549)).expect("no error"),
+        AppendOnce::LedgerUnreadable,
+        "the write is skipped when the ledger cannot be read"
+    );
+}
+
+/// Why (#7658): a ledger that does not exist yet is the ordinary state on a
+/// machine no producer has run on — absent, not unreadable, so the first row
+/// still lands.
+/// Test: itself.
+#[test]
+fn row_presence_of_a_missing_ledger_is_absent() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let ledger = savings_log_in(dir.path());
+    assert_eq!(
+        row_presence(&ledger, "sess-a", TECHNIQUE_INSTRUCTION_COMPRESSION, "b"),
+        RowPresence::Absent
+    );
+}
+
+/// Why (#7658): the presence check must see a row the FOLD rejects, or a
+/// producer whose row is unfoldable re-appends it on every invocation forever —
+/// the same unbounded growth by another route.
+/// Test: itself.
+#[test]
+fn row_presence_finds_a_row_the_fold_rejects() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let mut unfoldable = row("sess-a", 0, 0.0);
+    unfoldable.basis = "sources 10 B - compiled 10 B".to_string();
+    let line = serde_json::to_string(&unfoldable).expect("encode");
+    let ledger = ledger_with(&dir, &[&line]);
+
+    assert_eq!(
+        fold_session(&ledger, "sess-a").rows,
+        0,
+        "the fold rejects a row with non-positive tokens_saved"
+    );
+    assert_eq!(
+        row_presence(
+            &ledger,
+            "sess-a",
+            TECHNIQUE_INSTRUCTION_COMPRESSION,
+            "sources 10 B - compiled 10 B"
+        ),
+        RowPresence::Present,
+        "a rejected row is still on the file and must suppress a re-append"
+    );
+}
+
+/// Why (#7658): `basis` is what separates a repeat from a new measurement, so a
+/// presence check that ignored it would suppress real data.
+/// Test: itself.
+#[test]
+fn row_presence_distinguishes_a_different_basis() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let line = serde_json::to_string(&row("sess-a", 183, 0.000_549)).expect("encode");
+    let ledger = ledger_with(&dir, &[&line]);
+
+    assert_eq!(
+        row_presence(
+            &ledger,
+            "sess-a",
+            TECHNIQUE_INSTRUCTION_COMPRESSION,
+            "sources 1000 B - compiled 400 B"
+        ),
+        RowPresence::Present
+    );
+    assert_eq!(
+        row_presence(
+            &ledger,
+            "sess-a",
+            TECHNIQUE_INSTRUCTION_COMPRESSION,
+            "sources 9999 B - compiled 400 B"
+        ),
+        RowPresence::Absent
+    );
+}

--- a/crates/trusty-mpm/src/core/savings_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_tests.rs
@@ -530,6 +530,54 @@ fn append_row_once_writes_one_row_for_n_attempts() {
     );
 }
 
+/// Why (#7658, code-critic round 1): the single-threaded loop above does not
+/// exercise the interval between the presence read and the append. Two callers
+/// racing on one key both observe `Absent` and both append unless that pair is
+/// indivisible — the same duplicate class, bounded only by the number of racers.
+/// `with_exclusive_lock` serialises separate descriptors, so the threads here
+/// exercise the same lock two processes would contend on.
+/// What: 16 threads released together on one measurement, repeated 10 times
+/// because a race that survives once may not survive again.
+/// Test: itself.
+#[test]
+fn racing_threads_append_exactly_one_row() {
+    for attempt in 0..10 {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let ledger = savings_log_in(dir.path());
+        std::fs::create_dir_all(ledger.parent().expect("parent")).expect("mkdir");
+        let measurement = row("sess-race", 183, 0.000_549);
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(16));
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                let ledger = ledger.clone();
+                let measurement = measurement.clone();
+                let barrier = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    append_row_once(&ledger, &measurement).expect("append")
+                })
+            })
+            .collect();
+        let appended = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("thread"))
+            .filter(|outcome| *outcome == AppendOnce::Appended)
+            .count();
+
+        assert_eq!(
+            appended, 1,
+            "attempt {attempt}: exactly one racer may write"
+        );
+        let text = std::fs::read_to_string(&ledger).expect("read");
+        assert_eq!(
+            text.lines().filter(|line| !line.trim().is_empty()).count(),
+            1,
+            "attempt {attempt}: 16 racers must leave one row, got:\n{text}"
+        );
+    }
+}
+
 /// Why (#7658): a session whose prompt genuinely changes mid-run folds a second,
 /// DIFFERENT measurement, and suppressing that would lose real data. The key is
 /// `(session_id, technique, basis)`, never the session alone.


### PR DESCRIPTION
## Summary

Since #7622 both instruction-compression producers — the `savings_instructions.rs`
compose path (when `CLAUDE_CODE_SESSION_ID` is exported) and `savings_sidecar`'s
`claim_staged_row`, re-run by the sweep on every hook — appended via
`append_row` without reading the ledger. 312 identical rows landed for one live
session in bursts of 26.

`savings::append_row_once`, keyed on `(session_id, technique, basis)`, is now
the choke point below every instruction-compression writer. It holds
`trusty_common::file_lock::with_exclusive_lock` (#5344, `flock` on
`<ledger>.lock`, fails closed) across read-then-append. Presence is
three-valued so an unreadable ledger never reads as absent: the write is
skipped, logged, and the staged row kept. A staged row older than
`STRANDED_AFTER` against an unreadable ledger stops being re-staged — one
`error!`, file kept for the operator. `divert` and `compress` stay on the
plain `append_row` path.

`tm repair savings-ledger` gains a `Duplicate` class that collapses repeats to
the earliest copy per `(session_id, basis)` via the #7584
quarantine-then-rewrite path. Dry run is the default; a second apply on a
clean ledger writes nothing.

## Changes

- `crates/trusty-mpm/src/core/savings.rs`
- `crates/trusty-mpm/src/core/savings_instructions.rs`
- `crates/trusty-mpm/src/core/savings_sidecar.rs`
- `crates/trusty-mpm/src/core/savings_repair.rs`
- `crates/trusty-mpm/src/bin/tm/commands/repair_savings_ledger.rs`
- Four `*_tests.rs` files
- `crates/trusty-mpm/changelog.d/7658-dedupe-instruction-compression-rows.md`

## Risk

High — a persisted ledger, and a repair path that rewrites it.

Reviewed: the lock spans read+append on every call site; `flock` is
per-open-file-description, so the 16-thread race test proves the cross-process
primitive; fails closed on an uncreatable lock file
(`with_exclusive_lock_unopenable_errors`); the repair rewrite preserves other
techniques' rows byte-for-byte and carries a live tail.

## Tests

Rung 3, `-p trusty-mpm` at 78bdcc327:

- `cargo fmt --check` — 0
- `cargo clippy --all-targets -- -D warnings` — 0
- `cargo test -p trusty-mpm --no-fail-fast` — 61 targets, 0 failed (lib 6957
  passed / 8 ignored)
- `cargo doc --no-deps` — 0
- `check_test_pointers` — 0 dangling
- `check_line_cap` — 0
- changelog gate — OK

Regression tests that provably failed pre-fix:

- `n_composes_under_one_session_id_append_exactly_one_row` (26 vs 1)
- `n_hooks_sweeping_a_restaged_row_append_exactly_one` (26 vs 1)
- `plan_collapses_duplicate_rows` (0 vs 4 repeats)
- `racing_threads_append_exactly_one_row` (16 of 16 appended)
- `a_stranded_row_stops_being_restaged_against_an_unreadable_ledger`

Fourteen new tests total, all on tempdir roots.

## Baseline

None.

## Docs

Changelog fragment; module docs.

## Review

code-critic WARN (race, unbounded re-stage) — both closed — APPROVE.

Follow-ups recorded on #7658, not in this PR:
- `tm repair` does not yet sweep stranded `.claim-*` files under
  `pending-savings/`.
- `savings_repair::apply` does not take the new lock (its tail-carry
  mitigation is unchanged).

Refs #7658

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
