### PR TITLE
docs(specs): rtk compression covers native tm sessions since #1968 (Refs #1959)

### DIFF
--- a/docs/specs/tool-output-interception-seam.md
+++ b/docs/specs/tool-output-interception-seam.md
@@ -80,12 +80,15 @@ This rules out every post-hoc interception point:
   forward stdin JSON would enrich the *observability* copy (see
   [§ Not Recommended](#not-recommended)) but cannot touch the live copy, for the
   reason above.
-- **RTK is shipped but scoped to the wrong harness.** `compress_tool_output_async`
-  (`crates/trusty-agents/src/compress/tool_output/rtk.rs:84`) genuinely reduces live
-  tokens — but only inside `tagent`'s own LLM tool loop
-  (`llm/tool_loop/mod.rs:424`), which mediates its own tool calls and can rewrite a
-  result before it goes back to the model. Native `tm` sessions don't run that loop;
-  they run Claude Code's.
+- **RTK is now available to native `tm` sessions.** As of #1959/#1968, the
+  `compress_tool_output_async` function lives in
+  `crates/trusty-agents-common/src/compress/tool_output/rtk.rs` (shared across both
+  `tagent` and `tm`). The `tm compress` command
+  (`crates/trusty-mpm/src/bin/tm/commands/compress.rs`) routes every native Bash
+  PreToolUse rewrite through it, reducing live tool-output tokens in native Claude
+  Code sessions. Additionally, `tm compress` emits a `compress` savings row
+  (`crates/trusty-mpm/src/core/savings_compress.rs`) that the 💸 statusline folds
+  to show total context saved.
 - **ZTK doesn't exist in this workspace** — but a working equivalent exists in a
   sibling project, and it proves the seam is real. No `ztk` symbol appears anywhere
   under `crates/`; the `codejunkie99/ztk` Zig binary itself is not vendored, shelled

--- a/docs/trusty-agents/research/token-compression-rtk-ztk.md
+++ b/docs/trusty-agents/research/token-compression-rtk-ztk.md
@@ -8,6 +8,8 @@ Rust-applicable, rule-based approaches. Includes analysis of rtk-ai/rtk and code
 
 ## Implementation status (updated 2026-07-03, issue #1944)
 
+**Status update (2026-09-12, #1959/#1968):** The RTK pattern description below (lines starting with "RTK-*pattern* — shipped, but only in the `tagent` runtime") is now outdated. As of #1959/#1968, the compressor was hoisted to `crates/trusty-agents-common/src/compress/tool_output/rtk.rs` and is now available to both tagent and native `tm` sessions. The `tm compress` command routes every native Bash PreToolUse rewrite through it. This research document remains a valuable survey of the underlying techniques but does not reflect current shipping scope.
+
 This document is a **survey of external techniques**, not a description of shipped behavior. The
 current implementation status in `trusty-tools` is:
 


### PR DESCRIPTION
## Outcome

Refs #1959. docs/specs/tool-output-interception-seam.md carried a stale
passage saying RTK compression was scoped to the wrong harness; this has been
available to native tm sessions since #1968.

## Changes

Corrects the stale "scoped to the wrong harness" passage in
docs/specs/tool-output-interception-seam.md and adds a dated status note to
docs/trusty-agents/research/token-compression-rtk-ztk.md.

## Risk

None — documentation only, no code or behavior change.

## Tests

Not applicable — docs-only, rung 1.

## Baseline

Not applicable.

## Docs

`bash scripts/check_sld.sh`: 0 errors. `bash scripts/check_doc_paths.sh`: all
citations resolve.

## Review

No outstanding review findings.

Refs #1959

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01CKGWJ26v4qrWXTVRhdzDHd
