### PR TITLE
fix(trusty-mpm): scope the no-fold WARN and doctor message to the instruction-compression technique (Refs #7671)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7671-savings-no-fold-warn-wording.md
+++ b/crates/trusty-mpm/changelog.d/7671-savings-no-fold-warn-wording.md
@@ -1,0 +1,12 @@
+Fixed
+
+- The zero-fold decline no longer claims the `💸` statusline segment disappears.
+  `warn_no_fold_once` and the `tm doctor` instruction-compression check both said
+  the segment "stays absent" for a project that overrides no instruction section,
+  which stopped being true at #7617: the statusline folds `divert` and `compress`
+  rows beside instruction-compression, falls back to a linked sibling session,
+  and renders `💸—` as an explicit empty state. Both messages now scope the claim
+  to the one technique — this project contributes nothing under it until a
+  CLAUDE.md section override folds a bundled section away, while divert and
+  compress savings still count and the segment still renders
+  ([#7671](https://github.com/bobmatnyc/trusty-tools/issues/7671)).

--- a/crates/trusty-mpm/src/core/savings_instructions.rs
+++ b/crates/trusty-mpm/src/core/savings_instructions.rs
@@ -61,13 +61,17 @@
 //! id) appends it. The directory location is unchanged: one compiled prompt per
 //! managed session is what that path is for.
 //!
-//! **The decline that hides the segment (#7245).** When the compiled prompt is
-//! not smaller than its sources there is nothing to record, and for a project
-//! that overrides no instruction section that is permanently true — the composer
-//! ADDS generated context and folds nothing away. That decline logged at
-//! `debug!`, so the segment's absence had no explanation anywhere an operator
-//! would look. It now warns once per project through
+//! **The decline that zeroes this technique (#7245, narrowed by #7617).** When
+//! the compiled prompt is not smaller than its sources there is nothing to
+//! record, and for a project that overrides no instruction section that is
+//! permanently true — the composer ADDS generated context and folds nothing
+//! away. That decline logged at `debug!`, so the flat figure had no explanation
+//! anywhere an operator would look. It now warns once per project through
 //! [`crate::core::savings_sidecar::warn_no_fold_once`], naming both byte counts.
+//! The decline costs this technique's contribution only, never the `💸` segment:
+//! since #7617 the statusline folds `divert` and `compress` rows beside
+//! instruction-compression, falls back to a linked sibling session, and renders
+//! `💸—` as an explicit empty state.
 //!
 //! Test: the inline suite in `savings_instructions_tests.rs` —
 //! `no_row_when_the_compiled_prompt_is_not_smaller`,
@@ -220,9 +224,10 @@ fn record_instruction_compression_to(
         );
         return;
     }
-    // #7245: checked here, where the project root is in hand, so the decline that
-    // makes the 💸 segment structurally absent for an override-free project is
-    // stated once instead of hidden at `debug!` inside the row builder.
+    // #7245, narrowed by #7617: checked here, where the project root is in hand,
+    // so the decline that zeroes an override-free project's instruction-
+    // compression contribution is stated once instead of hidden at `debug!`
+    // inside the row builder.
     if compiled_bytes >= source_bytes {
         warn_no_fold_once(framework_root, &harness_root, source_bytes, compiled_bytes);
         return;

--- a/crates/trusty-mpm/src/core/savings_sidecar.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar.rs
@@ -660,13 +660,16 @@ pub(crate) fn no_fold_marker_path(root: &Path, project_dir: &Path) -> PathBuf {
 /// Warn — once per project — that the compiled prompt was not smaller than the
 /// sources that fed it, so no savings row can be written.
 ///
-/// Why (#7245): this decline is the reason the `💸` segment is structurally
-/// absent for a project that overrides no instruction section, and at `debug!`
-/// it was invisible: an operator saw a missing segment with nothing anywhere
-/// saying why. It cannot log on every launch either — the condition is
-/// permanent for such a project, and a warning that repeats every session is
-/// one an operator learns to skip. So it names both byte counts and the reason
-/// once, and repeats only when the numbers move.
+/// Why (#7245, narrowed by #7617): this decline is why a project that overrides
+/// no instruction section contributes zero instruction-compression savings, and
+/// at `debug!` it was invisible — an operator read a flat `💸` figure with
+/// nothing anywhere saying why. It cannot log on every launch either: the
+/// condition is permanent for such a project, and a warning that repeats every
+/// session is one an operator learns to skip. So it names both byte counts and
+/// the reason once, and repeats only when the numbers move. The message scopes
+/// its claim to this technique — since #7617 the statusline also folds `divert`
+/// and `compress` rows, falls back to a linked sibling session, and renders
+/// `💸—` as an explicit empty state, so the segment renders either way.
 /// What: compares the `<source> <compiled>` pair against the marker file for
 /// `project_dir`; when it differs (or no marker exists) emits one `warn!` and
 /// records the pair. Returns whether it warned. A marker that cannot be written
@@ -674,7 +677,8 @@ pub(crate) fn no_fold_marker_path(root: &Path, project_dir: &Path) -> PathBuf {
 /// never seeing it.
 /// Test: `the_no_fold_warning_fires_once_per_project`,
 /// `the_no_fold_warning_fires_again_when_the_byte_pair_moves`,
-/// `the_no_fold_warning_is_emitted_at_warn_level`.
+/// `the_no_fold_warning_is_emitted_at_warn_level`,
+/// `the_no_fold_warning_claims_no_segment_wide_absence`.
 pub fn warn_no_fold_once(
     root: &Path,
     project_dir: &Path,
@@ -686,15 +690,17 @@ pub fn warn_no_fold_once(
     if std::fs::read_to_string(&path).is_ok_and(|seen| seen.trim() == stamp) {
         return false;
     }
+    // #7671: scoped to this technique — #7617 made the segment render regardless.
     tracing::warn!(
         project = %project_dir.display(),
         source_bytes,
         compiled_bytes,
         "the compiled prompt is not smaller than the instruction sources it was \
          built from, so no instruction-compression savings row is written and \
-         the 💸 statusline segment stays absent for this project; this project \
-         configures no CLAUDE.md section overrides, and only an override folds \
-         a bundled section away"
+         this project contributes nothing to the 💸 statusline segment under \
+         that technique; add a CLAUDE.md section override to fold a bundled \
+         section away, because only an override folds one; divert and compress \
+         savings still count, and the segment still renders"
     );
     let _ = (|| -> Option<()> {
         std::fs::create_dir_all(path.parent()?).ok()?;

--- a/crates/trusty-mpm/src/core/savings_sidecar_tests.rs
+++ b/crates/trusty-mpm/src/core/savings_sidecar_tests.rs
@@ -361,3 +361,47 @@ fn the_no_fold_warning_is_emitted_at_warn_level() {
         "the warning must name both byte counts: {logged}"
     );
 }
+
+/// Why (#7617): the warning's first wording told an operator the `💸` segment
+/// "stays absent" for this project. Since #7617 the statusline folds `divert`
+/// and `compress` rows beside instruction-compression, falls back to a linked
+/// sibling session, and renders `💸—` as an explicit empty state — so the
+/// segment renders and the claim is false. A decline here zeroes ONE technique's
+/// contribution, never the segment, and an operator who reads the wider claim
+/// stops looking for the savings they do have.
+/// What: captures the warning and rejects any word that asserts the segment is
+/// gone, then pins the two facts that replaced it — the scope (this project) and
+/// the remedy (a CLAUDE.md section override).
+/// Test: itself.
+#[test]
+fn the_no_fold_warning_claims_no_segment_wide_absence() {
+    let root = tempfile::tempdir().expect("temp root");
+    let project = root.path().join("project");
+    let capture = CaptureWriter::default();
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(capture.clone())
+        .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
+        .finish();
+    tracing::subscriber::with_default(subscriber, || {
+        warn_no_fold_once(root.path(), &project, 26_741, 29_074);
+    });
+
+    let logged = String::from_utf8(capture.0.lock().expect("capture lock").clone())
+        .expect("the captured log must be utf-8");
+    for banned in ["stays absent", "absent", "hidden", "no 💸", "never renders"] {
+        assert!(
+            !logged.contains(banned),
+            "the warning must not claim the segment is gone, but says {banned:?}: {logged}"
+        );
+    }
+    assert!(
+        logged.contains("this project"),
+        "the warning must scope the decline to this project: {logged}"
+    );
+    assert!(
+        logged.contains("CLAUDE.md section override"),
+        "the warning must name the override that would fold a section away: {logged}"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/doctor_instruction_compression.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_instruction_compression.rs
@@ -1,7 +1,9 @@
 //! `tm doctor` instruction-compression probe (issue #7616).
 //!
-//! Why: when the fold produces no reduction the producer writes no ledger row
-//! and the `💸` statusline segment simply stays absent. #7245 gave that decline
+//! Why: when the fold produces no reduction the producer writes no ledger row,
+//! so this project adds nothing to the `💸` statusline segment under that
+//! technique — the segment itself still renders, folding `divert` and `compress`
+//! rows and a linked sibling session's (#7617). #7245 gave that decline
 //! a one-time `warn!` in the daemon log, which is the wrong surface — an
 //! operator asking "is instruction compression working on this project?" reads
 //! `tm doctor`, and `tm doctor` had no compression check at all. Silence and
@@ -94,11 +96,14 @@ fn describe(source_bytes: usize, compiled_bytes: usize) -> String {
              {compiled_bytes} B = {saved} B ({percent:.1}% smaller)"
         );
     }
+    // #7671: scoped to this technique — #7617 made the segment render regardless.
     format!(
         "instruction compression INACTIVE for this project: sources {source_bytes} B, \
          compiled {compiled_bytes} B — the compiled prompt is not smaller than the \
          instruction bodies it was built from, so no instruction-compression savings \
-         row is written and the 💸 statusline segment stays absent. See issue #7616."
+         row is written and this project contributes nothing to the 💸 statusline \
+         segment under that technique; divert and compress savings still count. \
+         See issue #7616."
     )
 }
 


### PR DESCRIPTION
## Outcome

Refs #7671. The no-fold WARN, the doctor INACTIVE message, and two source
comments claimed the 💸 segment stays absent entirely — false since #7617,
which restored the segment under other techniques even when
instruction-compression declines to fold.

## Changes

Scopes the WARN, the doctor message, and the two comments to the
instruction-compression technique specifically, instead of claiming
segment-wide absence.

## Risk

Low — wording/messaging only, no behavior change to the fold decision itself.

## Tests

New test `the_no_fold_warning_claims_no_segment_wide_absence` failed before
this change and passes after. Rung 3.

`cargo test -p trusty-mpm --no-fail-fast`: 12974 passed, 0 failed, 18 ignored,
61 targets. `cargo fmt --check`, `cargo check -p trusty-mpm`,
`cargo clippy -p trusty-mpm --all-targets -- -D warnings`: clean.

## Baseline

No pre-existing failures observed in this crate's run.

## Docs

Changelog fragment: `crates/trusty-mpm/changelog.d/7671-savings-no-fold-warn-wording.md`.

## Review

No outstanding review findings; net-new test covers the fix.

Refs #7671

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01CKGWJ26v4qrWXTVRhdzDHd
