### PR TITLE
fix(trusty-mpm): statusline seeding is idempotent again — a second ensure call on an unchanged file reports Unchanged (Refs #7689)

### DIFF
--- a/crates/trusty-mpm/changelog.d/7689-statusline-seeding-idempotent.md
+++ b/crates/trusty-mpm/changelog.d/7689-statusline-seeding-idempotent.md
@@ -1,0 +1,10 @@
+Fixed
+
+- Statusline seeding is idempotent again: a second `ensure_statusline_entry_in`
+  call on an unchanged settings file reports `Unchanged` and writes nothing.
+  Where no `tm` binary is installed, command resolution degrades to the bare
+  `tm statusline` literal, which the staleness predicate then claimed as its own
+  stale pre-#1914 default — so every launch and every resume republished the
+  file with byte-identical content. A repair that would write the identical
+  command is now a no-op; a genuinely missing or divergent entry is still
+  repointed. (#7689)

--- a/crates/trusty-mpm/src/core/statusline_settings.rs
+++ b/crates/trusty-mpm/src/core/statusline_settings.rs
@@ -97,7 +97,8 @@ impl StatuslineWrite {
 /// `a_customized_entry_is_kept`, `an_unparseable_file_is_refused`,
 /// `seeding_is_idempotent`, `other_keys_survive_the_seed`,
 /// `a_repair_backs_up_the_prior_bytes`,
-/// `a_repair_preserves_operator_fields`.
+/// `a_repair_preserves_operator_fields`,
+/// `a_divergent_entry_is_still_repaired_against_the_resolution`.
 pub fn ensure_statusline_entry_in(settings_path: &Path) -> StatuslineWrite {
     // #7617: held across the read AND the write below — see "Write safety".
     let _guard = crate::core::claude_json_guard::lock();
@@ -186,30 +187,67 @@ pub fn backup_of(settings_path: &Path) -> std::path::PathBuf {
 /// predicate is ever widened to claim a non-object, this branch is what stops
 /// the widening from turning into a silent no-op — which is the failure #1914's
 /// review flagged when the equivalent branch was first written.
+/// A REPAIR THAT WOULD WRITE THE IDENTICAL COMMAND IS NOT A REPAIR (#7689):
+/// [`resolve_statusline_command`] degrades to the bare literal `tm statusline`
+/// when `current_exe()` is an ephemeral build path AND no `tm`/`trusty-mpm` is
+/// resolvable — and that literal is itself in `KNOWN_BARE_STATUSLINE_COMMANDS`,
+/// so the predicate claims the seeder's own output. Without the equality check
+/// the second call on an untouched file reports `Repaired` and rewrites the
+/// file with byte-identical content, which is what this runs on every launch
+/// and every resume. The repair path survives intact: a command that differs
+/// from the resolution — a missing binary, a cleaned build tree — still differs
+/// from it, and still reports [`StatuslineWrite::Repaired`].
 /// Test: `a_fresh_file_is_seeded`, `a_stale_entry_is_repaired`,
 /// `a_customized_entry_is_kept`, `a_repair_preserves_operator_fields`,
-/// `a_non_object_statusline_is_left_alone`.
+/// `a_non_object_statusline_is_left_alone`,
+/// `an_unresolvable_seed_is_not_repaired_on_the_next_call`.
 pub fn apply_statusline_entry(
     obj: &mut serde_json::Map<String, serde_json::Value>,
 ) -> StatuslineWrite {
+    apply_statusline_entry_with(obj, resolve_statusline_command)
+}
+
+/// Testable core of [`apply_statusline_entry`] with the command resolution
+/// injected.
+///
+/// Why (#7689): the non-idempotent case only arises when
+/// [`resolve_statusline_command`] degrades to its bare last resort, which
+/// depends on the host having no installed `tm` — true on a CI runner, false on
+/// every developer machine, so the defect was invisible locally and red in CI.
+/// Injecting the resolver makes that branch deterministic here, the same
+/// `resolve_statusline_binary_with` pattern the resolution priority itself uses.
+/// What: [`apply_statusline_entry`]'s rule, with `resolve` supplying the command
+/// string. Called at most once, and never on the `Unchanged` path, so a steady
+/// install still costs no resolution.
+/// Test: `an_unresolvable_seed_is_not_repaired_on_the_next_call`.
+fn apply_statusline_entry_with(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    resolve: impl Fn() -> String,
+) -> StatuslineWrite {
     match obj.get("statusLine") {
         None => {
-            obj.insert("statusLine".to_string(), statusline_entry());
+            obj.insert("statusLine".to_string(), statusline_entry(&resolve()));
             StatuslineWrite::Seeded
         }
         Some(existing) if is_stale_statusline_command(existing) => {
+            let current = existing
+                .get("command")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned);
+            let resolved = resolve();
+            // See #7689
+            if current.as_deref() == Some(resolved.as_str()) {
+                return StatuslineWrite::Unchanged;
+            }
             match obj
                 .get_mut("statusLine")
                 .and_then(serde_json::Value::as_object_mut)
             {
                 Some(entry) => {
-                    entry.insert(
-                        "command".to_string(),
-                        serde_json::Value::String(resolve_statusline_command()),
-                    );
+                    entry.insert("command".to_string(), serde_json::Value::String(resolved));
                 }
                 None => {
-                    obj.insert("statusLine".to_string(), statusline_entry());
+                    obj.insert("statusLine".to_string(), statusline_entry(&resolved));
                 }
             }
             StatuslineWrite::Repaired
@@ -221,14 +259,14 @@ pub fn apply_statusline_entry(
 
 /// The entry every tier gets.
 ///
-/// What: `{"type":"command","command":"<abs tm> statusline","padding":0}`, with
-/// the command resolved absolutely by
-/// [`resolve_statusline_command`] — a bare `tm statusline` silently renders
-/// nothing under Claude Code's minimal `PATH` (#1914).
-fn statusline_entry() -> serde_json::Value {
+/// What: `{"type":"command","command":"<command>","padding":0}`, where
+/// `command` is normally [`resolve_statusline_command`]'s absolute
+/// `<abs tm> statusline` — a bare `tm statusline` silently renders nothing
+/// under Claude Code's minimal `PATH` (#1914).
+fn statusline_entry(command: &str) -> serde_json::Value {
     serde_json::json!({
         "type": "command",
-        "command": resolve_statusline_command(),
+        "command": command,
         "padding": 0
     })
 }

--- a/crates/trusty-mpm/src/core/statusline_settings_tests.rs
+++ b/crates/trusty-mpm/src/core/statusline_settings_tests.rs
@@ -111,6 +111,11 @@ fn an_unparseable_file_is_refused() {
 /// Why: this runs on every launch and every resume. A second call must not
 /// rewrite the file, or every session bumps the mtime of the operator's
 /// settings for nothing.
+///
+/// #7689: the enum alone let the real contract drift — assert the BYTES and the
+/// mtime too, plus the absence of the `<path>.bak` that `write_json_atomic`
+/// takes before every publish. Those three are what "wrote nothing" actually
+/// means; `StatuslineWrite::Unchanged` is only the report of it.
 /// Test: itself.
 #[test]
 fn seeding_is_idempotent() {
@@ -118,10 +123,83 @@ fn seeding_is_idempotent() {
     let path = dir.path().join("settings.json");
 
     assert_eq!(ensure_statusline_entry_in(&path), StatuslineWrite::Seeded);
+    let seeded_bytes = std::fs::read(&path).expect("read after seed");
+    let seeded_mtime = std::fs::metadata(&path)
+        .and_then(|m| m.modified())
+        .expect("mtime after seed");
+
     assert_eq!(
         ensure_statusline_entry_in(&path),
         StatuslineWrite::Unchanged
     );
+    assert_eq!(
+        std::fs::read(&path).expect("read after second call"),
+        seeded_bytes,
+        "a second call must leave the file byte-for-byte as the seed wrote it"
+    );
+    assert_eq!(
+        std::fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .expect("mtime after second call"),
+        seeded_mtime,
+        "a second call must not bump the mtime of the operator's settings"
+    );
+    assert!(
+        !backup_of(&path).is_file(),
+        "a second call must not publish, so it must take no backup either"
+    );
+}
+
+/// Why (#7689): `resolve_statusline_command` degrades to the bare
+/// literal `tm statusline` when `current_exe()` is an ephemeral build path and
+/// no `tm`/`trusty-mpm` is installed — and that literal is one of
+/// `KNOWN_BARE_STATUSLINE_COMMANDS`, so `is_stale_statusline_command` claims the
+/// seeder's own output and the next call reports `Repaired` forever. That holds
+/// on a CI runner and not on a developer machine, which is why
+/// `seeding_is_idempotent` was green locally and red in CI for every run of
+/// shard 5. Injecting the resolver pins the degraded case on any host.
+/// FAILS BEFORE THIS CHANGE: the second call returned `Repaired`.
+/// Test: itself.
+#[test]
+fn an_unresolvable_seed_is_not_repaired_on_the_next_call() {
+    let degraded = || "tm statusline".to_string();
+    let mut obj = serde_json::Map::new();
+
+    assert_eq!(
+        apply_statusline_entry_with(&mut obj, degraded),
+        StatuslineWrite::Seeded
+    );
+    let seeded = obj.clone();
+
+    assert_eq!(
+        apply_statusline_entry_with(&mut obj, degraded),
+        StatuslineWrite::Unchanged,
+        "the resolution has not changed, so there is nothing to repoint to"
+    );
+    assert_eq!(obj, seeded, "nothing may be mutated on the second pass");
+}
+
+/// Why (#7689): the equality check must not cost the `--fix` repair its job. An
+/// entry that names a DIFFERENT binary from the one resolution offers is still
+/// stale, and still gets repointed.
+/// Test: itself.
+#[test]
+fn a_divergent_entry_is_still_repaired_against_the_resolution() {
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "statusLine".to_string(),
+        serde_json::json!({
+            "type": "command",
+            "command": "/definitely/not/here/tm statusline",
+            "padding": 0
+        }),
+    );
+
+    assert_eq!(
+        apply_statusline_entry_with(&mut obj, || "/opt/tm statusline".to_string()),
+        StatuslineWrite::Repaired
+    );
+    assert_eq!(obj["statusLine"]["command"], "/opt/tm statusline");
 }
 
 /// Why (critic CRITICAL): this writes `~/.claude/settings.json`, the file class


### PR DESCRIPTION
## Outcome

Statusline seeding is idempotent again. Refs bobmatnyc/trusty-tools#7689

## What changed

Root cause: the resolver's bare `tm` fallback collided with
`KNOWN_BARE_STATUSLINE_COMMANDS`, so on a host with no installed `tm` binary
every `ensure` call reported `Repaired` and republished identical bytes,
even when the on-disk entry already matched. `apply_statusline_entry` now
compares the incoming entry against the existing one before writing, so a
second call against an unchanged file reports `Unchanged` instead of
re-writing and re-reporting `Repaired`. Out of scope: the other two causes
of the red pre-publish shards tracked on #7351 — this PR fixes one of three.

## Risk / blast radius

Localized to `trusty-mpm`'s statusline-seeding path
(`apply_statusline_entry` and the bare-command resolver). No public API
change; no cross-crate surface touched. Rung 3.

## Test evidence

New tests pin the written bytes, the file mtime, and the absence of a
`.bak` file across a second `ensure` call on an unchanged file, plus an
injected-resolver test that fails on any host regardless of whether `tm` is
actually installed. `cargo test -p trusty-mpm --no-fail-fast`: 61 targets,
12975 passed, 0 failed, 18 ignored. `cargo fmt --check`, `cargo check -p
trusty-mpm`, and `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
all clean.

## Baseline / pre-existing failures

None observed on this branch. This fix addresses one of the three causes
tracked on #7351 for the red pre-publish shards; the other two remain open
there.

## Documentation / changelog

Fragment added at
`crates/trusty-mpm/changelog.d/7689-statusline-seeding-idempotent.md`. Line
cap and doc-comment (`Test:`) pointer gates both pass.

## Review disposition

Sprint mode — no code-critic round run for this PR.

Refs #7689

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

https://claude.ai/code/session_01CKGWJ26v4qrWXTVRhdzDHd
