### PR TITLE
chore(trusty-agents): bump to 0.39.3 for owner-authorized reinstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11300,7 +11300,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -10,7 +10,9 @@ name = "trusty-agents"
 # `--version` identifies the build); no public API change.
 # 0.39.2: patch bump for an owner-authorized reinstall carrying #7454/#7427
 # for live verification; no public API change.
-version = "0.39.2"
+# 0.39.3: patch bump for an owner-authorized reinstall carrying #7360/#7361/
+# #7653/#7443 for live verification; no public API change.
+version = "0.39.3"
 edition = "2024"
 description = "Trusty Agents: Rust-native agentic harness with multi-model routing, tool execution, and subprocess delegation."
 license.workspace = true


### PR DESCRIPTION
Owner-authorized reinstall of trusty-agents. Owner ruling: every reinstall carries a patch bump so `tagent --version` identifies the build.

Bumps `crates/trusty-agents/Cargo.toml` 0.39.2 -> 0.39.3, plus the corresponding `Cargo.lock` line.

Issues awaiting live verification on this build: [#7360](https://github.com/bobmatnyc/trusty-tools/issues/7360), [#7361](https://github.com/bobmatnyc/trusty-tools/issues/7361), [#7653](https://github.com/bobmatnyc/trusty-tools/issues/7653), [#7443](https://github.com/bobmatnyc/trusty-tools/issues/7443).

Refs #7360
Refs #7361
Refs #7653
Refs #7443

Test ladder rung 1 (mechanical metadata only, no `src/**` change, no changelog fragment owed). Gates run by local-ops: `cargo check -p trusty-agents` clean; `./scripts/check_workspace_dep_versions.sh` reports all 12 internal rows accept their member version (trusty-agents has no root workspace-dependency row).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_018WdomR2f9ERZME6nakj4qy
