### PR TITLE
fix(trusty-memory): register chat_asset tools in the count, scopes and README; bump to 0.26.1 (Refs #7654, #7549)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11892,7 +11892,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -32,7 +32,7 @@ name = "trusty-memory"
 # 0.26.0 (#6820): minor — `AppState` gained the public `machine` field. The struct
 # has public fields and is not `#[non_exhaustive]`, so a downstream struct literal
 # stops compiling; Cargo's 0.x rule puts that break in MINOR.
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 description = "MCP server (stdio + Unix socket) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-memory/README.md
+++ b/crates/trusty-memory/README.md
@@ -255,19 +255,22 @@ per-palace conversation store: turns are stored verbatim and bypass the
 `memory_remember` signal/noise and dedup gates.
 
 <!-- BEGIN GENERATED: mcp-tools -->
-The MCP server registers **49 tools**. Authoritative source: `trusty_memory::tools::tool_definitions` —
+The MCP server registers **52 tools**. Authoritative source: `trusty_memory::tools::tool_definitions` —
 this table is generated from it, not maintained by hand.
 
 | Tool | Arguments | Summary |
 |---|---|---|
 | `add_alias` | `palace`, `short`, `full`, `extra?` | Add a short→full alias (e.g. tga → trusty-git-analytics) to the prompt-facts surface. |
-| `chat_session_add_turn` | `palace`, `session_id`, `role`, `content` | Append a message (prompt or response) to a chat session's history. |
+| `chat_asset_capabilities` | — | Read supported durable chat attachment contract. |
+| `chat_asset_get` | `palace`, `session_id`, `asset_id` | Read an image owned by the supplied palace and session. |
+| `chat_asset_put` | `palace`, `session_id`, `name`, `mime_type`, `data_base64` | Store a bounded image in an existing palace chat session; returns generated asset_id. |
+| `chat_session_add_turn` | `palace`, `session_id`, `role`, `content`, `attachments?` | Append a message (prompt or response) to a chat session's history. |
 | `chat_session_create` | `palace`, `session_id?`, `title?` | Create a new chat session in a palace (spec-001 chat-session manager). |
 | `chat_session_delete` | `palace`, `session_id` | Delete a chat session (and its full history) from a palace. |
 | `chat_session_get` | `session_id`, `palace?` | Retrieve a full chat session: metadata plus every turn in chronological order. |
 | `chat_session_list` | `limit?`, `offset?`, `palace?` | List chat sessions in a palace as paginated metadata (id, title, timestamps, message_count) ordered most-recently-updated first. |
 | `chat_session_recall` | `session_id`, `palace?` | Retrieve a full chat session with all turns in order (alias for chat_session_get, preferred name for agent-facing recall). |
-| `chat_turn_append` | `palace`, `session_id`, `prompt`, `response` | Append a prompt/response PAIR to a chat session as two consecutive messages (user role then assistant role). |
+| `chat_turn_append` | `palace`, `session_id`, `prompt`, `response`, `attachments?` | Append a prompt/response PAIR to a chat session as two consecutive messages (user role then assistant role). |
 | `console_metrics` | — | Return a ConsoleMetricsReport with palace aggregate statistics (palace_count, counted_palace_count, cached_palace_count, total_drawers,… |
 | `discover_aliases` | `palace`, `project_root?` | Auto-discover project aliases by scanning Cargo workspace members, binary names, first-letter abbreviations, and the git remote. |
 | `dream_consolidate_room` | `palace`, `max_age_days?`, `room?` | Trigger LLM-driven semantic consolidation for one room (or all rooms) of a palace, on demand and synchronously (spec-001). |

--- a/crates/trusty-memory/changelog.d/7654-chat-asset-tool-surface.md
+++ b/crates/trusty-memory/changelog.d/7654-chat-asset-tool-surface.md
@@ -1,0 +1,5 @@
+Fixed
+
+- **The three `chat_asset_*` tools now appear in the scope map, the tool count and the generated README table.** #7370 registered `chat_asset_capabilities`, `chat_asset_put` and `chat_asset_get` in `tools::definitions` but changed nothing that enumerates the tool surface, so `rpc.discover` emitted them with an empty `x-scopes` array — an orchestrator enforcing least privilege had no rule to apply — and seven tests failed on `main` from the day it merged. `scopes_for_tool` now classifies capability discovery and an owned asset read as `memory.read` and the asset store as `memory.write`; the count assertions read 52; the roster contract in `tools::tests` lists all three ([#7654](https://github.com/bobmatnyc/trusty-tools/issues/7654))
+  - The README's generated `mcp-tools` region was refreshed from the code, which also picks up the `attachments?` argument #7370 added to `chat_session_add_turn` and `chat_turn_append`
+  - `read_write_classification` pins the split so a later change cannot quietly make the asset write a read

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -102,7 +102,9 @@ async fn tools_list_returns_all_tools() {
     // #4776 adds `kg_list_subjects`; `kg_retract_triple` adds the inverse of
     // `kg_assert`.
     // #5000 / #4786 add `palace_verify_embedded` and `palace_embed_sweep`.
-    assert_eq!(tools.len(), 49);
+    // #7370 adds `chat_asset_capabilities`, `chat_asset_put`, `chat_asset_get`
+    // — #7654: the count was left at 49 when they landed.
+    assert_eq!(tools.len(), 52);
 }
 
 #[tokio::test]

--- a/crates/trusty-memory/src/mcp_service.rs
+++ b/crates/trusty-memory/src/mcp_service.rs
@@ -87,8 +87,8 @@ mod tests {
         let tools = svc.tools();
         assert_eq!(
             tools.len(),
-            49,
-            "expected 49 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces + #4906 palace_reembed + #5005 palace_unalias + #4776 kg_list_subjects + kg_retract_triple + #5000 palace_verify_embedded and palace_embed_sweep), got {}",
+            52,
+            "expected 52 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces + #4906 palace_reembed + #5005 palace_unalias + #4776 kg_list_subjects + kg_retract_triple + #5000 palace_verify_embedded and palace_embed_sweep + #7370 chat_asset_capabilities, chat_asset_put and chat_asset_get), got {}",
             tools.len()
         );
     }
@@ -111,7 +111,8 @@ mod tests {
         //      so we must confirm dynamic dispatch resolves correctly here.
         let svc: Box<dyn ServiceDescriptor> = Box::new(MemoryMcpService);
         assert_eq!(svc.name(), "trusty-memory");
-        assert_eq!(svc.tools().len(), 49);
+        // #7654: #7370 added three chat-asset tools; the count tracks them.
+        assert_eq!(svc.tools().len(), 52);
         assert_eq!(svc.scopes_for("palace_create"), vec!["memory.write"]);
         // #5005: the repair deletes vector keys, so it must classify as a write.
         assert_eq!(svc.scopes_for("palace_unalias"), vec!["memory.write"]);

--- a/crates/trusty-memory/src/openrpc.rs
+++ b/crates/trusty-memory/src/openrpc.rs
@@ -72,6 +72,10 @@ pub fn scopes_for_tool(name: &str) -> Vec<String> {
         | "console_metrics"
         | "chat_session_get"
         | "chat_session_list"
+        // #7654: #7370 shipped the chat-asset tools with no scope entry at all.
+        // Capability discovery and an owned asset read mutate nothing.
+        | "chat_asset_capabilities"
+        | "chat_asset_get"
         | "chat_session_recall" => &[MEMORY_READ],
 
         // Mutating
@@ -98,6 +102,8 @@ pub fn scopes_for_tool(name: &str) -> Vec<String> {
         | "chat_session_add_turn"
         | "chat_session_delete"
         | "chat_turn_append"
+        // #7654: storing an asset writes bytes into the session store.
+        | "chat_asset_put"
         | "dream_consolidate_room"
         | "palace_dream" => &[MEMORY_WRITE],
 
@@ -179,6 +185,13 @@ mod tests {
         assert_eq!(scopes_for_tool("kg_assert"), vec!["memory.write"]);
         assert_eq!(scopes_for_tool("palace_compact"), vec!["memory.write"]);
         assert_eq!(scopes_for_tool("palace_info"), vec!["memory.read"]);
+        // #7654: pin the chat-asset split — only the put is a write.
+        assert_eq!(
+            scopes_for_tool("chat_asset_capabilities"),
+            vec!["memory.read"]
+        );
+        assert_eq!(scopes_for_tool("chat_asset_get"), vec!["memory.read"]);
+        assert_eq!(scopes_for_tool("chat_asset_put"), vec!["memory.write"]);
     }
 
     #[test]

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -231,6 +231,11 @@ fn tool_definitions_lists_all_tools() {
         "chat_session_list",
         "chat_session_delete",
         "chat_turn_append",
+        // #7654: the durable chat-asset surface (#7370) shipped without a
+        // roster entry, so the contract test failed on every run.
+        "chat_asset_capabilities",
+        "chat_asset_put",
+        "chat_asset_get",
         "dream_consolidate_room",
         "palace_dream",
         // spec-001 Phase 4 (issue #1722):


### PR DESCRIPTION
Refs [#7654](https://github.com/bobmatnyc/trusty-tools/issues/7654) (never `Closes`): PR [#7396](https://github.com/bobmatnyc/trusty-tools/pull/7396) registered `chat_asset_capabilities`, `chat_asset_get`, `chat_asset_put` in `tools/definitions.rs` without updating the four sites that enumerate the tool surface; seven trusty-memory tests were red on main since. Fix adds the three tools to the `memory.read` / `memory.write` scope arms in openrpc.rs, moves the count 49->52 in mcp_service.rs and lib_tests.rs, adds them to the hand-authored roster in tools/tests.rs, and regenerates the README `mcp-tools` region (`UPDATE_DOCS=1 cargo test -p trusty-memory --test generated_docs`). No test deleted, ignored or weakened.

Refs [#7549](https://github.com/bobmatnyc/trusty-tools/issues/7549): the bump to 0.26.1 is the owner-authorized reinstall build (every reinstall carries a patch bump).

Test ladder rung 3. Gates run by the engineer, all green: `cargo test -p trusty-memory --no-fail-fast` (34 targets, lib 878 passed 0 failed 4 ignored, exit 0; pre-fix run on 626c36eaf had 6 lib failures + 1 generated_docs failure); `cargo fmt --check`; `cargo clippy -p trusty-memory --all-targets -- -D warnings`; `./scripts/check_line_cap.sh`, `check_test_pointers.sh`, `check_sld.sh`, `check_doc_paths.sh`, `check_changelog_fragment.sh` all OK. Fragment: `crates/trusty-memory/changelog.d/7654-chat-asset-tool-surface.md` (Fixed).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_018WdomR2f9ERZME6nakj4qy
