### PR TITLE
chore(trusty-mpm): bump to 1.5.36 for owner-authorized reinstall (Refs #7616 #7617 #7658)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11932,7 +11932,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.5.35"
+version = "1.5.36"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -64,7 +64,10 @@ name = "trusty-mpm"
 # edits `src/**`, so the `PR version bump vs crates.io` gate (#4421) requires
 # the bump here. Patch because the change is a bug fix inside the existing
 # savings producer and compiled-prompt writer.
-version = "1.5.35"
+# 1.5.36 (Refs #7616 #7617 #7658): patch, version-only — owner-authorized
+# reinstall so `tm --version` identifies the build carrying the fold/doctor,
+# statusline core-setup, and ledger dedupe fixes merged since 1.5.35.
+version = "1.5.36"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Outcome
Installed tm is 1.5.35 (e9c9306d8); main at 0ca95c3a5 carries today's fixes — #7616 fold + doctor check, #7617 statusline core setup + doctor check 50, #7618, #7607, #7568, #7658 ledger dedupe + repair, #7580 #7602 #7588 #7513, #7533 #7550, #7603 #7542, #7558 #7561 #7612, #7641; the bump lets `--version` identify the reinstalled build per the owner's ruling.

## Changes
PATCH bump + lock.

## Risk
Low, metadata.

## Tests
`cargo check -p trusty-mpm` 0; `scripts/check_workspace_dep_versions.sh` all 12 rows OK; changelog gate `--staged`: no crate source changed. The full workspace gate on 0ca95c3a5 is running separately and gates the install, not this merge.

## Baseline
None.

## Docs
None.

## Review
None.

Refs #7616 #7617 #7658

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
